### PR TITLE
Fix Linux host clang static builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,13 +61,42 @@ jobs:
           tests/harness/npm.test.ts
           tests/harness/server.test.ts
 
+  # A real host-clang/glibc build, not the zig cross-target lane: catches
+  # Linux feature-test macro omissions at compile time and separate-libm
+  # omissions/order errors at link time.
+  linux_host_clang:
+    name: test (linux host clang/glibc)
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    env:
+      # The verdict must come from a live clang invocation, never a cached
+      # binary copied from a previous build.
+      SCRIPTC_NO_CACHE: "1"
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 11
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm build
+      - name: Host clang static-build regression
+        run: >-
+          pnpm test packages/compiler/test/cc-driver.test.ts
+          --testNamePattern "host-native clang static build"
+
   # Aggregate gate with the pre-matrix job's name, so anything keyed on the
   # single "test" check (branch protection, badges) keeps resolving. Fails
-  # unless every matrix shard succeeded.
+  # unless every matrix shard and the native Linux/glibc build succeeded.
   test:
-    needs: tests
+    needs: [tests, linux_host_clang]
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: All shards green
-        run: test "${{ needs.tests.result }}" = success
+      - name: All lanes green
+        run: |
+          test "${{ needs.tests.result }}" = success
+          test "${{ needs.linux_host_clang.result }}" = success

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -211,9 +211,9 @@ export function runtimeSrcDir(): string {
 /* ── alternate C compiler (SCRIPTC_CC) and cross target (SCRIPTC_TARGET) ──────────
  * SCRIPTC_CC=zigcc swaps the compiler driver to `zig cc` (clang underneath, with
  * zig's bundled sysroots — the door to cross-compiling). Unset or
- * SCRIPTC_CC=clang is the default and keeps the historical clang invocation byte
- * for byte: resolveCc returns ["clang"] with NO extra args, so every command
- * line below is exactly what it always was (pinned by cc-driver.test.ts).
+ * SCRIPTC_CC=clang is the default. Host Linux adds the two glibc requirements
+ * that macOS does not need: -D_GNU_SOURCE while compiling, and -lm after all
+ * link inputs. Other hosts keep the historical bare-clang command line.
  *
  * SCRIPTC_TARGET=<triple> (zigcc only — plain clang has no cross sysroots here)
  * adds `-target <triple>` to every compile. Linux-gnu triples also add
@@ -250,29 +250,45 @@ export interface CcDriver {
   argv: string[];
   /** The SCRIPTC_TARGET triple, or null for a host-native build. */
   target: string | null;
-  /** Extra compile args the target demands; ALWAYS [] on the default path. */
+  /** Extra compile args the produced platform demands. */
   targetArgs: string[];
+  /** Platform libraries appended after every object/archive input. */
+  linkArgs: string[];
 }
 
