### PR TITLE
fix: flush console output promptly

### DIFF
--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -76,8 +76,8 @@ declare namespace NodeJS {
 
 /* log/info/debug write stdout (info and debug ARE log in Node); error and
  * warn are ONE stream (warn IS error under another name) and write stderr
- * with the exact same formatting. stderr is unbuffered (stdout flushes
- * first, so merged 2>&1 output keeps source order). Arguments take Node's
+ * with the exact same formatting. Each call submits its output promptly;
+ * stdout settles first under merged 2>&1 output. Arguments take Node's
  * console semantics: strings verbatim, everything else through the static
  * util.inspect rendering — so the parameters are unknown[], like stock
  * lib's console; values inspect cannot render statically (functions inside
@@ -203,9 +203,9 @@ declare var process: {
    * per queued unfired immediate; unmodeled kinds absent (SEMANTICS.md). */
   getActiveResourcesInfo(): string[];
   /* The raw byte writes — no newline, no formatting. stdout shares
-   * console.log's stream and buffer, so ordering is preserved; stderr is
-   * unbuffered like Node's. The boolean is Node's backpressure signal —
-   * these synchronous writes always return true. The Uint8Array overload
+   * console.log's stream, each call is submitted promptly, and ordering is
+   * preserved. The boolean is Node's backpressure signal — these synchronous
+   * writes always return true. The Uint8Array overload
    * and isTTY exist so real CLIs TYPECHECK (they are @types/node surface);
    * only the one-string form has a lowering — everything else fences at
    * its use site. */

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -3049,7 +3049,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           }
           case "procStream.write":
             // The receiver IS the fd scalar; dispatches onto the exact
-            // stdout/stderr write paths (buffering/ordering identical).
+            // promptly-submitted stdout/stderr paths (ordering identical).
             return finish(`scr_proc_stream_write(${arg(0)}, ${arg(1)})`);
           case "child.killed":
             return finish(`scr_child_killed(${arg(0)})`);

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -5357,10 +5357,10 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     if (call.questionDotToken) return null;
     // process.stdout.write(s) / process.stderr.write(s): the raw byte
     // write — no newline, no formatting. stdout shares console.log's
-    // stream and buffer (source order preserved); stderr is unbuffered.
-    // Node's boolean is a backpressure signal; the synchronous write is
-    // constantly true. @types/node's wider forms (Buffer data, encoding,
-    // callback) typecheck and fence here.
+    // promptly-submitted stream, preserving source order. Node's boolean
+    // is a backpressure signal; this synchronous write is constantly true.
+    // @types/node's wider forms (Buffer data, encoding, callback) typecheck
+    // and fence here.
     // process.stdin.destroy(): a deliberate no-op — no stream machinery
     // exists to tear down, and no other stdin surface observes the
     // destroyed state (SEMANTICS.md documents it).
@@ -5498,8 +5498,8 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         if (data.type.kind === "dyn" && isJsSourceFile(call.getSourceFile())) {
           data = { kind: "dynCheck", value: data, type: STRING, loc };
         }
