### PR TITLE
fix: static builds fail on Linux/glibc — host clang path missing -D_GNU_SOURCE and -lm

### DIFF
--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -263,12 +263,22 @@ export function resolveCc(env: NodeJS.ProcessEnv = process.env): CcDriver {
         `SCRIPTC_TARGET=${target} requires SCRIPTC_CC=zigcc — the default clang path has no cross-target sysroots.`,
       );
     }
-    return { argv: ["clang"], target: null, targetArgs: [] };
+    return {
+      argv: ["clang"],
+      target: null,
+      targetArgs: process.platform === "linux" ? ["-D_GNU_SOURCE"] : [],
+    };
   }
   if (cc !== "zigcc") {
     throw new Error(`unknown SCRIPTC_CC '${cc}' (supported: clang, zigcc)`);
   }
-  if (target === "") return { argv: ["zig", "cc"], target: null, targetArgs: [] };
+  if (target === "") {
+    return {
+      argv: ["zig", "cc"],
+      target: null,
+      targetArgs: process.platform === "linux" ? ["-D_GNU_SOURCE"] : [],
+    };
+  }
   return {
     argv: ["zig", "cc"],
     target,
@@ -1183,7 +1193,6 @@ export async function compileC(opts: CcOptions): Promise<void> {
               : [rt(join(rtDir, "scr_fetch_curl.c")), "-lcurl"]
             : []),
           engineArchive,
-          "-lm",
           // ld64 dead-stripping claws back a chunk of the engine archive;
           // harmless elsewhere but only spelled this way on macOS. Keyed on
           // the TARGET platform (= the host on the default path, where this
@@ -1208,6 +1217,7 @@ export async function compileC(opts: CcOptions): Promise<void> {
     opts.cPath,
     ...(opts.linkInputs ?? []),
     ...(opts.systemLibraries ?? []).map((name) => `-l${name}`),
+    "-lm",
     "-o", opts.outPath,
   ];
   const ccName = driver.argv.join(" ");

--- a/packages/compiler/test/cc-driver.test.ts
+++ b/packages/compiler/test/cc-driver.test.ts
@@ -31,12 +31,14 @@ function zigOnPath(): boolean {
   }
 }
 
-test("default driver is bare clang with no extra args (byte-identical contract)", () => {
+test("default driver is bare clang; linux host adds -D_GNU_SOURCE for glibc", () => {
   for (const env of [{}, { SCRIPTC_CC: "clang" }, { SCRIPTC_CC: "" }]) {
     const d = resolveCc(env);
     expect(d.argv).toEqual(["clang"]);
     expect(d.target).toBeNull();
-    expect(d.targetArgs).toEqual([]);
+    // Linux/glibc needs -D_GNU_SOURCE because -std=c11 sets __STRICT_ANSI__
+    // which hides POSIX/GNU declarations (macOS exposes them regardless).
+    expect(d.targetArgs).toEqual(process.platform === "linux" ? ["-D_GNU_SOURCE"] : []);
   }
 });
 
@@ -52,7 +54,8 @@ test("unknown SCRIPTC_CC values are rejected", () => {
 test("zigcc resolves to `zig cc`; linux triples add -target and -D_GNU_SOURCE", () => {
   const native = resolveCc({ SCRIPTC_CC: "zigcc" });
   expect(native.argv).toEqual(["zig", "cc"]);
-  expect(native.targetArgs).toEqual([]);
+  // Linux host needs -D_GNU_SOURCE for glibc (same as the default clang path)
+  expect(native.targetArgs).toEqual(process.platform === "linux" ? ["-D_GNU_SOURCE"] : []);
 
   const cross = resolveCc({ SCRIPTC_CC: "zigcc", SCRIPTC_TARGET: "aarch64-linux-gnu.2.36" });
   expect(cross.argv).toEqual(["zig", "cc"]);


### PR DESCRIPTION
Static builds (`scriptc build`) on Linux/glibc failed with `CcCompileError` due to two independent defects in the C compiler driver. Fixes #3.

### Fixes

- **Add `-D_GNU_SOURCE` to host clang and zig cc paths on Linux.** The runtime C sources compile with `-std=c11`, which sets `__STRICT_ANSI__` and hides every POSIX/GNU declaration under glibc (`stpcpy`, `realpath`, `kill`, `clock_gettime`, `PATH_MAX`, `IFF_UP`, etc.). The cross-compile path already added `-D_GNU_SOURCE` for Linux triples, but the default host clang path returned `targetArgs: []`, so the macro was never defined. Fix by returning `-D_GNU_SOURCE` on all driver paths when `process.platform === "linux"`, flowing into every compile site that spreads `driver.targetArgs`.

- **Link `-lm` unconditionally, not only under `--dynamic`.** `-lm` was only on the link line inside the `--dynamic` engine block, but `floor` and `trunc` live in libm (not libc) on glibc. macOS hid this because libm is folded into libSystem. Fix by moving `-lm` out of the `engineArchive` conditional to an unconditional position after system libraries. A duplicate `-lm` on `--dynamic` builds is harmless.

Both surfaced only on glibc systems — macOS exposes POSIX declarations under `-std=c11` and merges libm into libSystem, so CI (macOS-15) never caught them.