-export function resolveCc(env: NodeJS.ProcessEnv = process.env): CcDriver {
+/** Resolve native platform flags independently of the machine running tests,
+ * so the host-Linux contract remains pinned on every development host. */
+function nativePlatformArgs(platform: NodeJS.Platform): Pick<CcDriver, "targetArgs" | "linkArgs"> {
+  return platform === "linux"
+    ? { targetArgs: ["-D_GNU_SOURCE"], linkArgs: ["-lm"] }
+    : { targetArgs: [], linkArgs: [] };
+}
+
+export function resolveCc(
+  env: NodeJS.ProcessEnv = process.env,
+  hostPlatform: NodeJS.Platform = process.platform,
+): CcDriver {
   const cc = env["SCRIPTC_CC"] ?? "";
   const target = env["SCRIPTC_TARGET"] ?? "";
+  const hostArgs = nativePlatformArgs(hostPlatform);
   if (cc === "" || cc === "clang") {
     if (target !== "") {
       throw new Error(
         `SCRIPTC_TARGET=${target} requires SCRIPTC_CC=zigcc — the default clang path has no cross-target sysroots.`,
       );
     }
-    return { argv: ["clang"], target: null, targetArgs: [] };
+    return { argv: ["clang"], target: null, ...hostArgs };
   }
   if (cc !== "zigcc") {
     throw new Error(`unknown SCRIPTC_CC '${cc}' (supported: clang, zigcc)`);
   }
-  if (target === "") return { argv: ["zig", "cc"], target: null, targetArgs: [] };
+  if (target === "") return { argv: ["zig", "cc"], target: null, ...hostArgs };
+  const linux = target.includes("linux");
   return {
     argv: ["zig", "cc"],
     target,
-    targetArgs: ["-target", target, ...(target.includes("linux") ? ["-D_GNU_SOURCE"] : [])],
+    targetArgs: ["-target", target, ...(linux ? ["-D_GNU_SOURCE"] : [])],
+    linkArgs: linux ? ["-lm"] : [],
   };
 }
 
@@ -652,7 +668,7 @@ async function ensureTlsArchive(sanitize: boolean, driver: CcDriver): Promise<st
     const sources = (await readdir(join(vendor, "library"))).filter((n) => n.endsWith(".c")).sort();
     const cflags = [
       "-std=c11",
-      ...driver.targetArgs, // ALWAYS empty on host builds
+      ...driver.targetArgs,
       ...(sanitize ? ["-O1", "-fsanitize=address"] : ["-Os"]),
       "-I", join(vendor, "include"),
       "-I", join(vendor, "library"),
@@ -1059,7 +1075,7 @@ export async function compileC(opts: CcOptions): Promise<void> {
   // the historical single invocation, cached-.o substitution on cache misses.
   const buildArgs = (rt: (path: string) => string): string[] => [
     "-std=c11",
-    ...driver.targetArgs, // ALWAYS empty on the default clang path
+    ...driver.targetArgs,
     ...(opts.sanitize
       ? ["-O1", "-fsanitize=address", "-DSCR_RC_AUDIT"]
       : ["-O2"]),
@@ -1183,7 +1199,10 @@ export async function compileC(opts: CcOptions): Promise<void> {
               : [rt(join(rtDir, "scr_fetch_curl.c")), "-lcurl"]
             : []),
           engineArchive,
-          "-lm",
+          // Linux's libm is appended after every input below for GNU ld's
+          // left-to-right archive resolution. Other dynamic targets keep
+          // the historical engine-adjacent spelling.
+          ...(driver.linkArgs.includes("-lm") ? [] : ["-lm"]),
           // ld64 dead-stripping claws back a chunk of the engine archive;
           // harmless elsewhere but only spelled this way on macOS. Keyed on
           // the TARGET platform (= the host on the default path, where this
@@ -1208,6 +1227,10 @@ export async function compileC(opts: CcOptions): Promise<void> {
     opts.cPath,
     ...(opts.linkInputs ?? []),
     ...(opts.systemLibraries ?? []).map((name) => `-l${name}`),
+    // glibc keeps libm separate from libc. This must trail the generated
+    // program and every native FFI input because GNU ld resolves archives
+    // from left to right.
+    ...driver.linkArgs,
     "-o", opts.outPath,
   ];
   const ccName = driver.argv.join(" ");

--- a/packages/compiler/test/cc-driver.test.ts
+++ b/packages/compiler/test/cc-driver.test.ts
@@ -1,16 +1,18 @@
 /* The SCRIPTC_CC / SCRIPTC_TARGET driver contract (cc.ts):
  *
- * - The DEFAULT path is pinned: no SCRIPTC_CC (or SCRIPTC_CC=clang) resolves to the
- *   bare ["clang"] driver with ZERO extra args, so the historical command
- *   line cannot change by a byte. SCRIPTC_TARGET without zigcc is an error, not
- *   a silently different clang invocation.
+ * - The DEFAULT path is pinned: no SCRIPTC_CC (or SCRIPTC_CC=clang) resolves to
+ *   ["clang"]. macOS keeps zero extra args; host Linux adds glibc's
+ *   -D_GNU_SOURCE compile flag and trailing -lm link library.
+ *   SCRIPTC_TARGET without zigcc is an error, not a silently different clang
+ *   invocation.
  * - SCRIPTC_CC=zigcc drives `zig cc`. Host-native zigcc builds must produce a
  *   working binary (zig cc is clang underneath); SCRIPTC_TARGET cross builds
  *   must produce an ELF for linux triples and reject the features whose
  *   inputs are host-built (vendored archives, system libs, kqueue units).
  *
- * The zig-requiring legs skip when zig is not on PATH — the driver pins
- * above run everywhere.
+ * The native-clang leg runs everywhere (and is selected alone by the
+ * ubuntu/glibc CI job). The zig-requiring legs skip when zig is not on
+ * PATH — the driver pins above run everywhere.
  */
 import { execFile, execFileSync } from "node:child_process";
 import { mkdtemp, readFile, writeFile } from "node:fs/promises";
@@ -31,12 +33,19 @@ function zigOnPath(): boolean {
   }
 }
 
-test("default driver is bare clang with no extra args (byte-identical contract)", () => {
+test("default driver keeps bare clang while selecting host platform flags", () => {
   for (const env of [{}, { SCRIPTC_CC: "clang" }, { SCRIPTC_CC: "" }]) {
-    const d = resolveCc(env);
+    const d = resolveCc(env, "darwin");
     expect(d.argv).toEqual(["clang"]);
     expect(d.target).toBeNull();
     expect(d.targetArgs).toEqual([]);
+    expect(d.linkArgs).toEqual([]);
+
+    const linux = resolveCc(env, "linux");
+    expect(linux.argv).toEqual(["clang"]);
+    expect(linux.target).toBeNull();
+    expect(linux.targetArgs).toEqual(["-D_GNU_SOURCE"]);
+    expect(linux.linkArgs).toEqual(["-lm"]);
   }
 });
 
@@ -50,21 +59,29 @@ test("unknown SCRIPTC_CC values are rejected", () => {
 });
 
 test("zigcc resolves to `zig cc`; linux triples add -target and -D_GNU_SOURCE", () => {
-  const native = resolveCc({ SCRIPTC_CC: "zigcc" });
+  const native = resolveCc({ SCRIPTC_CC: "zigcc" }, "darwin");
   expect(native.argv).toEqual(["zig", "cc"]);
   expect(native.targetArgs).toEqual([]);
+  expect(native.linkArgs).toEqual([]);
+
+  const nativeLinux = resolveCc({ SCRIPTC_CC: "zigcc" }, "linux");
+  expect(nativeLinux.targetArgs).toEqual(["-D_GNU_SOURCE"]);
+  expect(nativeLinux.linkArgs).toEqual(["-lm"]);
 
   const cross = resolveCc({ SCRIPTC_CC: "zigcc", SCRIPTC_TARGET: "aarch64-linux-gnu.2.36" });
   expect(cross.argv).toEqual(["zig", "cc"]);
   expect(cross.targetArgs).toEqual(["-target", "aarch64-linux-gnu.2.36", "-D_GNU_SOURCE"]);
+  expect(cross.linkArgs).toEqual(["-lm"]);
 
   // Non-linux triples get the -target but not glibc's visibility macro.
   const mac = resolveCc({ SCRIPTC_CC: "zigcc", SCRIPTC_TARGET: "aarch64-macos" });
   expect(mac.targetArgs).toEqual(["-target", "aarch64-macos"]);
+  expect(mac.linkArgs).toEqual([]);
 
   // Windows triples too: mingw-w64 headers expose everything by default.
   const win = resolveCc({ SCRIPTC_CC: "zigcc", SCRIPTC_TARGET: "x86_64-windows-gnu" });
   expect(win.targetArgs).toEqual(["-target", "x86_64-windows-gnu"]);
+  expect(win.linkArgs).toEqual([]);
 });
 
 /** Runs body with SCRIPTC_CC/SCRIPTC_TARGET set, restoring the previous values. */
@@ -84,6 +101,22 @@ async function withCcEnv(cc: string | undefined, target: string | undefined, bod
     else process.env["SCRIPTC_TARGET"] = prevTarget;
   }
 }
+
+const HOST_CLANG_C = '#include <stdio.h>\nint main(void) { printf("clang says hi\\n"); return 0; }\n';
+
+test("host-native clang static build compiles the runtime and runs", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "scr-host-clang-"));
+  const cPath = join(dir, "program.c");
+  await writeFile(cPath, HOST_CLANG_C);
+  const outPath = join(dir, "program");
+  // This exact default path caught both Linux regressions: without
+  // -D_GNU_SOURCE the glibc headers hide declarations used by the runtime;
+  // with the macro but no trailing -lm, the runtime's fmod/exp2 references
+  // fail to link. macOS keeps exercising its unchanged bare-clang path.
+  await withCcEnv(undefined, undefined, () => compileC({ cPath, outPath }));
+  const { stdout } = await execFileAsync(outPath);
+  expect(stdout).toBe("clang says hi\n");
+});
 
 const HELLO_C = '#include <stdio.h>\nint main(void) { printf("zigcc says hi\\n"); return 0; }\n';
 


### PR DESCRIPTION
- Add glibc feature visibility and trailing libm linkage.
- Gate native host clang builds with regression coverage and Ubuntu CI.

Fixes #3