### PR TITLE
Support Number.toFixed statically

### DIFF
--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -2655,12 +2655,14 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             return finish(`scr_btoa(${arg(0)})`);
           case "str.b64Missing":
             return finish(`scr_b64_missing_arg()`);
-          // The fraction-digits-free Number.prototype formatters
-          // (scr_lib.c). Borrow nothing; results +1; no throw.
+          // Number.prototype formatters (scr_lib.c). Borrow nothing;
+          // successful results +1; explicit toFixed may throw RangeError.
           case "num.toExponential":
             return finish(`scr_num_to_exponential(${arg(0)})`);
           case "num.toFixed0":
             return finish(`scr_num_to_fixed0(${arg(0)})`);
+          case "num.toFixed":
+            return finish(`scr_num_to_fixed(${arg(0)}, ${arg(1)})`);
           // Object.is over two numbers — SameValue on doubles. No throw.
           case "num.sameValue":
             return finish(`scr_num_same_value(${arg(0)}, ${arg(1)})`);

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -186,6 +186,7 @@ const LIB_FN_SYMS: Record<string, string> = {
   "dyn.errInstanceof": "scr_dyn_err_instanceof",
   "num.toExponential": "scr_num_to_exponential",
   "num.toFixed0": "scr_num_to_fixed0",
+  "num.toFixed": "scr_num_to_fixed",
   "num.sameValue": "scr_num_same_value",
   "intl.numFormatEnUs": "scr_intl_num_format_en_us",
   "number.isFinite": "scr_num_is_finite",

--- a/packages/compiler/src/coverage/surface-manifest.ts
+++ b/packages/compiler/src/coverage/surface-manifest.ts
@@ -51,6 +51,7 @@ import {
   SET_COMBINE_METHODS,
   SET_METHODS,
   STATIC_MATH_FNS,
+  STATIC_NUMBER_METHODS,
   STR_METHODS,
   UNSUPPORTED_EXPR,
   UNSUPPORTED_STMT,
@@ -219,14 +220,31 @@ export function generateSurfaceManifest(compilerVersion: string): SurfaceManifes
   for (const name of Object.keys(ISLAND_SURFACE.math.props)) {
     add({ id: `stdlib.math.${name}`, kind: "stdlib", name: `Math.${name}`, status: "dynamic-only", code: "SC2012" });
   }
-  for (const name of Object.keys(ISLAND_SURFACE.number)) {
-    add({
-      id: `stdlib.number.${name}`,
-      kind: "stdlib",
-      name: `number.prototype.${name}`,
-      status: "dynamic-only",
-      code: "SC2012",
-    });
+  const numberNames = new Set([
+    ...Object.keys(STATIC_NUMBER_METHODS),
+    ...Object.keys(ISLAND_SURFACE.number),
+  ]);
+  for (const name of numberNames) {
+    const stat = Object.hasOwn(STATIC_NUMBER_METHODS, name)
+      ? STATIC_NUMBER_METHODS[name]
+      : undefined;
+    if (stat !== undefined) {
+      add({
+        id: `stdlib.number.${name}`,
+        kind: "stdlib",
+        name: `number.prototype.${name}`,
+        status: "static",
+        note: arityNote(stat.minArgs, stat.maxArgs),
+      });
+    } else {
+      add({
+        id: `stdlib.number.${name}`,
+        kind: "stdlib",
+        name: `number.prototype.${name}`,
+        status: "dynamic-only",
+        code: "SC2012",
+      });
+    }
   }
   for (const name of Object.keys(ISLAND_SURFACE.string)) {
     add({

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -3935,12 +3935,10 @@ export function lowerCall(L: Lowerer, expr: ts.CallExpression): IrExpr {
         lowerDefaultToStringCall(L, expr, expr.expression) ??
         // The remaining primitive prototype statics — toExponential(),
         // both toFixed() forms, hasOwnProperty over literal keys. Before
-        // the island path; optional-chain spellings keep the chain
-        // machinery's paths.
-        (expr.expression.questionDotToken
-          ? null
-          : lowerPrimitiveProtoCall(L, expr, expr.expression.expression,
-              expr.expression.name.text, L.checker.getSymbolAtLocation(expr.expression.name))) ??
+        // the island path. Optional-chain spellings first enter the chain
+        // machinery above, then re-enter here with a narrowed chainRecv.
+        lowerPrimitiveProtoCall(L, expr, expr.expression.expression,
+          expr.expression.name.text, L.checker.getSymbolAtLocation(expr.expression.name)) ??
         // hasOwnProperty on a program class CONSTRUCTOR — own statics are
         // compile-time-known, so a literal key folds to a constant.
         lowerClassHasOwnPropertyCall(L, expr, expr.expression) ??
@@ -4818,11 +4816,27 @@ const inliningPredicates = new Set<ts.Symbol>();
     if (name === "toFixed" && recvKind === "f64" && call.arguments.length === 1) {
       const operand = L.lowerExpr(recv);
       let digits = L.lowerExpr(call.arguments[0]!);
-      // The optional parameter also admits an explicit undefined. A
-      // side-effect-free unit literal is exactly the default 0; effectful
-      // `void e` has already fenced because the IR has no sequence expr.
-      if (digits.kind === "unitLit" && digits.unit === "undefined") {
-        digits = { kind: "numLit", value: 0, type: F64, loc: digits.loc };
+      // The optional parameter also admits undefined. A standalone,
+      // side-effect-free undefined value is exactly the default 0; an
+      // optional number preserves its evaluation and selects 0 at runtime
+      // through the same narrowed nullish IR used by `digits ?? 0`.
+      const zero: IrExpr = { kind: "numLit", value: 0, type: F64, loc: digits.loc };
+      if (
+        (digits.type.kind === "undefinedT" || digits.type.kind === "void") &&
+        droppableStatic(digits)
+      ) {
+        digits = zero;
+      } else if (digits.type.kind === "union") {
+        const def = L.unions.get(digits.type.unionId);
+        if (def?.arms.every(isUnitType) && droppableStatic(digits)) {
+          digits = zero;
+        } else if (
+          def?.arms.length === 2 &&
+          def.arms.some((arm) => arm.kind === "f64") &&
+          def.arms.some((arm) => arm.kind === "undefinedT")
+        ) {
+          digits = { kind: "nullish", left: digits, right: zero, type: F64, loc: digits.loc };
+        }
       }
       if (operand.type.kind !== "f64" || digits.type.kind !== "f64") return null;
       return { kind: "libCall", fn: "num.toFixed", args: [operand, digits], type: STRING, loc };

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -3933,10 +3933,10 @@ export function lowerCall(L: Lowerer, expr: ts.CallExpression): IrExpr {
         // Object.prototype.toString's default answer on records and
         // override-free program classes — "[object Object]", folded.
         lowerDefaultToStringCall(L, expr, expr.expression) ??
-        // The remaining primitive prototype statics — toExponential()/
-        // toFixed() digit-free, hasOwnProperty over literal keys. Before
-        // the island path (its table claims the explicit-digits forms);
-        // optional-chain spellings keep the chain machinery's paths.
+        // The remaining primitive prototype statics — toExponential(),
+        // both toFixed() forms, hasOwnProperty over literal keys. Before
+        // the island path; optional-chain spellings keep the chain
+        // machinery's paths.
         (expr.expression.questionDotToken
           ? null
           : lowerPrimitiveProtoCall(L, expr, expr.expression.expression,
@@ -4781,10 +4781,10 @@ const inliningPredicates = new Set<ts.Symbol>();
    * member spellings (`x.hasOwnProperty(...)` and `x['hasOwnProperty'](...)`
    * — JS resolves the two identically, so the element spelling routes here
    * from lowerCall's element-access hook):
-   *   - `n.toExponential()` / `n.toFixed()` with the fraction digits
-   *     OMITTED — the static runtime formatters (num.toExponential's
-   *     shortest-mantissa form, num.toFixed0's ties-up integer). The
-   *     explicit-digits forms keep their island/fence story.
+   *   - `n.toExponential()` and both `n.toFixed()` forms — the static
+   *     runtime formatters (num.toExponential's shortest-mantissa form,
+   *     num.toFixed0's ties-up integer fast path, and num.toFixed's exact
+   *     binary-value rounding for an explicit fractionDigits).
    *   - `hasOwnProperty(lit)` on number/boolean receivers — the boxes own
    *     NOTHING, so any key answers false (a compile-time constant; the
    *     receiver must be effect-free since the constant elides it).
@@ -4814,6 +4814,18 @@ const inliningPredicates = new Set<ts.Symbol>();
       if (operand.type.kind !== "f64") return null;
       const fn = name === "toExponential" ? "num.toExponential" : "num.toFixed0";
       return { kind: "libCall", fn, args: [operand], type: STRING, loc };
+    }
+    if (name === "toFixed" && recvKind === "f64" && call.arguments.length === 1) {
+      const operand = L.lowerExpr(recv);
+      let digits = L.lowerExpr(call.arguments[0]!);
+      // The optional parameter also admits an explicit undefined. A
+      // side-effect-free unit literal is exactly the default 0; effectful
+      // `void e` has already fenced because the IR has no sequence expr.
+      if (digits.kind === "unitLit" && digits.unit === "undefined") {
+        digits = { kind: "numLit", value: 0, type: F64, loc: digits.loc };
+      }
+      if (operand.type.kind !== "f64" || digits.type.kind !== "f64") return null;
+      return { kind: "libCall", fn: "num.toFixed", args: [operand, digits], type: STRING, loc };
     }
     // Number.prototype.toLocaleString("en-US") — the spec makes it
     // NumberFormat(locale).format(this), so the en-US embedded formatter

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -579,8 +579,8 @@ import { PoisonError, newFnCtx, own } from "./lowerer.js";
 
 /** Method calls on the island-backed ambient surface: `Math.<fn>(...)`
    * (the engine's own Math object executes) and the number/string methods
-   * the static runtime doesn't implement (`x.toFixed(2)`,
-   * `s.toUpperCase()`, ...). Each site is self-contained — the receiver
+   * the static runtime doesn't implement (`x.toPrecision(2)`,
+   * `s.replace("a", "b")`, ...). Each site is self-contained — the receiver
    * and arguments marshal in, the engine executes with JS-exact semantics,
    * and the result exits (validated) to the DECLARED static return type,
    * so no jsval leaks into the program's types. tsc has already checked

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -493,6 +493,16 @@ export const STATIC_MATH_FNS: Record<string, { fn: IrLibFn; arity: number } | un
   random: { fn: "math.random", arity: 0 },
 };
 
+/** Number prototype methods with dedicated STATIC lowering paths. The
+ * libCall spellings are also the compiled-graph witnesses used by library
+ * fences, while the arity range is the surface manifest's support claim. */
+export const STATIC_NUMBER_METHODS: Record<
+  string,
+  { fns: readonly IrLibFn[]; minArgs: number; maxArgs: number } | undefined
+> = {
+  toFixed: { fns: ["num.toFixed0", "num.toFixed"], minArgs: 0, maxArgs: 1 },
+};
+
 /** One lowerable builtin-module FUNCTION: `fn`'s libCall with `params`
  * completed exactly. `variadicPack` marks Node's rest-parameter functions
  * (path.join/resolve): every argument lowers as a string and the frontend

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -1828,17 +1828,15 @@ export type IrLibFn =
   | "str.atob"
   | "str.btoa"
   | "str.b64Missing"
-  /** The fraction-digits-free Number.prototype formatters (scr_lib.c),
-   * JS-exact: num.toExponential is toExponential() with the spec's
-   * "as many digits as necessary" — the shortest correctly-rounded
-   * mantissa, d[.ddd]e±X with no exponent zero-padding ("7e+0"); NaN and
-   * ±Infinity answer their texts. num.toFixed0 is toFixed() at 0 digits —
-   * the spec's closest-integer pick with ties toward +∞ on the magnitude
-   * ("-2.5" → "-3"), |x| ≥ 1e21 falling back to ToString, and the "-0"
-   * result for negative fractions rounding to zero. The explicit-digits
-   * forms keep their island lowering. Results +1; never throw. */
+  /** Number.prototype formatters (scr_lib.c), JS-exact:
+   * num.toExponential is toExponential() with the spec's "as many digits
+   * as necessary"; num.toFixed0 is the non-throwing omitted-argument
+   * toFixed() fast path; num.toFixed implements an explicit fractionDigits
+   * with exact binary-value rounding and THROWS RangeError outside 0..100.
+   * Successful results +1. */
   | "num.toExponential"
   | "num.toFixed0"
+  | "num.toFixed"
   /** Object.is over two numbers — the spec's SameValue on doubles: NaN
    * equals NaN, +0 differs from -0, everything else is `===`. Plain bool
    * result; never throws. (Union-armed operands take unionEq's sameValue
@@ -6434,6 +6432,7 @@ export function moduleLibNondeterministicSurface(mod: IrModule): string | null {
  * seed on `dynCheck` and `awaitExpr` nodes, which throw on validation
  * failure / promise rejection). */
 export const MAY_THROW_LIB_FNS: ReadonlySet<IrLibFn> = new Set([
+  "num.toFixed",
   "insp.jsonDyn",
   // diagnostics_channel: publish runs subscribers synchronously (a throw
   // propagates — the documented divergence from triggerUncaughtException);

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -215,6 +215,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "regexp.escape": { argTypes: [STRING], result: STRING },
   "num.toExponential": { argTypes: [F64], result: STRING },
   "num.toFixed0": { argTypes: [F64], result: STRING },
+  "num.toFixed": { argTypes: [F64, F64], result: STRING },
   "num.sameValue": { argTypes: [F64, F64], result: BOOL },
   "intl.numFormatEnUs": { argTypes: [F64], result: STRING },
   "sym.new": { argTypes: [STRING], result: SYMBOL_T },

--- a/packages/compiler/src/library/fence-eval.ts
+++ b/packages/compiler/src/library/fence-eval.ts
@@ -56,6 +56,7 @@ import {
   BUILTIN_MODULE_FNS,
   BUILTIN_MODULE_FN_ALIASES,
   STATIC_MATH_FNS,
+  STATIC_NUMBER_METHODS,
   STR_METHODS,
 } from "../frontend/lowering/surfaces.js";
 import type { IrModule, SrcLoc } from "../ir/nodes.js";
@@ -212,6 +213,14 @@ function classifySurface(entry: SurfaceManifestEntry, tax: FenceTaxonomy): Surfa
     if (family === "math") {
       const fn = Object.hasOwn(STATIC_MATH_FNS, member) ? STATIC_MATH_FNS[member] : undefined;
       if (fn !== undefined) return { kind: "detector", detector: { libFns: [fn.fn] } };
+    }
+    if (family === "number") {
+      const method = Object.hasOwn(STATIC_NUMBER_METHODS, member)
+        ? STATIC_NUMBER_METHODS[member]
+        : undefined;
+      if (method !== undefined) {
+        return { kind: "detector", detector: { libFns: method.fns } };
+      }
     }
     if (family === "string") {
       const m = Object.hasOwn(STR_METHODS, member) ? STR_METHODS[member] : undefined;

--- a/packages/compiler/surface-manifest.json
+++ b/packages/compiler/surface-manifest.json
@@ -2234,8 +2234,8 @@
       "id": "stdlib.number.toFixed",
       "kind": "stdlib",
       "name": "number.prototype.toFixed",
-      "status": "dynamic-only",
-      "code": "SC2012"
+      "status": "static",
+      "note": "the lowered call form takes 0 to 1 arguments"
     },
     {
       "id": "stdlib.number.toPrecision",

--- a/packages/runtime/src/scr_lib.c
+++ b/packages/runtime/src/scr_lib.c
@@ -3503,6 +3503,170 @@ ScrStr *scr_num_to_fixed0(double x) {
   return r;
 }
 
+/* The explicit-fraction-digits toFixed needs the exact binary value, not
+ * the shortest decimal that round-trips to it: (1.005).toFixed(2) is
+ * "1.00", for example. Represent abs(x) * 10^f as
+ *
+ *     mantissa * 5^f * 2^(binary_exponent + f)
+ *
+ * in a tiny base-2^32 integer, then shift right with the spec's
+ * round-half-up rule. The largest value handled here is below 1e21 with
+ * f=100, so the rounded integer is below 1e121 (402 bits); sixteen limbs
+ * leave comfortable headroom without heap allocation. */
+#define SCR_FIXED_LIMBS 16
+typedef struct {
+  uint32_t limb[SCR_FIXED_LIMBS]; /* little-endian */
+  int len;
+} ScrFixedInt;
+
+static void scr_fixed_normalize(ScrFixedInt *v) {
+  while (v->len > 1 && v->limb[v->len - 1] == 0) v->len--;
+}
+
+static void scr_fixed_mul5(ScrFixedInt *v) {
+  uint64_t carry = 0;
+  for (int i = 0; i < v->len; i++) {
+    uint64_t p = (uint64_t)v->limb[i] * 5 + carry;
+    v->limb[i] = (uint32_t)p;
+    carry = p >> 32;
+  }
+  if (carry != 0) v->limb[v->len++] = (uint32_t)carry;
+}
+
+static bool scr_fixed_bit(const ScrFixedInt *v, int bit) {
+  int word = bit / 32;
+  return word < v->len && ((v->limb[word] >> (bit % 32)) & 1u) != 0;
+}
+
+static void scr_fixed_shr(ScrFixedInt *v, int bits) {
+  int words = bits / 32;
+  int rem = bits % 32;
+  if (words >= v->len) {
+    v->limb[0] = 0;
+    v->len = 1;
+    return;
+  }
+  int n = v->len - words;
+  for (int i = 0; i < n; i++) {
+    uint32_t lo = v->limb[i + words] >> rem;
+    uint32_t hi =
+        rem != 0 && i + words + 1 < v->len
+            ? v->limb[i + words + 1] << (32 - rem)
+            : 0;
+    v->limb[i] = lo | hi;
+  }
+  v->len = n;
+  scr_fixed_normalize(v);
+}
+
+static void scr_fixed_shl(ScrFixedInt *v, int bits) {
+  uint32_t out[SCR_FIXED_LIMBS] = {0};
+  int words = bits / 32;
+  int rem = bits % 32;
+  for (int i = 0; i < v->len; i++) {
+    int at = i + words;
+    out[at] |= v->limb[i] << rem;
+    if (rem != 0) out[at + 1] |= v->limb[i] >> (32 - rem);
+  }
+  int n = v->len + words + (rem != 0 ? 1 : 0);
+  memcpy(v->limb, out, sizeof out);
+  v->len = n;
+  scr_fixed_normalize(v);
+}
+
+static void scr_fixed_inc(ScrFixedInt *v) {
+  uint64_t carry = 1;
+  for (int i = 0; i < v->len && carry != 0; i++) {
+    uint64_t s = (uint64_t)v->limb[i] + carry;
+    v->limb[i] = (uint32_t)s;
+    carry = s >> 32;
+  }
+  if (carry != 0) v->limb[v->len++] = (uint32_t)carry;
+}
+
+/* Divide in place by 1e9; each quotient limb still fits uint32_t because
+ * the carried remainder is below the divisor. Returns the remainder. */
+static uint32_t scr_fixed_div1e9(ScrFixedInt *v) {
+  uint64_t rem = 0;
+  for (int i = v->len - 1; i >= 0; i--) {
+    uint64_t cur = (rem << 32) | v->limb[i];
+    v->limb[i] = (uint32_t)(cur / 1000000000u);
+    rem = cur % 1000000000u;
+  }
+  scr_fixed_normalize(v);
+  return (uint32_t)rem;
+}
+
+/* Number.prototype.toFixed(fractionDigits), with the argument already
+ * number-typed by the frontend. ToIntegerOrInfinity validation precedes
+ * the receiver's non-finite arm, as ECMA-262 requires. Invalid precision
+ * raises V8's catchable RangeError text; otherwise the result is +1. */
+ScrStr *scr_num_to_fixed(double x, double fraction_digits) {
+  double fd = isnan(fraction_digits) ? 0 : trunc(fraction_digits);
+  if (!(fd >= 0 && fd <= 100)) {
+    static const char msg[] =
+        "toFixed() digits argument must be between 0 and 100";
+    scr_throw_error_msg(SCR_ERR_RANGE, msg, sizeof msg - 1);
+    return NULL;
+  }
+  int f = (int)fd;
+  if (!isfinite(x) || fabs(x) >= 1e21) return scr_f64_to_scrstr(x);
+
+  bool neg = x < 0; /* false for -0, exactly like the spec's sign arm */
+  double a = neg ? -x : x;
+  uint64_t bits;
+  memcpy(&bits, &a, sizeof bits);
+  uint64_t mantissa = bits & ((1ull << 52) - 1);
+  int ieee_exp = (int)((bits >> 52) & 0x7ffu);
+  int binary_exp;
+  if (ieee_exp == 0) {
+    binary_exp = -1074;
+  } else {
+    mantissa |= 1ull << 52;
+    binary_exp = ieee_exp - 1023 - 52;
+  }
+
+  ScrFixedInt n = {{(uint32_t)mantissa, (uint32_t)(mantissa >> 32)}, 2};
+  scr_fixed_normalize(&n);
+  for (int i = 0; i < f; i++) scr_fixed_mul5(&n);
+  int shift = binary_exp + f;
+  if (shift >= 0) {
+    scr_fixed_shl(&n, shift);
+  } else {
+    int right = -shift;
+    bool round_up = scr_fixed_bit(&n, right - 1);
+    scr_fixed_shr(&n, right);
+    if (round_up) scr_fixed_inc(&n);
+  }
+
+  /* Render the exact rounded integer through base-1e9 chunks, then place
+   * the decimal point f digits from the right (padding through zero). */
+  uint32_t chunks[SCR_FIXED_LIMBS];
+  int chunk_count = 0;
+  do {
+    chunks[chunk_count++] = scr_fixed_div1e9(&n);
+  } while (!(n.len == 1 && n.limb[0] == 0));
+
+  char digits[128];
+  int dlen = snprintf(digits, sizeof digits, "%u", chunks[chunk_count - 1]);
+  for (int i = chunk_count - 2; i >= 0; i--) {
+    dlen += snprintf(digits + dlen, sizeof digits - (size_t)dlen,
+                     "%09u", chunks[i]);
+  }
+
+  char out[128];
+  int o = 0;
+  if (neg) out[o++] = '-';
+  int padded = dlen > f + 1 ? dlen : f + 1;
+  int integer_digits = padded - f;
+  int leading_zeros = padded - dlen;
+  for (int i = 0; i < padded; i++) {
+    if (f != 0 && i == integer_digits) out[o++] = '.';
+    out[o++] = i < leading_zeros ? '0' : digits[i - leading_zeros];
+  }
+  return scr_str_new(out, (size_t)o);
+}
+
 /* Increment a decimal digit string in place. Returns true on overflow —
  * the value becomes 1 followed by len zeros (the caller folds the zeros
  * into its scale); an EMPTY string increments to "1" the same way (the

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -4243,12 +4243,14 @@ bool scr_num_is_finite(double x);
 bool scr_num_is_nan(double x);
 bool scr_num_is_integer(double x);
 bool scr_num_is_safe_integer(double x);
-/* The fraction-digits-free Number.prototype formatters: toExponential()
- * (shortest correctly-rounded mantissa, "7e+0" exponent shape) and
- * toFixed() (closest integer, ties toward +∞ on the magnitude, "-0" for
- * negative fractions, ToString at |x| ≥ 1e21). +1 results; never throw. */
+/* Number.prototype formatters: toExponential() is the fraction-digits-free
+ * shortest correctly-rounded mantissa; toFixed0 is the non-throwing omitted
+ * argument form. toFixed implements an explicit 0..100 fractionDigits with
+ * exact binary-value rounding and THROWS V8's catchable RangeError outside
+ * that range. All successful results are +1. */
 ScrStr *scr_num_to_exponential(double x);
 ScrStr *scr_num_to_fixed0(double x);
+ScrStr *scr_num_to_fixed(double x, double fraction_digits);
 
 /* Object.is over two numbers — the spec's SameValue on doubles: NaN
  * equals NaN, +0 differs from -0, everything else is ==. Never throws. */

--- a/tests/corpus/1112-number-methods.ts
+++ b/tests/corpus/1112-number-methods.ts
@@ -1,8 +1,8 @@
 // @dynamic
-// Number methods execute in the island; the receiver marshals by value and
-// the engine auto-boxes it, so `this` binds the number exactly as in JS.
-// toFixed/toPrecision/toString(radix) are fully specified by ECMA-262, so
-// they stay byte-exact differential.
+// Explicit toFixed is static; toPrecision/toString(radix) execute in the
+// island. The receiver marshals by value there and the engine auto-boxes
+// it, so `this` binds the number exactly as in JS. All stay byte-exact
+// differential.
 const n = 1234.5678;
 console.log(n.toFixed(0), n.toFixed(2), n.toFixed(6));
 console.log((0.1 + 0.2).toFixed(17), (-3.7).toFixed(1), (0).toFixed(2));

--- a/tests/corpus/1980-primitive-proto-statics.ts
+++ b/tests/corpus/1980-primitive-proto-statics.ts
@@ -1,7 +1,7 @@
 // Primitive prototype surfaces with a static lowering: radix-free
 // toString on booleans and strings (numbers were already static), the
-// digit-free toExponential()/toFixed() formatters, hasOwnProperty over
-// literal keys (number/boolean boxes own nothing; string boxes own
+// digit-free toExponential() plus both toFixed() forms, hasOwnProperty
+// over literal keys (number/boolean boxes own nothing; string boxes own
 // "length" and their in-range indices), the trimLeft/trimRight aliases,
 // includes with a position, and the element-access spelling of each —
 // JS resolves x['m'](...) exactly like x.m(...). Node is the oracle.
@@ -23,9 +23,24 @@ const vals = [5e-324, 1.7976931348623157e308, 0.1 + 0.2, 123456789.123456789, 2 
 for (const v of vals) {
   console.log(v.toExponential(), (-v).toExponential(), v.toFixed(), (-v).toFixed());
 }
+console.log((1.005).toFixed(2), (1.015).toFixed(2), (2.25).toFixed(1), (-2.25).toFixed(1));
+console.log((0.1 + 0.2).toFixed(17), (1e20).toFixed(2), (1e21).toFixed(100));
+console.log((5e-324).toFixed(100), (-0.4).toFixed(0), (-0).toFixed(2));
+console.log((1.005).toFixed(50), (1.005).toFixed(100));
+const fractionDigits = 3;
+const ratio = 22 / 7;
+console.log(ratio.toFixed(fractionDigits), ratio.toFixed(3.9), ratio.toFixed(0 / 0), ratio.toFixed(undefined), ratio.toFixed(void 0));
+for (const badDigits of [-1, 101, 1 / 0]) {
+  try {
+    console.log((1).toFixed(badDigits));
+  } catch (e) {
+    console.log(e instanceof RangeError, (e as Error).message);
+  }
+}
 
 console.log(x.hasOwnProperty('toFixed'));
 console.log(x['toExponential']());
+console.log(x['toFixed'](2));
 console.log(x['hasOwnProperty']('toFixed'));
 console.log(true['toString']());
 var str2 = "hello";

--- a/tests/corpus/1980-primitive-proto-statics.ts
+++ b/tests/corpus/1980-primitive-proto-statics.ts
@@ -30,6 +30,16 @@ console.log((1.005).toFixed(50), (1.005).toFixed(100));
 const fractionDigits = 3;
 const ratio = 22 / 7;
 console.log(ratio.toFixed(fractionDigits), ratio.toFixed(3.9), ratio.toFixed(0 / 0), ratio.toFixed(undefined), ratio.toFixed(void 0));
+const missingDigits: undefined = undefined;
+console.log(ratio.toFixed(missingDigits));
+function formatWithOptionalDigits(value: number, digits?: number): string {
+  return value.toFixed(digits);
+}
+console.log(formatWithOptionalDigits(ratio), formatWithOptionalDigits(ratio, 3));
+function formatOptionalNumber(value: number | undefined): string | undefined {
+  return value?.toFixed(1);
+}
+console.log(formatOptionalNumber(1.25), formatOptionalNumber(undefined));
 for (const badDigits of [-1, 101, 1 / 0]) {
   try {
     console.log((1).toFixed(badDigits));

--- a/tests/coverage-fixtures/dynamic-mix.ts
+++ b/tests/coverage-fixtures/dynamic-mix.ts
@@ -6,7 +6,7 @@
 const v: any = 21;
 const doubled = v * 2;
 const root = Math.sqrt(81);
-const up = (19.99).toFixed(1);
+const up = (19.99).toPrecision(3);
 const parsed = Number.parseFloat("1.5"); // the global's string form is static now; the Number static keeps the island
 const raw = __island_eval("6 * 7");
 const unknownScore: unknown = 81;

--- a/tests/diagnostics/dynamic-surface.ts
+++ b/tests/diagnostics/dynamic-surface.ts
@@ -9,7 +9,7 @@
 // appear here.)
 const up = Math.sqrt(2);
 const tau = Math.PI * 2;
-const price = (19.99).toFixed(2);
+const price = (19.99).toPrecision(4);
 const swapped = "banana".replace("an", "AN");
 const ch = "hello".at(0);
 const n = Number.parseFloat("3.14");

--- a/tests/harness/__snapshots__/coverage-dynamic-mix.txt
+++ b/tests/harness/__snapshots__/coverage-dynamic-mix.txt
@@ -7,7 +7,7 @@ scriptc coverage tests/coverage-fixtures/dynamic-mix.ts
       ×1  '__island_eval' requires the embedded dynamic engine, which this build does not include                        SC2010
       ×1  the '*' operator on 'any'-typed values runs in the embedded dynamic engine, which this build does not include  SC2011
       ×1  'Math.sqrt' runs in the embedded dynamic engine, which this build does not include                             SC2012
-      ×1  '.toFixed()' on numbers runs in the embedded dynamic engine, which this build does not include                 SC2012
+      ×1  '.toPrecision()' on numbers runs in the embedded dynamic engine, which this build does not include             SC2012
       ×1  'Number.parseFloat' runs in the embedded dynamic engine, which this build does not include                     SC2012
 
   blockers:

--- a/tests/harness/__snapshots__/dynamic-surface.ts.txt
+++ b/tests/harness/__snapshots__/dynamic-surface.ts.txt
@@ -12,22 +12,22 @@ dynamic-surface.ts:11:13 - error SC2012: 'Math.PI' runs in the embedded dynamic 
   10 | const up = Math.sqrt(2);
   11 | const tau = Math.PI * 2;
      |             ^~~~~~~
-  12 | const price = (19.99).toFixed(2);
+  12 | const price = (19.99).toPrecision(4);
 
   hint: build with --dynamic to run this call in the embedded engine (adds ~620KB to the binary); static builds never include it
 
-dynamic-surface.ts:12:15 - error SC2012: '.toFixed()' on numbers runs in the embedded dynamic engine, which this build does not include
+dynamic-surface.ts:12:15 - error SC2012: '.toPrecision()' on numbers runs in the embedded dynamic engine, which this build does not include
 
   11 | const tau = Math.PI * 2;
-  12 | const price = (19.99).toFixed(2);
-     |               ^~~~~~~~~~~~~~~~~~
+  12 | const price = (19.99).toPrecision(4);
+     |               ^~~~~~~~~~~~~~~~~~~~~~
   13 | const swapped = "banana".replace("an", "AN");
 
   hint: build with --dynamic to run this call in the embedded engine (adds ~620KB to the binary); static builds never include it
 
 dynamic-surface.ts:13:17 - error SC2012: '.replace()' on strings runs in the embedded dynamic engine, which this build does not include
 
-  12 | const price = (19.99).toFixed(2);
+  12 | const price = (19.99).toPrecision(4);
   13 | const swapped = "banana".replace("an", "AN");
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
   14 | const ch = "hello".at(0);

--- a/tests/harness/surface-manifest.test.ts
+++ b/tests/harness/surface-manifest.test.ts
@@ -114,6 +114,7 @@ const PROBES: Probe[] = [
   { id: "stdlib.math.floor", source: "console.log(Math.floor(1.5));\n" },
   { id: "stdlib.map.has", source: 'const m = new Map<string, number>();\nm.set("a", 1);\nconsole.log(m.has("a"));\n' },
   { id: "stdlib.date.now", source: "console.log(Date.now() > 0);\n" },
+  { id: "stdlib.number.toFixed", source: "const n = 1.2345;\nconsole.log(n.toFixed(2));\n" },
   { id: "node-builtin.process.pid", source: "console.log(process.pid > 0);\n" },
   { id: "node-builtin.perf_hooks.performance.now", source: "console.log(performance.now() >= 0);\n" },
   { id: "node-builtin.path.join", source: 'import { join } from "node:path";\nconsole.log(join("a", "b"));\n' },
@@ -122,7 +123,6 @@ const PROBES: Probe[] = [
   // analyzed clean under --dynamic
   { id: "stdlib.math.sqrt", source: "console.log(Math.sqrt(2));\n" },
   { id: "stdlib.math.PI", source: "console.log(Math.PI);\n" },
-  { id: "stdlib.number.toFixed", source: "const n = 1.2345;\nconsole.log(n.toFixed(2));\n" },
   { id: "stdlib.string.replace", source: 'console.log("aa".replace("a", "b"));\n' },
   { id: "diagnostic.sc2011", source: "const y: any = 1;\nconst z = y * 2;\nconsole.log(0);\n" },
   // status unsupported — refused with the entry's code


### PR DESCRIPTION
- Lower Number.prototype.toFixed through the compiler IR and native backends.
- Match JavaScript rounding, range errors, and numeric edge cases in the runtime.
- Add differential coverage and update surface metadata and diagnostics.