### PR TITLE
fix: remove unused SC1020 diagnostic code

### DIFF
--- a/packages/compiler/src/diagnostics/diagnostic.ts
+++ b/packages/compiler/src/diagnostics/diagnostic.ts
@@ -180,8 +180,6 @@ export const UNSUPPORTED: Record<string, UnsupportedEntry> = {
     milestone: "later",
     hint: "cycles of ES modules with declaration-only top levels whose cycle-crossing bindings are only used inside function bodies compile as-is; move the named top-level read or call into a function body (or break the named edge) so nothing runs during the cycle's init window",
   },
-  // Class DECLARATIONS shipped; SC1020's remaining use is class expressions.
-  SC1020: { feature: "class expressions", milestone: "later" },
   // SC1021 (arrow functions/closures) and SC1022 (nested function
   // declarations) shipped — codes retired, do not reuse.
   // SC1023 (object literals) shipped as records — code retired, do not

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -42,7 +42,6 @@ export const UNSUPPORTED_STMT: Partial<Record<ts.SyntaxKind, { code: keyof typeo
 export const UNSUPPORTED_EXPR: Partial<Record<ts.SyntaxKind, { code: keyof typeof UNSUPPORTED; feature?: string }>> = {
   // ArrowFunction / FunctionExpression are supported (closures); handled in
   // lowerExpr before this table.
-  [ts.SyntaxKind.ClassExpression]: { code: "SC1020" },
   // ObjectLiteralExpression is supported (records); handled in lowerExpr.
   // ArrayLiteralExpression / ElementAccessExpression are supported (arrays);
   // handled in lowerExpr.

--- a/packages/compiler/surface-manifest.json
+++ b/packages/compiler/surface-manifest.json
@@ -59,13 +59,6 @@
       "note": "cycles of ES modules with declaration-only top levels whose cycle-crossing bindings are only used inside function bodies compile as-is; move the named top-level read or call into a function body (or break the named edge) so nothing runs during the cycle's init window"
     },
     {
-      "id": "diagnostic.sc1020",
-      "kind": "diagnostic-fence",
-      "name": "class expressions",
-      "status": "unsupported",
-      "code": "SC1020"
-    },
-    {
       "id": "diagnostic.sc1030",
       "kind": "diagnostic-fence",
       "name": "var declarations",
@@ -2504,13 +2497,6 @@
       "name": "class declarations inside functions",
       "status": "unsupported",
       "code": "SC1090"
-    },
-    {
-      "id": "syntax.class-expressions",
-      "kind": "syntax",
-      "name": "class expressions",
-      "status": "unsupported",
-      "code": "SC1020"
     },
     {
       "id": "syntax.compound-assignment.bitwise-and",


### PR DESCRIPTION
## Summary

Removes the unused `SC1020` diagnostic for class expressions. `ClassExpression` nodes are handled by the class-expression lowering path in `lower-classes.ts` before reaching the `UNSUPPORTED_EXPR` fallback, so this diagnostic is never emitted.

## Changes

- Remove the unused `SC1020` diagnostic entry from `diagnostic.ts`
- Remove the `ClassExpression` mapping to `SC1020` from `UNSUPPORTED_EXPR`

## Test plan

- `pnpm vitest run packages/compiler/test/cjs-lexer.test.ts packages/compiler/test/ir.test.ts` — PASS
- `pnpm lint` — PASS
- `pnpm -r build` — PASS
- Full differential test suite: NOT RUN LOCALLY — covered by GitHub Actions CI
- ASan lane: NOT RUN LOCALLY — covered by GitHub Actions CI

The change is limited to removing an unreachable diagnostic definition and its fallback mapping; no runtime behavior or public API is changed.