-        // The Buffer overload writes the raw bytes through the same
-        // streams (and stdout's shared buffer).
+        // The Buffer overload writes raw bytes through the same promptly
+        // submitted streams.
         if (data.type.kind === "bytes" && data.type.elem === "u8") {
           return {
             kind: "libCall",

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2788,8 +2788,8 @@ export type IrLibFn =
    * catchably. */
   | "zlib.deflateSync"
   | "zlib.inflateSync"
-  /** The Buffer overloads of the raw stream writes — same streams and
-   * buffering as process.stdoutWrite/stderrWrite, constantly true. */
+  /** The Buffer overloads of the raw stream writes — same promptly
+   * submitted streams as process.stdoutWrite/stderrWrite, constantly true. */
   | "process.stdoutWriteBytes"
   | "process.stderrWriteBytes"
   | "fsp.readFile"
@@ -2904,10 +2904,10 @@ export type IrLibFn =
    * whose fiber turns the throw into the rejection. */
   | "cp.execCapture"
   /** The raw byte writes: one borrowed string arg → bool (constantly true
-   * — Node's backpressure signal never fires on these synchronous writes).
-   * stdoutWrite shares console.log's stream AND buffer, so interleaved
-   * output keeps source order; stderrWrite is unbuffered like Node's
-   * stderr. No newline, no formatting, never throws. */
+   * — this synchronous runtime never queues backpressure). stdoutWrite
+   * shares console.log's stream, each call is submitted promptly, and
+   * interleaved output keeps source order. No newline, no formatting,
+   * never throws. */
   | "process.stdoutWrite"
   | "process.stderrWrite"
   | "timers.setTimeout"

--- a/packages/runtime/src/scr_bytes_io.c
+++ b/packages/runtime/src/scr_bytes_io.c
@@ -154,13 +154,12 @@ ScrBytes *scr_crypto_random_bytes(double n) {
 /* ── process.stdout/stderr.write(buf) ──────────────────────────────────── */
 
 bool scr_process_stdout_write_bytes(const ScrBytes *b) {
-  fwrite(b->data, 1, b->len * scr_bytes_elem_size(b->elem), stdout);
+  scr_stdio_write(1, b->data, b->len * scr_bytes_elem_size(b->elem));
   return true;
 }
 
 bool scr_process_stderr_write_bytes(const ScrBytes *b) {
-  fflush(stdout); /* merged 2>&1 output keeps source order (scr_lib.c) */
-  fwrite(b->data, 1, b->len * scr_bytes_elem_size(b->elem), stderr);
+  scr_stdio_write(2, b->data, b->len * scr_bytes_elem_size(b->elem));
   return true;
 }
 

--- a/packages/runtime/src/scr_console.c
+++ b/packages/runtime/src/scr_console.c
@@ -83,8 +83,11 @@ void scr_init(void) {
   _setmode(_fileno(stderr), _O_BINARY);
   _setmode(_fileno(stdin), _O_BINARY);
 #endif
-  /* Full buffering matches Node writing to a pipe (the differential harness
-   * never runs either side on a TTY) and makes output-heavy programs fast. */
+  /* A private formatting buffer coalesces the several stdio calls needed to
+   * render one console line. Every JavaScript-visible stdout write flushes
+   * before returning, so this buffer is never observable as delayed output:
+   * Node hands each console.log/process.stdout.write chunk to its backing
+   * stream immediately. */
   static char outbuf[1 << 16];
   setvbuf(stdout, outbuf, _IOFBF, sizeof outbuf);
   /* atexit is LIFO; registration order makes exit run: library cleanup
@@ -131,18 +134,36 @@ static void scr_console_write(FILE *out, size_t n, const ScrLogArg *args) {
     }
   }
   fputc('\n', out);
+  /* Console methods submit one formatted chunk to their backing stream.
+   * Keep the C buffer only as a formatter coalescing detail: a caller
+   * observing a live child must see this line before the next JS turn. */
+  fflush(out);
 }
 
 void scr_console_log(size_t n, const ScrLogArg *args) {
   scr_console_write(stdout, n, args);
 }
 
-/* console.error and console.warn. stderr is UNBUFFERED (C's default; Node
- * writes stderr synchronously too), and stdout FLUSHES first so a merged
- * redirection (2>&1) sees writes in source order despite stdout's full
- * buffering — Node's piped stdout/stderr preserve write order the same
- * way. */
+/* console.error and console.warn. Flush stdout first so runtime-internal
+ * output that is still being assembled cannot cross this stderr line under
+ * a merged redirection (2>&1); JavaScript-visible stdout writes have already
+ * flushed themselves. */
 void scr_console_error(size_t n, const ScrLogArg *args) {
   fflush(stdout);
   scr_console_write(stderr, n, args);
+}
+
+/* One JavaScript-visible raw write. Node's global console and process stream
+ * methods hand each chunk to the backing stream when called; they do not
+ * retain stdout until a later stderr write, a 64 KiB threshold, or process
+ * exit. The runtime remains synchronous internally, so its backpressure
+ * surface is still constantly true, but the bytes are observable promptly.
+ *
+ * stderr flushes any runtime-internal stdout fragment first to preserve the
+ * existing merged-fd ordering convention. */
+void scr_stdio_write(int fd, const void *data, size_t len) {
+  FILE *out = fd == 2 ? stderr : stdout;
+  if (fd == 2) fflush(stdout);
+  if (len > 0) fwrite(data, 1, len, out);
+  fflush(out);
 }

--- a/packages/runtime/src/scr_exception.c
+++ b/packages/runtime/src/scr_exception.c
@@ -307,8 +307,8 @@ int scr_exit_code_hint_get(void) { return scr_exit_code_hint; }
 
 void scr_exc_print_uncaught(void) {
   scr_exit_code_note(1);
-  /* Pre-throw stdout must land before the stderr line when both share a
-   * terminal; stdout is fully buffered (scr_init). */
+  /* Settle any runtime-internal stdout fragment before the stderr line when
+   * both share an fd. JavaScript-visible writes already flush themselves. */
   fflush(stdout);
   fputs("Uncaught ", stderr);
   switch (scr_exc_kind) {

--- a/packages/runtime/src/scr_island.c
+++ b/packages/runtime/src/scr_island.c
@@ -2682,7 +2682,7 @@ static JSValue isl_host_write(JSContext *ctx, JSValueConst this_val, int argc,
   size_t len;
   const char *s = JS_ToCStringLen(ctx, &len, argv[1]);
   if (!s) return JS_EXCEPTION;
-  fwrite(s, 1, len, fd == 2 ? stderr : stdout);
+  scr_stdio_write(fd, s, len);
   JS_FreeCString(ctx, s);
   return JS_TRUE;
 }

--- a/packages/runtime/src/scr_lib.c
+++ b/packages/runtime/src/scr_lib.c
@@ -584,21 +584,18 @@ ScrStr *scr_process_cwd(void) {
   return scr_str_new(buf, strlen(buf));
 }
 
-/* The raw byte writes. stdout goes through the SAME stdio stream and
- * buffer console.log uses (scr_init's setvbuf), so interleaved writes
- * keep source order; stderr is unbuffered, like Node's, and FLUSHES
- * stdout first (the console.error convention) so merged 2>&1 output
- * keeps source order despite stdout's full buffering. The boolean is
- * Node's backpressure signal — a synchronous fwrite has no backpressure,
- * so it is constantly true. */
+/* The raw byte writes use the SAME stdio stream as console, and each call
+ * flushes before returning so live consumers see Node's source order without
+ * an observable C buffering delay. The boolean is Node's backpressure signal
+ * — this synchronous runtime has no queued backpressure, so it is constantly
+ * true. */
 bool scr_process_stdout_write(const ScrStr *data) {
-  fwrite(data->data, 1, data->len, stdout);
+  scr_stdio_write(1, data->data, data->len);
   return true;
 }
 
 bool scr_process_stderr_write(const ScrStr *data) {
-  fflush(stdout);
-  fwrite(data->data, 1, data->len, stderr);
+  scr_stdio_write(2, data->data, data->len);
   return true;
 }
 
@@ -606,7 +603,7 @@ bool scr_process_stderr_write(const ScrStr *data) {
  * WritableStream-typed value — the prefixStream idiom): the value is the
  * stream's fd (1 or 2, minted by the process.stdout/stderr reads), and
  * the write dispatches onto the exact stdout/stderr paths above so
- * buffering and ordering stay identical. */
+ * prompt submission and ordering stay identical. */
 bool scr_proc_stream_write(double fd, const ScrStr *data) {
   return (int)fd == 2 ? scr_process_stderr_write(data) : scr_process_stdout_write(data);
 }

--- a/packages/runtime/src/scr_readline.c
+++ b/packages/runtime/src/scr_readline.c
@@ -235,9 +235,10 @@ void scr_rl_question(double id, const ScrStr *query, ScrClosure *cb /*moves*/,
     scr_throw_error_msg(SCR_ERR_ERROR, "readline was closed", 19);
     return;
   }
-  /* The prompt writes to stdout under pipes too (Node's question does);
-   * same stream and buffer as console.log, so ordering holds. */
-  fwrite(query->data, 1, query->len, stdout);
+  /* The prompt writes to stdout under pipes too (Node's question does), and
+   * must be visible before input arrives even though it has no trailing
+   * newline. */
+  scr_stdio_write(1, query->data, query->len);
   if (rl->dead) {
     /* Created after stdin ended: pinned against Node — the prompt still
      * writes, but the DESTROYED stream delivers nothing and 'close'

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -35,8 +35,9 @@ char *strcasestr(const char *hay, const char *needle);
 
 /* ── process ──────────────────────────────────────────────────────────── */
 
-/* Called once at the top of main: stdout buffering to match piped Node,
- * flush-at-exit, RC audit registration (when built with -DSCR_RC_AUDIT). */
+/* Called once at the top of main: private stdout formatter buffer,
+ * flush-at-exit, RC audit registration (when built with -DSCR_RC_AUDIT).
+ * JavaScript-visible writes flush before returning. */
 void scr_init(void);
 
 /* ── the trap funnel (scr_console.c; scr_library.c under -DSCR_LIB) ──────
@@ -1840,10 +1841,13 @@ int scr_lib_arg_count(void);
 const char *scr_lib_arg(int i);
 ScrStr *scr_process_platform(void); /* +1 interned ("darwin", "linux", ...) */
 ScrStr *scr_process_cwd(void);      /* +1 fresh (getcwd) */
-/* process.stdout/.stderr .write — the raw byte writes (no newline, no
- * formatting; data borrowed). stdout shares console.log's stream+buffer
- * (ordering preserved); stderr is unbuffered like Node's. Constantly true
- * (Node's backpressure boolean never fires on synchronous writes). */
+/* Submit one raw chunk to fd 1/2 and flush it before returning. Used by all
+ * JavaScript-visible console/process/readline/island output paths so the
+ * internal stdio formatting buffer never delays live output. */
+void scr_stdio_write(int fd, const void *data, size_t len);
+/* process.stdout/.stderr .write — raw bytes (no newline or formatting; data
+ * borrowed), promptly visible and ordered with console output. Constantly
+ * true (the synchronous runtime never queues backpressure). */
 bool scr_process_stdout_write(const ScrStr *data);
 bool scr_process_stderr_write(const ScrStr *data);
 /* The first-class WritableStream write: fd is the stream value itself
@@ -5835,11 +5839,11 @@ typedef struct {
   } v;
 } ScrLogArg;
 
-/* Space-joined args + '\n', single buffered write. Borrows string args. */
+/* Space-joined args + '\n', submitted before return. Borrows string args. */
 void scr_console_log(size_t n, const ScrLogArg *args);
 /* The stderr twin (console.error AND console.warn — one stream in Node):
- * identical formatting, unbuffered stderr, stdout flushed first so merged
- * (2>&1) output keeps source order. */
+ * identical formatting, with stdout settled first so merged (2>&1) output
+ * keeps source order. */
 void scr_console_error(size_t n, const ScrLogArg *args);
 
 #endif /* SCR_RUNTIME_H */

--- a/packages/runtime/src/scr_web.c
+++ b/packages/runtime/src/scr_web.c
@@ -1739,7 +1739,7 @@ static JSValue web_host_write(JSContext *ctx, JSValueConst this_val, int argc,
   size_t len;
   const char *s = JS_ToCStringLen(ctx, &len, argv[1]);
   if (!s) return JS_EXCEPTION;
-  fwrite(s, 1, len, fd == 2 ? stderr : stdout);
+  scr_stdio_write(fd, s, len);
   JS_FreeCString(ctx, s);
   return JS_UNDEFINED;
 }

--- a/tests/fixtures/console-io/live-stdout.ts
+++ b/tests/fixtures/console-io/live-stdout.ts
@@ -1,0 +1,8 @@
+console.log("log-ready");
+process.stdout.write("string-ready|");
+process.stdout.write(
+  new Uint8Array([98, 121, 116, 101, 115, 45, 114, 101, 97, 100, 121]),
+);
+
+// Keep the child alive so the parent can prove the bytes arrived before exit.
+setTimeout(() => {}, 30_000);

--- a/tests/fixtures/console-io/sigkill-stdout.ts
+++ b/tests/fixtures/console-io/sigkill-stdout.ts
@@ -1,0 +1,2 @@
+console.log("before-sigkill");
+process.kill(process.pid, "SIGKILL");

--- a/tests/harness/console-io.test.ts
+++ b/tests/harness/console-io.test.ts
@@ -1,0 +1,155 @@
+/* Live process-I/O parity. The differential corpus captures stdout/stderr
+ * only after each process exits, so it cannot detect an implementation that
+ * retains console.log/process.stdout.write bytes in a userspace buffer until
+ * a later error, a size threshold, or normal exit.
+ *
+ * These probes keep the child alive after writing and observe its stdout
+ * pipe directly. The abrupt-death case additionally proves byte parity when
+ * no exit hook can rescue retained output. SCRIPTC_SAN=1 builds the native
+ * probes with the same ASan + refcount-audit instrumentation as the corpus. */
+import { spawn } from "node:child_process";
+import { createHash } from "node:crypto";
+import { mkdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { describe, expect, test } from "vitest";
+import { compile } from "@scriptc/compiler";
+
+const repoRoot = join(import.meta.dirname, "../..");
+const fixtureDir = join(repoRoot, "tests/fixtures/console-io");
+const cacheDir = join(repoRoot, "node_modules/.cache/scriptc-tests");
+const sanitize = process.env["SCRIPTC_SAN"] === "1";
+
+interface ClosedChild {
+  stdout: Buffer;
+  stderr: Buffer;
+  code: number | null;
+  signal: NodeJS.Signals | null;
+}
+
+async function build(name: string): Promise<{ binary: string; sourceFile: string }> {
+  const sourceFile = join(fixtureDir, `${name}.ts`);
+  const key = createHash("sha256")
+    .update(sourceFile)
+    .update(readFileSync(sourceFile))
+    .update(sanitize ? "san" : "plain")
+    .digest("hex")
+    .slice(0, 16);
+  const outDir = join(cacheDir, `console-io-${key}`);
+  mkdirSync(outDir, { recursive: true });
+  const result = await compile(sourceFile, {
+    outPath: join(outDir, name),
+    outDir,
+    sanitize,
+    backend: "c",
+  });
+  if (!result.ok) {
+    throw new Error(
+      "console-I/O probe failed to compile:\n" +
+        result.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n"),
+    );
+  }
+  return { binary: result.binaryPath, sourceFile };
+}
+
+/** Resolve only after expected stdout was visible while the child was still
+ * alive. SIGKILL makes a false pass impossible: it runs no stdio/atexit
+ * flushing if the expected bytes were still retained by the child. */
+function observeLiveStdout(cmd: string, args: string[], expected: Buffer): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    let observed = false;
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, 5_000);
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout.push(chunk);
+      const all = Buffer.concat(stdout);
+      if (!observed && all.includes(expected)) {
+        observed = true;
+        child.kill("SIGKILL");
+      }
+    });
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      const out = Buffer.concat(stdout);
+      if (!observed) {
+        reject(
+          new Error(
+            `stdout was not visible before child exit` +
+              `${timedOut ? " (timed out)" : ""}; code=${code}, signal=${signal}, ` +
+              `stdout=${JSON.stringify(out.toString("utf8"))}, ` +
+              `stderr=${JSON.stringify(Buffer.concat(stderr).toString("utf8"))}`,
+          ),
+        );
+        return;
+      }
+      resolve(out);
+    });
+  });
+}
+
+function runToClose(cmd: string, args: string[]): Promise<ClosedChild> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ["ignore", "pipe", "pipe"] });
+    const stdout: Buffer[] = [];
+    const stderr: Buffer[] = [];
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      reject(new Error("abrupt console-I/O probe timed out"));
+    }, 5_000);
+    child.stdout.on("data", (chunk: Buffer) => stdout.push(chunk));
+    child.stderr.on("data", (chunk: Buffer) => stderr.push(chunk));
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on("close", (code, signal) => {
+      clearTimeout(timer);
+      resolve({
+        stdout: Buffer.concat(stdout),
+        stderr: Buffer.concat(stderr),
+        code,
+        signal,
+      });
+    });
+  });
+}
+
+describe(`console/process output visibility${sanitize ? " (sanitized)" : ""}`, () => {
+  test("console.log and string/byte stdout writes are visible before exit", async () => {
+    const expected = Buffer.from("log-ready\nstring-ready|bytes-ready");
+    const probe = await build("live-stdout");
+
+    const [nodeOut, nativeOut] = await Promise.all([
+      observeLiveStdout("node", [probe.sourceFile], expected),
+      observeLiveStdout(probe.binary, [], expected),
+    ]);
+    expect(nodeOut.subarray(0, expected.length)).toEqual(expected);
+    expect(nativeOut.subarray(0, expected.length)).toEqual(expected);
+  });
+
+  test("stdout already submitted before an unflushable SIGKILL matches Node", async () => {
+    const expected = Buffer.from("before-sigkill\n");
+    const probe = await build("sigkill-stdout");
+
+    const [nodeRes, nativeRes] = await Promise.all([
+      runToClose("node", [probe.sourceFile]),
+      runToClose(probe.binary, []),
+    ]);
+    expect(nodeRes.stdout).toEqual(expected);
+    expect(nativeRes.stdout).toEqual(nodeRes.stdout);
+    expect(nativeRes.stderr).toEqual(nodeRes.stderr);
+    expect(nativeRes.code).toBe(nodeRes.code);
+    expect(nativeRes.signal).toBe(nodeRes.signal);
+  });
+});


### PR DESCRIPTION
- Submit console, process, readline, and island writes before returning.
- Add live-pipe and SIGKILL parity coverage against Node 24.