### PR TITLE
Speed up full test validation with Vercel Sandbox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+**
+!package.json
+!pnpm-lock.yaml
+!pnpm-workspace.yaml
+!packages/
+!packages/cli/
+!packages/cli/package.json
+!packages/compiler/
+!packages/compiler/package.json
+!packages/runtime/
+!packages/runtime/package.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,12 +24,13 @@ jobs:
       SCRIPTC_TEST_WORKERS: "4"
       # san = ASan + RC audit over the same suite; anything but "1" is plain.
       SCRIPTC_SAN: ${{ matrix.flavor == 'san' && '1' || '' }}
-      # Within-file partition for the corpus-driven harnesses (differential,
-      # llvm-differential, npm, server): they hash stable case names into
-      # slice i of 3 (tests/harness/shard.ts), so the three shards' unions
-      # run every case exactly once. vitest's own --shard is FILE-granular
-      # and cannot split these monster files (differential.test.ts alone is
-      # ~9 min sequential), hence the second test step below.
+      # Within-file partition for the large case-driven harnesses
+      # (differential, llvm-differential, npm, server, coverage, and Vercel
+      # E2E): they hash stable case names into slice i of 3
+      # (tests/harness/shard.ts), so the three shards' unions run every case
+      # exactly once. vitest's own --shard is FILE-granular and cannot split
+      # these monster files (differential.test.ts alone is ~9 min
+      # sequential), hence the case-sharded steps below.
       SCRIPTC_TEST_SHARD: ${{ matrix.shard }}/3
     steps:
       - uses: actions/checkout@v4
@@ -42,24 +43,32 @@ jobs:
           cache: pnpm
       - run: pnpm install --frozen-lockfile
       - run: pnpm build
-      # Two vitest invocations because the shard axes must not mix: a file
+      # Separate vitest invocations because the shard axes must not mix: a file
       # lands in exactly ONE --shard slice, so an env-sharded file behind
       # --shard would run only one of its three case slices and silently
       # drop the rest. Files split by --shard here; cases split by env below.
-      - name: Tests (file-sharded, corpus lanes excluded)
+      - name: Tests (file-sharded, case-sharded files excluded)
         run: >-
           pnpm test --shard=${{ matrix.shard }}/3
           --exclude=tests/harness/differential.test.ts
           --exclude=tests/harness/llvm-differential.test.ts
           --exclude=tests/harness/npm.test.ts
           --exclude=tests/harness/server.test.ts
-      - name: Tests (corpus lanes, case slice ${{ matrix.shard }}/3)
+          --exclude=tests/harness/coverage.test.ts
+          --exclude=tests/harness/vercel-e2e.test.ts
+      - name: Tests (case-sharded, slice ${{ matrix.shard }}/3)
         run: >-
           pnpm test
           tests/harness/differential.test.ts
           tests/harness/llvm-differential.test.ts
           tests/harness/npm.test.ts
           tests/harness/server.test.ts
+          tests/harness/vercel-e2e.test.ts
+      # Coverage analysis is frontend-only: SCRIPTC_SAN cannot change its
+      # result, so the three plain slices cover the full corpus once.
+      - name: Tests (coverage sweep, slice ${{ matrix.shard }}/3)
+        if: matrix.flavor == 'plain'
+        run: pnpm test tests/harness/coverage.test.ts
 
   # A real host-clang/glibc build, not the zig cross-target lane: catches
   # Linux feature-test macro omissions at compile time and separate-libm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,10 @@ jobs:
       - run: pnpm build
       - name: Windows path regressions
         run: pnpm exec vitest run packages/compiler/test/ts7/program.test.ts packages/cli/test/paths.test.ts
+      - name: Windows Sandbox path regression
+        run: >-
+          pnpm exec vitest run tests/harness/worktree-files.test.ts
+          --testNamePattern "workspace reset keeps Linux Sandbox paths POSIX"
       - name: Windows scriptc run smoke
         shell: pwsh
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ packages/runtime/vendor/.cache/
 # fs corpus scratch directories (created in the test cwd, removed on clean runs)
 tmp-*/
 .claude/
+.vercel/
+.env.local

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,8 +12,10 @@ pnpm test:sandbox              # default full gate: plain + sanitized lanes (~4 
 Use focused local tests while iterating, then use `pnpm test:sandbox` whenever a
 full validation gate is required. It loads Sandbox configuration from the
 shell and `.env.local`, runs portable coverage across disposable Linux
-Sandboxes, and retains the Darwin-native contracts on the host. Both lanes
-green is the bar before shipping any change.
+Sandboxes, and retains the Darwin-native contracts on macOS. Linux hosts run
+their supported native-clang contracts locally; other hosts retain those
+checks in the Sandboxes. Both lanes green is the bar before shipping any
+change.
 
 Only when Vercel Sandbox credentials or `SCRIPTC_SANDBOX_IMAGE` are unavailable,
 run the slower local fallback:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,12 +5,27 @@ Guidance for agents (and humans) working on this repository. These conventions a
 ## Build and test
 
 ```bash
-pnpm install && pnpm -r build      # build the workspace
-SCRIPTC_TEST_WORKERS=4 pnpm test   # plain lane: differential corpus + diagnostics snapshots
-SCRIPTC_SAN=1 pnpm test            # sanitized lane: the same corpus under ASan + refcount audit
+pnpm install && pnpm -r build   # build the workspace
+pnpm test:sandbox              # default full gate: plain + sanitized lanes (~4 minutes)
 ```
 
-Both lanes green is the bar before shipping any change. `SCRIPTC_TEST_WORKERS` caps the vitest worker pool so concurrent agents don't contend for cores; full-suite runs also queue behind an advisory lock per lane.
+Use focused local tests while iterating, then use `pnpm test:sandbox` whenever a
+full validation gate is required. It loads Sandbox configuration from the
+shell and `.env.local`, runs portable coverage across disposable Linux
+Sandboxes, and retains the Darwin-native contracts on the host. Both lanes
+green is the bar before shipping any change.
+
+Only when Vercel Sandbox credentials or `SCRIPTC_SANDBOX_IMAGE` are unavailable,
+run the slower local fallback:
+
+```bash
+SCRIPTC_TEST_WORKERS=4 pnpm test                 # plain lane
+SCRIPTC_TEST_WORKERS=4 SCRIPTC_SAN=1 pnpm test  # sanitized lane
+```
+
+`SCRIPTC_TEST_WORKERS` caps the vitest worker pool so concurrent agents don't
+contend for cores; full local suites also queue behind an advisory lock per
+lane.
 
 Corpus programs are differential tests against Node: every program runs under Node and as a compiled native binary, and stdout, stderr, and exit codes must match byte-for-byte. A new feature lands with corpus programs that pin its behavior both ways.
 

--- a/Dockerfile.sandbox
+++ b/Dockerfile.sandbox
@@ -1,0 +1,46 @@
+ARG NODE_VERSION=24.15.0
+FROM ubuntu:24.04
+
+ARG NODE_VERSION
+ARG PNPM_VERSION=11.1.3
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get update \
+    && apt-get install --yes --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        ccache \
+        clang \
+        cmake \
+        curl \
+        git \
+        libclang-rt-dev \
+        llvm \
+        xz-utils \
+        zlib1g-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN curl --fail --silent --show-error --location \
+        --output /tmp/node.tar.xz \
+        "https://nodejs.org/dist/v${NODE_VERSION}/node-v${NODE_VERSION}-linux-x64.tar.xz" \
+    && curl --fail --silent --show-error --location \
+        --output /tmp/SHASUMS256.txt \
+        "https://nodejs.org/dist/v${NODE_VERSION}/SHASUMS256.txt" \
+    && grep " node-v${NODE_VERSION}-linux-x64.tar.xz$" /tmp/SHASUMS256.txt \
+        | sed 's#node-v[^ ]*-linux-x64.tar.xz#/tmp/node.tar.xz#' \
+        | sha256sum --check --strict - \
+    && tar -xJf /tmp/node.tar.xz --directory /usr/local --strip-components=1 \
+    && rm /tmp/node.tar.xz /tmp/SHASUMS256.txt
+
+RUN npm install --global "pnpm@${PNPM_VERSION}"
+
+WORKDIR /workspace
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY packages/cli/package.json packages/cli/package.json
+COPY packages/compiler/package.json packages/compiler/package.json
+COPY packages/runtime/package.json packages/runtime/package.json
+
+RUN pnpm install --frozen-lockfile \
+    && chmod -R a+rwX /workspace

--- a/README.md
+++ b/README.md
@@ -116,9 +116,11 @@ The hybrid sandbox runner uploads the exact dirty worktree and case-shards the
 corpus-heavy harnesses across eight 8-vCPU sandboxes per lane. Portable test
 files are file-sharded over the same Sandboxes. Files whose behavior cannot
 change under `SCRIPTC_SAN` run once; sanitizer-aware files and the differential
-corpus still run in both lanes. Full portable behavior runs on Linux, while a
-compact host contract retains the native ABI, Mach-O size, linker, libc,
-filesystem, and Apple-ASan checks that can genuinely differ on macOS.
+corpus still run in both lanes. Full portable behavior runs on Linux. On
+macOS, compact host contracts retain the native ABI, Mach-O size, linker,
+libc, kqueue network/dgram/watch/child/stdin behavior, and Apple-ASan checks
+that can genuinely differ there. Linux contributors run the supported native
+clang contracts locally; other hosts retain that coverage in the Sandboxes.
 Acceptance suites whose oracle lives in an external worktree run locally;
 case-addressable suites are sharded there. No assertion or sanitizer coverage
 is dropped.

--- a/README.md
+++ b/README.md
@@ -106,7 +106,24 @@ flowchart LR
 $ pnpm install && pnpm build
 $ pnpm test                      # differential corpus + diagnostics snapshots
 $ SCRIPTC_SAN=1 pnpm test        # the same corpus under ASan + RC audit
+$ export SCRIPTC_SANDBOX_IMAGE=vcr.vercel.com/your-team/your-project/sandbox-tests:node24
+$ pnpm test:sandbox:image        # build + publish the custom Sandbox image
+$ pnpm test:sandbox              # both lanes, corpus sharded over 6 Sandboxes
 $ pnpm scriptc build x.ts --emit-ir   # keep .scriptc/x.c and x.ir.json
 ```
+
+The hybrid sandbox runner uploads the exact dirty worktree and case-shards the
+four corpus-heavy differential harnesses across three 8-vCPU sandboxes per
+lane. The platform-sensitive tests stay on the host and run concurrently, so
+host-specific ABI and binary-size assertions remain honest. Disposable
+sandboxes are removed when the run finishes. The remote sanitized lane disables
+Linux LeakSanitizer to match Apple ASan; ASan memory-safety checks and scriptc's
+RC audit remain enabled. Authenticate with Vercel, choose a Vercel project you
+control, and set `SCRIPTC_SANDBOX_IMAGE` to a fully qualified image in that
+project's Vercel Container Registry. Both sandbox commands load `.env.local`
+when it exists, including the `VERCEL_OIDC_TOKEN` written by `vercel env pull`;
+variables exported by the agent or shell take precedence. Re-run
+`pnpm test:sandbox:image` when the Dockerfile's Node, pnpm, or system
+dependencies change.
 
 Every feature lands with differential tests; both lanes green is the merge bar.

--- a/README.md
+++ b/README.md
@@ -119,8 +119,9 @@ change under `SCRIPTC_SAN` run once; sanitizer-aware files and the differential
 corpus still run in both lanes. Full portable behavior runs on Linux, while a
 compact host contract retains the native ABI, Mach-O size, linker, libc,
 filesystem, and Apple-ASan checks that can genuinely differ on macOS.
-Acceptance suites whose oracle lives in an external worktree remain
-case-sharded locally. No assertion or sanitizer coverage is dropped.
+Acceptance suites whose oracle lives in an external worktree run locally;
+case-addressable suites are sharded there. No assertion or sanitizer coverage
+is dropped.
 Disposable sandboxes are removed when the run finishes. The remote sanitized
 lane disables Linux LeakSanitizer to match Apple ASan; ASan memory-safety
 checks and scriptc's RC audit remain enabled. Authenticate with Vercel, choose

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ macOS, compact host contracts retain the native ABI, Mach-O size, linker,
 libc, kqueue network/dgram/watch/child/stdin behavior, and Apple-ASan checks
 that can genuinely differ there. Linux contributors run the supported native
 clang contracts locally; other hosts retain that coverage in the Sandboxes.
+Before extraction, each Sandbox clears image-seeded workspace files while
+retaining its dependency cache, so local deletions and renames cannot reappear
+from the image.
 Acceptance suites whose oracle lives in an external worktree run locally;
 case-addressable suites are sharded there. No assertion or sanitizer coverage
 is dropped.

--- a/README.md
+++ b/README.md
@@ -108,7 +108,9 @@ $ pnpm test                      # differential corpus + diagnostics snapshots
 $ SCRIPTC_SAN=1 pnpm test        # the same corpus under ASan + RC audit
 $ export SCRIPTC_SANDBOX_IMAGE=vcr.vercel.com/your-team/your-project/sandbox-tests:node24
 $ pnpm test:sandbox:image        # build + publish the custom Sandbox image
-$ pnpm test:sandbox              # both lanes, suite sharded over 16 Sandboxes
+$ pnpm test:sandbox              # fast Pro+ gate: 16 concurrent 8-vCPU Sandboxes
+$ SCRIPTC_SANDBOX_VCPUS=4 pnpm test:sandbox --shards 4
+                                  # Hobby gate: same coverage, 8 concurrent Sandboxes
 $ pnpm scriptc build x.ts --emit-ir   # keep .scriptc/x.c and x.ir.json
 ```
 
@@ -131,10 +133,14 @@ Disposable sandboxes are removed when the run finishes. The remote sanitized
 lane disables Linux LeakSanitizer to match Apple ASan; ASan memory-safety
 checks and scriptc's RC audit remain enabled. Authenticate with Vercel, choose
 a Vercel project you control, and set `SCRIPTC_SANDBOX_IMAGE` to a fully
-qualified image in that project's Vercel Container Registry. Both sandbox
-commands load `.env.local` when it exists, including the `VERCEL_OIDC_TOKEN`
-written by `vercel env pull`; variables exported by the agent or shell take
-precedence. Re-run
+qualified image in that project's Vercel Container Registry. The fast default
+requires a Pro or Enterprise project because it allocates 16 concurrent 8-vCPU
+Sandboxes. Hobby projects use the 4-shard, 4-vCPU command above; it retains the
+same assertions and sanitizer coverage with lower parallelism. `pnpm install`
+provides the repository's pinned Vercel CLI, so no global CLI is required. Both
+sandbox commands load `.env.local` when it exists, including the
+`VERCEL_OIDC_TOKEN` written by `vercel env pull`; variables exported by the
+agent or shell take precedence. Re-run
 `pnpm test:sandbox:image` when the Dockerfile's Node, pnpm, or system
 dependencies change.
 

--- a/README.md
+++ b/README.md
@@ -108,21 +108,27 @@ $ pnpm test                      # differential corpus + diagnostics snapshots
 $ SCRIPTC_SAN=1 pnpm test        # the same corpus under ASan + RC audit
 $ export SCRIPTC_SANDBOX_IMAGE=vcr.vercel.com/your-team/your-project/sandbox-tests:node24
 $ pnpm test:sandbox:image        # build + publish the custom Sandbox image
-$ pnpm test:sandbox              # both lanes, corpus sharded over 6 Sandboxes
+$ pnpm test:sandbox              # both lanes, suite sharded over 16 Sandboxes
 $ pnpm scriptc build x.ts --emit-ir   # keep .scriptc/x.c and x.ir.json
 ```
 
 The hybrid sandbox runner uploads the exact dirty worktree and case-shards the
-four corpus-heavy differential harnesses across three 8-vCPU sandboxes per
-lane. The platform-sensitive tests stay on the host and run concurrently, so
-host-specific ABI and binary-size assertions remain honest. Disposable
-sandboxes are removed when the run finishes. The remote sanitized lane disables
-Linux LeakSanitizer to match Apple ASan; ASan memory-safety checks and scriptc's
-RC audit remain enabled. Authenticate with Vercel, choose a Vercel project you
-control, and set `SCRIPTC_SANDBOX_IMAGE` to a fully qualified image in that
-project's Vercel Container Registry. Both sandbox commands load `.env.local`
-when it exists, including the `VERCEL_OIDC_TOKEN` written by `vercel env pull`;
-variables exported by the agent or shell take precedence. Re-run
+corpus-heavy harnesses across eight 8-vCPU sandboxes per lane. Portable test
+files are file-sharded over the same Sandboxes. Files whose behavior cannot
+change under `SCRIPTC_SAN` run once; sanitizer-aware files and the differential
+corpus still run in both lanes. Full portable behavior runs on Linux, while a
+compact host contract retains the native ABI, Mach-O size, linker, libc,
+filesystem, and Apple-ASan checks that can genuinely differ on macOS.
+Acceptance suites whose oracle lives in an external worktree remain
+case-sharded locally. No assertion or sanitizer coverage is dropped.
+Disposable sandboxes are removed when the run finishes. The remote sanitized
+lane disables Linux LeakSanitizer to match Apple ASan; ASan memory-safety
+checks and scriptc's RC audit remain enabled. Authenticate with Vercel, choose
+a Vercel project you control, and set `SCRIPTC_SANDBOX_IMAGE` to a fully
+qualified image in that project's Vercel Container Registry. Both sandbox
+commands load `.env.local` when it exists, including the `VERCEL_OIDC_TOKEN`
+written by `vercel env pull`; variables exported by the agent or shell take
+precedence. Re-run
 `pnpm test:sandbox:image` when the Dockerfile's Node, pnpm, or system
 dependencies change.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "tsx": "^4.19.0",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.24.0",
+    "vercel": "56.2.0",
     "vitest": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "tsx": "^4.19.0",
     "typescript": "5.9.3",
     "typescript-eslint": "^8.24.0",
-    "vercel": "56.2.0",
+    "vercel": "58.1.0",
     "vitest": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
     "build:fresh": "rm -rf packages/compiler/dist packages/cli/dist node_modules/.cache/scriptc-tsc && pnpm build",
     "test": "vitest run",
     "test:cache-identity": "node tests/harness/cache-identity.mjs",
+    "test:sandbox": "node scripts/sandbox-test.mjs",
+    "test:sandbox:image": "node scripts/sandbox-image.mjs",
     "test:watch": "vitest",
     "lint": "eslint packages/compiler/src packages/cli/src",
     "manifest": "tsx scripts/surface-manifest.mjs",

--- a/packages/runtime/test/array.test.ts
+++ b/packages/runtime/test/array.test.ts
@@ -26,6 +26,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_exception.c"),
     join(testDir, "../src/scr_object.c"),
     join(testDir, "../src/scr_cycle.c"),
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE", "-lm"] : []),
   ]);
 });
 

--- a/packages/runtime/test/bytes.test.ts
+++ b/packages/runtime/test/bytes.test.ts
@@ -46,6 +46,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_url.c"),
     "-Wno-deprecated-declarations",
     "-lz",
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE", "-lm"] : []),
   ]);
   scratch = await mkdtemp(join(tmpdir(), "scriptc-bytes-"));
 });

--- a/packages/runtime/test/closure.test.ts
+++ b/packages/runtime/test/closure.test.ts
@@ -27,6 +27,7 @@ test("closure/box runtime: RC cascades clean under ASan + audit", async () => {
     join(srcDir, "scr_error.c"),
     join(srcDir, "scr_exception.c"),
     join(srcDir, "scr_object.c"),
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE", "-lm"] : []),
   ]);
   const { stderr } = await execFileAsync(bin);
   expect(stderr.trim()).toBe("all closure tests passed");

--- a/packages/runtime/test/inspect.test.ts
+++ b/packages/runtime/test/inspect.test.ts
@@ -32,6 +32,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_exception.c"),
     join(testDir, "../src/scr_object.c"),
     join(testDir, "../src/scr_cycle.c"),
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE", "-lm"] : []),
   ]);
 });
 

--- a/packages/runtime/test/json.test.ts
+++ b/packages/runtime/test/json.test.ts
@@ -33,6 +33,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_cycle.c"),
     join(testDir, "../src/scr_lib.c"),
     join(testDir, "../src/scr_bytes.c"),
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE", "-lm"] : []),
   ]);
 });
 

--- a/packages/runtime/test/lib.test.ts
+++ b/packages/runtime/test/lib.test.ts
@@ -18,6 +18,7 @@ beforeAll(async () => {
   await execFileAsync("clang", [
     "-std=c11", "-O1", "-Wall", "-Wextra",
     "-fsanitize=address", "-DSCR_RC_AUDIT",
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE"] : []),
     "-I", join(testDir, "../src"),
     "-o", bin,
     join(testDir, "test_lib.c"),
@@ -35,6 +36,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_cycle.c"),
     join(testDir, "../src/scr_json.c"),
     join(testDir, "../src/scr_bytes.c"),
+    ...(process.platform === "linux" ? ["-lm"] : []),
   ]);
   scratch = await mkdtemp(join(tmpdir(), "scriptc-lib-"));
 });

--- a/packages/runtime/test/map.test.ts
+++ b/packages/runtime/test/map.test.ts
@@ -32,6 +32,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_bytes.c"),
     join(testDir, "../src/scr_error.c"),
     join(testDir, "../src/scr_exception.c"),
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE", "-lm"] : []),
   ]);
 });
 

--- a/packages/runtime/test/number.test.ts
+++ b/packages/runtime/test/number.test.ts
@@ -16,9 +16,11 @@ test("scr_f64_to_str matches Node String(x) on committed oracle cases", async ()
   const bin = join(buildDir, "test_number");
   await execFileAsync("clang", [
     "-std=c11", "-O2", "-Wall", "-Wextra",
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE"] : []),
     "-o", bin,
     join(testDir, "test_number.c"),
     join(testDir, "../src/scr_number.c"),
+    ...(process.platform === "linux" ? ["-lm"] : []),
   ]);
   const { stderr } = await execFileAsync(bin, [join(testDir, "number-cases.txt")]);
   expect(stderr.trim()).toMatch(/^(\d+)\/\1 cases passed$/);

--- a/packages/runtime/test/path.test.ts
+++ b/packages/runtime/test/path.test.ts
@@ -29,6 +29,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_exception.c"),
     join(testDir, "../src/scr_object.c"),
     join(testDir, "../src/scr_cycle.c"),
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE", "-lm"] : []),
   ]);
 });
 

--- a/packages/runtime/test/regex.test.ts
+++ b/packages/runtime/test/regex.test.ts
@@ -43,6 +43,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_cycle.c"),
     join(testDir, "../src/scr_lib.c"),
     join(testDir, "../src/scr_bytes.c"),
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE", "-lm"] : []),
   ]);
 }, 60_000);
 

--- a/packages/runtime/test/runtime.test.ts
+++ b/packages/runtime/test/runtime.test.ts
@@ -22,9 +22,11 @@ test("runtime smoke.c: output exact, ASan and RC audit clean", async () => {
   await execFileAsync("clang", [
     "-std=c11", "-O1", "-Wall", "-Wextra",
     "-fsanitize=address", "-DSCR_RC_AUDIT",
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE"] : []),
     "-o", bin,
     join(testDir, "smoke.c"),
     ...RUNTIME_SOURCES,
+    ...(process.platform === "linux" ? ["-lm"] : []),
   ]);
   const { stdout } = await execFileAsync(bin);
   expect(stdout).toBe(

--- a/packages/runtime/test/string.test.ts
+++ b/packages/runtime/test/string.test.ts
@@ -16,6 +16,7 @@ beforeAll(async () => {
   await execFileAsync("clang", [
     "-std=c11", "-O1", "-Wall", "-Wextra",
     "-fsanitize=address", "-DSCR_RC_AUDIT",
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE"] : []),
     "-o", bin,
     join(testDir, "test_string.c"),
     join(testDir, "../src/scr_string.c"),
@@ -28,6 +29,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_exception.c"),
     join(testDir, "../src/scr_object.c"),
     join(testDir, "../src/scr_cycle.c"),
+    ...(process.platform === "linux" ? ["-lm"] : []),
   ]);
 });
 

--- a/packages/runtime/test/tonumber.test.ts
+++ b/packages/runtime/test/tonumber.test.ts
@@ -24,6 +24,7 @@ test("scr_string_to_number matches Node Number(s) on committed oracle cases", as
   await execFileAsync("clang", [
     "-std=c11", "-O1", "-Wall", "-Wextra",
     "-fsanitize=address", "-DSCR_RC_AUDIT",
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE"] : []),
     "-o", bin,
     join(testDir, "test_tonumber.c"),
     join(testDir, "../src/scr_string.c"),
@@ -36,6 +37,7 @@ test("scr_string_to_number matches Node Number(s) on committed oracle cases", as
     join(testDir, "../src/scr_exception.c"),
     join(testDir, "../src/scr_object.c"),
     join(testDir, "../src/scr_cycle.c"),
+    ...(process.platform === "linux" ? ["-lm"] : []),
   ]);
   const { stderr } = await execFileAsync(bin, [join(testDir, "tonumber-cases.txt")]);
   expect(stderr.trim()).toMatch(/^(\d+)\/\1 cases passed$/);

--- a/packages/runtime/test/url.test.ts
+++ b/packages/runtime/test/url.test.ts
@@ -15,6 +15,7 @@ beforeAll(async () => {
   await execFileAsync("clang", [
     "-std=c11", "-O1", "-Wall", "-Wextra",
     "-fsanitize=address", "-DSCR_RC_AUDIT",
+    ...(process.platform === "linux" ? ["-D_GNU_SOURCE"] : []),
     "-o", bin,
     join(testDir, "test_url.c"),
     join(testDir, "../src/scr_url.c"),
@@ -27,6 +28,7 @@ beforeAll(async () => {
     join(testDir, "../src/scr_exception.c"),
     join(testDir, "../src/scr_object.c"),
     join(testDir, "../src/scr_cycle.c"),
+    ...(process.platform === "linux" ? ["-lm"] : []),
   ]);
 });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,8 +27,8 @@ importers:
         specifier: ^8.24.0
         version: 8.63.0(eslint@9.39.5)(typescript@5.9.3)
       vercel:
-        specifier: 56.2.0
-        version: 56.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
+        specifier: 58.1.0
+        version: 58.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
       vitest:
         specifier: ^3.0.0
         version: 3.2.7(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(tsx@4.23.0)
@@ -952,9 +952,6 @@ packages:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
     engines: {node: '>= 10'}
 
-  '@tootallnate/quickjs-emscripten@0.23.0':
-    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
-
   '@ts-morph/common@0.11.1':
     resolution: {integrity: sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==}
 
@@ -1158,44 +1155,44 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vercel/backends@0.8.23':
-    resolution: {integrity: sha512-E+MzO+KGpkz8RN0RYIGKJloThdGtwCehST2THP84N60gSJ9ratb8XsJXezda1jwes1sJ/6CWNBWIb/LehLTX6A==}
+  '@vercel/backends@0.8.27':
+    resolution: {integrity: sha512-WW9hfF0mWZDQr23RcjLgVUIoo3V07aq25t6f3RSbq0yIQ2zKZ41x8+0nhNKjzAP7GB7yFmwX4UOv4wV2fWqDDQ==}
 
   '@vercel/blob@2.4.0':
     resolution: {integrity: sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==}
     engines: {node: '>=20.0.0'}
 
-  '@vercel/build-utils@13.33.0':
-    resolution: {integrity: sha512-vxAcks5cAMSKlWRwu6WSwqxdJtZ2DMpLnxYaIscYVCYIacfDd4kzwZYxxufRb3gk932klAELjxGVCcuFVuxhXA==}
+  '@vercel/build-utils@13.36.0':
+    resolution: {integrity: sha512-5Az1XAzro80WJDuANR2UpDWyYnMi2S4Ms1tYvg1YfwiruipyRr0FUf8s0WG8ErBZTBWf95nfZfofpcRJIBDV5w==}
 
-  '@vercel/cervel@0.1.31':
-    resolution: {integrity: sha512-nGUx2PBiIFbYS25Eq3c58X/bbcCwWP5Tc1i2pPmuaBx7sDGOLnlYVKy4FB+tU6nFMpgSC9c/SKXiINFGMkevRQ==}
+  '@vercel/cervel@0.1.35':
+    resolution: {integrity: sha512-DRVj/dDa0AcMPGuxFqp4dXA1onstD9ujwkt8B4PB6E4yYuMcF7+ZZGFzMMpjJJtpeDCmzFs75cuOvGMhwXSk2A==}
     hasBin: true
 
-  '@vercel/cli-auth@0.3.0':
-    resolution: {integrity: sha512-9nsdxUpV/L+9CBVGeRw/Qby2azhi2lk01jp0aTH+Hxx2U61+mAmbi5qChHnrbEmQdx2Ih7dp4LxO3nj1Q7f/5Q==}
+  '@vercel/cli-auth@0.3.1':
+    resolution: {integrity: sha512-TaMXMiPrwcLoLxu6ExcJ8yEw8b8Qss6UZkNYF4xIq+/VdvAk0l8JCpeAwzuHgKuJqmIDrOvtfjHO2+T/MBR3dg==}
 
-  '@vercel/cli-config@0.2.0':
-    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+  '@vercel/cli-config@0.2.1':
+    resolution: {integrity: sha512-RhfyXmRLHdbnry8RJqHDc+5rGxMZ0bu+fpysZjtv3bE+BubpuwxTancHOKiH5zKQREsdwFVr3mOI2kOvxlOyxA==}
 
-  '@vercel/container@0.0.5':
-    resolution: {integrity: sha512-kYggcjyTsBKbQi3wM647x6g174OrriK9oNQ/KI9LGAwBKqZ75g4zir88cNO3FcLiA6RJ4pQe74wyAisxhDgR5A==}
+  '@vercel/container@0.1.0':
+    resolution: {integrity: sha512-m1Y3qT1JOUFKLXUI54hVHSkRTGrvI8LC7EPNsEE1MBME8gk8aoIB+lJWl59jd56MjTDcTc3NCzPdHIZ65grZkA==}
 
   '@vercel/detect-agent@1.2.3':
     resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
     engines: {node: '>=14'}
 
-  '@vercel/elysia@0.1.100':
-    resolution: {integrity: sha512-LVykGWnAfLcDKeVwsHlh5e1Fi6dNuZwUe0piIMw6/BRFPw7TgQuaN++DX0teJPx80artTqVM/RDta6YQu/V5cg==}
+  '@vercel/elysia@0.1.104':
+    resolution: {integrity: sha512-vwiHvO6yHGSxc6NoT2AocoDk8DhOgjLXtK8eWsnuHYHS2yoA7EnacXVQycSRVUFcz75Hs70M1JlXk2DjXdr8HQ==}
 
   '@vercel/error-utils@2.2.0':
     resolution: {integrity: sha512-WFWiRxfPzoYWYifaj4thSKvAaZZwUOqD4k5GINRIgZgCiS2E3iAJbWbIsIZmkQdTecWFHcWGA6q48CjisgpOBA==}
 
-  '@vercel/express@0.1.114':
-    resolution: {integrity: sha512-dfgGSBfpxPobT4T7ZS9RJUMlMNzEgeX/FVCb71WYEWyKa6+wmli8SHUrJpfWizXv4I/y0i4nqC7RXqcYDBLXgg==}
+  '@vercel/express@0.1.118':
+    resolution: {integrity: sha512-wEoq7HMqJx2Op7kh8z+fvbhxK9GsuX6/EpFT5GFvV6Ne3TLalFg3B1GHxrsE0ETB12yAUD0wvZyXANtEuGwwZA==}
 
-  '@vercel/fastify@0.1.103':
-    resolution: {integrity: sha512-XFggAS+vf9vyV52OEcKfP3NPcUXkCFQYDRPSuxskT31sx9EHIFjTnEqqj0M5EUVSR4sjBud0R4M5x6iWyRMlDg==}
+  '@vercel/fastify@0.1.107':
+    resolution: {integrity: sha512-8eo5UBFcFKRwe035MnMYX0EhetKmFDDBqCrBulHVMY8xOmfROxGiJuMTakWhdXgdEZCQLrLTZdBQX0PGcjpHQg==}
 
   '@vercel/fun@1.3.0':
     resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
@@ -1204,26 +1201,26 @@ packages:
   '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
     resolution: {integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==}
 
-  '@vercel/gatsby-plugin-vercel-builder@2.2.26':
-    resolution: {integrity: sha512-oRLC63BxGyPOx9KNtQTutA0JawRkY0vslTjHjtX6N7ojVZY66WcjdzAGm44j9HiNXlEbP9/EysK5+IHbrsNa5A==}
+  '@vercel/gatsby-plugin-vercel-builder@2.2.30':
+    resolution: {integrity: sha512-FHxPBkXztl5XE23Yw/JI6pKfBZmhunr5ZARmd8ltFIR0/crEQ7Kyv++tA8GZUXwXjvYLkhpAg3ssfSA24Yk4jw==}
 
   '@vercel/go@3.10.2':
     resolution: {integrity: sha512-ZJqx1GzD1qqMkI92jEHp04zCwbZ7tNwcgI58e7t8HiYvILwCZ4Rvq0hfjTjsk+0Zn8A369qs4eAHvCYu38uB5A==}
 
-  '@vercel/h3@0.1.109':
-    resolution: {integrity: sha512-UriOfF/p9tviJ3oE46dlZLFB18+cSbJzCMZlTSR5MQcBQkXaZ7o1mVD1jOEMyQH+WENcbsJodC1AR/VKa7xnIA==}
+  '@vercel/h3@0.1.113':
+    resolution: {integrity: sha512-hMfd8g6bCy/61c/nM27BLxLwYA0FAPQN04RAsPAR86s9pXz+tOMM23sQgn1X1Y1tDlChI3K0tWFvU2wf2NrmKA==}
 
-  '@vercel/hono@0.2.103':
-    resolution: {integrity: sha512-11+TsB7Hc3MJUtLoVa4E5fngd8JSjH7sMk2FijLMClxcL+qQt5j5QXmkdBKh7QNg0+JqTeza2eSntRs8BisVdw==}
+  '@vercel/hono@0.2.107':
+    resolution: {integrity: sha512-zfnmi1IK9m5PhU1a7sZ/HVzt3iVRRPizxjnL4pxQPQlCHAniPSClME8FKlUKEbxi2fY0Bq5FBzjm/2HiD68Wvw==}
 
   '@vercel/hydrogen@1.4.0':
     resolution: {integrity: sha512-gf3ELmAjcia7WNGNHAB/rFWFU0l5fJ7mTMgGC5hvcCjSIE4kp8WWuGYiTQgQ8W6GF/1FJAxa2J3BhY/yxjY8tA==}
 
-  '@vercel/koa@0.1.83':
-    resolution: {integrity: sha512-GVby0yjNJ4qVGQKfLgBwpqeSM+LNoqxdzu9spLHF53gomB13fJmcxw7NPV5NzXt1BjCVjzt5WE8q//KL5nN69Q==}
+  '@vercel/koa@0.1.87':
+    resolution: {integrity: sha512-3L1pI7bXH+TkPB9tAvbW+y1DnHd85zimkCcP0RvEH2rglENri16BT4iA0Ux+5GtPCvL5wE59fY2qI9LoGnTFHA==}
 
-  '@vercel/nestjs@0.2.104':
-    resolution: {integrity: sha512-B7UvsXCW0ZGCslToA0DPrvlTWpvOeXiWK7IZUY8t3DN7uqA5rKrsGqRHMBNghNW44oMZ1x8J8FIJ14837c94Qw==}
+  '@vercel/nestjs@0.2.108':
+    resolution: {integrity: sha512-dBpun89S+GbtLqqkvlHAxmCuprd9yVu9UJCowx69wC3W+u4Z7xfqRuRihP8jWiPu7s3d5d/6hMbLES/GRlzPYw==}
 
   '@vercel/next@4.20.4':
     resolution: {integrity: sha512-8m39IHTAgO5yE9xAW8lnjv01z8qQ/qm1FWqyg46qBH2GPtn0MHEME2tAbRy+XzV0Q2J/KGSwmH4xFq8FgECAfg==}
@@ -1233,8 +1230,8 @@ packages:
     engines: {node: '>=20'}
     hasBin: true
 
-  '@vercel/node@5.8.24':
-    resolution: {integrity: sha512-Zi5LvZaKZsUZIUCrf16pa1np6HOImygrt6/HMoDOZjcHHaeKZUda+KB/O1CZEp1ipDjvPKK03igELagrj44hiw==}
+  '@vercel/node@5.9.0':
+    resolution: {integrity: sha512-uuN9OTSOqhzszonUC7gpOqoaLvPIMffCp3Xsmnb+jWWn1chVQvW0X59yUkx+pVFgT6HA+CIp89PNA3IY08ITHA==}
 
   '@vercel/oidc@3.2.0':
     resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
@@ -1243,11 +1240,11 @@ packages:
   '@vercel/prepare-flags-definitions@0.3.0':
     resolution: {integrity: sha512-/0nuDFwYje0nqZnVKSd2VfJy2wOPQwbkas1qO1JQgtb0sLl+EeSCW4O9hrvq55pN50PNlAZ/APSeWHIAT9ZGHg==}
 
-  '@vercel/python-analysis@0.11.1':
-    resolution: {integrity: sha512-EPPLuXJQhIDUx08H9nG76AR2HSgBquwe3OAX5s2w20M923iaWeGGVkhX/4yZ89CJfXEZgE1Aj/mX7lVHOVIcYA==}
+  '@vercel/python-analysis@0.12.0':
+    resolution: {integrity: sha512-T9YgtINVJfZmDhXe6ULKoLC1Zr3LU3Cl4CgC+m+S1KsNDPlfGfXdr93K7aOqkMaJEDLpUH8dqrPP3/TuZXTjRw==}
 
-  '@vercel/python@6.50.0':
-    resolution: {integrity: sha512-OhM5Se6FfA2LFi0peMQXNfzy5jOZiqhFaIMSqSEe8BTD5Htz0aypLDWjWPREasNh2lXdpZGHP5ZJ0kSfurqGOA==}
+  '@vercel/python@6.53.0':
+    resolution: {integrity: sha512-AmhEnovnTjksuPR3qEswwyL0zZWYb0NrEZKoEhxmXvEDh9K13YrtydUKUeCj1IHdDXILC34rCOdKVLSPJmv+7Q==}
 
   '@vercel/redwood@2.5.0':
     resolution: {integrity: sha512-LO24CbieV57rGAqrq5n5z/B+fMYeUqbE/Ge3qMeKRuS3Q9awgcBgB6WYLCe8crHM7XJd5AZjbuyoS/6k3r0X0w==}
@@ -1264,8 +1261,8 @@ packages:
   '@vercel/sandbox@2.4.0':
     resolution: {integrity: sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==}
 
-  '@vercel/static-build@2.11.6':
-    resolution: {integrity: sha512-fw4G4dnTmfkuYPdvO9GLQ3NreMpRiX1TgblLhVkbeBpxXdU8KBf0I19nDrmJtul3g1qmwkkpdjNp4RHMXkmp9Q==}
+  '@vercel/static-build@2.11.10':
+    resolution: {integrity: sha512-MJjSpJAeTTHVi8oLSXXMbj/9ah+1llb3CjRBx/7kZD2S5Kpn8+8cFzmho1QjX4ywI5GYDpVYoQawgFt8ZMSbHQ==}
 
   '@vercel/static-config@3.4.0':
     resolution: {integrity: sha512-wCq90CMUB//ggnFh77NQO1xaLFsS4LigQIqKrH6ohnr9Br/KI1FhlErx62WfCOuueWaW+LVsbLOqNXIUjK8t6A==}
@@ -1348,10 +1345,6 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
-  ast-types@0.13.4:
-    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
-    engines: {node: '>=4'}
-
   async-listen@1.2.0:
     resolution: {integrity: sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA==}
 
@@ -1391,10 +1384,6 @@ packages:
     peerDependenciesMeta:
       bare-abort-controller:
         optional: true
-
-  basic-ftp@5.3.1:
-    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
-    engines: {node: '>=10.0.0'}
 
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
@@ -1477,10 +1466,6 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
-  data-uri-to-buffer@6.0.2:
-    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
-    engines: {node: '>= 14'}
-
   debug@4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
     engines: {node: '>=6.0'}
@@ -1509,10 +1494,6 @@ packages:
   define-lazy-prop@2.0.0:
     resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
     engines: {node: '>=8'}
-
-  degenerator@5.0.1:
-    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
-    engines: {node: '>= 14'}
 
   depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -1556,11 +1537,6 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
-
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1590,11 +1566,6 @@ packages:
   espree@10.4.0:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
-
-  esprima@4.0.1:
-    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
-    engines: {node: '>=4'}
-    hasBin: true
 
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
@@ -1725,10 +1696,6 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
-  get-uri@6.0.5:
-    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
-    engines: {node: '>= 14'}
-
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
     engines: {node: '>= 6'}
@@ -1755,10 +1722,6 @@ packages:
   http-errors@1.7.3:
     resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
     engines: {node: '>= 0.6'}
-
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -1794,10 +1757,6 @@ packages:
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ip-address@10.3.1:
-    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
-    engines: {node: '>= 12'}
 
   is-buffer@2.0.5:
     resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
@@ -1900,10 +1859,6 @@ packages:
     resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
     engines: {node: '>=10'}
 
-  lru-cache@7.18.3:
-    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
-    engines: {node: '>=12'}
-
   luxon@3.7.2:
     resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
     engines: {node: '>=12'}
@@ -1984,10 +1939,6 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
-  netmask@2.1.1:
-    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
-    engines: {node: '>= 0.4.0'}
-
   node-fetch@2.6.7:
     resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
     engines: {node: 4.x || >=6.0.0}
@@ -2066,14 +2017,6 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
-  pac-proxy-agent@7.2.0:
-    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
-    engines: {node: '>= 14'}
-
-  pac-resolver@7.0.1:
-    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
-    engines: {node: '>= 14'}
-
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -2148,13 +2091,6 @@ packages:
 
   promisepipe@3.0.0:
     resolution: {integrity: sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==}
-
-  proxy-agent@6.4.0:
-    resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
-    engines: {node: '>= 14'}
-
-  proxy-from-env@1.1.0:
-    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
@@ -2256,28 +2192,12 @@ packages:
     resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
     engines: {node: '>=14'}
 
-  smart-buffer@4.2.0:
-    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
-    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
-
   smol-toml@1.5.2:
     resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
     engines: {node: '>= 18'}
 
-  socks-proxy-agent@8.0.5:
-    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
-    engines: {node: '>= 14'}
-
-  socks@2.8.9:
-    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
-    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
-    engines: {node: '>=0.10.0'}
-
-  source-map@0.6.1:
-    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
 
   srvx@0.11.16:
@@ -2465,8 +2385,8 @@ packages:
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
 
-  vercel@56.2.0:
-    resolution: {integrity: sha512-4k4WzaLhZuPuksw96qQbmXqEQvhEAwuZACDtL3aiF7Ys5XplRapidWBQAnXx6dYemj8Q7Nf8W8A43uhnJA49aQ==}
+  vercel@58.1.0:
+    resolution: {integrity: sha512-IaveydZepbxIciXIskd032O31cVKjI+8YFD4Y9EuvNLNnIltsYL+0hE0AIhol5wEPDBGm3zKtYA8GKrQNAJ12w==}
     engines: {node: '>= 18'}
     hasBin: true
 
@@ -3170,8 +3090,6 @@ snapshots:
 
   '@tootallnate/once@2.0.0': {}
 
-  '@tootallnate/quickjs-emscripten@0.23.0': {}
-
   '@ts-morph/common@0.11.1':
     dependencies:
       fast-glob: 3.3.3
@@ -3354,9 +3272,9 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
-  '@vercel/backends@0.8.23(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)':
+  '@vercel/backends@0.8.27(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)':
     dependencies:
-      '@vercel/build-utils': 13.33.0
+      '@vercel/build-utils': 13.36.0
       '@vercel/nft': 1.10.0(rollup@4.62.2)
       '@vercel/static-config': 3.4.0
       execa: 3.2.0
@@ -3385,15 +3303,15 @@ snapshots:
       throttleit: 2.1.0
       undici: 6.28.0
 
-  '@vercel/build-utils@13.33.0':
+  '@vercel/build-utils@13.36.0':
     dependencies:
-      '@vercel/python-analysis': 0.11.1
+      '@vercel/python-analysis': 0.12.0
       cjs-module-lexer: 1.2.3
       es-module-lexer: 1.5.0
 
-  '@vercel/cervel@0.1.31(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)':
+  '@vercel/cervel@0.1.35(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)':
     dependencies:
-      '@vercel/backends': 0.8.23(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
+      '@vercel/backends': 0.8.27(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
     transitivePeerDependencies:
       - '@emnapi/core'
       - '@emnapi/runtime'
@@ -3401,26 +3319,26 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/cli-auth@0.3.0':
+  '@vercel/cli-auth@0.3.1':
     dependencies:
       '@napi-rs/keyring': 1.2.0
-      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-config': 0.2.1
       async-listen: 3.0.0
       open: 8.4.0
       zod: 4.1.11
 
-  '@vercel/cli-config@0.2.0':
+  '@vercel/cli-config@0.2.1':
     dependencies:
       xdg-app-paths: 5.5.1
       zod: 4.1.11
 
-  '@vercel/container@0.0.5': {}
+  '@vercel/container@0.1.0': {}
 
   '@vercel/detect-agent@1.2.3': {}
 
-  '@vercel/elysia@0.1.100(rollup@4.62.2)':
+  '@vercel/elysia@0.1.104(rollup@4.62.2)':
     dependencies:
-      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/node': 5.9.0(rollup@4.62.2)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
@@ -3429,11 +3347,11 @@ snapshots:
 
   '@vercel/error-utils@2.2.0': {}
 
-  '@vercel/express@0.1.114(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)':
+  '@vercel/express@0.1.118(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)':
     dependencies:
-      '@vercel/cervel': 0.1.31(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
+      '@vercel/cervel': 0.1.35(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
       '@vercel/nft': 1.10.0(rollup@4.62.2)
-      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/node': 5.9.0(rollup@4.62.2)
       '@vercel/static-config': 3.4.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -3446,9 +3364,9 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/fastify@0.1.103(rollup@4.62.2)':
+  '@vercel/fastify@0.1.107(rollup@4.62.2)':
     dependencies:
-      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/node': 5.9.0(rollup@4.62.2)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
@@ -3483,29 +3401,29 @@ snapshots:
     dependencies:
       web-vitals: 0.2.4
 
-  '@vercel/gatsby-plugin-vercel-builder@2.2.26':
+  '@vercel/gatsby-plugin-vercel-builder@2.2.30':
     dependencies:
       '@sinclair/typebox': 0.25.24
-      '@vercel/build-utils': 13.33.0
+      '@vercel/build-utils': 13.36.0
       esbuild: 0.27.0
       etag: 1.8.1
       fs-extra: 11.1.0
 
   '@vercel/go@3.10.2': {}
 
-  '@vercel/h3@0.1.109(rollup@4.62.2)':
+  '@vercel/h3@0.1.113(rollup@4.62.2)':
     dependencies:
-      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/node': 5.9.0(rollup@4.62.2)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/hono@0.2.103(rollup@4.62.2)':
+  '@vercel/hono@0.2.107(rollup@4.62.2)':
     dependencies:
       '@vercel/nft': 1.10.0(rollup@4.62.2)
-      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/node': 5.9.0(rollup@4.62.2)
       '@vercel/static-config': 3.4.0
       fs-extra: 11.1.0
       path-to-regexp: 8.3.0
@@ -3521,18 +3439,18 @@ snapshots:
       '@vercel/static-config': 3.4.0
       ts-morph: 12.0.0
 
-  '@vercel/koa@0.1.83(rollup@4.62.2)':
+  '@vercel/koa@0.1.87(rollup@4.62.2)':
     dependencies:
-      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/node': 5.9.0(rollup@4.62.2)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
       - rollup
       - supports-color
 
-  '@vercel/nestjs@0.2.104(rollup@4.62.2)':
+  '@vercel/nestjs@0.2.108(rollup@4.62.2)':
     dependencies:
-      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/node': 5.9.0(rollup@4.62.2)
       '@vercel/static-config': 3.4.0
     transitivePeerDependencies:
       - encoding
@@ -3566,13 +3484,13 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vercel/node@5.8.24(rollup@4.62.2)':
+  '@vercel/node@5.9.0(rollup@4.62.2)':
     dependencies:
       '@edge-runtime/node-utils': 2.3.0
       '@edge-runtime/primitives': 4.1.0
       '@edge-runtime/vm': 3.2.0
       '@types/node': 20.11.0
-      '@vercel/build-utils': 13.33.0
+      '@vercel/build-utils': 13.36.0
       '@vercel/error-utils': 2.2.0
       '@vercel/nft': 1.10.0(rollup@4.62.2)
       '@vercel/static-config': 3.4.0
@@ -3599,7 +3517,7 @@ snapshots:
 
   '@vercel/prepare-flags-definitions@0.3.0': {}
 
-  '@vercel/python-analysis@0.11.1':
+  '@vercel/python-analysis@0.12.0':
     dependencies:
       '@bytecodealliance/preview2-shim': 0.17.6
       '@renovatebot/pep440': 4.2.1
@@ -3609,9 +3527,9 @@ snapshots:
       smol-toml: 1.5.2
       zod: 3.22.4
 
-  '@vercel/python@6.50.0':
+  '@vercel/python@6.53.0':
     dependencies:
-      '@vercel/python-analysis': 0.11.1
+      '@vercel/python-analysis': 0.12.0
 
   '@vercel/redwood@2.5.0(rollup@4.62.2)':
     dependencies:
@@ -3662,10 +3580,10 @@ snapshots:
       - bare-abort-controller
       - react-native-b4a
 
-  '@vercel/static-build@2.11.6':
+  '@vercel/static-build@2.11.10':
     dependencies:
       '@vercel/gatsby-plugin-vercel-analytics': 1.0.11
-      '@vercel/gatsby-plugin-vercel-builder': 2.2.26
+      '@vercel/gatsby-plugin-vercel-builder': 2.2.30
       '@vercel/static-config': 3.4.0
       ts-morph: 12.0.0
 
@@ -3759,10 +3677,6 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
-  ast-types@0.13.4:
-    dependencies:
-      tslib: 2.8.1
-
   async-listen@1.2.0: {}
 
   async-listen@3.0.0: {}
@@ -3782,8 +3696,6 @@ snapshots:
   balanced-match@4.0.4: {}
 
   bare-events@2.9.1: {}
-
-  basic-ftp@5.3.1: {}
 
   bindings@1.5.0:
     dependencies:
@@ -3855,8 +3767,6 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  data-uri-to-buffer@6.0.2: {}
-
   debug@4.3.4:
     dependencies:
       ms: 2.1.2
@@ -3870,12 +3780,6 @@ snapshots:
   deep-is@0.1.4: {}
 
   define-lazy-prop@2.0.0: {}
-
-  degenerator@5.0.1:
-    dependencies:
-      ast-types: 0.13.4
-      escodegen: 2.1.0
-      esprima: 4.0.1
 
   depd@1.1.2: {}
 
@@ -3967,14 +3871,6 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-
   eslint-scope@8.4.0:
     dependencies:
       esrecurse: 4.3.0
@@ -4030,8 +3926,6 @@ snapshots:
       acorn: 8.17.0
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 4.2.1
-
-  esprima@4.0.1: {}
 
   esquery@1.7.0:
     dependencies:
@@ -4167,14 +4061,6 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
-  get-uri@6.0.5:
-    dependencies:
-      basic-ftp: 5.3.1
-      data-uri-to-buffer: 6.0.2
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   glob-parent@5.1.2:
     dependencies:
       is-glob: 4.0.3
@@ -4203,13 +4089,6 @@ snapshots:
       statuses: 1.5.0
       toidentifier: 1.0.0
 
-  http-proxy-agent@7.0.2:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
-
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
@@ -4237,8 +4116,6 @@ snapshots:
   imurmurhash@0.1.4: {}
 
   inherits@2.0.4: {}
-
-  ip-address@10.3.1: {}
 
   is-buffer@2.0.5: {}
 
@@ -4322,8 +4199,6 @@ snapshots:
     dependencies:
       yallist: 4.0.0
 
-  lru-cache@7.18.3: {}
-
   luxon@3.7.2: {}
 
   magic-string@0.30.21:
@@ -4384,8 +4259,6 @@ snapshots:
   nanoid@3.3.15: {}
 
   natural-compare@1.4.0: {}
-
-  netmask@2.1.1: {}
 
   node-fetch@2.6.7:
     dependencies:
@@ -4474,24 +4347,6 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
-  pac-proxy-agent@7.2.0:
-    dependencies:
-      '@tootallnate/quickjs-emscripten': 0.23.0
-      agent-base: 7.1.4
-      debug: 4.4.3
-      get-uri: 6.0.5
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      pac-resolver: 7.0.1
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  pac-resolver@7.0.1:
-    dependencies:
-      degenerator: 5.0.1
-      netmask: 2.1.1
-
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -4544,21 +4399,6 @@ snapshots:
       parse-ms: 2.1.0
 
   promisepipe@3.0.0: {}
-
-  proxy-agent@6.4.0:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      lru-cache: 7.18.3
-      pac-proxy-agent: 7.2.0
-      proxy-from-env: 1.1.0
-      socks-proxy-agent: 8.0.5
-    transitivePeerDependencies:
-      - supports-color
-
-  proxy-from-env@1.1.0: {}
 
   pump@3.0.4:
     dependencies:
@@ -4687,27 +4527,9 @@ snapshots:
 
   signal-exit@4.0.2: {}
 
-  smart-buffer@4.2.0: {}
-
   smol-toml@1.5.2: {}
 
-  socks-proxy-agent@8.0.5:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-      socks: 2.8.9
-    transitivePeerDependencies:
-      - supports-color
-
-  socks@2.8.9:
-    dependencies:
-      ip-address: 10.3.1
-      smart-buffer: 4.2.0
-
   source-map-js@1.2.1: {}
-
-  source-map@0.6.1:
-    optional: true
 
   srvx@0.11.16: {}
 
@@ -4823,7 +4645,8 @@ snapshots:
 
   ts-toolbelt@6.15.5: {}
 
-  tslib@2.8.1: {}
+  tslib@2.8.1:
+    optional: true
 
   tsx@4.21.0:
     dependencies:
@@ -4904,40 +4727,39 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vercel@56.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2):
+  vercel@58.1.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2):
     dependencies:
-      '@vercel/backends': 0.8.23(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
+      '@vercel/backends': 0.8.27(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
       '@vercel/blob': 2.4.0
-      '@vercel/build-utils': 13.33.0
-      '@vercel/cli-auth': 0.3.0
-      '@vercel/cli-config': 0.2.0
-      '@vercel/container': 0.0.5
+      '@vercel/build-utils': 13.36.0
+      '@vercel/cli-auth': 0.3.1
+      '@vercel/cli-config': 0.2.1
+      '@vercel/container': 0.1.0
       '@vercel/detect-agent': 1.2.3
-      '@vercel/elysia': 0.1.100(rollup@4.62.2)
-      '@vercel/express': 0.1.114(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
-      '@vercel/fastify': 0.1.103(rollup@4.62.2)
+      '@vercel/elysia': 0.1.104(rollup@4.62.2)
+      '@vercel/express': 0.1.118(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
+      '@vercel/fastify': 0.1.107(rollup@4.62.2)
       '@vercel/fun': 1.3.0
       '@vercel/go': 3.10.2
-      '@vercel/h3': 0.1.109(rollup@4.62.2)
-      '@vercel/hono': 0.2.103(rollup@4.62.2)
+      '@vercel/h3': 0.1.113(rollup@4.62.2)
+      '@vercel/hono': 0.2.107(rollup@4.62.2)
       '@vercel/hydrogen': 1.4.0
-      '@vercel/koa': 0.1.83(rollup@4.62.2)
-      '@vercel/nestjs': 0.2.104(rollup@4.62.2)
+      '@vercel/koa': 0.1.87(rollup@4.62.2)
+      '@vercel/nestjs': 0.2.108(rollup@4.62.2)
       '@vercel/next': 4.20.4(rollup@4.62.2)
-      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/node': 5.9.0(rollup@4.62.2)
       '@vercel/prepare-flags-definitions': 0.3.0
-      '@vercel/python': 6.50.0
+      '@vercel/python': 6.53.0
       '@vercel/redwood': 2.5.0(rollup@4.62.2)
       '@vercel/remix-builder': 5.9.1(rollup@4.62.2)
       '@vercel/ruby': 2.5.1
       '@vercel/rust': 1.4.0
-      '@vercel/static-build': 2.11.6
+      '@vercel/static-build': 2.11.10
       chokidar: 4.0.0
       esbuild: 0.27.0
       jose: 5.9.6
       jsonc-parser: 3.3.1
       luxon: 3.7.2
-      proxy-agent: 6.4.0
       sandbox: 3.4.0
       smol-toml: 1.5.2
       undici: 5.29.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  '@napi-rs/wasm-runtime': 1.1.6
+
 importers:
 
   .:
@@ -23,9 +26,12 @@ importers:
       typescript-eslint:
         specifier: ^8.24.0
         version: 8.63.0(eslint@9.39.5)(typescript@5.9.3)
+      vercel:
+        specifier: 56.2.0
+        version: 56.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
       vitest:
         specifier: ^3.0.0
-        version: 3.2.7(@types/node@24.13.3)(tsx@4.23.0)
+        version: 3.2.7(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(tsx@4.23.0)
 
   packages/cli:
     dependencies:
@@ -49,16 +55,66 @@ importers:
 
 packages:
 
+  '@bytecodealliance/preview2-shim@0.17.6':
+    resolution: {integrity: sha512-n3cM88gTen5980UOBAD6xDcNNL3ocTK8keab21bpx1ONdA+ARj7uD1qoFxOWCyKlkpSi195FH+GeAut7Oc6zZw==}
+
+  '@edge-runtime/format@2.2.1':
+    resolution: {integrity: sha512-JQTRVuiusQLNNLe2W9tnzBlV/GvSVcozLl4XZHk5swnRZ/v6jp8TqR8P7sqmJsQqblDZ3EztcWmLDbhRje/+8g==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/node-utils@2.3.0':
+    resolution: {integrity: sha512-uUtx8BFoO1hNxtHjp3eqVPC/mWImGb2exOfGjMLUoipuWgjej+f4o/VP4bUI8U40gu7Teogd5VTeZUkGvJSPOQ==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/ponyfill@2.4.2':
+    resolution: {integrity: sha512-oN17GjFr69chu6sDLvXxdhg0Qe8EZviGSuqzR9qOiKh4MhFYGdBBcqRNzdmYeAdeRzOW2mM9yil4RftUQ7sUOA==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/primitives@4.1.0':
+    resolution: {integrity: sha512-Vw0lbJ2lvRUqc7/soqygUX216Xb8T3WBZ987oywz6aJqRxcwSVWwr9e+Nqo2m9bxobA9mdbWNNoRY6S9eko1EQ==}
+    engines: {node: '>=16'}
+
+  '@edge-runtime/vm@3.2.0':
+    resolution: {integrity: sha512-0dEVyRLM/lG4gp1R/Ik5bfPl/1wX00xFwd5KcNH602tzBa09oF7pbTKETEhR1GjZ75K6OJnYFu8II2dyMhONMw==}
+    engines: {node: '>=16'}
+
+  '@emnapi/core@2.0.0-alpha.3':
+    resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
+
+  '@emnapi/runtime@2.0.0-alpha.3':
+    resolution: {integrity: sha512-hFPAhMUjJD9BSyCANEISPOogeXC9Zo9ZQl7L6vKnaVsMkCtzznaW/naYypeyl0Gv5rYfWYsZbpixTMpjDJzQeA==}
+
+  '@emnapi/wasi-threads@2.0.1':
+    resolution: {integrity: sha512-9DsSk+o5NBX0CCJT8s0EROGSGxjR/tKu6aBTaVyq+SjAEQH4XcdcRxPBRzsBLizTTJ49MJjF+jgu3qnO9GLQcQ==}
+
+  '@esbuild/aix-ppc64@0.27.0':
+    resolution: {integrity: sha512-KuZrd2hRjz01y5JK9mEBSD3Vj3mbCvemhT466rSuJYeE/hjuBrHfjjcjMdTm/sz7au+++sdbJZJmuBwQLuw68A==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.27.0':
+    resolution: {integrity: sha512-CC3vt4+1xZrs97/PKDkl0yN7w8edvU2vZvAFGD16n9F0Cvniy5qvzRXjfO1l94efczkkQE6g1x0i73Qf5uthOQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.28.1':
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.27.0':
+    resolution: {integrity: sha512-j67aezrPNYWJEOHUNLPj9maeJte7uSMM6gMoxfPC9hOg8N02JuQi/T7ewumf4tNvJadFkvLZMlAq73b9uwdMyQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.28.1':
@@ -67,16 +123,34 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.27.0':
+    resolution: {integrity: sha512-wurMkF1nmQajBO1+0CJmcN17U4BP6GqNSROP8t0X/Jiw2ltYGLHpEksp9MpoBqkrFR3kv2/te6Sha26k3+yZ9Q==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.28.1':
     resolution: {integrity: sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.27.0':
+    resolution: {integrity: sha512-uJOQKYCcHhg07DL7i8MzjvS2LaP7W7Pn/7uA0B5S1EnqAirJtbyw4yC5jQ5qcFjHK9l6o/MX9QisBg12kNkdHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.28.1':
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.0':
+    resolution: {integrity: sha512-8mG6arH3yB/4ZXiEnXof5MK72dE6zM9cDvUcPtxhUZsDjESl9JipZYW60C3JGreKCEP+p8P/72r69m4AZGJd5g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.28.1':
@@ -85,10 +159,22 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.27.0':
+    resolution: {integrity: sha512-9FHtyO988CwNMMOE3YIeci+UV+x5Zy8fI2qHNpsEtSF83YPBmE8UWmfYAQg6Ux7Gsmd4FejZqnEUZCMGaNQHQw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.28.1':
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.0':
+    resolution: {integrity: sha512-zCMeMXI4HS/tXvJz8vWGexpZj2YVtRAihHLk1imZj4efx1BQzN76YFeKqlDr3bUWI26wHwLWPd3rwh6pe4EV7g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.28.1':
@@ -97,10 +183,22 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.27.0':
+    resolution: {integrity: sha512-AS18v0V+vZiLJyi/4LphvBE+OIX682Pu7ZYNsdUHyUKSoRwdnOsMf6FDekwoAFKej14WAkOef3zAORJgAtXnlQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.28.1':
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.0':
+    resolution: {integrity: sha512-t76XLQDpxgmq2cNXKTVEB7O7YMb42atj2Re2Haf45HkaUpjM2J0UuJZDuaGbPbamzZ7bawyGFUkodL+zcE+jvQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.28.1':
@@ -109,10 +207,22 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.0':
+    resolution: {integrity: sha512-Mz1jxqm/kfgKkc/KLHC5qIujMvnnarD9ra1cEcrs7qshTUSksPihGrWHVG5+osAIQ68577Zpww7SGapmzSt4Nw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.28.1':
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.0':
+    resolution: {integrity: sha512-QbEREjdJeIreIAbdG2hLU1yXm1uu+LTdzoq1KCo4G4pFOLlvIspBm36QrQOar9LFduavoWX2msNFAAAY9j4BDg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.28.1':
@@ -121,10 +231,22 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.0':
+    resolution: {integrity: sha512-sJz3zRNe4tO2wxvDpH/HYJilb6+2YJxo/ZNbVdtFiKDufzWq4JmKAiHy9iGoLjAV7r/W32VgaHGkk35cUXlNOg==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.28.1':
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.0':
+    resolution: {integrity: sha512-z9N10FBD0DCS2dmSABDBb5TLAyF1/ydVb+N4pi88T45efQ/w4ohr/F/QYCkxDPnkhkp6AIpIcQKQ8F0ANoA2JA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.28.1':
@@ -133,10 +255,22 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.0':
+    resolution: {integrity: sha512-pQdyAIZ0BWIC5GyvVFn5awDiO14TkT/19FTmFcPdDec94KJ1uZcmFs21Fo8auMXzD4Tt+diXu1LW1gHus9fhFQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.28.1':
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.0':
+    resolution: {integrity: sha512-hPlRWR4eIDDEci953RI1BLZitgi5uqcsjKMxwYfmi4LcwyWo2IcRP+lThVnKjNtk90pLS8nKdroXYOqW+QQH+w==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.28.1':
@@ -145,16 +279,34 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.0':
+    resolution: {integrity: sha512-1hBWx4OUJE2cab++aVZ7pObD6s+DK4mPGpemtnAORBvb5l/g5xFGk0vc0PjSkrDs0XaXj9yyob3d14XqvnQ4gw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.28.1':
     resolution: {integrity: sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-6m0sfQfxfQfy1qRuecMkJlf1cIzTOgyaeXaiVaaki8/v+WB+U4hc6ik15ZW6TAllRlg/WuQXxWj1jx6C+dfy3w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.28.1':
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.27.0':
+    resolution: {integrity: sha512-xbbOdfn06FtcJ9d0ShxxvSn2iUsGd/lgPIO2V3VZIPDbEaIj1/3nBBe1AwuEZKXVXkMmpr6LUAgMkLD/4D2PPA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.28.1':
@@ -163,10 +315,22 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.27.0':
+    resolution: {integrity: sha512-fWgqR8uNbCQ/GGv0yhzttj6sU/9Z5/Sv/VGU3F5OuXK6J6SlriONKrQ7tNlwBrJZXRYk5jUhuWvF7GYzGguBZQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.28.1':
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.27.0':
+    resolution: {integrity: sha512-aCwlRdSNMNxkGGqQajMUza6uXzR/U0dIl1QmLjPtRbLOx3Gy3otfFu/VjATy4yQzo9yFDGTxYDo1FfAD9oRD2A==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.28.1':
@@ -175,11 +339,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.27.0':
+    resolution: {integrity: sha512-nyvsBccxNAsNYz2jVFYwEGuRRomqZ149A39SHWk4hV0jWxKM0hjBPm3AmdxcbHiFLbBSwG6SbpIcUbXjgyECfA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.28.1':
     resolution: {integrity: sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.27.0':
+    resolution: {integrity: sha512-Q1KY1iJafM+UX6CFEL+F4HRTgygmEW568YMqDA5UV97AuZSm21b7SXIrRJDwXWPzr8MGr75fUZPV67FdtMHlHA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.28.1':
     resolution: {integrity: sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==}
@@ -187,16 +363,34 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.27.0':
+    resolution: {integrity: sha512-W1eyGNi6d+8kOmZIwi/EDjrL9nxQIQ0MiGqe/AWc6+IaHloxHSGoeRgDRKHFISThLmsewZ5nHFvGFWdBYlgKPg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.28.1':
     resolution: {integrity: sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.0':
+    resolution: {integrity: sha512-30z1aKL9h22kQhilnYkORFYt+3wp7yZsHWus+wSKAJR8JtdfI76LJ4SBdMsCopTR3z/ORqVu5L1vtnHZWVj4cQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.28.1':
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.0':
+    resolution: {integrity: sha512-aIitBcjQeyOhMTImhLZmtxfdOcuNRpwlPNmlFKPcHQYPhEssw75Cl1TSXJXpMkzaua9FUetx/4OQKq7eJul5Cg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.28.1':
@@ -243,6 +437,10 @@ packages:
     resolution: {integrity: sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@fastify/busboy@2.1.1':
+    resolution: {integrity: sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==}
+    engines: {node: '>=14'}
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -263,8 +461,351 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.1':
+    resolution: {integrity: sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/fs-minipass@4.0.1':
+    resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
+    engines: {node: '>=18.0.0'}
+
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@mapbox/node-pre-gyp@2.0.3':
+    resolution: {integrity: sha512-uwPAhccfFJlsfCxMYTwOdVfOz3xqyj8xYL3zJj8f0pb30tLohnnFPhLuqp4/qoEz8sNxe4SESZedcBojRefIzg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    resolution: {integrity: sha512-CA83rDeyONDADO25JLZsh3eHY8yTEtm/RS6ecPsY+1v+dSawzT9GywBMu2r6uOp1IEhQs/xAfxgybGAFr17lSA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    resolution: {integrity: sha512-dBHjtKRCj4ByfnfqIKIJLo3wueQNJhLRyuxtX/rR4K/XtcS7VLlRD01XXizjpre54vpmObj63w+ZpHG+mGM8uA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    resolution: {integrity: sha512-DPZFr11pNJSnaoh0dzSUNF+T6ORhy3CkzUT3uGixbA71cAOPJ24iG8e8QrLOkuC/StWrAku3gBnth2XMWOcR3Q==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    resolution: {integrity: sha512-8xv6DyEMlvRdqJzp4F39RLUmmTQsLcGYYv/3eIfZNZN1O5257tHxTrFYqAsny659rJJK2EKeSa7PhrSibQqRWQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    resolution: {integrity: sha512-Pu2V6Py+PBt7inryEecirl+t+ti8bhZphjP+W68iVaXHUxLdWmkgL9KI1VkbRHbx5k8K5Tew9OP218YfmVguIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    resolution: {integrity: sha512-8TDymrpC4P1a9iDEaegT7RnrkmrJN5eNZh3Im3UEV5PPYGtrb82CRxsuFohthCWQW81O483u1bu+25+XA4nKUw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    resolution: {integrity: sha512-awsB5XI1MYL7fwfjMDGmKOWvNgJEO7mM7iVEMS0fO39f0kVJnOSjlu7RHcXAF0LOx+0VfF3oxbWqJmZbvRCRHw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    resolution: {integrity: sha512-8E+7z4tbxSJXxIBqA+vfB1CGajpCDRyTyqXkBig5NtASrv4YXcntSo96Iah2QDR5zD3dSTsmbqJudcj9rKKuHQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    resolution: {integrity: sha512-8RZ8yVEnmWr/3BxKgBSzmgntI7lNEsY7xouNfOsQkuVAiCNmxzJwETspzK3PQ2FHtDxgz5vHQDEBVGMyM4hUHA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    resolution: {integrity: sha512-AoqaDZpQ6KPE19VBLpxyORcp+yWmHI9Xs9Oo0PJ4mfHma4nFSLVdhAubJCxdlNptHe5va7ghGCHj3L9Akiv4cQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    resolution: {integrity: sha512-EYL+EEI6bCsYi3LfwcQdnX3P/R76ENKNn+3PmpGheBsUFLuh0gQuP7aMVHM4rTw6UVe+L3vCLZSptq/oeacz0A==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    resolution: {integrity: sha512-xFlx/TsmqmCwNU9v+AVnEJgoEAlBYgzFF5Ihz1rMpPAt4qQWWkMd4sCyM1gMJ1A/GnRqRegDiQpwaxGUHFtFbA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/keyring@1.2.0':
+    resolution: {integrity: sha512-d0d4Oyxm+v980PEq1ZH2PmS6cvpMIRc17eYpiU47KgW+lzxklMu6+HOEOPmxrpnF/XQZ0+Q78I2mgMhbIIo/dg==}
+    engines: {node: '>= 10'}
+
+  '@napi-rs/wasm-runtime@1.1.6':
+    resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
+    peerDependencies:
+      '@emnapi/core': ^1.7.1
+      '@emnapi/runtime': ^1.7.1
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@oxc-project/types@0.110.0':
+    resolution: {integrity: sha512-6Ct21OIlrEnFEJk5LT4e63pk3btsI6/TusD/GStLi7wYlGJNOl1GI9qvXAnRAxQU9zqA2Oz+UwhfTOU2rPZVow==}
+
+  '@oxc-transform/binding-android-arm-eabi@0.111.0':
+    resolution: {integrity: sha512-NdFLicvorfHYu0g2ftjVJaH7+Dz27AQUNJOq8t/ofRUoWmczOodgUCHx8C1M1htCN4ZmhS/FzfSy6yd/UngJGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-transform/binding-android-arm64@0.111.0':
+    resolution: {integrity: sha512-J2v9ajarD2FYlhHtjbgZUFsS2Kvi27pPxDWLGCy7i8tO60xBoozX9/ktSgbiE/QsxKaUhfv4zVKppKWUo71PmQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-transform/binding-darwin-arm64@0.111.0':
+    resolution: {integrity: sha512-2UYmExxpXzmiHTldhNlosWqG9Nc4US51K0GB9RLcGlTE23WO33vVo1NVAKwxPE+KYuhffwDnRYTovTMUjzwvZA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-transform/binding-darwin-x64@0.111.0':
+    resolution: {integrity: sha512-c4YRwfLV8Pj/ToiTCbndZaHxM2BD4W3bltr/fjXZcGypEK+U2RZFDL7tIZYT/tyneAC9hCORZKDaKhLLNuzPtA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-transform/binding-freebsd-x64@0.111.0':
+    resolution: {integrity: sha512-prvf32IcEuLnLZbNVomFosBu0CaZpyj3YsZ6epbOgJy8iJjfLsXBb+PrkO/NBKzjuJoJa2+u7jFKRE0KT7gSOw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.111.0':
+    resolution: {integrity: sha512-+se3579Wp7VOk8TnTZCpT+obTAyzOw2b/UuoM0+51LtbzCSfjKxd4A+o7zRl7GyPrPZvx57KdbMOC9rWB1xNrw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.111.0':
+    resolution: {integrity: sha512-8faC99pStqaSDPK/vBgaagAHUeL0LcIzfeSjSiDTtvPGc3AwZIeqC1tx3CP15a6tWXjdgS/IUw4IjfD5HweBlg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.111.0':
+    resolution: {integrity: sha512-HtfQv8j796gzI5WR/RaP6IMwFpiL0vYeDrUA1hYhlPzTHKYan/B+NlhJkKOI1v24yAl/yEnFmb0pxIxLNqBqBA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-arm64-musl@0.111.0':
+    resolution: {integrity: sha512-ARyfcMCIxVLDgLf6FQ8Oo1/TFySpnquV+vuSb4SFQZfYDqgMklzwv0NYXxWD0aB6enElyMDs6pQJBzusEKCkOg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
+    resolution: {integrity: sha512-PKpVRrSvBNK3tv9vwxn7Fay+QWZmprPGlEqJcseBJllQc5mFMD4Q/w44chu5iR9ZLsDeSHzmNWrgMLo4J0sP2A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
+    resolution: {integrity: sha512-9bUml6rMgk+8GF5rvNMweFspkzSiCjqpV6HduwiUyexqfGKrmjq9IZOxxvnzkE2RGdQzP507NNDoVNYIoGQYuA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
+    resolution: {integrity: sha512-tzGCohGxaeH6KRJjfYZd4mHCoGjCai6N+zZi1Oj+tSDMAAdyvs1dRzYb8PNUGnybCg3Te4M0jLPzWZaSmnKraQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
+    resolution: {integrity: sha512-sRG1KIfZ0ML9ToEygm5aM/5GJeBA05uHlgW3M0Rx/DNWMJhuahLmqWuB02aWSmijndLfEKXLLXIWhvWupRG8lg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-x64-gnu@0.111.0':
+    resolution: {integrity: sha512-T0Kmvk+OdlUdABdXlDIf3MQReMzFfC75NEI9x8jxy5pKooACEFg0k0V8gyR3gq4DzbDCfucqFQDWNvSgIopAbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-transform/binding-linux-x64-musl@0.111.0':
+    resolution: {integrity: sha512-EgoutsP3YfqzN8a9vpc9+XLr0bmBl0dA3uOMiP77+exATCPxJBkJErGmQkqk6RtTp5XqX6q6mB45qWQyKk6+pA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-transform/binding-openharmony-arm64@0.111.0':
+    resolution: {integrity: sha512-d8J+ejc0j5WODbVwR/QxFaI65YMwvG0W53vcVCHwa6ja1QI5lpe7sislrefG2EFYgnY47voMRzlXab5d4gEcDw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-transform/binding-wasm32-wasi@0.111.0':
+    resolution: {integrity: sha512-HtyIZO8IwuZgXkyb56rysLz1OLbfLhEu8A3BeuyJXzUseAj96yuxgGt3cu3QYX9AXb9pfRfA3c/fvlhsDugyTQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.111.0':
+    resolution: {integrity: sha512-YeP80Riptc0MkVVBnzbmoFuHVLUq278+MbwNo9sTLALmzTIJxJqN029xRZbG+Bun7aLsoZhmRnm3J5JZ1NcP5w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.111.0':
+    resolution: {integrity: sha512-A6ztCXpoSHt6PbvGAFqB0MLOcGG7ZJrrPXY1iB0zfOB1atLgI8oNePGxPl03XSbwpiTsFJ1oo8rj9DXcBzgT9g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-transform/binding-win32-x64-msvc@0.111.0':
+    resolution: {integrity: sha512-QddKW4kBH0Wof6Y65eYCNHM4iOGmCTWLLcNYY1FGswhzmTYOUVXajNROR+iCXAOFnOF0ldtsR79SyqgyHH1Bgg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@renovatebot/pep440@4.2.1':
+    resolution: {integrity: sha512-2FK1hF93Fuf1laSdfiEmJvSJPVIDHEUTz68D3Fi9s0IZrrpaEcj6pTFBTbYvsgC5du4ogrtf5re7yMMvrKNgkw==}
+    engines: {node: ^20.9.0 || ^22.11.0 || ^24, pnpm: ^10.0.0}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-He6ZoCfv5D7dlRbrhNBkuMVIHd0GDnjJwbICE1OWpG7G3S2gmJ+eXkcNLJjzjNDpeI2aRy56ou39AJM9AD8YFA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-YzJdn08kSOXnj85ghHauH2iHpOJ6eSmstdRTLyaziDcUxe9SyQJgGyx/5jDIhDvtOcNvMm2Ju7m19+S/Rm1jFg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-cIvAbqM+ZVV6lBSKSBtlNqH5iCiW933t1q8j0H66B3sjbe8AxIRetVqfGgcHcJtMzBIkIALlL9fcDrElWLJQcQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
+    resolution: {integrity: sha512-rVt+B1B/qmKwCl1XD02wKfgh3vQPXRXdB/TicV2w6g7RVAM1+cZcpigwhLarqiVCxDObFZ7UgXCxPC7tpDoRog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    resolution: {integrity: sha512-69YKwJJBOFprQa1GktPgbuBOfnn+EGxu8sBJ1TjPER+zhSpYeaU4N07uqmyBiksOLGXsMegymuecLobfz03h8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-9JDhHUf3WcLfnViFWm+TyorqUtnSAHaCzlSNmMOq824prVuuzDOK91K0Hl8DUcEb9M5x2O+d2/jmBMsetRIn3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-UvApLEGholmxw/HIwmUnLq3CwdydbhaHHllvWiCTNbyGom7wTwOtz5OAQbAKZYyiEOeIXZNPkM7nA4Dtng7CLw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
+    resolution: {integrity: sha512-uVctNgZHiGnJx5Fij7wHLhgw4uyZBVi6mykeWKOqE7bVy9Hcxn0fM/IuqdMwk6hXlaf9fFShDTFz2+YejP+x0A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
+    resolution: {integrity: sha512-T6Eg0xWwcxd/MzBcuv4Z37YVbUbJxy5cMNnbIt/Yr99wFwli30O4BPlY8hKeGyn6lWNtU0QioBS46lVzDN38bg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    resolution: {integrity: sha512-PuGZVS2xNJyLADeh2F04b+Cz4NwvpglbtWACgrDOa5YDTEHKwmiTDjoD5eZ9/ptXtcpeFrMqD2H4Zn33KAh1Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1':
+    resolution: {integrity: sha512-2mOxY562ihHlz9lEXuaGEIDCZ1vI+zyFdtsoa3M62xsEunDXQE+DVPO4S4x5MPK9tKulG/aFcA/IH5eVN257Cw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-oQVOP5cfAWZwRD0Q3nGn/cA9FW3KhMMuQ0NIndALAe6obqjLhqYVYDiGGRGrxvnjJsVbpLwR14gIUYnpIcHR1g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
+    resolution: {integrity: sha512-Ydsxxx++FNOuov3wCBPaYjZrEvKOOGq3k+BF4BPridhg2pENfitSRD2TEuQ8i33bp5VptuNdC9IzxRKU031z5A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.1':
+    resolution: {integrity: sha512-UTBjtTxVOhodhzFVp/ayITaTETRHPUPYZPXQe0WU0wOgxghMojXxYjOiPOauKIYNWJAWS2fd7gJgGQK8GU8vDA==}
+
+  '@rollup/pluginutils@5.4.0':
+    resolution: {integrity: sha512-MfPp06CjRLfXQ3wY0R8vJDYBy/MvVcc9OulEfR0B8Iv9ko+GCNaRZ+EpJYFl27LhKsZK0o420sYCRHCjfCgeUg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0||^3.0.0||^4.0.0
+    peerDependenciesMeta:
+      rollup:
+        optional: true
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     resolution: {integrity: sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==}
@@ -404,6 +945,22 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@sinclair/typebox@0.25.24':
+    resolution: {integrity: sha512-XJfwUVUKDHF5ugKwIcxEgc9k8b7HbznCp6eUfWgu710hMPNIO4aw4/zB5RogDQz8nd6gyCDpU9O/m6qYEWY6yQ==}
+
+  '@tootallnate/once@2.0.0':
+    resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
+    engines: {node: '>= 10'}
+
+  '@tootallnate/quickjs-emscripten@0.23.0':
+    resolution: {integrity: sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==}
+
+  '@ts-morph/common@0.11.1':
+    resolution: {integrity: sha512-7hWZS0NRpEsNV8vWJzg7FEz6V8MaLNeJOmwmghqUXTpzk16V1LLZhdo+4QvE/+zv4cVci0OviuJFnqhEfoV3+g==}
+
+  '@tybys/wasm-util@0.10.3':
+    resolution: {integrity: sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==}
+
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
@@ -415,6 +972,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/node@20.11.0':
+    resolution: {integrity: sha512-o9bjXmDNcF7GbM4CNQpmi+TutCgap/K3w1JyKgxAjqx41zp9qlIAVFi0IhCNsJcXolEqLWhbFbEeL0PvYm4pcQ==}
 
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
@@ -598,6 +1158,118 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@vercel/backends@0.8.23':
+    resolution: {integrity: sha512-E+MzO+KGpkz8RN0RYIGKJloThdGtwCehST2THP84N60gSJ9ratb8XsJXezda1jwes1sJ/6CWNBWIb/LehLTX6A==}
+
+  '@vercel/blob@2.4.0':
+    resolution: {integrity: sha512-ncQ8CRb6XoEAYJwjOTRGpACRT6h/AeY+/33gLyeVxG5BIes27OPm1jmqreF+JHjcTmGhClTP+kBpmyLfbV0xew==}
+    engines: {node: '>=20.0.0'}
+
+  '@vercel/build-utils@13.33.0':
+    resolution: {integrity: sha512-vxAcks5cAMSKlWRwu6WSwqxdJtZ2DMpLnxYaIscYVCYIacfDd4kzwZYxxufRb3gk932klAELjxGVCcuFVuxhXA==}
+
+  '@vercel/cervel@0.1.31':
+    resolution: {integrity: sha512-nGUx2PBiIFbYS25Eq3c58X/bbcCwWP5Tc1i2pPmuaBx7sDGOLnlYVKy4FB+tU6nFMpgSC9c/SKXiINFGMkevRQ==}
+    hasBin: true
+
+  '@vercel/cli-auth@0.3.0':
+    resolution: {integrity: sha512-9nsdxUpV/L+9CBVGeRw/Qby2azhi2lk01jp0aTH+Hxx2U61+mAmbi5qChHnrbEmQdx2Ih7dp4LxO3nj1Q7f/5Q==}
+
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/container@0.0.5':
+    resolution: {integrity: sha512-kYggcjyTsBKbQi3wM647x6g174OrriK9oNQ/KI9LGAwBKqZ75g4zir88cNO3FcLiA6RJ4pQe74wyAisxhDgR5A==}
+
+  '@vercel/detect-agent@1.2.3':
+    resolution: {integrity: sha512-VYNCgUc0nOmC4WJmWw9GkrKdfr8Zl4/rxhC5SvgacBgxiW9W/9NRttUoHHXV8xdII3MaRgkZZVX8Ikzc/Jmjag==}
+    engines: {node: '>=14'}
+
+  '@vercel/elysia@0.1.100':
+    resolution: {integrity: sha512-LVykGWnAfLcDKeVwsHlh5e1Fi6dNuZwUe0piIMw6/BRFPw7TgQuaN++DX0teJPx80artTqVM/RDta6YQu/V5cg==}
+
+  '@vercel/error-utils@2.2.0':
+    resolution: {integrity: sha512-WFWiRxfPzoYWYifaj4thSKvAaZZwUOqD4k5GINRIgZgCiS2E3iAJbWbIsIZmkQdTecWFHcWGA6q48CjisgpOBA==}
+
+  '@vercel/express@0.1.114':
+    resolution: {integrity: sha512-dfgGSBfpxPobT4T7ZS9RJUMlMNzEgeX/FVCb71WYEWyKa6+wmli8SHUrJpfWizXv4I/y0i4nqC7RXqcYDBLXgg==}
+
+  '@vercel/fastify@0.1.103':
+    resolution: {integrity: sha512-XFggAS+vf9vyV52OEcKfP3NPcUXkCFQYDRPSuxskT31sx9EHIFjTnEqqj0M5EUVSR4sjBud0R4M5x6iWyRMlDg==}
+
+  '@vercel/fun@1.3.0':
+    resolution: {integrity: sha512-8erw9uPe0dFg45THkNxmjtvMX143SkZebmjgSVbcM3XCkXu3RIiBaJMcMNG8aaS+rnTuw8+d4De9HVT0M/r3wg==}
+    engines: {node: '>= 18'}
+
+  '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
+    resolution: {integrity: sha512-iTEA0vY6RBPuEzkwUTVzSHDATo1aF6bdLLspI68mQ/BTbi5UQEGjpjyzdKOVcSYApDtFU6M6vypZ1t4vIEnHvw==}
+
+  '@vercel/gatsby-plugin-vercel-builder@2.2.26':
+    resolution: {integrity: sha512-oRLC63BxGyPOx9KNtQTutA0JawRkY0vslTjHjtX6N7ojVZY66WcjdzAGm44j9HiNXlEbP9/EysK5+IHbrsNa5A==}
+
+  '@vercel/go@3.10.2':
+    resolution: {integrity: sha512-ZJqx1GzD1qqMkI92jEHp04zCwbZ7tNwcgI58e7t8HiYvILwCZ4Rvq0hfjTjsk+0Zn8A369qs4eAHvCYu38uB5A==}
+
+  '@vercel/h3@0.1.109':
+    resolution: {integrity: sha512-UriOfF/p9tviJ3oE46dlZLFB18+cSbJzCMZlTSR5MQcBQkXaZ7o1mVD1jOEMyQH+WENcbsJodC1AR/VKa7xnIA==}
+
+  '@vercel/hono@0.2.103':
+    resolution: {integrity: sha512-11+TsB7Hc3MJUtLoVa4E5fngd8JSjH7sMk2FijLMClxcL+qQt5j5QXmkdBKh7QNg0+JqTeza2eSntRs8BisVdw==}
+
+  '@vercel/hydrogen@1.4.0':
+    resolution: {integrity: sha512-gf3ELmAjcia7WNGNHAB/rFWFU0l5fJ7mTMgGC5hvcCjSIE4kp8WWuGYiTQgQ8W6GF/1FJAxa2J3BhY/yxjY8tA==}
+
+  '@vercel/koa@0.1.83':
+    resolution: {integrity: sha512-GVby0yjNJ4qVGQKfLgBwpqeSM+LNoqxdzu9spLHF53gomB13fJmcxw7NPV5NzXt1BjCVjzt5WE8q//KL5nN69Q==}
+
+  '@vercel/nestjs@0.2.104':
+    resolution: {integrity: sha512-B7UvsXCW0ZGCslToA0DPrvlTWpvOeXiWK7IZUY8t3DN7uqA5rKrsGqRHMBNghNW44oMZ1x8J8FIJ14837c94Qw==}
+
+  '@vercel/next@4.20.4':
+    resolution: {integrity: sha512-8m39IHTAgO5yE9xAW8lnjv01z8qQ/qm1FWqyg46qBH2GPtn0MHEME2tAbRy+XzV0Q2J/KGSwmH4xFq8FgECAfg==}
+
+  '@vercel/nft@1.10.0':
+    resolution: {integrity: sha512-iLOW4fcsgkipfOh2Bw3wB38YDfxTlxr7+j4uFeui2OswkNT28jIitS/aMce7tS0mef1YPQ8zLIDYr3a0aahNrA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  '@vercel/node@5.8.24':
+    resolution: {integrity: sha512-Zi5LvZaKZsUZIUCrf16pa1np6HOImygrt6/HMoDOZjcHHaeKZUda+KB/O1CZEp1ipDjvPKK03igELagrj44hiw==}
+
+  '@vercel/oidc@3.2.0':
+    resolution: {integrity: sha512-UycprH3T6n3jH0k44NHMa7pnFHGu/N05MjojYr+Mc6I7obkoLIJujSWwin1pCvdy/eOxrI/l3uDLQsmcrOb4ug==}
+    engines: {node: '>= 20'}
+
+  '@vercel/prepare-flags-definitions@0.3.0':
+    resolution: {integrity: sha512-/0nuDFwYje0nqZnVKSd2VfJy2wOPQwbkas1qO1JQgtb0sLl+EeSCW4O9hrvq55pN50PNlAZ/APSeWHIAT9ZGHg==}
+
+  '@vercel/python-analysis@0.11.1':
+    resolution: {integrity: sha512-EPPLuXJQhIDUx08H9nG76AR2HSgBquwe3OAX5s2w20M923iaWeGGVkhX/4yZ89CJfXEZgE1Aj/mX7lVHOVIcYA==}
+
+  '@vercel/python@6.50.0':
+    resolution: {integrity: sha512-OhM5Se6FfA2LFi0peMQXNfzy5jOZiqhFaIMSqSEe8BTD5Htz0aypLDWjWPREasNh2lXdpZGHP5ZJ0kSfurqGOA==}
+
+  '@vercel/redwood@2.5.0':
+    resolution: {integrity: sha512-LO24CbieV57rGAqrq5n5z/B+fMYeUqbE/Ge3qMeKRuS3Q9awgcBgB6WYLCe8crHM7XJd5AZjbuyoS/6k3r0X0w==}
+
+  '@vercel/remix-builder@5.9.1':
+    resolution: {integrity: sha512-s0SpfV640nmQ1BsKCPMYugGrH/V+319onTo2ZILSmsy6NTBlmeN0zJU9nPcP8dBEotGqtp68NfOlOUUdrVBzkw==}
+
+  '@vercel/ruby@2.5.1':
+    resolution: {integrity: sha512-e23M7pfORQyyxSUmeQ8PqEnyLJ4swhtNrnyctU5E02UCaUYFm5YAdNfdPYRP4It874H4Wyvm+LV8u7CPBrfcPA==}
+
+  '@vercel/rust@1.4.0':
+    resolution: {integrity: sha512-/zRJtaf3pvdxZ7+tShmIo8StdbkCSBDcY7Gy7LOwNTIxm6GU9vkS+BlCwJHkOu6qNkbcSRH6ZQIeo4vNmqzKdQ==}
+
+  '@vercel/sandbox@2.4.0':
+    resolution: {integrity: sha512-pifnr8hex/rgQ3EPyLYHYwHyf0Kwmc4Vbya9kHGk4aERFVGj44P+742S8/SDdt2guMxBriXBOMkMLq1Kaiyyeg==}
+
+  '@vercel/static-build@2.11.6':
+    resolution: {integrity: sha512-fw4G4dnTmfkuYPdvO9GLQ3NreMpRiX1TgblLhVkbeBpxXdU8KBf0I19nDrmJtul3g1qmwkkpdjNp4RHMXkmp9Q==}
+
+  '@vercel/static-config@3.4.0':
+    resolution: {integrity: sha512-wCq90CMUB//ggnFh77NQO1xaLFsS4LigQIqKrH6ohnr9Br/KI1FhlErx62WfCOuueWaW+LVsbLOqNXIUjK8t6A==}
+
   '@vitest/expect@3.2.7':
     resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
 
@@ -627,6 +1299,18 @@ packages:
   '@vitest/utils@3.2.7':
     resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
+  '@workflow/serde@4.1.0-beta.2':
+    resolution: {integrity: sha512-8kkeoQKLDaKXefjV5dbhBj2aErfKp1Mc4pb6tj8144cF+Em5SPbyMbyLCHp+BVrFfFVCBluCtMx+jjvaFVZGww==}
+
+  abbrev@3.0.1:
+    resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
+  acorn-import-attributes@1.9.5:
+    resolution: {integrity: sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==}
+    peerDependencies:
+      acorn: ^8
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -637,12 +1321,25 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.6.3:
+    resolution: {integrity: sha512-SMJOdDP6LqTkD0Uq8qLi+gMwSt0imXLSV080qFVwJCpH9U6Mb+SUGHAXM0KNbcBPguytWyvFxcHgMLe2D2XSpw==}
 
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  arg@4.1.0:
+    resolution: {integrity: sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -651,6 +1348,35 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  ast-types@0.13.4:
+    resolution: {integrity: sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==}
+    engines: {node: '>=4'}
+
+  async-listen@1.2.0:
+    resolution: {integrity: sha512-CcEtRh/oc9Jc4uWeUwdpG/+Mb2YUHKmdaTf0gUr7Wa+bfp4xx70HOb3RuSTJMvqKNB1TkdTfjLdrcz2X4rkkZA==}
+
+  async-listen@3.0.0:
+    resolution: {integrity: sha512-V+SsTpDqkrWTimiotsyl33ePSjA5/KrithwupuvJ6ztsqPvGv6ge4OredFhPffVXiLN/QUWvE0XcqJaYgt6fOg==}
+    engines: {node: '>= 14'}
+
+  async-listen@3.0.1:
+    resolution: {integrity: sha512-cWMaNwUJnf37C/S5TfCkk/15MwbPRwVYALA2jtjkbHjCmAPiDXyNJy2q3p1KAZzDLHAWyarUWSujUoHR4pEgrA==}
+    engines: {node: '>= 14'}
+
+  async-retry@1.3.3:
+    resolution: {integrity: sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==}
+
+  async-sema@3.1.1:
+    resolution: {integrity: sha512-tLRNUXati5MFePdAk8dw7Qt7DpxPB60ofAgn8WRhW6a2rcimZnYBP9oxHiv0OHy+Wz7kPMG+t4LGdt31+4EmGg==}
+
+  b4a@1.8.1:
+    resolution: {integrity: sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==}
+    peerDependencies:
+      react-native-b4a: '*'
+    peerDependenciesMeta:
+      react-native-b4a:
+        optional: true
+
   balanced-match@1.0.2:
     resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
 
@@ -658,12 +1384,38 @@ packages:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
 
+  bare-events@2.9.1:
+    resolution: {integrity: sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==}
+    peerDependencies:
+      bare-abort-controller: '*'
+    peerDependenciesMeta:
+      bare-abort-controller:
+        optional: true
+
+  basic-ftp@5.3.1:
+    resolution: {integrity: sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==}
+    engines: {node: '>=10.0.0'}
+
+  bindings@1.5.0:
+    resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+
   brace-expansion@1.1.16:
     resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  buffer-crc32@0.2.13:
+    resolution: {integrity: sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==}
+
+  bytes@3.1.0:
+    resolution: {integrity: sha512-zauLjrfCG+xvoyaqLoV8bLVXXNGC4JqlxFCutSDWA6fJrTo2ZuvLYTqZ7aHBLZSMOopbzwv8f+wZcVzfVTI2Dg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -685,6 +1437,20 @@ packages:
     resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
     engines: {node: '>= 16'}
 
+  chokidar@4.0.0:
+    resolution: {integrity: sha512-mxIojEAQcuEvT/lyXq+jf/3cO/KoA6z4CeNDGGevTybECPOMFCnQy3OPahluUkbqgPNGw5Bi78UC7Po6Lhy+NA==}
+    engines: {node: '>= 14.16.0'}
+
+  chownr@3.0.0:
+    resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
+    engines: {node: '>=18'}
+
+  cjs-module-lexer@1.2.3:
+    resolution: {integrity: sha512-0TNiGstbQmCFwt4akjjBg5pLRTSyj/PkWQ1ZoO2zntmg9yLqSRxwEa4iCfQLGjqhiqBfOJa7W/E8wfGrTDmlZQ==}
+
+  code-block-writer@10.1.1:
+    resolution: {integrity: sha512-67ueh2IRGst/51p0n6FvPrnRjAGHY5F8xdjkgrYE7DDzpJe6qA07RYQ9VcoUeo5ATOjSOiWpSL3SWBRRbempMw==}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -695,9 +1461,34 @@ packages:
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  content-type@1.0.4:
+    resolution: {integrity: sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==}
+    engines: {node: '>= 0.6'}
+
+  convert-hrtime@3.0.0:
+    resolution: {integrity: sha512-7V+KqSvMiHp8yWDuwfww06XleMWVVB9b9tURBx+G7UTADuo5hYPuowKloz4OzOqbPezxgo+fdQ1522WzPG4OeA==}
+    engines: {node: '>=8'}
+
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  data-uri-to-buffer@6.0.2:
+    resolution: {integrity: sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==}
+    engines: {node: '>= 14'}
+
+  debug@4.3.4:
+    resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -715,8 +1506,46 @@ packages:
   deep-is@0.1.4:
     resolution: {integrity: sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==}
 
+  define-lazy-prop@2.0.0:
+    resolution: {integrity: sha512-Ds09qNh8yw3khSjiJjiUInaGX9xlqZDY7JVryGxdxV7NPeuqQfplOpQ66yJFZut3jLa5zOwkXw1g9EI2uKh4Og==}
+    engines: {node: '>=8'}
+
+  degenerator@5.0.1:
+    resolution: {integrity: sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==}
+    engines: {node: '>= 14'}
+
+  depd@1.1.2:
+    resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
+    engines: {node: '>= 0.6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  edge-runtime@2.5.9:
+    resolution: {integrity: sha512-pk+k0oK0PVXdlT4oRp4lwh+unuKB7Ng4iZ2HB+EZ7QCEQizX360Rp/F4aRpgpRgdP2ufB35N+1KppHmYjqIGSg==}
+    engines: {node: '>=16'}
+    hasBin: true
+
+  end-of-stream@1.1.0:
+    resolution: {integrity: sha512-EoulkdKF/1xa92q25PbjuDcgJ9RDHYU2Rs3SCIvs2/dSQ3BpmxneNHmA/M7fe60M3PrV7nNGTTNbkK62l6vXiQ==}
+
+  end-of-stream@1.4.5:
+    resolution: {integrity: sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==}
+
+  es-module-lexer@1.4.1:
+    resolution: {integrity: sha512-cXLGjP0c4T3flZJKQSuziYoq7MlT+rnvfZjfp7h+I7K9BNX54kP9nyWvdbwjQ4u1iWbOL4u96fgeZLToQlZC7w==}
+
+  es-module-lexer@1.5.0:
+    resolution: {integrity: sha512-pqrTKmwEIgafsYZAGw9kszYzmagcE/n4dbgwGWLEXg7J4QFJVQRBld8j3Q3GNez79jzxZshq0bcT962QHOghjw==}
+
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.27.0:
+    resolution: {integrity: sha512-jd0f4NHbD6cALCyGElNpGAOtWxSq46l9X/sWB0Nzd5er4Kz2YTm+Vl0qKFT9KUJvD8+fiO8AvoHhFvEatfVixA==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.28.1:
     resolution: {integrity: sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw==}
@@ -726,6 +1555,11 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  escodegen@2.1.0:
+    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
+    engines: {node: '>=6.0'}
+    hasBin: true
 
   eslint-scope@8.4.0:
     resolution: {integrity: sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==}
@@ -757,6 +1591,11 @@ packages:
     resolution: {integrity: sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  esprima@4.0.1:
+    resolution: {integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==}
+    engines: {node: '>=4'}
+    hasBin: true
+
   esquery@1.7.0:
     resolution: {integrity: sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g==}
     engines: {node: '>=0.10'}
@@ -769,12 +1608,33 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@2.0.2:
+    resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
+
   estree-walker@3.0.3:
     resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
 
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
+
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
+  events-intercept@2.0.0:
+    resolution: {integrity: sha512-blk1va0zol9QOrdZt0rFXo5KMkNPVSp92Eju/Qz8THwKWKRKeE0T8Br/1aW6+Edkyq9xHYgYxn2QtOnUKPUp+Q==}
+
+  events-universal@1.0.1:
+    resolution: {integrity: sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==}
+
+  execa@3.2.0:
+    resolution: {integrity: sha512-kJJfVbI/lZE1PZYDI5VPxp8zXPO9rtxOkhpZ0jMKha56AI9y2gGVC6bkukStQf0ka5Rh15BA5m7cCCH4jmHqkw==}
+    engines: {node: ^8.12.0 || >=9.7.0}
+
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
 
   expect-type@1.4.0:
     resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
@@ -783,11 +1643,24 @@ packages:
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
   fast-json-stable-stringify@2.1.0:
     resolution: {integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==}
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fd-slicer@1.1.0:
+    resolution: {integrity: sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -802,6 +1675,13 @@ packages:
     resolution: {integrity: sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==}
     engines: {node: '>=16.0.0'}
 
+  file-uri-to-path@1.0.0:
+    resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
     engines: {node: '>=10'}
@@ -813,22 +1693,88 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
+  fs-extra@11.1.0:
+    resolution: {integrity: sha512-0rcTq621PD5jM/e0a3EJoGC/1TC5ZBCERW82LQuwfGnCa1V8w7dpYH1yNu+SLb6E5dkeCBzKEyLGlFrnr+dUyw==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.1.1:
+    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
+    engines: {node: '>=14.14'}
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  generic-pool@3.4.2:
+    resolution: {integrity: sha512-H7cUpwCQSiJmAHM4c/aFu6fUfrhWXW1ncyh8ftxEPMu6AiYkHw9K8br720TGPZJbk5eOH2bynjZD1yPvdDAmag==}
+    engines: {node: '>= 4'}
+
+  get-port@5.1.1:
+    resolution: {integrity: sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==}
+    engines: {node: '>=8'}
+
+  get-stream@5.2.0:
+    resolution: {integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==}
+    engines: {node: '>=8'}
+
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  get-uri@6.0.5:
+    resolution: {integrity: sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==}
+    engines: {node: '>= 14'}
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
     engines: {node: '>=18'}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  http-errors@1.7.3:
+    resolution: {integrity: sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==}
+    engines: {node: '>= 0.6'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  human-signals@1.1.1:
+    resolution: {integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==}
+    engines: {node: '>=8.12.0'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -846,6 +1792,22 @@ packages:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
     engines: {node: '>=0.8.19'}
 
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  ip-address@10.3.1:
+    resolution: {integrity: sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==}
+    engines: {node: '>= 12'}
+
+  is-buffer@2.0.5:
+    resolution: {integrity: sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==}
+    engines: {node: '>=4'}
+
+  is-docker@2.2.1:
+    resolution: {integrity: sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==}
+    engines: {node: '>=8'}
+    hasBin: true
+
   is-extglob@2.1.1:
     resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
     engines: {node: '>=0.10.0'}
@@ -854,11 +1816,36 @@ packages:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
 
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
+  is-wsl@2.2.0:
+    resolution: {integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==}
+    engines: {node: '>=8'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  jose@5.9.6:
+    resolution: {integrity: sha512-AMlnetc9+CV9asI19zHmrgS/WYsWUwCn2R7RzlbJWD7F9eWYUTGyBmU9o6PxngtLGOiDGPRu+Uc4fhKzbpteZQ==}
+
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@9.0.1:
     resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
+
+  js-yaml@4.1.1:
+    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+    hasBin: true
 
   js-yaml@4.3.0:
     resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
@@ -867,11 +1854,26 @@ packages:
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
+  json-schema-to-ts@1.6.4:
+    resolution: {integrity: sha512-pR4yQ9DHz6itqswtHCm26mw45FSNfQ9rEQjosaZErhn5J3J2sIViQiz8rDaezjKAhFGpmsoczYVBgGHzFw/stA==}
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
+
+  jsonc-parser@3.3.1:
+    resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
+
+  jsonfile@6.2.1:
+    resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
+
+  jsonlines@0.1.1:
+    resolution: {integrity: sha512-ekDrAGso79Cvf+dtm+mL8OBI2bmAOt3gssYs833De/C9NmIpWDWyUO4zPgB5x2/OhY366dkhgfPMYfwZF7yOZA==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -890,8 +1892,56 @@ packages:
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
 
+  lru-cache@11.5.2:
+    resolution: {integrity: sha512-4pfM1Ff0x50o0tQwb5ucw/RzNyD0/YJME6IVcStalZuMWxdt3sR3huStTtxz4PUmvZfRguvDejasvQ2kifR11g==}
+    engines: {node: 20 || >=22}
+
+  lru-cache@6.0.0:
+    resolution: {integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==}
+    engines: {node: '>=10'}
+
+  lru-cache@7.18.3:
+    resolution: {integrity: sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==}
+    engines: {node: '>=12'}
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micro@9.3.5-canary.3:
+    resolution: {integrity: sha512-viYIo9PefV+w9dvoIBh1gI44Mvx1BOk67B4BpC2QK77qdY0xZF0Q+vWLt/BII6cLkIc8rLmSIcJaB/OrXXKe1g==}
+    engines: {node: '>= 8.0.0'}
+    hasBin: true
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
+
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+    engines: {node: 20 || >=22}
 
   minimatch@10.2.5:
     resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
@@ -899,6 +1949,29 @@ packages:
 
   minimatch@3.1.5:
     resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minizlib@3.1.0:
+    resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
+    engines: {node: '>= 18'}
+
+  mkdirp@1.0.4:
+    resolution: {integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  mri@1.2.0:
+    resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
+    engines: {node: '>=4'}
+
+  ms@2.1.1:
+    resolution: {integrity: sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==}
+
+  ms@2.1.2:
+    resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -911,9 +1984,79 @@ packages:
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
+  netmask@2.1.1:
+    resolution: {integrity: sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==}
+    engines: {node: '>= 0.4.0'}
+
+  node-fetch@2.6.7:
+    resolution: {integrity: sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@2.6.9:
+    resolution: {integrity: sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-gyp-build@4.8.4:
+    resolution: {integrity: sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==}
+    hasBin: true
+
+  nopt@8.1.0:
+    resolution: {integrity: sha512-ieGu42u/Qsa4TFktmaKEwM6MQH0pOWnaB3htzh0JRtx84+Mebc0cbZYN5bC+6WTZ4+77xrL9Pn5m7CV6VIkV7A==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+    hasBin: true
+
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
+  once@1.3.3:
+    resolution: {integrity: sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==}
+
+  once@1.4.0:
+    resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
+
+  open@8.4.0:
+    resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
+    engines: {node: '>=12'}
+
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
+
+  oxc-transform@0.111.0:
+    resolution: {integrity: sha512-oa5KKSDNLHZGaiqIGAbCWXeN9IJUAz9MElWcQX90epDxdKc9Hrt/BsLj3K4gDqfAYa5dwdH+ZCFJG9hR74fiGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  p-finally@2.0.1:
+    resolution: {integrity: sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==}
+    engines: {node: '>=8'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -923,9 +2066,24 @@ packages:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
 
+  pac-proxy-agent@7.2.0:
+    resolution: {integrity: sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==}
+    engines: {node: '>= 14'}
+
+  pac-resolver@7.0.1:
+    resolution: {integrity: sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==}
+    engines: {node: '>= 14'}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse-ms@2.1.0:
+    resolution: {integrity: sha512-kHt7kzLoS9VBZfUsiKjv43mr91ea+U05EyKkEtqp7vNbHxmaVuEqN7XxeEVnGrMtYOAxGrDElSi96K7EgO1zCA==}
+    engines: {node: '>=6'}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -935,6 +2093,23 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@6.1.0:
+    resolution: {integrity: sha512-h9DqehX3zZZDCEm+xbfU0ZmwCGFCAAraPJWMXJ4+v32NjZJilVg3k1TcKsRgIb8IQ/izZSaydDc1OhJCZvs2Dw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
+
+  path-to-regexp@8.2.0:
+    resolution: {integrity: sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ==}
+    engines: {node: '>=16'}
+
+  path-to-regexp@8.3.0:
+    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -942,8 +2117,18 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  pend@1.2.0:
+    resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
+
+  picocolors@1.0.0:
+    resolution: {integrity: sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
 
   picomatch@4.0.5:
     resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
@@ -957,23 +2142,101 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
+  pretty-ms@7.0.1:
+    resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
+    engines: {node: '>=10'}
+
+  promisepipe@3.0.0:
+    resolution: {integrity: sha512-V6TbZDJ/ZswevgkDNpGt/YqNCiZP9ASfgU+p83uJE6NrGtvSGoOcHLiDCqkMs2+yg7F5qHdLV8d0aS8O26G/KA==}
+
+  proxy-agent@6.4.0:
+    resolution: {integrity: sha512-u0piLU+nCOHMgGjRbimiXmA9kM/L9EHh3zL81xCdp7m+Y2pHIsnmbdDoEDoAz5geaonNR6q6+yOPQs6n4T6sBQ==}
+    engines: {node: '>= 14'}
+
+  proxy-from-env@1.1.0:
+    resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  pump@3.0.4:
+    resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
 
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  raw-body@2.4.1:
+    resolution: {integrity: sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==}
+    engines: {node: '>= 0.8'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
+
+  resolve-from@5.0.0:
+    resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
+    engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve.exports@2.0.3:
+    resolution: {integrity: sha512-OcXjMsGdhL4XnbShKpAcSqPMzQoYkYyhbEaeSko47MjRP9NfEQMhZkXL1DoFlt9LWQn4YttrdnV6X2OiyzBi+A==}
+    engines: {node: '>=10'}
+
+  retry@0.13.1:
+    resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
+    engines: {node: '>= 4'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rolldown@1.0.0-rc.1:
+    resolution: {integrity: sha512-M3AeZjYE6UclblEf531Hch0WfVC/NOL43Cc+WdF3J50kk5/fvouHhDumSGTh0oRjbZ8C4faaVr5r6Nx1xMqDGg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   rollup@4.62.2:
     resolution: {integrity: sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  sandbox@3.4.0:
+    resolution: {integrity: sha512-JPdADikobt6zFuuCRhl6whNrCJlLPxpUmT/hNxLij70mkpeejHKDN+HeVlrdHI8snDTzRIiF3Ye8KyMIyVWA+A==}
+    hasBin: true
+
+  semver@6.3.1:
+    resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.5.4:
+    resolution: {integrity: sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
   semver@7.8.5:
     resolution: {integrity: sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==}
     engines: {node: '>=10'}
     hasBin: true
+
+  setprototypeof@1.1.1:
+    resolution: {integrity: sha512-JvdAWfbXeIGaZ9cILp38HntZSFSo3mWg6xGcJJsd+d4aRMOqauag1C63dJfDw7OaMYwEbHMOxEZ1lqVRYP2OAw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -986,15 +2249,68 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
+  signal-exit@4.0.2:
+    resolution: {integrity: sha512-MY2/qGx4enyjprQnFaZsHib3Yadh3IXyV2C321GY0pjGfVBu4un0uDJkwgdxqO+Rdx8JMT8IfJIRwbYVz3Ob3Q==}
+    engines: {node: '>=14'}
+
+  smart-buffer@4.2.0:
+    resolution: {integrity: sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==}
+    engines: {node: '>= 6.0.0', npm: '>= 3.0.0'}
+
+  smol-toml@1.5.2:
+    resolution: {integrity: sha512-QlaZEqcAH3/RtNyet1IPIYPsEWAaYyXXv1Krsi+1L/QHppjX4Ifm8MQsBISz9vE8cHicIq3clogsheili5vhaQ==}
+    engines: {node: '>= 18'}
+
+  socks-proxy-agent@8.0.5:
+    resolution: {integrity: sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==}
+    engines: {node: '>= 14'}
+
+  socks@2.8.9:
+    resolution: {integrity: sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==}
+    engines: {node: '>= 10.0.0', npm: '>= 3.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  srvx@0.11.16:
+    resolution: {integrity: sha512-bp07zRuycfTY43IjAvvTFnmnJi8ikW0VFiHwOhhYcVW/L4xQ1XY4PAd4Nuum1rsA17C39zL7x+CDhrn5AL32Rw==}
+    engines: {node: '>=20.16.0'}
+    hasBin: true
+
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  stat-mode@0.3.0:
+    resolution: {integrity: sha512-QjMLR0A3WwFY2aZdV0okfFEJB5TRjkggXZjxP3A1RsWsNHNu3YPv8btmtc6iCFZ0Rul3FE93OYogvhOUClU+ng==}
+
+  statuses@1.5.0:
+    resolution: {integrity: sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==}
+    engines: {node: '>= 0.6'}
+
   std-env@3.10.0:
     resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  stream-to-array@2.3.0:
+    resolution: {integrity: sha512-UsZtOYEn4tWU2RGLOXr/o/xjRBftZRlG3dEWoaHr8j4GuypJ3isitGbVyjQKAuMu+xbiop8q224TjiZWc4XTZA==}
+
+  stream-to-promise@2.2.0:
+    resolution: {integrity: sha512-HAGUASw8NT0k8JvIVutB2Y/9iBk7gpgEyAudXwNJmZERdMITGdajOa4VJfD/kNiA3TppQpTP4J+CtcHwdzKBAw==}
+    deprecated: Deprecated. Use node:stream/promises and node:stream/consumers instead.
+
+  streamx@2.28.0:
+    resolution: {integrity: sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -1006,6 +2322,29 @@ packages:
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
+
+  tar-stream@3.1.7:
+    resolution: {integrity: sha512-qJj60CXt7IU1Ffyc3NJMjh6EkuCFej46zUqJ4J7pqYlThyd9bO0XBTmcOIhSzZJVWfsLks0+nle/j538YAW9RQ==}
+
+  tar@7.5.22:
+    resolution: {integrity: sha512-MFO/QzvtAOmJbkhOaCTvbGcFN9L9b+JunIsDwaKljSOdcLMea3NJ1k9Usz/rjdfSXTq4dfzfeS7W4p4YOAAHeA==}
+    engines: {node: '>=18'}
+
+  tar@7.5.7:
+    resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
+    engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
+
+  text-decoder@1.2.7:
+    resolution: {integrity: sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==}
+
+  throttleit@2.1.0:
+    resolution: {integrity: sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==}
+    engines: {node: '>=18'}
+
+  time-span@4.0.0:
+    resolution: {integrity: sha512-MyqZCTGLDZ77u4k+jqg4UlrzPTPZ49NDlaekU6uuFaJLzPIN1woaRXCbGeqOfxwc3Y37ZROGAJ614Rdv7Olt+g==}
+    engines: {node: '>=10'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1029,11 +2368,40 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  toidentifier@1.0.0:
+    resolution: {integrity: sha512-yaOH/Pk/VEhBWWTlhI+qXxDFXlejDGcQipMlyxda9nthulaxLZUNcUqFxokp0vcYnvteJln5FNQDRrxj3YcbVw==}
+    engines: {node: '>=0.6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tree-kill@1.2.2:
+    resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
+    hasBin: true
+
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
     engines: {node: '>=18.12'}
     peerDependencies:
       typescript: '>=4.8.4'
+
+  ts-morph@12.0.0:
+    resolution: {integrity: sha512-VHC8XgU2fFW7yO1f/b3mxKDje1vmyzFXHWzOYmKEkCEwcLjDtbdLgBQviqj4ZwP4MJkQtRo6Ha2I29lq/B+VxA==}
+
+  ts-toolbelt@6.15.5:
+    resolution: {integrity: sha512-FZIXf1ksVyLcfr7M317jbB67XFJhOO1YqdTcuGaq9q5jLUoTikukZ+98TPjKiP2jC5CgmYdWWYs0s2nLSU0/1A==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   tsx@4.23.0:
     resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
@@ -1061,11 +2429,46 @@ packages:
     engines: {node: '>=16.20.0'}
     hasBin: true
 
+  uid-promise@1.0.0:
+    resolution: {integrity: sha512-R8375j0qwXyIu/7R0tjdF06/sElHqbmdmWC9M2qQHpEVbvE4I5+38KJI7LUUmQMp7NVq4tKHiBMkT0NFM453Ig==}
+
+  undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
 
+  undici@5.28.4:
+    resolution: {integrity: sha512-72RFADWFqKmUb2hmmvNODKL3p9hcB6Gt2DOQMis1SEBaV6a4MH8soBvzg+95CYhCKPFedut2JY9bMfrDl9D23g==}
+    engines: {node: '>=14.0'}
+
+  undici@5.29.0:
+    resolution: {integrity: sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==}
+    engines: {node: '>=14.0'}
+
+  undici@6.28.0:
+    resolution: {integrity: sha512-LIY910g9TI13YS95lrMFrs8Rm/u/irgHeTWoKCoteeJ04CUJ92eEfj0rVn+7VKMPBpUPiUoBKfhNyLI23EE/KA==}
+    engines: {node: '>=18.17'}
+
+  undici@7.29.0:
+    resolution: {integrity: sha512-IDxfleLmmbSskfWSUATiN1nfn2rDuvnMOqb5CWR92iIfojA0Ud+ulOAAEQ57LPr9rWmsreUyf5lwyao+7GNNVw==}
+    engines: {node: '>=20.18.1'}
+
+  universalify@2.0.1:
+    resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
+    engines: {node: '>= 10.0.0'}
+
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  vercel@56.2.0:
+    resolution: {integrity: sha512-4k4WzaLhZuPuksw96qQbmXqEQvhEAwuZACDtL3aiF7Ys5XplRapidWBQAnXx6dYemj8Q7Nf8W8A43uhnJA49aQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
 
   vite-node@3.2.4:
     resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
@@ -1140,6 +2543,15 @@ packages:
       jsdom:
         optional: true
 
+  web-vitals@0.2.4:
+    resolution: {integrity: sha512-6BjspCO9VriYy12z356nL6JBS0GYeEcA457YyRzD+dD6XYCQ75NKhcOHUMHentOE7OcVCIXXDvOm0jKFfQG2Gg==}
+
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
+
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
@@ -1154,85 +2566,244 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrappy@1.0.2:
+    resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.21.1:
+    resolution: {integrity: sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xdg-app-paths@5.1.0:
+    resolution: {integrity: sha512-RAQ3WkPf4KTU1A8RtFx3gWywzVKe00tfOPFfl2NDGqbIFENQO4kqAJp7mhQjNj/33W5x5hiWWUdyfPq/5SU3QA==}
+    engines: {node: '>=6'}
+
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
+  yallist@4.0.0:
+    resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
+
+  yallist@5.0.0:
+    resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yauzl-clone@1.0.4:
+    resolution: {integrity: sha512-igM2RRCf3k8TvZoxR2oguuw4z1xasOnA31joCqHIyLkeWrvAc2Jgay5ISQ2ZplinkoGaJ6orCz56Ey456c5ESA==}
+    engines: {node: '>=6'}
+
+  yauzl-promise@2.1.3:
+    resolution: {integrity: sha512-A1pf6fzh6eYkK0L4Qp7g9jzJSDrM6nN0bOn5T0IbY4Yo3w+YkWlHFkJP7mzknMXjqusHFHlKsK2N+4OLsK2MRA==}
+    engines: {node: '>=6'}
+
+  yauzl@2.10.0:
+    resolution: {integrity: sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
 
+  zod@3.22.4:
+    resolution: {integrity: sha512-iC+8Io04lddc+mVqQ9AZ7OQ2MrUKGN+oIQyq1vemgt46jwCwLfhq7/pwnBnNXXXZb8VTVLKwp9EDkx+ryxIWmg==}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
+
 snapshots:
 
+  '@bytecodealliance/preview2-shim@0.17.6': {}
+
+  '@edge-runtime/format@2.2.1': {}
+
+  '@edge-runtime/node-utils@2.3.0': {}
+
+  '@edge-runtime/ponyfill@2.4.2': {}
+
+  '@edge-runtime/primitives@4.1.0': {}
+
+  '@edge-runtime/vm@3.2.0':
+    dependencies:
+      '@edge-runtime/primitives': 4.1.0
+
+  '@emnapi/core@2.0.0-alpha.3':
+    dependencies:
+      '@emnapi/wasi-threads': 2.0.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@2.0.0-alpha.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@2.0.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.27.0':
+    optional: true
+
   '@esbuild/aix-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.0':
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
     optional: true
 
+  '@esbuild/android-arm@0.27.0':
+    optional: true
+
   '@esbuild/android-arm@0.28.1':
+    optional: true
+
+  '@esbuild/android-x64@0.27.0':
     optional: true
 
   '@esbuild/android-x64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.0':
+    optional: true
+
   '@esbuild/darwin-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.0':
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.0':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.0':
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.0':
+    optional: true
+
   '@esbuild/linux-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.0':
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.0':
+    optional: true
+
   '@esbuild/linux-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.0':
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.0':
+    optional: true
+
   '@esbuild/linux-mips64el@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.0':
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.0':
+    optional: true
+
   '@esbuild/linux-riscv64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.0':
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
     optional: true
 
+  '@esbuild/linux-x64@0.27.0':
+    optional: true
+
   '@esbuild/linux-x64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.0':
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.0':
+    optional: true
+
   '@esbuild/netbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.0':
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.0':
+    optional: true
+
   '@esbuild/openbsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.0':
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.0':
+    optional: true
+
   '@esbuild/sunos-x64@0.28.1':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.0':
     optional: true
 
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.0':
+    optional: true
+
   '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.0':
     optional: true
 
   '@esbuild/win32-x64@0.28.1':
@@ -1284,6 +2855,8 @@ snapshots:
       '@eslint/core': 0.17.0
       levn: 0.4.1
 
+  '@fastify/busboy@2.1.1': {}
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -1300,7 +2873,223 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.1':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
+  '@isaacs/fs-minipass@4.0.1':
+    dependencies:
+      minipass: 7.1.3
+
   '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@mapbox/node-pre-gyp@2.0.3':
+    dependencies:
+      consola: 3.4.2
+      detect-libc: 2.1.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 2.7.0
+      nopt: 8.1.0
+      semver: 7.8.5
+      tar: 7.5.22
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@napi-rs/keyring-darwin-arm64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-darwin-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-freebsd-x64@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm-gnueabihf@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-arm64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-riscv64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-gnu@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-linux-x64-musl@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-arm64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-ia32-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring-win32-x64-msvc@1.2.0':
+    optional: true
+
+  '@napi-rs/keyring@1.2.0':
+    optionalDependencies:
+      '@napi-rs/keyring-darwin-arm64': 1.2.0
+      '@napi-rs/keyring-darwin-x64': 1.2.0
+      '@napi-rs/keyring-freebsd-x64': 1.2.0
+      '@napi-rs/keyring-linux-arm-gnueabihf': 1.2.0
+      '@napi-rs/keyring-linux-arm64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-arm64-musl': 1.2.0
+      '@napi-rs/keyring-linux-riscv64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-gnu': 1.2.0
+      '@napi-rs/keyring-linux-x64-musl': 1.2.0
+      '@napi-rs/keyring-win32-arm64-msvc': 1.2.0
+      '@napi-rs/keyring-win32-ia32-msvc': 1.2.0
+      '@napi-rs/keyring-win32-x64-msvc': 1.2.0
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+    dependencies:
+      '@emnapi/core': 2.0.0-alpha.3
+      '@emnapi/runtime': 2.0.0-alpha.3
+      '@tybys/wasm-util': 0.10.3
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@oxc-project/types@0.110.0': {}
+
+  '@oxc-transform/binding-android-arm-eabi@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-android-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-darwin-x64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-freebsd-x64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-gnueabihf@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm-musleabihf@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-arm64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-ppc64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-riscv64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-s390x-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-gnu@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-linux-x64-musl@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-openharmony-arm64@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-wasm32-wasi@0.111.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@oxc-transform/binding-win32-arm64-msvc@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-ia32-msvc@0.111.0':
+    optional: true
+
+  '@oxc-transform/binding-win32-x64-msvc@0.111.0':
+    optional: true
+
+  '@renovatebot/pep440@4.2.1': {}
+
+  '@rolldown/binding-android-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.1':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.1': {}
+
+  '@rollup/pluginutils@5.4.0(rollup@4.62.2)':
+    dependencies:
+      '@types/estree': 1.0.9
+      estree-walker: 2.0.2
+      picomatch: 4.0.5
+    optionalDependencies:
+      rollup: 4.62.2
 
   '@rollup/rollup-android-arm-eabi@4.62.2':
     optional: true
@@ -1377,6 +3166,24 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.62.2':
     optional: true
 
+  '@sinclair/typebox@0.25.24': {}
+
+  '@tootallnate/once@2.0.0': {}
+
+  '@tootallnate/quickjs-emscripten@0.23.0': {}
+
+  '@ts-morph/common@0.11.1':
+    dependencies:
+      fast-glob: 3.3.3
+      minimatch: 3.1.5
+      mkdirp: 1.0.4
+      path-browserify: 1.0.1
+
+  '@tybys/wasm-util@0.10.3':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@types/chai@5.2.3':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -1387,6 +3194,10 @@ snapshots:
   '@types/estree@1.0.9': {}
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/node@20.11.0':
+    dependencies:
+      undici-types: 5.26.5
 
   '@types/node@24.13.3':
     dependencies:
@@ -1543,6 +3354,327 @@ snapshots:
   '@typescript/typescript-win32-x64@7.0.2':
     optional: true
 
+  '@vercel/backends@0.8.23(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)':
+    dependencies:
+      '@vercel/build-utils': 13.33.0
+      '@vercel/nft': 1.10.0(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+      execa: 3.2.0
+      fs-extra: 11.1.0
+      get-port: 5.1.1
+      oxc-transform: 0.111.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      path-to-regexp: 8.3.0
+      resolve.exports: 2.0.3
+      rolldown: 1.0.0-rc.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      srvx: 0.11.16
+      ts-morph: 12.0.0
+      tsx: 4.21.0
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/blob@2.4.0':
+    dependencies:
+      async-retry: 1.3.3
+      is-buffer: 2.0.5
+      is-node-process: 1.2.0
+      throttleit: 2.1.0
+      undici: 6.28.0
+
+  '@vercel/build-utils@13.33.0':
+    dependencies:
+      '@vercel/python-analysis': 0.11.1
+      cjs-module-lexer: 1.2.3
+      es-module-lexer: 1.5.0
+
+  '@vercel/cervel@0.1.31(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)':
+    dependencies:
+      '@vercel/backends': 0.8.23(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/cli-auth@0.3.0':
+    dependencies:
+      '@napi-rs/keyring': 1.2.0
+      '@vercel/cli-config': 0.2.0
+      async-listen: 3.0.0
+      open: 8.4.0
+      zod: 4.1.11
+
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/container@0.0.5': {}
+
+  '@vercel/detect-agent@1.2.3': {}
+
+  '@vercel/elysia@0.1.100(rollup@4.62.2)':
+    dependencies:
+      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/error-utils@2.2.0': {}
+
+  '@vercel/express@0.1.114(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)':
+    dependencies:
+      '@vercel/cervel': 0.1.31(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
+      '@vercel/nft': 1.10.0(rollup@4.62.2)
+      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+      fs-extra: 11.1.0
+      path-to-regexp: 8.3.0
+      ts-morph: 12.0.0
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/fastify@0.1.103(rollup@4.62.2)':
+    dependencies:
+      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/fun@1.3.0':
+    dependencies:
+      '@tootallnate/once': 2.0.0
+      async-listen: 1.2.0
+      debug: 4.3.4
+      generic-pool: 3.4.2
+      micro: 9.3.5-canary.3
+      ms: 2.1.1
+      node-fetch: 2.6.7
+      path-to-regexp: 8.2.0
+      promisepipe: 3.0.0
+      semver: 7.5.4
+      stat-mode: 0.3.0
+      stream-to-promise: 2.2.0
+      tar: 7.5.7
+      tinyexec: 0.3.2
+      tree-kill: 1.2.2
+      uid-promise: 1.0.0
+      xdg-app-paths: 5.1.0
+      yauzl-promise: 2.1.3
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
+  '@vercel/gatsby-plugin-vercel-analytics@1.0.11':
+    dependencies:
+      web-vitals: 0.2.4
+
+  '@vercel/gatsby-plugin-vercel-builder@2.2.26':
+    dependencies:
+      '@sinclair/typebox': 0.25.24
+      '@vercel/build-utils': 13.33.0
+      esbuild: 0.27.0
+      etag: 1.8.1
+      fs-extra: 11.1.0
+
+  '@vercel/go@3.10.2': {}
+
+  '@vercel/h3@0.1.109(rollup@4.62.2)':
+    dependencies:
+      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/hono@0.2.103(rollup@4.62.2)':
+    dependencies:
+      '@vercel/nft': 1.10.0(rollup@4.62.2)
+      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+      fs-extra: 11.1.0
+      path-to-regexp: 8.3.0
+      ts-morph: 12.0.0
+      zod: 3.22.4
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/hydrogen@1.4.0':
+    dependencies:
+      '@vercel/static-config': 3.4.0
+      ts-morph: 12.0.0
+
+  '@vercel/koa@0.1.83(rollup@4.62.2)':
+    dependencies:
+      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/nestjs@0.2.104(rollup@4.62.2)':
+    dependencies:
+      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/next@4.20.4(rollup@4.62.2)':
+    dependencies:
+      '@vercel/nft': 1.10.0(rollup@4.62.2)
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/nft@1.10.0(rollup@4.62.2)':
+    dependencies:
+      '@mapbox/node-pre-gyp': 2.0.3
+      '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
+      acorn: 8.17.0
+      acorn-import-attributes: 1.9.5(acorn@8.17.0)
+      async-sema: 3.1.1
+      bindings: 1.5.0
+      estree-walker: 2.0.2
+      glob: 13.0.6
+      graceful-fs: 4.2.11
+      node-gyp-build: 4.8.4
+      picomatch: 4.0.5
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/node@5.8.24(rollup@4.62.2)':
+    dependencies:
+      '@edge-runtime/node-utils': 2.3.0
+      '@edge-runtime/primitives': 4.1.0
+      '@edge-runtime/vm': 3.2.0
+      '@types/node': 20.11.0
+      '@vercel/build-utils': 13.33.0
+      '@vercel/error-utils': 2.2.0
+      '@vercel/nft': 1.10.0(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+      async-listen: 3.0.0
+      cjs-module-lexer: 1.2.3
+      edge-runtime: 2.5.9
+      es-module-lexer: 1.4.1
+      esbuild: 0.27.0
+      etag: 1.8.1
+      mime-types: 2.1.35
+      node-fetch: 2.6.9
+      path-to-regexp: 6.1.0
+      path-to-regexp-updated: path-to-regexp@6.3.0
+      ts-morph: 12.0.0
+      tsx: 4.21.0
+      typescript: 5.9.3
+      undici: 5.28.4
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/oidc@3.2.0': {}
+
+  '@vercel/prepare-flags-definitions@0.3.0': {}
+
+  '@vercel/python-analysis@0.11.1':
+    dependencies:
+      '@bytecodealliance/preview2-shim': 0.17.6
+      '@renovatebot/pep440': 4.2.1
+      fs-extra: 11.1.1
+      js-yaml: 4.1.1
+      minimatch: 10.1.1
+      smol-toml: 1.5.2
+      zod: 3.22.4
+
+  '@vercel/python@6.50.0':
+    dependencies:
+      '@vercel/python-analysis': 0.11.1
+
+  '@vercel/redwood@2.5.0(rollup@4.62.2)':
+    dependencies:
+      '@vercel/nft': 1.10.0(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+      semver: 6.3.1
+      ts-morph: 12.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/remix-builder@5.9.1(rollup@4.62.2)':
+    dependencies:
+      '@vercel/error-utils': 2.2.0
+      '@vercel/nft': 1.10.0(rollup@4.62.2)
+      '@vercel/static-config': 3.4.0
+      path-to-regexp: 6.1.0
+      path-to-regexp-updated: path-to-regexp@6.3.0
+      ts-morph: 12.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
+
+  '@vercel/ruby@2.5.1': {}
+
+  '@vercel/rust@1.4.0':
+    dependencies:
+      execa: 5.1.1
+      get-port: 5.1.1
+      smol-toml: 1.5.2
+
+  '@vercel/sandbox@2.4.0':
+    dependencies:
+      '@vercel/oidc': 3.2.0
+      '@workflow/serde': 4.1.0-beta.2
+      async-retry: 1.3.3
+      jose: 6.2.3
+      jsonlines: 0.1.1
+      ms: 2.1.3
+      picocolors: 1.1.1
+      tar-stream: 3.1.7
+      undici: 7.29.0
+      xdg-app-paths: 5.1.0
+      zod: 4.1.11
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  '@vercel/static-build@2.11.6':
+    dependencies:
+      '@vercel/gatsby-plugin-vercel-analytics': 1.0.11
+      '@vercel/gatsby-plugin-vercel-builder': 2.2.26
+      '@vercel/static-config': 3.4.0
+      ts-morph: 12.0.0
+
+  '@vercel/static-config@3.4.0':
+    dependencies:
+      ajv: 8.6.3
+      json-schema-to-ts: 1.6.4
+      ts-morph: 12.0.0
+
   '@vitest/expect@3.2.7':
     dependencies:
       '@types/chai': 5.2.3
@@ -1585,11 +3717,21 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
+  '@workflow/serde@4.1.0-beta.2': {}
+
+  abbrev@3.0.1: {}
+
+  acorn-import-attributes@1.9.5(acorn@8.17.0):
+    dependencies:
+      acorn: 8.17.0
+
   acorn-jsx@5.3.2(acorn@8.17.0):
     dependencies:
       acorn: 8.17.0
 
   acorn@8.17.0: {}
+
+  agent-base@7.1.4: {}
 
   ajv@6.15.0:
     dependencies:
@@ -1598,17 +3740,54 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.6.3:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  any-promise@1.3.0: {}
+
+  arg@4.1.0: {}
 
   argparse@2.0.1: {}
 
   assertion-error@2.0.1: {}
 
+  ast-types@0.13.4:
+    dependencies:
+      tslib: 2.8.1
+
+  async-listen@1.2.0: {}
+
+  async-listen@3.0.0: {}
+
+  async-listen@3.0.1: {}
+
+  async-retry@1.3.3:
+    dependencies:
+      retry: 0.13.1
+
+  async-sema@3.1.1: {}
+
+  b4a@1.8.1: {}
+
   balanced-match@1.0.2: {}
 
   balanced-match@4.0.4: {}
+
+  bare-events@2.9.1: {}
+
+  basic-ftp@5.3.1: {}
+
+  bindings@1.5.0:
+    dependencies:
+      file-uri-to-path: 1.0.0
 
   brace-expansion@1.1.16:
     dependencies:
@@ -1618,6 +3797,14 @@ snapshots:
   brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  buffer-crc32@0.2.13: {}
+
+  bytes@3.1.0: {}
 
   cac@6.7.14: {}
 
@@ -1638,6 +3825,16 @@ snapshots:
 
   check-error@2.1.3: {}
 
+  chokidar@4.0.0:
+    dependencies:
+      readdirp: 4.1.2
+
+  chownr@3.0.0: {}
+
+  cjs-module-lexer@1.2.3: {}
+
+  code-block-writer@10.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -1646,11 +3843,23 @@ snapshots:
 
   concat-map@0.0.1: {}
 
+  consola@3.4.2: {}
+
+  content-type@1.0.4: {}
+
+  convert-hrtime@3.0.0: {}
+
   cross-spawn@7.0.6:
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  data-uri-to-buffer@6.0.2: {}
+
+  debug@4.3.4:
+    dependencies:
+      ms: 2.1.2
 
   debug@4.4.3:
     dependencies:
@@ -1660,7 +3869,72 @@ snapshots:
 
   deep-is@0.1.4: {}
 
+  define-lazy-prop@2.0.0: {}
+
+  degenerator@5.0.1:
+    dependencies:
+      ast-types: 0.13.4
+      escodegen: 2.1.0
+      esprima: 4.0.1
+
+  depd@1.1.2: {}
+
+  detect-libc@2.1.2: {}
+
+  edge-runtime@2.5.9:
+    dependencies:
+      '@edge-runtime/format': 2.2.1
+      '@edge-runtime/ponyfill': 2.4.2
+      '@edge-runtime/vm': 3.2.0
+      async-listen: 3.0.1
+      mri: 1.2.0
+      picocolors: 1.0.0
+      pretty-ms: 7.0.1
+      signal-exit: 4.0.2
+      time-span: 4.0.0
+
+  end-of-stream@1.1.0:
+    dependencies:
+      once: 1.3.3
+
+  end-of-stream@1.4.5:
+    dependencies:
+      once: 1.4.0
+
+  es-module-lexer@1.4.1: {}
+
+  es-module-lexer@1.5.0: {}
+
   es-module-lexer@1.7.0: {}
+
+  esbuild@0.27.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.0
+      '@esbuild/android-arm': 0.27.0
+      '@esbuild/android-arm64': 0.27.0
+      '@esbuild/android-x64': 0.27.0
+      '@esbuild/darwin-arm64': 0.27.0
+      '@esbuild/darwin-x64': 0.27.0
+      '@esbuild/freebsd-arm64': 0.27.0
+      '@esbuild/freebsd-x64': 0.27.0
+      '@esbuild/linux-arm': 0.27.0
+      '@esbuild/linux-arm64': 0.27.0
+      '@esbuild/linux-ia32': 0.27.0
+      '@esbuild/linux-loong64': 0.27.0
+      '@esbuild/linux-mips64el': 0.27.0
+      '@esbuild/linux-ppc64': 0.27.0
+      '@esbuild/linux-riscv64': 0.27.0
+      '@esbuild/linux-s390x': 0.27.0
+      '@esbuild/linux-x64': 0.27.0
+      '@esbuild/netbsd-arm64': 0.27.0
+      '@esbuild/netbsd-x64': 0.27.0
+      '@esbuild/openbsd-arm64': 0.27.0
+      '@esbuild/openbsd-x64': 0.27.0
+      '@esbuild/openharmony-arm64': 0.27.0
+      '@esbuild/sunos-x64': 0.27.0
+      '@esbuild/win32-arm64': 0.27.0
+      '@esbuild/win32-ia32': 0.27.0
+      '@esbuild/win32-x64': 0.27.0
 
   esbuild@0.28.1:
     optionalDependencies:
@@ -1692,6 +3966,14 @@ snapshots:
       '@esbuild/win32-x64': 0.28.1
 
   escape-string-regexp@4.0.0: {}
+
+  escodegen@2.1.0:
+    dependencies:
+      esprima: 4.0.1
+      estraverse: 5.3.0
+      esutils: 2.0.3
+    optionalDependencies:
+      source-map: 0.6.1
 
   eslint-scope@8.4.0:
     dependencies:
@@ -1749,6 +4031,8 @@ snapshots:
       acorn-jsx: 5.3.2(acorn@8.17.0)
       eslint-visitor-keys: 4.2.1
 
+  esprima@4.0.1: {}
+
   esquery@1.7.0:
     dependencies:
       estraverse: 5.3.0
@@ -1759,19 +4043,74 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@2.0.2: {}
+
   estree-walker@3.0.3:
     dependencies:
       '@types/estree': 1.0.9
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
+  events-intercept@2.0.0: {}
+
+  events-universal@1.0.1:
+    dependencies:
+      bare-events: 2.9.1
+    transitivePeerDependencies:
+      - bare-abort-controller
+
+  execa@3.2.0:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 5.2.0
+      human-signals: 1.1.1
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      p-finally: 2.0.1
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   expect-type@1.4.0: {}
 
   fast-deep-equal@3.1.3: {}
 
+  fast-fifo@1.3.2: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fd-slicer@1.1.0:
+    dependencies:
+      pend: 1.2.0
 
   fdir@6.5.0(picomatch@4.0.5):
     optionalDependencies:
@@ -1780,6 +4119,12 @@ snapshots:
   file-entry-cache@8.0.0:
     dependencies:
       flat-cache: 4.0.1
+
+  file-uri-to-path@1.0.0: {}
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
 
   find-up@5.0.0:
     dependencies:
@@ -1793,16 +4138,92 @@ snapshots:
 
   flatted@3.4.2: {}
 
+  fs-extra@11.1.0:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
+  fs-extra@11.1.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.1
+      universalify: 2.0.1
+
   fsevents@2.3.3:
     optional: true
+
+  generic-pool@3.4.2: {}
+
+  get-port@5.1.1: {}
+
+  get-stream@5.2.0:
+    dependencies:
+      pump: 3.0.4
+
+  get-stream@6.0.1: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  get-uri@6.0.5:
+    dependencies:
+      basic-ftp: 5.3.1
+      data-uri-to-buffer: 6.0.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
 
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
   globals@14.0.0: {}
 
+  graceful-fs@4.2.11: {}
+
   has-flag@4.0.0: {}
+
+  http-errors@1.7.3:
+    dependencies:
+      depd: 1.1.2
+      inherits: 2.0.4
+      setprototypeof: 1.1.1
+      statuses: 1.5.0
+      toidentifier: 1.0.0
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  human-signals@1.1.1: {}
+
+  human-signals@2.1.0: {}
+
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -1815,15 +4236,41 @@ snapshots:
 
   imurmurhash@0.1.4: {}
 
+  inherits@2.0.4: {}
+
+  ip-address@10.3.1: {}
+
+  is-buffer@2.0.5: {}
+
+  is-docker@2.2.1: {}
+
   is-extglob@2.1.1: {}
 
   is-glob@4.0.3:
     dependencies:
       is-extglob: 2.1.1
 
+  is-node-process@1.2.0: {}
+
+  is-number@7.0.0: {}
+
+  is-stream@2.0.1: {}
+
+  is-wsl@2.2.0:
+    dependencies:
+      is-docker: 2.2.1
+
   isexe@2.0.0: {}
 
+  jose@5.9.6: {}
+
+  jose@6.2.3: {}
+
   js-tokens@9.0.1: {}
+
+  js-yaml@4.1.1:
+    dependencies:
+      argparse: 2.0.1
 
   js-yaml@4.3.0:
     dependencies:
@@ -1831,9 +4278,26 @@ snapshots:
 
   json-buffer@3.0.1: {}
 
+  json-schema-to-ts@1.6.4:
+    dependencies:
+      '@types/json-schema': 7.0.15
+      ts-toolbelt: 6.15.5
+
   json-schema-traverse@0.4.1: {}
 
+  json-schema-traverse@1.0.0: {}
+
   json-stable-stringify-without-jsonify@1.0.1: {}
+
+  jsonc-parser@3.3.1: {}
+
+  jsonfile@6.2.1:
+    dependencies:
+      universalify: 2.0.1
+    optionalDependencies:
+      graceful-fs: 4.2.11
+
+  jsonlines@0.1.1: {}
 
   keyv@4.5.4:
     dependencies:
@@ -1852,9 +4316,46 @@ snapshots:
 
   loupe@3.2.1: {}
 
+  lru-cache@11.5.2: {}
+
+  lru-cache@6.0.0:
+    dependencies:
+      yallist: 4.0.0
+
+  lru-cache@7.18.3: {}
+
+  luxon@3.7.2: {}
+
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  merge-stream@2.0.0: {}
+
+  merge2@1.4.1: {}
+
+  micro@9.3.5-canary.3:
+    dependencies:
+      arg: 4.1.0
+      content-type: 1.0.4
+      raw-body: 2.4.1
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime-db@1.52.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mimic-fn@2.1.0: {}
+
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@10.2.5:
     dependencies:
@@ -1864,11 +4365,67 @@ snapshots:
     dependencies:
       brace-expansion: 1.1.16
 
+  minipass@7.1.3: {}
+
+  minizlib@3.1.0:
+    dependencies:
+      minipass: 7.1.3
+
+  mkdirp@1.0.4: {}
+
+  mri@1.2.0: {}
+
+  ms@2.1.1: {}
+
+  ms@2.1.2: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.15: {}
 
   natural-compare@1.4.0: {}
+
+  netmask@2.1.1: {}
+
+  node-fetch@2.6.7:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@2.6.9:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-gyp-build@4.8.4: {}
+
+  nopt@8.1.0:
+    dependencies:
+      abbrev: 3.0.1
+
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
+  once@1.3.3:
+    dependencies:
+      wrappy: 1.0.2
+
+  once@1.4.0:
+    dependencies:
+      wrappy: 1.0.2
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
+
+  open@8.4.0:
+    dependencies:
+      define-lazy-prop: 2.0.0
+      is-docker: 2.2.1
+      is-wsl: 2.2.0
 
   optionator@0.9.4:
     dependencies:
@@ -1879,6 +4436,36 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  os-paths@4.4.0: {}
+
+  oxc-transform@0.111.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3):
+    optionalDependencies:
+      '@oxc-transform/binding-android-arm-eabi': 0.111.0
+      '@oxc-transform/binding-android-arm64': 0.111.0
+      '@oxc-transform/binding-darwin-arm64': 0.111.0
+      '@oxc-transform/binding-darwin-x64': 0.111.0
+      '@oxc-transform/binding-freebsd-x64': 0.111.0
+      '@oxc-transform/binding-linux-arm-gnueabihf': 0.111.0
+      '@oxc-transform/binding-linux-arm-musleabihf': 0.111.0
+      '@oxc-transform/binding-linux-arm64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-arm64-musl': 0.111.0
+      '@oxc-transform/binding-linux-ppc64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-riscv64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-riscv64-musl': 0.111.0
+      '@oxc-transform/binding-linux-s390x-gnu': 0.111.0
+      '@oxc-transform/binding-linux-x64-gnu': 0.111.0
+      '@oxc-transform/binding-linux-x64-musl': 0.111.0
+      '@oxc-transform/binding-openharmony-arm64': 0.111.0
+      '@oxc-transform/binding-wasm32-wasi': 0.111.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@oxc-transform/binding-win32-arm64-msvc': 0.111.0
+      '@oxc-transform/binding-win32-ia32-msvc': 0.111.0
+      '@oxc-transform/binding-win32-x64-msvc': 0.111.0
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
+  p-finally@2.0.1: {}
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -1887,19 +4474,60 @@ snapshots:
     dependencies:
       p-limit: 3.1.0
 
+  pac-proxy-agent@7.2.0:
+    dependencies:
+      '@tootallnate/quickjs-emscripten': 0.23.0
+      agent-base: 7.1.4
+      debug: 4.4.3
+      get-uri: 6.0.5
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      pac-resolver: 7.0.1
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  pac-resolver@7.0.1:
+    dependencies:
+      degenerator: 5.0.1
+      netmask: 2.1.1
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse-ms@2.1.0: {}
+
+  path-browserify@1.0.1: {}
 
   path-exists@4.0.0: {}
 
   path-key@3.1.1: {}
 
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.2
+      minipass: 7.1.3
+
+  path-to-regexp@6.1.0: {}
+
+  path-to-regexp@6.3.0: {}
+
+  path-to-regexp@8.2.0: {}
+
+  path-to-regexp@8.3.0: {}
+
   pathe@2.0.3: {}
 
   pathval@2.0.1: {}
 
+  pend@1.2.0: {}
+
+  picocolors@1.0.0: {}
+
   picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
 
   picomatch@4.0.5: {}
 
@@ -1911,9 +4539,80 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
+  pretty-ms@7.0.1:
+    dependencies:
+      parse-ms: 2.1.0
+
+  promisepipe@3.0.0: {}
+
+  proxy-agent@6.4.0:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      lru-cache: 7.18.3
+      pac-proxy-agent: 7.2.0
+      proxy-from-env: 1.1.0
+      socks-proxy-agent: 8.0.5
+    transitivePeerDependencies:
+      - supports-color
+
+  proxy-from-env@1.1.0: {}
+
+  pump@3.0.4:
+    dependencies:
+      end-of-stream: 1.4.5
+      once: 1.4.0
+
   punycode@2.3.1: {}
 
+  queue-microtask@1.2.3: {}
+
+  raw-body@2.4.1:
+    dependencies:
+      bytes: 3.1.0
+      http-errors: 1.7.3
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
+
+  readdirp@4.1.2: {}
+
+  require-from-string@2.0.2: {}
+
   resolve-from@4.0.0: {}
+
+  resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  resolve.exports@2.0.3: {}
+
+  retry@0.13.1: {}
+
+  reusify@1.1.0: {}
+
+  rolldown@1.0.0-rc.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3):
+    dependencies:
+      '@oxc-project/types': 0.110.0
+      '@rolldown/pluginutils': 1.0.0-rc.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.1
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.1
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.1
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.1
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.1
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.1(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.1
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   rollup@4.62.2:
     dependencies:
@@ -1946,7 +4645,35 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.62.2
       fsevents: 2.3.3
 
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safer-buffer@2.1.2: {}
+
+  sandbox@3.4.0:
+    dependencies:
+      '@vercel/sandbox': 2.4.0
+      async-retry: 1.3.3
+      debug: 4.4.3
+      ws: 8.21.1
+      zod: 4.1.11
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bufferutil
+      - react-native-b4a
+      - supports-color
+      - utf-8-validate
+
+  semver@6.3.1: {}
+
+  semver@7.5.4:
+    dependencies:
+      lru-cache: 6.0.0
+
   semver@7.8.5: {}
+
+  setprototypeof@1.1.1: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -1956,11 +4683,62 @@ snapshots:
 
   siginfo@2.0.0: {}
 
+  signal-exit@3.0.7: {}
+
+  signal-exit@4.0.2: {}
+
+  smart-buffer@4.2.0: {}
+
+  smol-toml@1.5.2: {}
+
+  socks-proxy-agent@8.0.5:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+      socks: 2.8.9
+    transitivePeerDependencies:
+      - supports-color
+
+  socks@2.8.9:
+    dependencies:
+      ip-address: 10.3.1
+      smart-buffer: 4.2.0
+
   source-map-js@1.2.1: {}
+
+  source-map@0.6.1:
+    optional: true
+
+  srvx@0.11.16: {}
 
   stackback@0.0.2: {}
 
+  stat-mode@0.3.0: {}
+
+  statuses@1.5.0: {}
+
   std-env@3.10.0: {}
+
+  stream-to-array@2.3.0:
+    dependencies:
+      any-promise: 1.3.0
+
+  stream-to-promise@2.2.0:
+    dependencies:
+      any-promise: 1.3.0
+      end-of-stream: 1.1.0
+      stream-to-array: 2.3.0
+
+  streamx@2.28.0:
+    dependencies:
+      events-universal: 1.0.1
+      fast-fifo: 1.3.2
+      text-decoder: 1.2.7
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -1971,6 +4749,43 @@ snapshots:
   supports-color@7.2.0:
     dependencies:
       has-flag: 4.0.0
+
+  tar-stream@3.1.7:
+    dependencies:
+      b4a: 1.8.1
+      fast-fifo: 1.3.2
+      streamx: 2.28.0
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - react-native-b4a
+
+  tar@7.5.22:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  tar@7.5.7:
+    dependencies:
+      '@isaacs/fs-minipass': 4.0.1
+      chownr: 3.0.0
+      minipass: 7.1.3
+      minizlib: 3.1.0
+      yallist: 5.0.0
+
+  text-decoder@1.2.7:
+    dependencies:
+      b4a: 1.8.1
+    transitivePeerDependencies:
+      - react-native-b4a
+
+  throttleit@2.1.0: {}
+
+  time-span@4.0.0:
+    dependencies:
+      convert-hrtime: 3.0.0
 
   tinybench@2.9.0: {}
 
@@ -1987,9 +4802,35 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  toidentifier@1.0.0: {}
+
+  tr46@0.0.3: {}
+
+  tree-kill@1.2.2: {}
+
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  ts-morph@12.0.0:
+    dependencies:
+      '@ts-morph/common': 0.11.1
+      code-block-writer: 10.1.1
+
+  ts-toolbelt@6.15.5: {}
+
+  tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.0
+      get-tsconfig: 4.14.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   tsx@4.23.0:
     dependencies:
@@ -2037,11 +4878,80 @@ snapshots:
       '@typescript/typescript-win32-arm64': 7.0.2
       '@typescript/typescript-win32-x64': 7.0.2
 
+  uid-promise@1.0.0: {}
+
+  undici-types@5.26.5: {}
+
   undici-types@7.18.2: {}
+
+  undici@5.28.4:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@5.29.0:
+    dependencies:
+      '@fastify/busboy': 2.1.1
+
+  undici@6.28.0: {}
+
+  undici@7.29.0: {}
+
+  universalify@2.0.1: {}
+
+  unpipe@1.0.0: {}
 
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  vercel@56.2.0(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2):
+    dependencies:
+      '@vercel/backends': 0.8.23(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
+      '@vercel/blob': 2.4.0
+      '@vercel/build-utils': 13.33.0
+      '@vercel/cli-auth': 0.3.0
+      '@vercel/cli-config': 0.2.0
+      '@vercel/container': 0.0.5
+      '@vercel/detect-agent': 1.2.3
+      '@vercel/elysia': 0.1.100(rollup@4.62.2)
+      '@vercel/express': 0.1.114(@emnapi/core@2.0.0-alpha.3)(@emnapi/runtime@2.0.0-alpha.3)(rollup@4.62.2)
+      '@vercel/fastify': 0.1.103(rollup@4.62.2)
+      '@vercel/fun': 1.3.0
+      '@vercel/go': 3.10.2
+      '@vercel/h3': 0.1.109(rollup@4.62.2)
+      '@vercel/hono': 0.2.103(rollup@4.62.2)
+      '@vercel/hydrogen': 1.4.0
+      '@vercel/koa': 0.1.83(rollup@4.62.2)
+      '@vercel/nestjs': 0.2.104(rollup@4.62.2)
+      '@vercel/next': 4.20.4(rollup@4.62.2)
+      '@vercel/node': 5.8.24(rollup@4.62.2)
+      '@vercel/prepare-flags-definitions': 0.3.0
+      '@vercel/python': 6.50.0
+      '@vercel/redwood': 2.5.0(rollup@4.62.2)
+      '@vercel/remix-builder': 5.9.1(rollup@4.62.2)
+      '@vercel/ruby': 2.5.1
+      '@vercel/rust': 1.4.0
+      '@vercel/static-build': 2.11.6
+      chokidar: 4.0.0
+      esbuild: 0.27.0
+      jose: 5.9.6
+      jsonc-parser: 3.3.1
+      luxon: 3.7.2
+      proxy-agent: 6.4.0
+      sandbox: 3.4.0
+      smol-toml: 1.5.2
+      undici: 5.29.0
+      zod: 4.1.11
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - bare-abort-controller
+      - bufferutil
+      - encoding
+      - react-native-b4a
+      - rollup
+      - supports-color
+      - utf-8-validate
 
   vite-node@3.2.4(@types/node@24.13.3)(tsx@4.23.0):
     dependencies:
@@ -2077,7 +4987,7 @@ snapshots:
       fsevents: 2.3.3
       tsx: 4.23.0
 
-  vitest@3.2.7(@types/node@24.13.3)(tsx@4.23.0):
+  vitest@3.2.7(@edge-runtime/vm@3.2.0)(@types/node@24.13.3)(tsx@4.23.0):
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.7
@@ -2103,6 +5013,7 @@ snapshots:
       vite-node: 3.2.4(@types/node@24.13.3)(tsx@4.23.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
+      '@edge-runtime/vm': 3.2.0
       '@types/node': 24.13.3
     transitivePeerDependencies:
       - jiti
@@ -2118,6 +5029,15 @@ snapshots:
       - tsx
       - yaml
 
+  web-vitals@0.2.4: {}
+
+  webidl-conversions@3.0.1: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
+
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
@@ -2129,4 +5049,43 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrappy@1.0.2: {}
+
+  ws@8.21.1: {}
+
+  xdg-app-paths@5.1.0:
+    dependencies:
+      xdg-portable: 7.3.0
+
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
+  yallist@4.0.0: {}
+
+  yallist@5.0.0: {}
+
+  yauzl-clone@1.0.4:
+    dependencies:
+      events-intercept: 2.0.0
+
+  yauzl-promise@2.1.3:
+    dependencies:
+      yauzl: 2.10.0
+      yauzl-clone: 1.0.4
+
+  yauzl@2.10.0:
+    dependencies:
+      buffer-crc32: 0.2.13
+      fd-slicer: 1.1.0
+
   yocto-queue@0.1.0: {}
+
+  zod@3.22.4: {}
+
+  zod@4.1.11: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,7 @@
 packages:
   - "packages/*"
+minimumReleaseAgeExclude:
+  - "vercel@58.1.0"
 allowBuilds:
   esbuild: true
 overrides:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,3 +2,5 @@ packages:
   - "packages/*"
 allowBuilds:
   esbuild: true
+overrides:
+  "@napi-rs/wasm-runtime": "1.1.6"

--- a/scripts/oci-manifest.mjs
+++ b/scripts/oci-manifest.mjs
@@ -1,0 +1,31 @@
+const IMAGE_MANIFEST_MEDIA_TYPES = new Set([
+  "application/vnd.oci.image.manifest.v1+json",
+  "application/vnd.docker.distribution.manifest.v2+json",
+]);
+
+/**
+ * Resolve the descriptor digest VCR reports for a linux/amd64 image.
+ *
+ * `docker buildx imagetools inspect --format "{{json .}}"` includes the
+ * canonical descriptor digest even when the tag points directly at a
+ * single-platform manifest. Raw manifest JSON does not: its `config.digest`
+ * names the image configuration blob, which is a different registry object.
+ */
+export function linuxAmd64ManifestDigest(inspection) {
+  const manifest = inspection?.manifest;
+  const platformManifest = manifest?.manifests?.find(
+    (candidate) =>
+      candidate.platform?.os === "linux" &&
+      candidate.platform?.architecture === "amd64",
+  );
+  if (typeof platformManifest?.digest === "string") return platformManifest.digest;
+
+  if (
+    IMAGE_MANIFEST_MEDIA_TYPES.has(manifest?.mediaType) &&
+    typeof manifest?.digest === "string"
+  ) {
+    return manifest.digest;
+  }
+
+  throw new Error("could not find a linux/amd64 image manifest descriptor");
+}

--- a/scripts/sandbox-config.mjs
+++ b/scripts/sandbox-config.mjs
@@ -17,6 +17,18 @@ function loadLocalEnv() {
   }
 }
 
+export function sandboxRunnerConfig(env) {
+  loadLocalEnv();
+  const source = env ?? process.env;
+  return {
+    vcpus: source.SCRIPTC_SANDBOX_VCPUS ?? "8",
+    testWorkers: source.SCRIPTC_TEST_WORKERS ?? "4",
+    localTestWorkers: source.SCRIPTC_LOCAL_TEST_WORKERS ?? "2",
+    localCaseShards: source.SCRIPTC_LOCAL_CASE_SHARDS ?? "2",
+    sandboxTimeout: source.SCRIPTC_SANDBOX_TIMEOUT ?? "45m",
+  };
+}
+
 export function sandboxImageConfig() {
   loadLocalEnv();
   // Keep tenancy explicit: a public clone must use a Vercel project its

--- a/scripts/sandbox-config.mjs
+++ b/scripts/sandbox-config.mjs
@@ -1,0 +1,43 @@
+import { loadEnvFile } from "node:process";
+import { fileURLToPath } from "node:url";
+
+const example = "vcr.vercel.com/<team>/<project>/<repository>:<tag>";
+const localEnv = fileURLToPath(new URL("../.env.local", import.meta.url));
+let loadedLocalEnv = false;
+
+function loadLocalEnv() {
+  if (loadedLocalEnv) return;
+  loadedLocalEnv = true;
+  try {
+    // Node preserves variables already present in the process environment,
+    // allowing an agent or shell to override values from this local file.
+    loadEnvFile(localEnv);
+  } catch (error) {
+    if (error?.code !== "ENOENT") throw error;
+  }
+}
+
+export function sandboxImageConfig() {
+  loadLocalEnv();
+  // Keep tenancy explicit: a public clone must use a Vercel project its
+  // operator owns rather than inheriting a maintainer's scope or project.
+  const reference = process.env.SCRIPTC_SANDBOX_IMAGE;
+  if (!reference) {
+    throw new Error(`SCRIPTC_SANDBOX_IMAGE is required (for example: ${example})`);
+  }
+
+  const match = /^vcr\.vercel\.com\/([^/]+)\/([^/]+)\/([^/:]+):([^/:]+)$/.exec(reference);
+  if (!match) {
+    throw new Error(`SCRIPTC_SANDBOX_IMAGE must be a fully qualified VCR image (${example})`);
+  }
+
+  const [, team, project, repository, tag] = match;
+  return {
+    reference,
+    team,
+    project,
+    repository,
+    tag,
+    sandboxImage: `${repository}:${tag}`,
+  };
+}

--- a/scripts/sandbox-image.mjs
+++ b/scripts/sandbox-image.mjs
@@ -3,6 +3,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { spawn } from "node:child_process";
 import { sandboxImageConfig } from "./sandbox-config.mjs";
+import { linuxAmd64ManifestDigest } from "./oci-manifest.mjs";
 
 const root = fileURLToPath(new URL("../", import.meta.url));
 const { project, reference: image, repository, tag, team } = sandboxImageConfig();
@@ -49,13 +50,21 @@ await run("docker", [
   ".",
 ]);
 
-const rawManifest = JSON.parse(await run("docker", ["buildx", "imagetools", "inspect", image, "--raw"], { capture: true }));
-const amd64Digest =
-  rawManifest.manifests?.find(
-    (manifest) => manifest.platform?.os === "linux" && manifest.platform?.architecture === "amd64",
-  )?.digest ?? rawManifest.config?.digest;
-
-if (!amd64Digest) throw new Error(`could not find the linux/amd64 manifest for ${image}`);
+const inspection = JSON.parse(
+  await run(
+    "docker",
+    ["buildx", "imagetools", "inspect", image, "--format", "{{json .}}"],
+    { capture: true },
+  ),
+);
+let amd64Digest;
+try {
+  amd64Digest = linuxAmd64ManifestDigest(inspection);
+} catch (error) {
+  throw new Error(`could not find the linux/amd64 manifest for ${image}`, {
+    cause: error,
+  });
+}
 
 console.log("Waiting for VCR to prepare the image for Sandbox...");
 const deadline = Date.now() + 5 * 60_000;

--- a/scripts/sandbox-image.mjs
+++ b/scripts/sandbox-image.mjs
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+import { sandboxImageConfig } from "./sandbox-config.mjs";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const { project, reference: image, repository, tag, team } = sandboxImageConfig();
+const nodeVersion = (await readFile(new URL("../.node-version", import.meta.url), "utf8")).trim();
+
+function run(command, args, { capture = false } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: root,
+      env: { ...process.env, NO_UPDATE_NOTIFIER: "1" },
+      stdio: capture ? ["ignore", "pipe", "pipe"] : "inherit",
+    });
+    let stdout = "";
+    let stderr = "";
+    if (capture) {
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => (stdout += chunk));
+      child.stderr.on("data", (chunk) => (stderr += chunk));
+    }
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      if (code === 0) resolve(stdout);
+      else reject(new Error(`${command} exited ${signal ?? code}${stderr ? `\n${stderr.trim()}` : ""}`));
+    });
+  });
+}
+
+console.log(`Authenticating Docker for ${team}/${project}...`);
+await run("vercel", ["vcr", "login", "docker", "--scope", team, "--project", project]);
+
+console.log(`Building and pushing ${image} for linux/amd64...`);
+await run("docker", [
+  "buildx",
+  "build",
+  "--platform",
+  "linux/amd64",
+  "--build-arg",
+  `NODE_VERSION=${nodeVersion}`,
+  "--file",
+  "Dockerfile.sandbox",
+  "--output",
+  `type=image,name=${image},push=true,oci-mediatypes=true,compression=zstd,compression-level=3,force-compression=true`,
+  ".",
+]);
+
+const rawManifest = JSON.parse(await run("docker", ["buildx", "imagetools", "inspect", image, "--raw"], { capture: true }));
+const amd64Digest =
+  rawManifest.manifests?.find(
+    (manifest) => manifest.platform?.os === "linux" && manifest.platform?.architecture === "amd64",
+  )?.digest ?? rawManifest.config?.digest;
+
+if (!amd64Digest) throw new Error(`could not find the linux/amd64 manifest for ${image}`);
+
+console.log("Waiting for VCR to prepare the image for Sandbox...");
+const deadline = Date.now() + 5 * 60_000;
+while (Date.now() < deadline) {
+  const listing = JSON.parse(
+    await run(
+      "vercel",
+      ["vcr", "image", "ls", repository, "--format", "json", "--scope", team, "--project", project],
+      { capture: true },
+    ),
+  );
+  const manifest = listing.images?.find((candidate) => candidate.manifestDigest === amd64Digest);
+  if (manifest?.status === "ready") {
+    console.log(`${repository}:${tag} is ready for Vercel Sandbox.`);
+    process.exit(0);
+  }
+  if (manifest?.status === "unoptimized") {
+    throw new Error(`${repository}:${tag} is unoptimized; Vercel Sandbox requires linux/amd64`);
+  }
+  await new Promise((resolve) => setTimeout(resolve, 2000));
+}
+
+throw new Error(`VCR did not prepare ${repository}:${tag} within 5 minutes`);

--- a/scripts/sandbox-platform.mjs
+++ b/scripts/sandbox-platform.mjs
@@ -15,3 +15,15 @@ export function sandboxHostSchedule(platform, invariantFiles) {
     remoteInvariantFiles: runsNative ? [] : invariantFiles,
   };
 }
+
+/**
+ * Pin lane identity even when the parent shell, .env.local, or Sandbox image
+ * already defines SCRIPTC_SAN. Tests enable sanitizers only for the exact
+ * string "1", so an empty value explicitly restores the plain lane.
+ */
+export function sandboxLaneEnv(lane) {
+  return {
+    CI: "1",
+    SCRIPTC_SAN: lane === "san" ? "1" : "",
+  };
+}

--- a/scripts/sandbox-platform.mjs
+++ b/scripts/sandbox-platform.mjs
@@ -1,0 +1,15 @@
+/**
+ * Choose where tests that exercise the native host toolchain run.
+ *
+ * Darwin and Linux have supported native clang paths, so those files should
+ * test the contributor's actual host. Other hosts keep the coverage in the
+ * Linux Sandboxes. Darwin alone adds the compact kqueue/Mach-O contracts.
+ */
+export function sandboxHostSchedule(platform, invariantFiles) {
+  const runsNative = platform === "darwin" || platform === "linux";
+  return {
+    darwinContracts: platform === "darwin",
+    localInvariantFiles: runsNative ? invariantFiles : [],
+    remoteInvariantFiles: runsNative ? [] : invariantFiles,
+  };
+}

--- a/scripts/sandbox-platform.mjs
+++ b/scripts/sandbox-platform.mjs
@@ -9,7 +9,9 @@ export function sandboxHostSchedule(platform, invariantFiles) {
   const runsNative = platform === "darwin" || platform === "linux";
   return {
     darwinContracts: platform === "darwin",
+    localArtifactContracts: runsNative,
     localInvariantFiles: runsNative ? invariantFiles : [],
+    remoteArtifactContracts: !runsNative,
     remoteInvariantFiles: runsNative ? [] : invariantFiles,
   };
 }

--- a/scripts/sandbox-platform.mjs
+++ b/scripts/sandbox-platform.mjs
@@ -17,13 +17,16 @@ export function sandboxHostSchedule(platform, invariantFiles) {
 }
 
 /**
- * Pin lane identity even when the parent shell, .env.local, or Sandbox image
- * already defines SCRIPTC_SAN. Tests enable sanitizers only for the exact
- * string "1", so an empty value explicitly restores the plain lane.
+ * Pin lane and scheduler identity even when the parent shell, .env.local, or
+ * Sandbox image already defines these variables. Empty values restore the
+ * unsharded, platform-native defaults; intentional remote and local shards
+ * override them at their call sites.
  */
 export function sandboxLaneEnv(lane) {
   return {
     CI: "1",
+    SCRIPTC_PORTABLE_ONLY: "",
     SCRIPTC_SAN: lane === "san" ? "1" : "",
+    SCRIPTC_TEST_SHARD: "",
   };
 }

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -12,13 +12,101 @@ const root = fileURLToPath(new URL("../", import.meta.url));
 const vcpus = process.env.SCRIPTC_SANDBOX_VCPUS ?? "8";
 const testWorkers = process.env.SCRIPTC_TEST_WORKERS ?? "4";
 const localTestWorkers = process.env.SCRIPTC_LOCAL_TEST_WORKERS ?? "2";
+const localCaseShards = process.env.SCRIPTC_LOCAL_CASE_SHARDS ?? "2";
 const sandboxTimeout = process.env.SCRIPTC_SANDBOX_TIMEOUT ?? "45m";
-const corpusFiles = [
+const laneCaseShardedFiles = [
   "tests/harness/differential.test.ts",
   "tests/harness/llvm-differential.test.ts",
   "tests/harness/npm.test.ts",
   "tests/harness/server.test.ts",
 ];
+// Coverage analysis is frontend-only: SCRIPTC_SAN cannot change its result.
+// It still case-shards across the selected lane so every corpus entry is
+// checked, but running the same sweep in the second lane adds no coverage.
+const invariantCaseShardedFiles = ["tests/harness/coverage.test.ts"];
+const caseShardedFiles = [...laneCaseShardedFiles, ...invariantCaseShardedFiles];
+
+// These files neither consume SCRIPTC_SAN nor delegate to a helper that does.
+// Run their full coverage once. Files absent from this allowlist remain in
+// both lanes by default, so a new test never silently loses sanitizer coverage.
+const invariantRemoteFiles = [
+  "packages/cli/test/flush.test.ts",
+  "packages/cli/test/paths.test.ts",
+  "packages/compiler/src/library/int-infer.test.ts",
+  "packages/compiler/test/cjs-lexer.test.ts",
+  "packages/compiler/test/emit-c.test.ts",
+  "packages/compiler/test/ir.test.ts",
+  "packages/compiler/test/llvm-runtime-abi.test.ts",
+  "packages/compiler/test/ts7/bench.test.ts",
+  "packages/compiler/test/ts7/coverage.test.ts",
+  "packages/compiler/test/ts7/facade.test.ts",
+  "packages/compiler/test/ts7/order-parity.test.ts",
+  "packages/compiler/test/ts7/parity.test.ts",
+  "packages/compiler/test/ts7/program.test.ts",
+  "packages/compiler/test/ts7/resolver-parity.test.ts",
+  // These C runtime units compile with ASan + SCR_RC_AUDIT themselves.
+  "packages/runtime/test/array.test.ts",
+  "packages/runtime/test/bytes.test.ts",
+  "packages/runtime/test/closure.test.ts",
+  "packages/runtime/test/inspect.test.ts",
+  "packages/runtime/test/json.test.ts",
+  "packages/runtime/test/map.test.ts",
+  "packages/runtime/test/path.test.ts",
+  "packages/runtime/test/regex.test.ts",
+  "tests/harness/island-surface.test.ts",
+  "tests/harness/library-mode.test.ts",
+  "tests/harness/library-profile.test.ts",
+  "tests/harness/linux-differential.test.ts",
+  "tests/harness/shard.test.ts",
+  "tests/harness/smoke.test.ts",
+  "tests/harness/surface-manifest.test.ts",
+  "tests/harness/windows-differential.test.ts",
+];
+
+// Full native-oracle coverage stays on the host where the expected answer
+// really is Darwin-, libc-, architecture-, or linker-specific. Each test is
+// already explicitly sanitized where useful, so a second flavor is identical.
+const hostInvariantFiles = [
+  "packages/compiler/test/cc-driver.test.ts",
+  "packages/runtime/test/lib.test.ts",
+  "packages/runtime/test/number.test.ts",
+  "packages/runtime/test/runtime.test.ts",
+  "packages/runtime/test/string.test.ts",
+  "packages/runtime/test/tonumber.test.ts",
+  "packages/runtime/test/url.test.ts",
+];
+
+// The full portable behavior of these suites runs remotely. A compact
+// host-native contract additionally pins the places Darwin can disagree:
+// object/archive ABI, Mach-O size classes, linker diagnostics, and ucontext
+// behavior under both ordinary and Apple-ASan builds.
+const hostLaneContractFiles = [
+  "tests/harness/ffi.test.ts",
+  "tests/harness/island.test.ts",
+];
+const hostLaneContractPattern = [
+  "calls the manifest-bound archive across every v1 ABI class",
+  "a missing FFI symbol is an SC5004 diagnostic",
+  "deep island recursion on a fiber is a catchable RangeError",
+].join("|");
+const hostInvariantContractFiles = [
+  "tests/harness/island.test.ts",
+  "tests/harness/library-mode.test.ts",
+  "tests/harness/regex.test.ts",
+];
+const hostInvariantContractPattern = [
+  "static hello-world stays in its size class",
+  "K1/K2/K8: scalar round-trips, symbol exactness, ambient audit",
+  "K3: buffer round-trips \\+ lifetime, auto-reset posture",
+  "K5: a trap delivers to the sink exactly once, host survives",
+  "K10: K4 under ASan \\+ RC audit",
+  "K10: K5/K7 under ASan",
+  "regex-free programs never reference the regex runtime",
+].join("|");
+
+// Logically portable acceptance suites whose oracle lives in an external
+// worktree that is intentionally not uploaded. Split their cases locally.
+const localCaseShardedFiles = ["tests/harness/vercel-e2e.test.ts"];
 
 const { values } = parseArgs({
   options: {
@@ -26,7 +114,7 @@ const { values } = parseArgs({
     keep: { type: "boolean" },
     lane: { type: "string", default: "both" },
     "remote-only": { type: "boolean" },
-    shards: { type: "string", default: "3" },
+    shards: { type: "string", default: "8" },
   },
 });
 
@@ -34,14 +122,15 @@ if (values.help) {
   console.log(`Run the scriptc test suite across Vercel Sandboxes.
 
 Usage:
-  pnpm test:sandbox [--lane plain|san|both] [--shards 3] [--remote-only] [--keep]
+  pnpm test:sandbox [--lane plain|san|both] [--shards 8] [--remote-only] [--keep]
 
 Environment:
   SCRIPTC_SANDBOX_IMAGE     Fully qualified VCR image (required; may be in .env.local)
   SCRIPTC_SANDBOX_VCPUS     vCPUs per sandbox (default: 8)
   SCRIPTC_SANDBOX_TIMEOUT   sandbox and command timeout (default: 45m)
   SCRIPTC_TEST_WORKERS      Vitest workers per sandbox (default: 4)
-  SCRIPTC_LOCAL_TEST_WORKERS Vitest workers per local lane (default: 2)`);
+  SCRIPTC_LOCAL_TEST_WORKERS Vitest workers per local lane (default: 2)
+  SCRIPTC_LOCAL_CASE_SHARDS local shards per external suite lane (default: 2)`);
   process.exit(0);
 }
 
@@ -56,6 +145,26 @@ if (!Number.isInteger(shardCount) || shardCount < 1 || shardCount > 10) {
 }
 
 const lanes = values.lane === "both" ? ["plain", "san"] : [values.lane];
+const remoteWorkerCount = Number(testWorkers);
+if (!Number.isInteger(remoteWorkerCount) || remoteWorkerCount < 1) {
+  throw new Error(`SCRIPTC_TEST_WORKERS must be a positive integer (got ${testWorkers})`);
+}
+const caseWorkers = String(Math.max(1, remoteWorkerCount - 1));
+const fileWorkers = "1";
+const localCaseShardCount = Number(localCaseShards);
+if (!Number.isInteger(localCaseShardCount) || localCaseShardCount < 1) {
+  throw new Error(`SCRIPTC_LOCAL_CASE_SHARDS must be a positive integer (got ${localCaseShards})`);
+}
+const onceLane = lanes.includes("plain") ? "plain" : lanes[0];
+const specialFiles = [
+  ...caseShardedFiles,
+  ...invariantRemoteFiles,
+  ...hostInvariantFiles,
+  ...localCaseShardedFiles,
+];
+if (new Set(specialFiles).size !== specialFiles.length) {
+  throw new Error("a test file cannot belong to more than one execution path");
+}
 const nonce = `${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
 const workers = lanes.flatMap((lane) =>
   Array.from({ length: shardCount }, (_, offset) => {
@@ -90,7 +199,11 @@ function lineWriter(destination, prefix, handleLine) {
   };
 }
 
-function run(command, args, { env = {}, exitMarker, label, quiet = false } = {}) {
+function run(
+  command,
+  args,
+  { env = {}, exitMarker, idleTimeoutMs, label, quiet = false, timeoutMs } = {},
+) {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, {
       cwd: root,
@@ -100,6 +213,30 @@ function run(command, args, { env = {}, exitMarker, label, quiet = false } = {})
     children.add(child);
     const prefix = label ? `[${label}] ` : "";
     let remoteExitCode;
+    let timedOut = false;
+    let timeoutReason = "";
+    const stopForTimeout = (reason) => {
+      if (timedOut) return;
+      timedOut = true;
+      timeoutReason = reason;
+      child.kill("SIGTERM");
+    };
+    const timeout =
+      timeoutMs === undefined
+        ? undefined
+        : setTimeout(() => {
+            stopForTimeout(`after ${Math.round(timeoutMs / 1000)}s`);
+          }, timeoutMs);
+    let idleTimeout;
+    const resetIdleTimeout = () => {
+      if (idleTimeoutMs === undefined) return;
+      if (idleTimeout !== undefined) clearTimeout(idleTimeout);
+      idleTimeout = setTimeout(
+        () => stopForTimeout(`after ${Math.round(idleTimeoutMs / 1000)}s without output`),
+        idleTimeoutMs,
+      );
+    };
+    resetIdleTimeout();
     const stdout = lineWriter(process.stdout, prefix, (line) => {
       if (!exitMarker) return false;
       const match = new RegExp(`^${exitMarker}(\\d+)$`).exec(line);
@@ -111,15 +248,29 @@ function run(command, args, { env = {}, exitMarker, label, quiet = false } = {})
     if (!quiet) {
       child.stdout.setEncoding("utf8");
       child.stderr.setEncoding("utf8");
-      child.stdout.on("data", (chunk) => stdout.write(chunk));
-      child.stderr.on("data", (chunk) => stderr.write(chunk));
+      child.stdout.on("data", (chunk) => {
+        resetIdleTimeout();
+        stdout.write(chunk);
+      });
+      child.stderr.on("data", (chunk) => {
+        resetIdleTimeout();
+        stderr.write(chunk);
+      });
     }
     child.on("error", reject);
-    child.on("exit", (code, signal) => {
+    child.on("close", (code, signal) => {
+      if (timeout !== undefined) clearTimeout(timeout);
+      if (idleTimeout !== undefined) clearTimeout(idleTimeout);
       children.delete(child);
       stdout.end();
       stderr.end();
-      if (code !== 0) {
+      if (timedOut) {
+        reject(
+          Object.assign(new Error(`${label ?? command} timed out ${timeoutReason}`), {
+            code: "SCRIPTC_RUN_TIMEOUT",
+          }),
+        );
+      } else if (code !== 0) {
         reject(new Error(`${label ?? command} exited ${signal ?? code}`));
       } else if (exitMarker && remoteExitCode === undefined) {
         reject(new Error(`${label ?? command} did not report its remote exit status`));
@@ -138,26 +289,63 @@ const vercel = ([group, command, ...args], options) =>
 // `vercel sandbox exec` does not propagate the remote process's exit code.
 // Print a per-command nonce after it finishes and enforce that status here.
 const shellQuote = (value) => `'${value.replaceAll("'", `'\"'\"'`)}'`;
-const execIn = (worker, command, args, env = {}) => {
+const execIn = async (worker, command, args, env = {}, task = "", wallTimeoutMs = 15 * 60_000) => {
   const envArgs = Object.entries(env).flatMap(([key, value]) => ["--env", `${key}=${value}`]);
   const exitMarker = `__SCRIPTC_REMOTE_EXIT_${randomBytes(12).toString("hex")}__`;
-  const script = `${[command, ...args].map(shellQuote).join(" ")}; scriptc_status=$?; printf '\\n${exitMarker}%s\\n' "$scriptc_status"`;
-  return vercel(
-    [
-      "sandbox",
-      "exec",
-      "--timeout",
-      sandboxTimeout,
-      "--workdir",
-      "/workspace",
-      ...envArgs,
-      worker.name,
-      "sh",
-      "-c",
-      script,
-    ],
-    { exitMarker, label: worker.label },
-  );
+  const statusPath = `/tmp/${exitMarker}.status`;
+  const script =
+    `${[command, ...args].map(shellQuote).join(" ")}; scriptc_status=$?; ` +
+    `printf '%s\\n' "$scriptc_status" > ${shellQuote(statusPath)}; ` +
+    `printf '\\n${exitMarker}%s\\n' "$scriptc_status"`;
+  const label = task ? `${worker.label} ${task}` : worker.label;
+  const commandArgs = [
+    "sandbox",
+    "exec",
+    "--timeout",
+    sandboxTimeout,
+    "--workdir",
+    "/workspace",
+    ...envArgs,
+    worker.name,
+    "sh",
+    "-c",
+    script,
+  ];
+  try {
+    await vercel(commandArgs, {
+      exitMarker,
+      idleTimeoutMs: 90_000,
+      label,
+      timeoutMs: wallTimeoutMs,
+    });
+  } catch (error) {
+    console.warn(`[${label}] CLI completion was not confirmed; checking the remote command status...`);
+    const probeMarker = `__SCRIPTC_REMOTE_PROBE_${randomBytes(12).toString("hex")}__`;
+    const probeScript =
+      `scriptc_status=125; test ! -f ${shellQuote(statusPath)} || ` +
+      `scriptc_status=$(cat ${shellQuote(statusPath)}); ` +
+      `printf '\\n${probeMarker}%s\\n' "$scriptc_status"`;
+    await vercel(
+      [
+        "sandbox",
+        "exec",
+        "--timeout",
+        "1m",
+        "--workdir",
+        "/workspace",
+        worker.name,
+        "sh",
+        "-c",
+        probeScript,
+      ],
+      {
+        exitMarker: probeMarker,
+        idleTimeoutMs: 30_000,
+        label: `${label} status`,
+        timeoutMs: 60_000,
+      },
+    );
+  }
 };
 
 async function createArchive(path) {
@@ -194,10 +382,79 @@ async function createArchive(path) {
   await Promise.all([wait(git, "git ls-files"), wait(tar, "tar")]);
 }
 
-async function allWorkers(phase, task) {
+async function createWorker(worker) {
+  const args = [
+    "sandbox",
+    "create",
+    "--name",
+    worker.name,
+    "--image",
+    image,
+    "--timeout",
+    sandboxTimeout,
+    "--vcpus",
+    vcpus,
+    "--non-persistent",
+  ];
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      await vercel(args, {
+        idleTimeoutMs: 60_000,
+        label: worker.label,
+        timeoutMs: 2 * 60_000,
+      });
+      return;
+    } catch {
+      console.warn(`[${worker.label}] create completion was not confirmed; checking the Sandbox...`);
+      try {
+        await execIn(worker, "true", [], {}, "create status", 60_000);
+        return;
+      } catch (error) {
+        if (attempt === 2) throw error;
+        console.warn(`[${worker.label}] Sandbox is not reachable; retrying creation once...`);
+      }
+    }
+  }
+}
+
+async function uploadArchive(worker, archive) {
+  for (let attempt = 1; attempt <= 2; attempt++) {
+    try {
+      await vercel(["sandbox", "copy", archive, `${worker.name}:/tmp/worktree.tar.gz`], {
+        idleTimeoutMs: 60_000,
+        label: worker.label,
+        timeoutMs: 2 * 60_000,
+      });
+      return;
+    } catch {
+      console.warn(`[${worker.label}] copy completion was not confirmed; checking the remote archive...`);
+      try {
+        // Listing every member also verifies the gzip stream reached its
+        // footer; a merely non-empty, partially uploaded file is rejected.
+        await execIn(
+          worker,
+          "sh",
+          ["-c", "tar -tzf /tmp/worktree.tar.gz >/dev/null"],
+          {},
+          "copy status",
+          60_000,
+        );
+        return;
+      } catch (error) {
+        if (attempt === 2) throw error;
+        console.warn(`[${worker.label}] remote archive is absent or incomplete; retrying the copy once...`);
+      }
+    }
+  }
+}
+
+async function allWorkers(phase, task, concurrency = workers.length) {
   const started = Date.now();
   console.log(`\n${phase} (${workers.length} sandboxes)...`);
-  const results = await Promise.allSettled(workers.map(task));
+  const results = [];
+  for (let offset = 0; offset < workers.length; offset += concurrency) {
+    results.push(...(await Promise.allSettled(workers.slice(offset, offset + concurrency).map(task))));
+  }
   const failures = results.filter((result) => result.status === "rejected");
   if (failures.length) {
     for (const failure of failures) console.error(failure.reason);
@@ -262,39 +519,34 @@ try {
   const remote = (async () => {
     await allWorkers("Creating", async (worker) => {
       created.add(worker.name);
-      await vercel(
-        [
-          "sandbox",
-          "create",
-          "--name",
-          worker.name,
-          "--image",
-          image,
-          "--timeout",
-          sandboxTimeout,
-          "--vcpus",
-          vcpus,
-          "--non-persistent",
-        ],
-        { label: worker.label },
-      );
+      await createWorker(worker);
     });
 
-    await allWorkers("Uploading worktree", (worker) =>
-      vercel(["sandbox", "copy", archive, `${worker.name}:/tmp/worktree.tar.gz`], { label: worker.label }),
+    await allWorkers(
+      "Uploading worktree",
+      (worker) => uploadArchive(worker, archive),
+      8,
     );
 
     await allWorkers("Preparing worktree", async (worker) => {
-      await execIn(worker, "tar", ["-xzf", "/tmp/worktree.tar.gz", "-C", "/workspace"]);
-      await execIn(worker, "pnpm", ["install", "--frozen-lockfile"]);
-      await execIn(worker, "pnpm", ["build"]);
+      await execIn(
+        worker,
+        "tar",
+        ["-xzf", "/tmp/worktree.tar.gz", "-C", "/workspace"],
+        {},
+        "",
+        2 * 60_000,
+      );
+      await execIn(worker, "pnpm", ["install", "--frozen-lockfile"], {}, "", 2 * 60_000);
+      await execIn(worker, "pnpm", ["build"], {}, "", 2 * 60_000);
     });
 
-    await allWorkers("Testing corpus", async (worker) => {
-      const testEnv = {
+    await allWorkers("Testing", async (worker) => {
+      const sharedTestEnv = {
         CI: "1",
-        SCRIPTC_TEST_SHARD: `${worker.shard}/${shardCount}`,
-        SCRIPTC_TEST_WORKERS: testWorkers,
+        // Platform artifact contracts run against the native host below.
+        // Remote lanes retain every portable behavior assertion.
+        SCRIPTC_PORTABLE_ONLY: "1",
         ...(worker.lane === "san"
           ? {
               SCRIPTC_SAN: "1",
@@ -305,33 +557,133 @@ try {
             }
           : {}),
       };
-      await execIn(worker, "pnpm", ["test", ...corpusFiles], testEnv);
+      const workerCaseFiles = [
+        ...laneCaseShardedFiles,
+        ...(worker.lane === onceLane ? invariantCaseShardedFiles : []),
+      ];
+      const cases = () =>
+        execIn(
+          worker,
+          "pnpm",
+          ["test", "--reporter=dot", ...workerCaseFiles],
+          {
+            ...sharedTestEnv,
+            SCRIPTC_TEST_SHARD: `${worker.shard}/${shardCount}`,
+            SCRIPTC_TEST_WORKERS: caseWorkers,
+          },
+          "cases",
+        );
+      const files = () =>
+        execIn(
+          worker,
+          "pnpm",
+          [
+            "test",
+            "--reporter=dot",
+            `--shard=${worker.shard}/${shardCount}`,
+            ...caseShardedFiles.map((file) => `--exclude=${file}`),
+            ...hostInvariantFiles.map((file) => `--exclude=${file}`),
+            ...localCaseShardedFiles.map((file) => `--exclude=${file}`),
+            ...(worker.lane === onceLane
+              ? []
+              : invariantRemoteFiles.map((file) => `--exclude=${file}`)),
+          ],
+          {
+            ...sharedTestEnv,
+            SCRIPTC_TEST_WORKERS: fileWorkers,
+          },
+          "files",
+        );
+      if (remoteWorkerCount === 1) {
+        await cases();
+        await files();
+      } else {
+        await Promise.all([cases(), files()]);
+      }
     });
   })();
 
   const local = values["remote-only"]
     ? Promise.resolve()
     : (async () => {
-        console.log("\nBuilding and testing platform-sensitive files locally...");
+        console.log(
+          `\nBuilding and testing ${hostInvariantFiles.length} Darwin-native files, compact platform contracts, and ${localCaseShardedFiles.length} case-sharded external suite locally...`,
+        );
         await run("pnpm", ["build"], { label: "local build" });
-        const results = await Promise.allSettled(
-          lanes.map((lane) =>
-            run(
+        const laneEnv = (lane) => ({
+          CI: "1",
+          ...(lane === "san" ? { SCRIPTC_SAN: "1" } : {}),
+        });
+        const invariantHostTask =
+          run(
+            "pnpm",
+            [
+              "test",
+              ...hostInvariantFiles,
+            ],
+            {
+              env: {
+                ...laneEnv(onceLane),
+                SCRIPTC_TEST_WORKERS: localTestWorkers,
+              },
+              label: `local ${onceLane} Darwin`,
+            },
+          );
+        const invariantContractTask = run(
+          "pnpm",
+          [
+            "test",
+            "--reporter=dot",
+            "-t",
+            hostInvariantContractPattern,
+            ...hostInvariantContractFiles,
+          ],
+          {
+            env: {
+              ...laneEnv(onceLane),
+              SCRIPTC_TEST_WORKERS: localTestWorkers,
+            },
+            label: `local ${onceLane} Darwin contract`,
+          },
+        );
+        const laneContractTasks = lanes.map((lane) =>
+          run(
+            "pnpm",
+            [
+              "test",
+              "--reporter=dot",
+              "-t",
+              hostLaneContractPattern,
+              ...hostLaneContractFiles,
+            ],
+            {
+              env: {
+                ...laneEnv(lane),
+                SCRIPTC_TEST_WORKERS: localTestWorkers,
+              },
+              label: `local ${lane} Darwin contract`,
+            },
+          ),
+        );
+        const caseTasks = lanes.flatMap((lane) =>
+          Array.from({ length: localCaseShardCount }, (_, offset) => {
+            const shard = offset + 1;
+            return run(
               "pnpm",
-              [
-                "test",
-                ...corpusFiles.map((file) => `--exclude=${file}`),
-              ],
+              ["test", "--reporter=dot", ...localCaseShardedFiles],
               {
                 env: {
-                  CI: "1",
-                  SCRIPTC_TEST_WORKERS: localTestWorkers,
-                  ...(lane === "san" ? { SCRIPTC_SAN: "1" } : {}),
+                  ...laneEnv(lane),
+                  SCRIPTC_TEST_SHARD: `${shard}/${localCaseShardCount}`,
+                  SCRIPTC_TEST_WORKERS: "1",
                 },
-                label: `local ${lane}`,
+                label: `local ${lane} external ${shard}/${localCaseShardCount}`,
               },
-            ),
-          ),
+            );
+          }),
+        );
+        const results = await Promise.allSettled(
+          [invariantHostTask, invariantContractTask, ...laneContractTasks, ...caseTasks],
         );
         const failures = results.filter((result) => result.status === "rejected");
         if (failures.length) {

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -250,11 +250,15 @@ function run(
     let remoteExitCode;
     let timedOut = false;
     let timeoutReason = "";
+    let killTimeout;
     const stopForTimeout = (reason) => {
       if (timedOut) return;
       timedOut = true;
       timeoutReason = reason;
       child.kill("SIGTERM");
+      // A network-stalled CLI may not honor SIGTERM promptly. Escalate so a
+      // wall timeout also bounds the time spent waiting for the close event.
+      killTimeout = setTimeout(() => child.kill("SIGKILL"), 5_000);
     };
     const timeout =
       timeoutMs === undefined
@@ -296,6 +300,7 @@ function run(
     child.on("close", (code, signal) => {
       if (timeout !== undefined) clearTimeout(timeout);
       if (idleTimeout !== undefined) clearTimeout(idleTimeout);
+      if (killTimeout !== undefined) clearTimeout(killTimeout);
       children.delete(child);
       stdout.end();
       stderr.end();
@@ -505,7 +510,11 @@ async function cleanup() {
       console.log(`\nRemoving ${created.size} disposable sandbox${created.size === 1 ? "" : "es"}...`);
       const results = await Promise.allSettled(
         [...created].map((name) =>
-          vercel(["sandbox", "remove", name], { label: name, quiet: true }).then(() => created.delete(name)),
+          vercel(["sandbox", "remove", name], {
+            label: name,
+            quiet: true,
+            timeoutMs: 60_000,
+          }).then(() => created.delete(name)),
         ),
       );
       const failures = results.filter((result) => result.status === "rejected");

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -4,9 +4,11 @@ import { randomBytes } from "node:crypto";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pipeline } from "node:stream/promises";
 import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 import { sandboxImageConfig } from "./sandbox-config.mjs";
+import { filterExistingWorktreePaths } from "./worktree-files.mjs";
 
 const root = fileURLToPath(new URL("../", import.meta.url));
 const vcpus = process.env.SCRIPTC_SANDBOX_VCPUS ?? "8";
@@ -61,6 +63,7 @@ const invariantRemoteFiles = [
   "tests/harness/smoke.test.ts",
   "tests/harness/surface-manifest.test.ts",
   "tests/harness/windows-differential.test.ts",
+  "tests/harness/worktree-files.test.ts",
 ];
 
 // Full native-oracle coverage stays on the host where the expected answer
@@ -105,7 +108,9 @@ const hostInvariantContractPattern = [
 ].join("|");
 
 // Logically portable acceptance suites whose oracle lives in an external
-// worktree that is intentionally not uploaded. Split their cases locally.
+// worktree that is intentionally not uploaded. Run them locally in both
+// flavors, sharding suites whose individual cases are independently addressable.
+const localLaneFiles = ["tests/harness/prettier-e2e.test.ts"];
 const localCaseShardedFiles = ["tests/harness/vercel-e2e.test.ts"];
 
 const { values } = parseArgs({
@@ -160,6 +165,7 @@ const specialFiles = [
   ...caseShardedFiles,
   ...invariantRemoteFiles,
   ...hostInvariantFiles,
+  ...localLaneFiles,
   ...localCaseShardedFiles,
 ];
 if (new Set(specialFiles).size !== specialFiles.length) {
@@ -369,7 +375,7 @@ async function createArchive(path) {
   });
   children.add(git);
   children.add(tar);
-  git.stdout.pipe(tar.stdin);
+  const pack = pipeline(git.stdout, filterExistingWorktreePaths(root), tar.stdin);
   const wait = (child, name) =>
     new Promise((resolve, reject) => {
       child.on("error", reject);
@@ -379,7 +385,7 @@ async function createArchive(path) {
         else reject(new Error(`${name} exited ${signal ?? code}`));
       });
     });
-  await Promise.all([wait(git, "git ls-files"), wait(tar, "tar")]);
+  await Promise.all([wait(git, "git ls-files"), wait(tar, "tar"), pack]);
 }
 
 async function createWorker(worker) {
@@ -580,9 +586,11 @@ try {
           [
             "test",
             "--reporter=dot",
+            "--passWithNoTests",
             `--shard=${worker.shard}/${shardCount}`,
             ...caseShardedFiles.map((file) => `--exclude=${file}`),
             ...hostInvariantFiles.map((file) => `--exclude=${file}`),
+            ...localLaneFiles.map((file) => `--exclude=${file}`),
             ...localCaseShardedFiles.map((file) => `--exclude=${file}`),
             ...(worker.lane === onceLane
               ? []
@@ -607,7 +615,7 @@ try {
     ? Promise.resolve()
     : (async () => {
         console.log(
-          `\nBuilding and testing ${hostInvariantFiles.length} Darwin-native files, compact platform contracts, and ${localCaseShardedFiles.length} case-sharded external suite locally...`,
+          `\nBuilding and testing ${hostInvariantFiles.length} Darwin-native files, compact platform contracts, and ${localLaneFiles.length + localCaseShardedFiles.length} external suites locally...`,
         );
         await run("pnpm", ["build"], { label: "local build" });
         const laneEnv = (lane) => ({
@@ -665,6 +673,20 @@ try {
             },
           ),
         );
+        const laneFileTasks = lanes.map((lane) =>
+          run(
+            "pnpm",
+            ["test", "--reporter=dot", ...localLaneFiles],
+            {
+              env: {
+                ...laneEnv(lane),
+                SCRIPTC_TEST_RUN_ID: nonce,
+                SCRIPTC_TEST_WORKERS: "1",
+              },
+              label: `local ${lane} external files`,
+            },
+          ),
+        );
         const caseTasks = lanes.flatMap((lane) =>
           Array.from({ length: localCaseShardCount }, (_, offset) => {
             const shard = offset + 1;
@@ -675,6 +697,7 @@ try {
                 env: {
                   ...laneEnv(lane),
                   SCRIPTC_TEST_SHARD: `${shard}/${localCaseShardCount}`,
+                  SCRIPTC_TEST_RUN_ID: nonce,
                   SCRIPTC_TEST_WORKERS: "1",
                 },
                 label: `local ${lane} external ${shard}/${localCaseShardCount}`,
@@ -683,7 +706,13 @@ try {
           }),
         );
         const results = await Promise.allSettled(
-          [invariantHostTask, invariantContractTask, ...laneContractTasks, ...caseTasks],
+          [
+            invariantHostTask,
+            invariantContractTask,
+            ...laneContractTasks,
+            ...laneFileTasks,
+            ...caseTasks,
+          ],
         );
         const failures = results.filter((result) => result.status === "rejected");
         if (failures.length) {

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -8,6 +8,7 @@ import { pipeline } from "node:stream/promises";
 import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 import { sandboxImageConfig } from "./sandbox-config.mjs";
+import { sandboxHostSchedule } from "./sandbox-platform.mjs";
 import { filterExistingWorktreePaths } from "./worktree-files.mjs";
 
 const root = fileURLToPath(new URL("../", import.meta.url));
@@ -59,6 +60,8 @@ const invariantRemoteFiles = [
   "tests/harness/library-mode.test.ts",
   "tests/harness/library-profile.test.ts",
   "tests/harness/linux-differential.test.ts",
+  "tests/harness/oci-manifest.test.ts",
+  "tests/harness/sandbox-platform.test.ts",
   "tests/harness/shard.test.ts",
   "tests/harness/smoke.test.ts",
   "tests/harness/surface-manifest.test.ts",
@@ -78,19 +81,32 @@ const hostInvariantFiles = [
   "packages/runtime/test/tonumber.test.ts",
   "packages/runtime/test/url.test.ts",
 ];
+const hostSchedule = sandboxHostSchedule(process.platform, hostInvariantFiles);
+const nativeHostInvariantFiles = hostSchedule.localInvariantFiles;
 
 // The full portable behavior of these suites runs remotely. A compact
 // host-native contract additionally pins the places Darwin can disagree:
-// object/archive ABI, Mach-O size classes, linker diagnostics, and ucontext
-// behavior under both ordinary and Apple-ASan builds.
+// object/archive ABI, Mach-O size classes, linker diagnostics, ucontext,
+// and the kqueue event-loop arms under both ordinary and Apple-ASan builds.
+// Non-Darwin hosts retain the full portable remote suites without trying
+// to execute these macOS-specific contracts locally.
 const hostLaneContractFiles = [
   "tests/harness/ffi.test.ts",
   "tests/harness/island.test.ts",
+  "tests/harness/differential.test.ts",
+  "tests/harness/server.test.ts",
+  "tests/harness/dgram.test.ts",
+  "tests/harness/event-loop.test.ts",
 ];
 const hostLaneContractPattern = [
   "calls the manifest-bound archive across every v1 ABI class",
   "a missing FFI symbol is an SC5004 diagnostic",
   "deep island recursion on a fiber is a catchable RangeError",
+  "net-echo",
+  "udp-loopback-pair",
+  "1564-fs-watch.ts",
+  "1470-child-lifecycle.ts",
+  "read-all: chunked writes with delays, then EOF",
 ].join("|");
 const hostInvariantContractFiles = [
   "tests/harness/island.test.ts",
@@ -589,12 +605,15 @@ try {
             "--passWithNoTests",
             `--shard=${worker.shard}/${shardCount}`,
             ...caseShardedFiles.map((file) => `--exclude=${file}`),
-            ...hostInvariantFiles.map((file) => `--exclude=${file}`),
+            ...nativeHostInvariantFiles.map((file) => `--exclude=${file}`),
             ...localLaneFiles.map((file) => `--exclude=${file}`),
             ...localCaseShardedFiles.map((file) => `--exclude=${file}`),
             ...(worker.lane === onceLane
               ? []
-              : invariantRemoteFiles.map((file) => `--exclude=${file}`)),
+              : [
+                  ...invariantRemoteFiles,
+                  ...hostSchedule.remoteInvariantFiles,
+                ].map((file) => `--exclude=${file}`)),
           ],
           {
             ...sharedTestEnv,
@@ -614,65 +633,89 @@ try {
   const local = values["remote-only"]
     ? Promise.resolve()
     : (async () => {
+        const hostName =
+          process.platform === "darwin"
+            ? "Darwin"
+            : process.platform === "linux"
+              ? "Linux"
+              : process.platform;
+        const localWork = [
+          ...(nativeHostInvariantFiles.length > 0
+            ? [`${nativeHostInvariantFiles.length} ${hostName}-native files`]
+            : []),
+          ...(hostSchedule.darwinContracts
+            ? ["compact Darwin platform contracts"]
+            : []),
+          `${localLaneFiles.length + localCaseShardedFiles.length} external suites`,
+        ];
         console.log(
-          `\nBuilding and testing ${hostInvariantFiles.length} Darwin-native files, compact platform contracts, and ${localLaneFiles.length + localCaseShardedFiles.length} external suites locally...`,
+          `\nBuilding and testing ${localWork.join(", ")} locally...`,
         );
         await run("pnpm", ["build"], { label: "local build" });
         const laneEnv = (lane) => ({
           CI: "1",
           ...(lane === "san" ? { SCRIPTC_SAN: "1" } : {}),
         });
-        const invariantHostTask =
-          run(
-            "pnpm",
-            [
-              "test",
-              ...hostInvariantFiles,
-            ],
-            {
-              env: {
-                ...laneEnv(onceLane),
-                SCRIPTC_TEST_WORKERS: localTestWorkers,
-              },
-              label: `local ${onceLane} Darwin`,
-            },
-          );
-        const invariantContractTask = run(
-          "pnpm",
-          [
-            "test",
-            "--reporter=dot",
-            "-t",
-            hostInvariantContractPattern,
-            ...hostInvariantContractFiles,
-          ],
-          {
-            env: {
-              ...laneEnv(onceLane),
-              SCRIPTC_TEST_WORKERS: localTestWorkers,
-            },
-            label: `local ${onceLane} Darwin contract`,
-          },
-        );
-        const laneContractTasks = lanes.map((lane) =>
-          run(
-            "pnpm",
-            [
-              "test",
-              "--reporter=dot",
-              "-t",
-              hostLaneContractPattern,
-              ...hostLaneContractFiles,
-            ],
-            {
-              env: {
-                ...laneEnv(lane),
-                SCRIPTC_TEST_WORKERS: localTestWorkers,
-              },
-              label: `local ${lane} Darwin contract`,
-            },
-          ),
-        );
+        const nativeHostTasks =
+          nativeHostInvariantFiles.length === 0
+            ? []
+            : [
+                run(
+                  "pnpm",
+                  [
+                    "test",
+                    ...nativeHostInvariantFiles,
+                  ],
+                  {
+                    env: {
+                      ...laneEnv(onceLane),
+                      SCRIPTC_TEST_WORKERS: localTestWorkers,
+                    },
+                    label: `local ${onceLane} ${hostName}`,
+                  },
+                ),
+              ];
+        const darwinContractTasks =
+          !hostSchedule.darwinContracts
+            ? []
+            : [
+                run(
+                  "pnpm",
+                  [
+                    "test",
+                    "--reporter=dot",
+                    "-t",
+                    hostInvariantContractPattern,
+                    ...hostInvariantContractFiles,
+                  ],
+                  {
+                    env: {
+                      ...laneEnv(onceLane),
+                      SCRIPTC_TEST_WORKERS: localTestWorkers,
+                    },
+                    label: `local ${onceLane} Darwin contract`,
+                  },
+                ),
+                ...lanes.map((lane) =>
+                  run(
+                    "pnpm",
+                    [
+                      "test",
+                      "--reporter=dot",
+                      "-t",
+                      hostLaneContractPattern,
+                      ...hostLaneContractFiles,
+                    ],
+                    {
+                      env: {
+                        ...laneEnv(lane),
+                        SCRIPTC_TEST_WORKERS: localTestWorkers,
+                      },
+                      label: `local ${lane} Darwin contract`,
+                    },
+                  ),
+                ),
+              ];
         const laneFileTasks = lanes.map((lane) =>
           run(
             "pnpm",
@@ -707,9 +750,8 @@ try {
         );
         const results = await Promise.allSettled(
           [
-            invariantHostTask,
-            invariantContractTask,
-            ...laneContractTasks,
+            ...nativeHostTasks,
+            ...darwinContractTasks,
             ...laneFileTasks,
             ...caseTasks,
           ],

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -9,7 +9,10 @@ import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 import { sandboxImageConfig } from "./sandbox-config.mjs";
 import { sandboxHostSchedule } from "./sandbox-platform.mjs";
-import { filterExistingWorktreePaths } from "./worktree-files.mjs";
+import {
+  filterExistingWorktreePaths,
+  workspaceResetCommand,
+} from "./worktree-files.mjs";
 
 const root = fileURLToPath(new URL("../", import.meta.url));
 const vcpus = process.env.SCRIPTC_SANDBOX_VCPUS ?? "8";
@@ -83,6 +86,7 @@ const hostInvariantFiles = [
 ];
 const hostSchedule = sandboxHostSchedule(process.platform, hostInvariantFiles);
 const nativeHostInvariantFiles = hostSchedule.localInvariantFiles;
+const remoteWorkspaceReset = workspaceResetCommand("/workspace");
 
 // The full portable behavior of these suites runs remotely. A compact
 // host-native contract additionally pins the places Darwin can disagree:
@@ -553,6 +557,14 @@ try {
     await allWorkers("Preparing worktree", async (worker) => {
       await execIn(
         worker,
+        remoteWorkspaceReset.command,
+        remoteWorkspaceReset.args,
+        {},
+        "reset",
+        2 * 60_000,
+      );
+      await execIn(
+        worker,
         "tar",
         ["-xzf", "/tmp/worktree.tar.gz", "-C", "/workspace"],
         {},
@@ -628,6 +640,31 @@ try {
         await Promise.all([cases(), files()]);
       }
     });
+
+    if (hostSchedule.remoteArtifactContracts) {
+      const contractWorker = workers.find(
+        (worker) => worker.lane === onceLane && worker.shard === 1,
+      );
+      if (!contractWorker) throw new Error("could not select a host artifact contract worker");
+      console.log("\nTesting host artifact contracts in a Linux Sandbox...");
+      await execIn(
+        contractWorker,
+        "pnpm",
+        [
+          "test",
+          "--reporter=dot",
+          "-t",
+          hostInvariantContractPattern,
+          ...hostInvariantContractFiles,
+        ],
+        {
+          CI: "1",
+          ASAN_OPTIONS: "detect_leaks=0",
+          SCRIPTC_TEST_WORKERS: fileWorkers,
+        },
+        "host artifact contracts",
+      );
+    }
   })();
 
   const local = values["remote-only"]
@@ -645,6 +682,9 @@ try {
             : []),
           ...(hostSchedule.darwinContracts
             ? ["compact Darwin platform contracts"]
+            : []),
+          ...(hostSchedule.localArtifactContracts
+            ? ["compact host artifact contracts"]
             : []),
           `${localLaneFiles.length + localCaseShardedFiles.length} external suites`,
         ];
@@ -675,8 +715,8 @@ try {
                   },
                 ),
               ];
-        const darwinContractTasks =
-          !hostSchedule.darwinContracts
+        const artifactContractTasks =
+          !hostSchedule.localArtifactContracts
             ? []
             : [
                 run(
@@ -691,31 +731,37 @@ try {
                   {
                     env: {
                       ...laneEnv(onceLane),
+                      ...(process.platform === "linux"
+                        ? { ASAN_OPTIONS: "detect_leaks=0" }
+                        : {}),
                       SCRIPTC_TEST_WORKERS: localTestWorkers,
                     },
-                    label: `local ${onceLane} Darwin contract`,
+                    label: `local ${onceLane} ${hostName} artifact contract`,
                   },
                 ),
-                ...lanes.map((lane) =>
-                  run(
-                    "pnpm",
-                    [
-                      "test",
-                      "--reporter=dot",
-                      "-t",
-                      hostLaneContractPattern,
-                      ...hostLaneContractFiles,
-                    ],
-                    {
-                      env: {
-                        ...laneEnv(lane),
-                        SCRIPTC_TEST_WORKERS: localTestWorkers,
-                      },
-                      label: `local ${lane} Darwin contract`,
-                    },
-                  ),
-                ),
               ];
+        const darwinContractTasks =
+          !hostSchedule.darwinContracts
+            ? []
+            : lanes.map((lane) =>
+                run(
+                  "pnpm",
+                  [
+                    "test",
+                    "--reporter=dot",
+                    "-t",
+                    hostLaneContractPattern,
+                    ...hostLaneContractFiles,
+                  ],
+                  {
+                    env: {
+                      ...laneEnv(lane),
+                      SCRIPTC_TEST_WORKERS: localTestWorkers,
+                    },
+                    label: `local ${lane} Darwin contract`,
+                  },
+                ),
+              );
         const laneFileTasks = lanes.map((lane) =>
           run(
             "pnpm",
@@ -751,6 +797,7 @@ try {
         const results = await Promise.allSettled(
           [
             ...nativeHostTasks,
+            ...artifactContractTasks,
             ...darwinContractTasks,
             ...laneFileTasks,
             ...caseTasks,

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -7,7 +7,10 @@ import { join } from "node:path";
 import { pipeline } from "node:stream/promises";
 import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
-import { sandboxImageConfig } from "./sandbox-config.mjs";
+import {
+  sandboxImageConfig,
+  sandboxRunnerConfig,
+} from "./sandbox-config.mjs";
 import {
   sandboxHostSchedule,
   sandboxLaneEnv,
@@ -18,11 +21,6 @@ import {
 } from "./worktree-files.mjs";
 
 const root = fileURLToPath(new URL("../", import.meta.url));
-const vcpus = process.env.SCRIPTC_SANDBOX_VCPUS ?? "8";
-const testWorkers = process.env.SCRIPTC_TEST_WORKERS ?? "4";
-const localTestWorkers = process.env.SCRIPTC_LOCAL_TEST_WORKERS ?? "2";
-const localCaseShards = process.env.SCRIPTC_LOCAL_CASE_SHARDS ?? "2";
-const sandboxTimeout = process.env.SCRIPTC_SANDBOX_TIMEOUT ?? "45m";
 const laneCaseShardedFiles = [
   "tests/harness/differential.test.ts",
   "tests/harness/llvm-differential.test.ts",
@@ -67,6 +65,7 @@ const invariantRemoteFiles = [
   "tests/harness/library-profile.test.ts",
   "tests/harness/linux-differential.test.ts",
   "tests/harness/oci-manifest.test.ts",
+  "tests/harness/sandbox-config.test.ts",
   "tests/harness/sandbox-platform.test.ts",
   "tests/harness/shard.test.ts",
   "tests/harness/smoke.test.ts",
@@ -163,6 +162,13 @@ Environment:
 }
 
 const { project, sandboxImage: image, team } = sandboxImageConfig();
+const {
+  vcpus,
+  testWorkers,
+  localTestWorkers,
+  localCaseShards,
+  sandboxTimeout,
+} = sandboxRunnerConfig();
 
 if (!["plain", "san", "both"].includes(values.lane)) {
   throw new Error(`--lane must be plain, san, or both (got ${values.lane})`);

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+import { spawn, spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseArgs } from "node:util";
+import { fileURLToPath } from "node:url";
+import { sandboxImageConfig } from "./sandbox-config.mjs";
+
+const root = fileURLToPath(new URL("../", import.meta.url));
+const vcpus = process.env.SCRIPTC_SANDBOX_VCPUS ?? "8";
+const testWorkers = process.env.SCRIPTC_TEST_WORKERS ?? "4";
+const localTestWorkers = process.env.SCRIPTC_LOCAL_TEST_WORKERS ?? "2";
+const sandboxTimeout = process.env.SCRIPTC_SANDBOX_TIMEOUT ?? "45m";
+const corpusFiles = [
+  "tests/harness/differential.test.ts",
+  "tests/harness/llvm-differential.test.ts",
+  "tests/harness/npm.test.ts",
+  "tests/harness/server.test.ts",
+];
+
+const { values } = parseArgs({
+  options: {
+    help: { type: "boolean", short: "h" },
+    keep: { type: "boolean" },
+    lane: { type: "string", default: "both" },
+    "remote-only": { type: "boolean" },
+    shards: { type: "string", default: "3" },
+  },
+});
+
+if (values.help) {
+  console.log(`Run the scriptc test suite across Vercel Sandboxes.
+
+Usage:
+  pnpm test:sandbox [--lane plain|san|both] [--shards 3] [--remote-only] [--keep]
+
+Environment:
+  SCRIPTC_SANDBOX_IMAGE     Fully qualified VCR image (required; may be in .env.local)
+  SCRIPTC_SANDBOX_VCPUS     vCPUs per sandbox (default: 8)
+  SCRIPTC_SANDBOX_TIMEOUT   sandbox and command timeout (default: 45m)
+  SCRIPTC_TEST_WORKERS      Vitest workers per sandbox (default: 4)
+  SCRIPTC_LOCAL_TEST_WORKERS Vitest workers per local lane (default: 2)`);
+  process.exit(0);
+}
+
+const { project, sandboxImage: image, team } = sandboxImageConfig();
+
+if (!["plain", "san", "both"].includes(values.lane)) {
+  throw new Error(`--lane must be plain, san, or both (got ${values.lane})`);
+}
+const shardCount = Number(values.shards);
+if (!Number.isInteger(shardCount) || shardCount < 1 || shardCount > 10) {
+  throw new Error(`--shards must be an integer from 1 to 10 (got ${values.shards})`);
+}
+
+const lanes = values.lane === "both" ? ["plain", "san"] : [values.lane];
+const nonce = `${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
+const workers = lanes.flatMap((lane) =>
+  Array.from({ length: shardCount }, (_, offset) => {
+    const shard = offset + 1;
+    return {
+      lane,
+      shard,
+      label: `${lane} ${shard}/${shardCount}`,
+      name: `scriptc-${lane}-${shard}-${nonce}`,
+    };
+  }),
+);
+const created = new Set();
+const children = new Set();
+let cleanupPromise;
+let handlingSignal = false;
+
+function lineWriter(destination, prefix, handleLine) {
+  let buffered = "";
+  return {
+    write(chunk) {
+      buffered += chunk;
+      const lines = buffered.split(/\r?\n/);
+      buffered = lines.pop() ?? "";
+      for (const line of lines) {
+        if (!handleLine?.(line)) destination.write(`${prefix}${line}\n`);
+      }
+    },
+    end() {
+      if (buffered && !handleLine?.(buffered)) destination.write(`${prefix}${buffered}\n`);
+    },
+  };
+}
+
+function run(command, args, { env = {}, exitMarker, label, quiet = false } = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      cwd: root,
+      env: { ...process.env, NO_UPDATE_NOTIFIER: "1", ...env },
+      stdio: quiet ? "ignore" : ["ignore", "pipe", "pipe"],
+    });
+    children.add(child);
+    const prefix = label ? `[${label}] ` : "";
+    let remoteExitCode;
+    const stdout = lineWriter(process.stdout, prefix, (line) => {
+      if (!exitMarker) return false;
+      const match = new RegExp(`^${exitMarker}(\\d+)$`).exec(line);
+      if (!match) return false;
+      remoteExitCode = Number(match[1]);
+      return true;
+    });
+    const stderr = lineWriter(process.stderr, prefix);
+    if (!quiet) {
+      child.stdout.setEncoding("utf8");
+      child.stderr.setEncoding("utf8");
+      child.stdout.on("data", (chunk) => stdout.write(chunk));
+      child.stderr.on("data", (chunk) => stderr.write(chunk));
+    }
+    child.on("error", reject);
+    child.on("exit", (code, signal) => {
+      children.delete(child);
+      stdout.end();
+      stderr.end();
+      if (code !== 0) {
+        reject(new Error(`${label ?? command} exited ${signal ?? code}`));
+      } else if (exitMarker && remoteExitCode === undefined) {
+        reject(new Error(`${label ?? command} did not report its remote exit status`));
+      } else if (remoteExitCode !== undefined && remoteExitCode !== 0) {
+        reject(new Error(`${label ?? command} remote command exited ${remoteExitCode}`));
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+const scopeArgs = ["--scope", team, "--project", project];
+const vercel = ([group, command, ...args], options) =>
+  run("vercel", [group, command, ...scopeArgs, ...args], options);
+// `vercel sandbox exec` does not propagate the remote process's exit code.
+// Print a per-command nonce after it finishes and enforce that status here.
+const shellQuote = (value) => `'${value.replaceAll("'", `'\"'\"'`)}'`;
+const execIn = (worker, command, args, env = {}) => {
+  const envArgs = Object.entries(env).flatMap(([key, value]) => ["--env", `${key}=${value}`]);
+  const exitMarker = `__SCRIPTC_REMOTE_EXIT_${randomBytes(12).toString("hex")}__`;
+  const script = `${[command, ...args].map(shellQuote).join(" ")}; scriptc_status=$?; printf '\\n${exitMarker}%s\\n' "$scriptc_status"`;
+  return vercel(
+    [
+      "sandbox",
+      "exec",
+      "--timeout",
+      sandboxTimeout,
+      "--workdir",
+      "/workspace",
+      ...envArgs,
+      worker.name,
+      "sh",
+      "-c",
+      script,
+    ],
+    { exitMarker, label: worker.label },
+  );
+};
+
+async function createArchive(path) {
+  const git = spawn("git", ["ls-files", "--cached", "--others", "--exclude-standard", "-z"], {
+    cwd: root,
+    env: { ...process.env, COPYFILE_DISABLE: "1" },
+    stdio: ["ignore", "pipe", "inherit"],
+  });
+  const tarArgs = [
+    ...(process.platform === "darwin" ? ["--no-xattrs", "--no-mac-metadata"] : []),
+    "--null",
+    "-T",
+    "-",
+    "-czf",
+    path,
+  ];
+  const tar = spawn("tar", tarArgs, {
+    cwd: root,
+    env: { ...process.env, COPYFILE_DISABLE: "1" },
+    stdio: ["pipe", "inherit", "inherit"],
+  });
+  children.add(git);
+  children.add(tar);
+  git.stdout.pipe(tar.stdin);
+  const wait = (child, name) =>
+    new Promise((resolve, reject) => {
+      child.on("error", reject);
+      child.on("exit", (code, signal) => {
+        children.delete(child);
+        if (code === 0) resolve();
+        else reject(new Error(`${name} exited ${signal ?? code}`));
+      });
+    });
+  await Promise.all([wait(git, "git ls-files"), wait(tar, "tar")]);
+}
+
+async function allWorkers(phase, task) {
+  const started = Date.now();
+  console.log(`\n${phase} (${workers.length} sandboxes)...`);
+  const results = await Promise.allSettled(workers.map(task));
+  const failures = results.filter((result) => result.status === "rejected");
+  if (failures.length) {
+    for (const failure of failures) console.error(failure.reason);
+    throw new Error(`${phase} failed for ${failures.length} sandbox${failures.length === 1 ? "" : "es"}`);
+  }
+  console.log(`${phase} completed in ${((Date.now() - started) / 1000).toFixed(1)}s`);
+}
+
+async function cleanup() {
+  if (values.keep || created.size === 0) return;
+  if (!cleanupPromise) {
+    cleanupPromise = (async () => {
+      console.log(`\nRemoving ${created.size} disposable sandbox${created.size === 1 ? "" : "es"}...`);
+      const results = await Promise.allSettled(
+        [...created].map((name) =>
+          vercel(["sandbox", "remove", name], { label: name, quiet: true }).then(() => created.delete(name)),
+        ),
+      );
+      const failures = results.filter((result) => result.status === "rejected");
+      if (failures.length) {
+        console.error(`Failed to remove ${failures.length} sandbox${failures.length === 1 ? "" : "es"}.`);
+      }
+    })();
+  }
+  await cleanupPromise;
+}
+
+for (const signal of ["SIGINT", "SIGTERM"]) {
+  process.once(signal, () => {
+    if (handlingSignal) return;
+    handlingSignal = true;
+    for (const child of children) child.kill("SIGTERM");
+    if (!values.keep && created.size) {
+      console.log(`\nRemoving ${created.size} disposable sandbox${created.size === 1 ? "" : "es"}...`);
+      spawnSync(
+        "vercel",
+        ["sandbox", "remove", ...scopeArgs, ...created],
+        {
+          cwd: root,
+          env: { ...process.env, NO_UPDATE_NOTIFIER: "1" },
+          stdio: "inherit",
+          timeout: 30_000,
+        },
+      );
+    }
+    process.exit(signal === "SIGINT" ? 130 : 143);
+  });
+}
+
+const temp = await mkdtemp(join(tmpdir(), "scriptc-sandbox-test-"));
+const archive = join(temp, "worktree.tar.gz");
+const suiteStarted = Date.now();
+let failure;
+
+try {
+  console.log(
+    `Running ${lanes.join("+")} corpus lanes in ${workers.length} ${vcpus}-vCPU sandboxes from ${image} (${shardCount} shards/lane).`,
+  );
+  console.log("Packing the exact tracked + untracked, non-ignored worktree...");
+  await createArchive(archive);
+
+  const remote = (async () => {
+    await allWorkers("Creating", async (worker) => {
+      created.add(worker.name);
+      await vercel(
+        [
+          "sandbox",
+          "create",
+          "--name",
+          worker.name,
+          "--image",
+          image,
+          "--timeout",
+          sandboxTimeout,
+          "--vcpus",
+          vcpus,
+          "--non-persistent",
+        ],
+        { label: worker.label },
+      );
+    });
+
+    await allWorkers("Uploading worktree", (worker) =>
+      vercel(["sandbox", "copy", archive, `${worker.name}:/tmp/worktree.tar.gz`], { label: worker.label }),
+    );
+
+    await allWorkers("Preparing worktree", async (worker) => {
+      await execIn(worker, "tar", ["-xzf", "/tmp/worktree.tar.gz", "-C", "/workspace"]);
+      await execIn(worker, "pnpm", ["install", "--frozen-lockfile"]);
+      await execIn(worker, "pnpm", ["build"]);
+    });
+
+    await allWorkers("Testing corpus", async (worker) => {
+      const testEnv = {
+        CI: "1",
+        SCRIPTC_TEST_SHARD: `${worker.shard}/${shardCount}`,
+        SCRIPTC_TEST_WORKERS: testWorkers,
+        ...(worker.lane === "san"
+          ? {
+              SCRIPTC_SAN: "1",
+              // Match the macOS shipping lane: Apple ASan has no
+              // LeakSanitizer, while scriptc's RC audit owns leak
+              // detection (including its intentional-abandonment rules).
+              ASAN_OPTIONS: "detect_leaks=0",
+            }
+          : {}),
+      };
+      await execIn(worker, "pnpm", ["test", ...corpusFiles], testEnv);
+    });
+  })();
+
+  const local = values["remote-only"]
+    ? Promise.resolve()
+    : (async () => {
+        console.log("\nBuilding and testing platform-sensitive files locally...");
+        await run("pnpm", ["build"], { label: "local build" });
+        const results = await Promise.allSettled(
+          lanes.map((lane) =>
+            run(
+              "pnpm",
+              [
+                "test",
+                ...corpusFiles.map((file) => `--exclude=${file}`),
+              ],
+              {
+                env: {
+                  CI: "1",
+                  SCRIPTC_TEST_WORKERS: localTestWorkers,
+                  ...(lane === "san" ? { SCRIPTC_SAN: "1" } : {}),
+                },
+                label: `local ${lane}`,
+              },
+            ),
+          ),
+        );
+        const failures = results.filter((result) => result.status === "rejected");
+        if (failures.length) {
+          for (const result of failures) console.error(result.reason);
+          throw new Error(`${failures.length} local test lane${failures.length === 1 ? "" : "s"} failed`);
+        }
+      })();
+
+  const results = await Promise.allSettled([remote, local]);
+  const failures = results.filter((result) => result.status === "rejected");
+  if (failures.length) {
+    for (const result of failures) console.error(result.reason);
+    throw new Error(`${failures.length} test path${failures.length === 1 ? "" : "s"} failed`);
+  }
+
+  console.log(
+    `\n${lanes.length === 2 ? "Both test lanes" : `${lanes[0]} test lane`} passed in ${((Date.now() - suiteStarted) / 60_000).toFixed(1)} minutes.`,
+  );
+} catch (error) {
+  failure = error;
+} finally {
+  await cleanup();
+  await rm(temp, { recursive: true, force: true });
+  if (values.keep && created.size) {
+    console.log(`Kept sandboxes:\n${[...created].map((name) => `  ${name}`).join("\n")}`);
+  }
+}
+
+if (failure) throw failure;

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -8,7 +8,10 @@ import { pipeline } from "node:stream/promises";
 import { parseArgs } from "node:util";
 import { fileURLToPath } from "node:url";
 import { sandboxImageConfig } from "./sandbox-config.mjs";
-import { sandboxHostSchedule } from "./sandbox-platform.mjs";
+import {
+  sandboxHostSchedule,
+  sandboxLaneEnv,
+} from "./sandbox-platform.mjs";
 import {
   filterExistingWorktreePaths,
   workspaceResetCommand,
@@ -577,13 +580,12 @@ try {
 
     await allWorkers("Testing", async (worker) => {
       const sharedTestEnv = {
-        CI: "1",
+        ...sandboxLaneEnv(worker.lane),
         // Platform artifact contracts run against the native host below.
         // Remote lanes retain every portable behavior assertion.
         SCRIPTC_PORTABLE_ONLY: "1",
         ...(worker.lane === "san"
           ? {
-              SCRIPTC_SAN: "1",
               // Match the macOS shipping lane: Apple ASan has no
               // LeakSanitizer, while scriptc's RC audit owns leak
               // detection (including its intentional-abandonment rules).
@@ -692,10 +694,6 @@ try {
           `\nBuilding and testing ${localWork.join(", ")} locally...`,
         );
         await run("pnpm", ["build"], { label: "local build" });
-        const laneEnv = (lane) => ({
-          CI: "1",
-          ...(lane === "san" ? { SCRIPTC_SAN: "1" } : {}),
-        });
         const nativeHostTasks =
           nativeHostInvariantFiles.length === 0
             ? []
@@ -708,7 +706,7 @@ try {
                   ],
                   {
                     env: {
-                      ...laneEnv(onceLane),
+                      ...sandboxLaneEnv(onceLane),
                       SCRIPTC_TEST_WORKERS: localTestWorkers,
                     },
                     label: `local ${onceLane} ${hostName}`,
@@ -730,7 +728,7 @@ try {
                   ],
                   {
                     env: {
-                      ...laneEnv(onceLane),
+                      ...sandboxLaneEnv(onceLane),
                       ...(process.platform === "linux"
                         ? { ASAN_OPTIONS: "detect_leaks=0" }
                         : {}),
@@ -755,7 +753,7 @@ try {
                   ],
                   {
                     env: {
-                      ...laneEnv(lane),
+                      ...sandboxLaneEnv(lane),
                       SCRIPTC_TEST_WORKERS: localTestWorkers,
                     },
                     label: `local ${lane} Darwin contract`,
@@ -768,7 +766,7 @@ try {
             ["test", "--reporter=dot", ...localLaneFiles],
             {
               env: {
-                ...laneEnv(lane),
+                ...sandboxLaneEnv(lane),
                 SCRIPTC_TEST_RUN_ID: nonce,
                 SCRIPTC_TEST_WORKERS: "1",
               },
@@ -784,7 +782,7 @@ try {
               ["test", "--reporter=dot", ...localCaseShardedFiles],
               {
                 env: {
-                  ...laneEnv(lane),
+                  ...sandboxLaneEnv(lane),
                   SCRIPTC_TEST_SHARD: `${shard}/${localCaseShardCount}`,
                   SCRIPTC_TEST_RUN_ID: nonce,
                   SCRIPTC_TEST_WORKERS: "1",

--- a/scripts/worktree-files.mjs
+++ b/scripts/worktree-files.mjs
@@ -1,5 +1,5 @@
 import { lstatSync } from "node:fs";
-import { isAbsolute, parse, resolve, sep } from "node:path";
+import { posix, sep } from "node:path";
 import { Transform } from "node:stream";
 
 const NUL = Buffer.from([0]);
@@ -59,11 +59,11 @@ export function filterExistingWorktreePaths(root) {
  * deleted or renamed in the uploaded worktree cannot survive from the image.
  */
 export function workspaceResetCommand(workspaceRoot) {
-  if (!isAbsolute(workspaceRoot)) {
+  if (!posix.isAbsolute(workspaceRoot)) {
     throw new Error("workspace reset root must be absolute");
   }
-  const normalizedRoot = resolve(workspaceRoot);
-  if (normalizedRoot === parse(normalizedRoot).root) {
+  const normalizedRoot = posix.resolve(workspaceRoot);
+  if (normalizedRoot === posix.parse(normalizedRoot).root) {
     throw new Error("refusing to reset a filesystem root");
   }
   return {

--- a/scripts/worktree-files.mjs
+++ b/scripts/worktree-files.mjs
@@ -1,5 +1,5 @@
 import { lstatSync } from "node:fs";
-import { sep } from "node:path";
+import { isAbsolute, parse, resolve, sep } from "node:path";
 import { Transform } from "node:stream";
 
 const NUL = Buffer.from([0]);
@@ -48,4 +48,41 @@ export function filterExistingWorktreePaths(root) {
       }
     },
   });
+}
+
+/**
+ * Build the command that clears image-seeded worktree entries before an
+ * uploaded archive is extracted. The dependency tree is an image cache rather
+ * than worktree input, so retain it for pnpm to reconcile after extraction.
+ *
+ * Removing every other top-level entry makes absence meaningful: a manifest
+ * deleted or renamed in the uploaded worktree cannot survive from the image.
+ */
+export function workspaceResetCommand(workspaceRoot) {
+  if (!isAbsolute(workspaceRoot)) {
+    throw new Error("workspace reset root must be absolute");
+  }
+  const normalizedRoot = resolve(workspaceRoot);
+  if (normalizedRoot === parse(normalizedRoot).root) {
+    throw new Error("refusing to reset a filesystem root");
+  }
+  return {
+    command: "find",
+    args: [
+      normalizedRoot,
+      "-mindepth",
+      "1",
+      "-maxdepth",
+      "1",
+      "!",
+      "-name",
+      "node_modules",
+      "-exec",
+      "rm",
+      "-rf",
+      "--",
+      "{}",
+      "+",
+    ],
+  };
 }

--- a/scripts/worktree-files.mjs
+++ b/scripts/worktree-files.mjs
@@ -1,0 +1,51 @@
+import { lstatSync } from "node:fs";
+import { sep } from "node:path";
+import { Transform } from "node:stream";
+
+const NUL = Buffer.from([0]);
+
+/**
+ * Filter a NUL-delimited `git ls-files` stream to paths that still exist in
+ * the working tree. The index continues to report tracked files after an
+ * unstaged delete or filesystem rename; handing those names to tar makes an
+ * otherwise valid dirty-worktree gate fail before any tests run.
+ *
+ * lstat intentionally retains broken symlinks: they are real worktree entries
+ * even though existsSync would report them missing.
+ */
+export function filterExistingWorktreePaths(root) {
+  const rootPrefix = Buffer.from(root.endsWith(sep) ? root : `${root}${sep}`);
+  let buffered = Buffer.alloc(0);
+
+  return new Transform({
+    transform(chunk, _encoding, callback) {
+      try {
+        buffered = Buffer.concat([buffered, chunk]);
+        let nul;
+        while ((nul = buffered.indexOf(0)) !== -1) {
+          const path = buffered.subarray(0, nul);
+          buffered = buffered.subarray(nul + 1);
+          if (path.length === 0) continue;
+          try {
+            lstatSync(Buffer.concat([rootPrefix, path]));
+          } catch (error) {
+            if (error?.code === "ENOENT" || error?.code === "ENOTDIR") continue;
+            throw error;
+          }
+          this.push(path);
+          this.push(NUL);
+        }
+        callback();
+      } catch (error) {
+        callback(error);
+      }
+    },
+    flush(callback) {
+      if (buffered.length !== 0) {
+        callback(new Error("git ls-files returned a path without a NUL terminator"));
+      } else {
+        callback();
+      }
+    },
+  });
+}

--- a/tests/harness/coverage.test.ts
+++ b/tests/harness/coverage.test.ts
@@ -2,6 +2,7 @@ import { globSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { expect, test } from "vitest";
 import { analyze, renderCoverage } from "@scriptc/compiler";
+import { shardSelect, shardSuffix } from "./shard.js";
 
 const repoRoot = join(import.meta.dirname, "../..");
 const fixture = (name: string) => join(repoRoot, "tests/coverage-fixtures", name);
@@ -147,7 +148,7 @@ test("a cycle whose top level calls a builtin with a builtin function value is a
   expect(out).toContain("statements analyzed");
 });
 
-test("every corpus program is 100% static (corpus and coverage agree)", async () => {
+test(`every corpus program is 100% static (corpus and coverage agree${shardSuffix()})`, async () => {
   // The differential corpus compiles by definition; coverage must agree.
   // `// @dynamic` programs compile under --dynamic, so analyze them that way.
   // The sweep runs minutes on slow machines and each analyze() blocks the
@@ -155,10 +156,13 @@ test("every corpus program is 100% static (corpus and coverage agree)", async ()
   // ("Timeout calling onTaskUpdate") even while every check passes, and the
   // default per-test timeout is far too small for a whole-corpus analysis.
   let n = 0;
-  const flatEntries = ["ts", "js", "mjs", "cjs"].flatMap((ext) =>
-    globSync(join(repoRoot, `tests/corpus/*.${ext}`)),
+  const flatEntries = shardSelect(
+    ["ts", "js", "mjs", "cjs"].flatMap((ext) =>
+      globSync(join(repoRoot, `tests/corpus/*.${ext}`)),
+    ).sort(),
+    (file) => file.slice(repoRoot.length + 1),
   );
-  for (const file of flatEntries.sort()) {
+  for (const file of flatEntries) {
     const firstLine = readFileSync(file, "utf8").split("\n", 1)[0] ?? "";
     // `// @deferred-fences: N` on the first line: a JS program that
     // DELIBERATELY carries N runtime-fence statements on untaken paths

--- a/tests/harness/island.test.ts
+++ b/tests/harness/island.test.ts
@@ -30,6 +30,7 @@ const execFileAsync = promisify(execFile);
 const repoRoot = join(import.meta.dirname, "../..");
 const cacheDir = join(repoRoot, "node_modules/.cache/scriptc-tests");
 const sanitize = process.env["SCRIPTC_SAN"] === "1";
+const platformTest = process.env["SCRIPTC_PORTABLE_ONLY"] === "1" ? test.skip : test;
 
 interface RunResult {
   stdout: string;
@@ -354,7 +355,7 @@ console.log(greet("world"), 6 * 7);
     expect(body(dyn)).toBe(body(stat));
   });
 
-  test("static hello-world stays in its size class; island use pays the engine", async () => {
+  platformTest("static hello-world stays in its size class; island use pays the engine", async () => {
     // The engine must NEVER leak into static builds: a default-built
     // hello-world is ~200KB today (page-granular — macOS segments round
     // to 16KB), and the embedded engine alone is ~620KB — a static binary

--- a/tests/harness/island.test.ts
+++ b/tests/harness/island.test.ts
@@ -357,12 +357,9 @@ console.log(greet("world"), 6 * 7);
 
   platformTest("static hello-world stays in its size class; island use pays the engine", async () => {
     // The engine must NEVER leak into static builds: a default-built
-    // hello-world is ~200KB today (page-granular — macOS segments round
-    // to 16KB), and the embedded engine alone is ~620KB — a static binary
-    // crossing 240KB means the fence broke. The upper assertion pins the
-    // flip side: a program actually entering the island carries the
-    // engine. (An island-FREE --dynamic binary stays small too — the
-    // linker dead-strips the unreferenced archive.)
+    // hello-world stays in the platform's compact class, while entering an
+    // island carries the embedded engine. An island-FREE --dynamic binary
+    // stays small too because the linker dead-strips the unreferenced archive.
     // Measured on plain (non-ASan) builds in both lanes.
     const [stat, dyn] = await Promise.all([
       build("size-static", `console.log("hello", "world");\n`, {
@@ -376,29 +373,11 @@ console.log(greet("world"), 6 * 7);
     ]);
     const staticSize = statSync(stat.binaryPath).size;
     const dynamicSize = statSync(dyn.binaryPath).size;
-    // The budget is page-granular (Mach-O rounds segments to 16KB): the
-    // loop's net hooks, the console/process/child surface, the
-    // fs-scandir/Math-static slice, the path.win32 port (~14KB of
-    // always-linked path algorithms), the Buffer numeric/encoding/
-    // search families (~11KB of always-linked bytes runtime with Node's
-    // exact error ladders), and the primitive-prototype formatters
-    // (toExponential/toFixed0, Date.UTC, String.raw — a page of
-    // always-linked scr_lib/scr_array bytes) each tipped a page on real
-    // deltas — 320_000 keeps the intent: an accidentally-linked engine
-    // is a ~620KB jump, not a page.
-    // The static class forks per platform like the regex class: the
-    // server-callbacks + LLVM-phase-2 runtime growth (~6,900 always-linked
-    // lines) measured 322,528 on native Linux (AL2023 ELF alignment +
-    // glibc static bits + the sandbox link shim) while Mach-O stays at
-    // 312,024 — a page-scale cushion on each arm; an accidentally-linked
-    // engine is a ~620KB jump, not a page. The globals lane (DOMException,
-    // structuredClone + the dyn object walks, atob/btoa, queueMicrotask —
-    // always-linked TUs) re-based both arms by ~2 pages (Mach-O measured
-    // 333,544). StringToNumber (Number(aString) — ~1.3KB in the
-    // always-linked string TU) tipped the Mach-O arm one more page from
-    // 336,328 to a measured 353,000; the cushion stays under a page so
-    // the next tip still fails loudly.
-    expect(staticSize).toBeLessThan(process.platform === "linux" ? 360_000 : 361_000);
+    // The class is toolchain-specific and page-granular. The canonical
+    // Ubuntu 24.04/clang Sandbox measures 387,600 bytes; Mach-O measures
+    // about 353KB. Each bound leaves roughly one native page of growth,
+    // far below the >1MB jump measured when the engine is linked.
+    expect(staticSize).toBeLessThan(process.platform === "linux" ? 392_000 : 361_000);
     expect(dynamicSize).toBeGreaterThan(500_000);
   });
 

--- a/tests/harness/library-mode.test.ts
+++ b/tests/harness/library-mode.test.ts
@@ -75,6 +75,7 @@ import { compileLibrary } from "@scriptc/compiler";
 
 const repoRoot = join(import.meta.dirname, "../..");
 const fixtureRoot = join(repoRoot, "tests/library-mode");
+const platformTest = process.env["SCRIPTC_PORTABLE_ONLY"] === "1" ? test.skip : test;
 /* The plain and SCRIPTC_SAN=1 suites may run concurrently by design (the
  * suite lock is per flavor) and this suite runs the same ordinary builds in
  * both, so the cache path carries the SUITE flavor — otherwise the two runs
@@ -506,7 +507,7 @@ survived, sink_calls=1
 
   /* ── K10: the sanitized lane (ASan + the RC audit's re-init seam) ────── */
 
-  test("K10: K4 under ASan + RC audit (zero live heap across re-init)", async () => {
+  platformTest("K10: K4 under ASan + RC audit (zero live heap across re-init)", async () => {
     const { archive, outDir } = await buildLibrary("reinit", emission, { sanitize: true });
     const probe = buildProbe("reinit", archive, outDir, { sanitize: true });
     const run = runProbe(probe);
@@ -515,7 +516,7 @@ survived, sink_calls=1
     expect(run.stdout).toBe(SESSION + SESSION + SESSION);
   });
 
-  test("K10: K5/K7 under ASan", async () => {
+  platformTest("K10: K5/K7 under ASan", async () => {
     const { archive, outDir } = await buildLibrary("traps", emission, { sanitize: true });
     const probe = buildProbe("traps", archive, outDir, { sanitize: true });
     const trap = runProbe(probe, ["trap"]);

--- a/tests/harness/oci-manifest.test.ts
+++ b/tests/harness/oci-manifest.test.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "vitest";
+import { linuxAmd64ManifestDigest } from "../../scripts/oci-manifest.mjs";
+
+const digest = (character: string): string => `sha256:${character.repeat(64)}`;
+
+test("selects the linux/amd64 child descriptor from an image index", () => {
+  expect(
+    linuxAmd64ManifestDigest({
+      manifest: {
+        mediaType: "application/vnd.oci.image.index.v1+json",
+        digest: digest("a"),
+        manifests: [
+          {
+            digest: digest("b"),
+            platform: { os: "linux", architecture: "arm64" },
+          },
+          {
+            digest: digest("c"),
+            platform: { os: "linux", architecture: "amd64" },
+          },
+        ],
+      },
+    }),
+  ).toBe(digest("c"));
+});
+
+test("selects a direct image manifest descriptor, never its config blob", () => {
+  expect(
+    linuxAmd64ManifestDigest({
+      manifest: {
+        mediaType: "application/vnd.oci.image.manifest.v1+json",
+        digest: digest("d"),
+        config: { digest: digest("e") },
+      },
+    }),
+  ).toBe(digest("d"));
+});
+
+test("rejects an index without a linux/amd64 descriptor", () => {
+  expect(() =>
+    linuxAmd64ManifestDigest({
+      manifest: {
+        mediaType: "application/vnd.oci.image.index.v1+json",
+        digest: digest("f"),
+        manifests: [],
+      },
+    }),
+  ).toThrow("could not find a linux/amd64 image manifest descriptor");
+});

--- a/tests/harness/prettier-e2e.test.ts
+++ b/tests/harness/prettier-e2e.test.ts
@@ -30,12 +30,19 @@ import { createHash } from "node:crypto";
 import { existsSync, globSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, realpathSync, rmSync, statSync, symlinkSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { basename, join } from "node:path";
-import { describe, beforeAll, expect, test } from "vitest";
+import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { compile } from "@scriptc/compiler";
 
 const repoRoot = join(import.meta.dirname, "../..");
 const cacheDir = join(repoRoot, "node_modules/.cache/scriptc-tests");
 const sanitize = process.env["SCRIPTC_SAN"] === "1";
+const executionTag = [
+  sanitize ? "san" : "plain",
+  process.env["SCRIPTC_TEST_RUN_ID"] ?? `pid-${process.pid}`,
+  process.env["SCRIPTC_TEST_SHARD"] ?? "all",
+]
+  .join("-")
+  .replace(/[^a-zA-Z0-9_.-]+/g, "-");
 
 const prettierRoot = process.env["SCRIPTC_PRETTIER_ROOT"] ?? join(homedir(), "Developer/prettier-scratch");
 const prettierPkg = join(prettierRoot, "node_modules/prettier");
@@ -44,6 +51,8 @@ const binEntry = join(prettierPkg, "bin/prettier.cjs");
 const havePrettier = existsSync(cliEntry) && existsSync(binEntry);
 
 let driverBinary = "";
+let driverDir = "";
+let driverOutDir = "";
 
 /* ── driver generation + build ───────────────────────────────────────── */
 
@@ -94,20 +103,25 @@ function hashInputs(): string {
 async function buildDriver(): Promise<string> {
   // realpath: macOS's tmpdir is a symlink (/var → /private/var), and Node
   // resolves the entry at its REAL path.
-  const dir = join(realpathSync(tmpdir()), "scriptc-prettier-e2e-driver");
-  rmSync(dir, { recursive: true, force: true });
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(join(dir, "main.ts"), DRIVER_ENTRY);
-  writeFileSync(join(dir, "prettier-cli.d.ts"), DRIVER_AMBIENT);
-  writeFileSync(join(dir, "tsconfig.json"), DRIVER_TSCONFIG);
-  writeFileSync(join(dir, "package.json"), JSON.stringify({ name: "prettier-e2e-driver", type: "module" }));
+  driverDir = join(realpathSync(tmpdir()), `scriptc-prettier-e2e-driver-${executionTag}`);
+  rmSync(driverDir, { recursive: true, force: true });
+  mkdirSync(driverDir, { recursive: true });
+  writeFileSync(join(driverDir, "main.ts"), DRIVER_ENTRY);
+  writeFileSync(join(driverDir, "prettier-cli.d.ts"), DRIVER_AMBIENT);
+  writeFileSync(join(driverDir, "tsconfig.json"), DRIVER_TSCONFIG);
+  writeFileSync(join(driverDir, "package.json"), JSON.stringify({ name: "prettier-e2e-driver", type: "module" }));
   // The bare "prettier/…" specifier resolves through the scratch install.
-  symlinkSync(join(prettierRoot, "node_modules"), join(dir, "node_modules"));
+  symlinkSync(join(prettierRoot, "node_modules"), join(driverDir, "node_modules"));
   const key = hashInputs();
-  const outDir = join(cacheDir, `prettier-e2e-${key}`);
-  const binary = join(outDir, "program");
-  mkdirSync(outDir, { recursive: true });
-  const result = await compile(join(dir, "main.ts"), { outPath: binary, outDir, sanitize, dynamic: true });
+  driverOutDir = join(cacheDir, `prettier-e2e-${key}-${executionTag}`);
+  const binary = join(driverOutDir, "program");
+  mkdirSync(driverOutDir, { recursive: true });
+  const result = await compile(join(driverDir, "main.ts"), {
+    outPath: binary,
+    outDir: driverOutDir,
+    sanitize,
+    dynamic: true,
+  });
   if (!result.ok) {
     throw new Error(
       "prettier e2e driver failed to compile:\n" +
@@ -251,6 +265,11 @@ describe.skipIf(!havePrettier)(`prettier e2e (real published CLI vs Node${saniti
   beforeAll(async () => {
     driverBinary = await buildDriver();
   }, 300_000);
+
+  afterAll(() => {
+    rmSync(driverDir, { recursive: true, force: true });
+    rmSync(driverOutDir, { recursive: true, force: true });
+  });
 
   test("version, help, and usage errors", async () => {
     await runBoth(["--version"]);

--- a/tests/harness/regex.test.ts
+++ b/tests/harness/regex.test.ts
@@ -126,12 +126,12 @@ console.log(/${"(a)".repeat(300)}/.test("a"));
     expect(err.stderr).toContain("SyntaxError: Invalid regular expression:");
   });
 
-  platformTest("regex-free programs never reference the regex runtime; regex use stays under 300KB", async () => {
+  platformTest("regex-free programs never reference the regex runtime; regex use stays in its size class", async () => {
     // Measured on plain (non-ASan) builds. A regex-free program's C names
     // no ScrRegex symbol, so its link line is the historical one (the
-    // <200KB static size class is pinned by island.test.ts). A regex-USING
-    // binary links libregexp + libunicode (~110KB of matcher) — it must
-    // stay far below the ~700KB engine size class.
+    // compact static size class is pinned by island.test.ts). A regex-USING
+    // binary links libregexp + libunicode, but must stay far below the
+    // embedded-engine size class.
     const [plainBuild, regexBuild] = await Promise.all([
       build("size-plain", `console.log("hello", "world");\n`, { sanitize: false }),
       build(
@@ -161,31 +161,15 @@ console.log(/${"(a)".repeat(300)}/.test("a"));
     // the %j dyn stringify walk, and the runtime-encoding readFileSync
     // form (all in always-linked TUs) tipped the regex class one more
     // page.
-    // The static class forks per platform (see island.test.ts's twin):
-    // Linux measured 322,528 at the same commit where Mach-O sits at
-    // 312,024. The globals lane (DOMException, structuredClone + the checked-dynamic tree
-    // object walks, atob/btoa, queueMicrotask — all in always-linked
-    // TUs) re-based both arms by ~2 pages (Mach-O measured 333,544).
-    // StringToNumber (Number(aString) — ~1.3KB in the always-linked
-    // string TU) tipped the Mach-O arm one more page from 336,328 to a
-    // measured 353,000; the cushion stays under a page so the next tip
-    // still fails loudly.
-    expect(statSync(plainBuild.binaryPath).size).toBeLessThan(process.platform === "linux" ? 360_000 : 361_000);
-// The regex class re-bases per platform: the same program measured
-    // 461,456 bytes on native Linux (scripts/sandbox-suite.mjs — AL2023
-    // clang 15, ELF section alignment, glibc static bits, and the lane's
-    // link shim appending -lm plus an arc4random_buf compat object),
-    // where the Mach-O calibration sits BELOW the class. The
-    // server-callbacks additions (ambient-receiver stack, %j dyn
-    // stringify walk, runtime-encoding readFileSync — always-linked TUs)
-    // re-based BOTH arms by a page. The fences are unchanged on both
-    // platforms: regex linkage is a ~110KB jump above the static class
-    // and the engine a ~620KB one, so a page-scale cushion cannot mask
-    // either regression.
-    // (The dyn-async page re-base above moves this arm in step. Re-based
-    // +8KB for the engine-handle kind arms and validation-ladder strings.)
+    // The canonical Ubuntu 24.04/clang Sandbox measures 387,600 bytes for
+    // the plain binary and 540,232 with regex linked. The Linux bounds leave
+    // roughly one ELF page of growth. Mach-O keeps its independently
+    // calibrated bounds; neither cushion can hide an engine-sized jump.
+    expect(statSync(plainBuild.binaryPath).size).toBeLessThan(
+      process.platform === "linux" ? 392_000 : 361_000,
+    );
     expect(statSync(regexBuild.binaryPath).size).toBeLessThan(
-      process.platform === "linux" ? 540_000 : 512_000,
+      process.platform === "linux" ? 545_000 : 512_000,
     );
   });
 });

--- a/tests/harness/regex.test.ts
+++ b/tests/harness/regex.test.ts
@@ -26,6 +26,7 @@ const execFileAsync = promisify(execFile);
 const repoRoot = join(import.meta.dirname, "../..");
 const cacheDir = join(repoRoot, "node_modules/.cache/scriptc-tests");
 const sanitize = process.env["SCRIPTC_SAN"] === "1";
+const platformTest = process.env["SCRIPTC_PORTABLE_ONLY"] === "1" ? test.skip : test;
 
 interface BuildResult {
   binaryPath: string;
@@ -125,7 +126,7 @@ console.log(/${"(a)".repeat(300)}/.test("a"));
     expect(err.stderr).toContain("SyntaxError: Invalid regular expression:");
   });
 
-  test("regex-free programs never reference the regex runtime; regex use stays under 300KB", async () => {
+  platformTest("regex-free programs never reference the regex runtime; regex use stays under 300KB", async () => {
     // Measured on plain (non-ASan) builds. A regex-free program's C names
     // no ScrRegex symbol, so its link line is the historical one (the
     // <200KB static size class is pinned by island.test.ts). A regex-USING

--- a/tests/harness/sandbox-config.test.ts
+++ b/tests/harness/sandbox-config.test.ts
@@ -1,0 +1,30 @@
+import { expect, test } from "vitest";
+import { sandboxRunnerConfig } from "../../scripts/sandbox-config.mjs";
+
+test("runner settings are read after loading the sandbox environment", () => {
+  expect(
+    sandboxRunnerConfig({
+      SCRIPTC_SANDBOX_VCPUS: "16",
+      SCRIPTC_TEST_WORKERS: "7",
+      SCRIPTC_LOCAL_TEST_WORKERS: "3",
+      SCRIPTC_LOCAL_CASE_SHARDS: "4",
+      SCRIPTC_SANDBOX_TIMEOUT: "90m",
+    }),
+  ).toEqual({
+    vcpus: "16",
+    testWorkers: "7",
+    localTestWorkers: "3",
+    localCaseShards: "4",
+    sandboxTimeout: "90m",
+  });
+});
+
+test("runner settings retain their documented defaults", () => {
+  expect(sandboxRunnerConfig({})).toEqual({
+    vcpus: "8",
+    testWorkers: "4",
+    localTestWorkers: "2",
+    localCaseShards: "2",
+    sandboxTimeout: "45m",
+  });
+});

--- a/tests/harness/sandbox-platform.test.ts
+++ b/tests/harness/sandbox-platform.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "vitest";
-import { sandboxHostSchedule } from "../../scripts/sandbox-platform.mjs";
+import {
+  sandboxHostSchedule,
+  sandboxLaneEnv,
+} from "../../scripts/sandbox-platform.mjs";
 
 const files = ["native-a.test.ts", "native-b.test.ts"];
 
@@ -30,5 +33,16 @@ test("other hosts retain native-file coverage in Linux Sandboxes", () => {
     localInvariantFiles: [],
     remoteArtifactContracts: true,
     remoteInvariantFiles: files,
+  });
+});
+
+test("lane environments override an inherited sanitizer setting", () => {
+  expect(sandboxLaneEnv("plain")).toEqual({
+    CI: "1",
+    SCRIPTC_SAN: "",
+  });
+  expect(sandboxLaneEnv("san")).toEqual({
+    CI: "1",
+    SCRIPTC_SAN: "1",
   });
 });

--- a/tests/harness/sandbox-platform.test.ts
+++ b/tests/harness/sandbox-platform.test.ts
@@ -36,13 +36,17 @@ test("other hosts retain native-file coverage in Linux Sandboxes", () => {
   });
 });
 
-test("lane environments override an inherited sanitizer setting", () => {
+test("lane environments override inherited sanitizer and scheduler settings", () => {
   expect(sandboxLaneEnv("plain")).toEqual({
     CI: "1",
+    SCRIPTC_PORTABLE_ONLY: "",
     SCRIPTC_SAN: "",
+    SCRIPTC_TEST_SHARD: "",
   });
   expect(sandboxLaneEnv("san")).toEqual({
     CI: "1",
+    SCRIPTC_PORTABLE_ONLY: "",
     SCRIPTC_SAN: "1",
+    SCRIPTC_TEST_SHARD: "",
   });
 });

--- a/tests/harness/sandbox-platform.test.ts
+++ b/tests/harness/sandbox-platform.test.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "vitest";
+import { sandboxHostSchedule } from "../../scripts/sandbox-platform.mjs";
+
+const files = ["native-a.test.ts", "native-b.test.ts"];
+
+test("Darwin runs native files and kqueue contracts locally", () => {
+  expect(sandboxHostSchedule("darwin", files)).toEqual({
+    darwinContracts: true,
+    localInvariantFiles: files,
+    remoteInvariantFiles: [],
+  });
+});
+
+test("Linux runs its supported native files locally without Darwin contracts", () => {
+  expect(sandboxHostSchedule("linux", files)).toEqual({
+    darwinContracts: false,
+    localInvariantFiles: files,
+    remoteInvariantFiles: [],
+  });
+});
+
+test("other hosts retain native-file coverage in Linux Sandboxes", () => {
+  expect(sandboxHostSchedule("win32", files)).toEqual({
+    darwinContracts: false,
+    localInvariantFiles: [],
+    remoteInvariantFiles: files,
+  });
+});

--- a/tests/harness/sandbox-platform.test.ts
+++ b/tests/harness/sandbox-platform.test.ts
@@ -6,7 +6,9 @@ const files = ["native-a.test.ts", "native-b.test.ts"];
 test("Darwin runs native files and kqueue contracts locally", () => {
   expect(sandboxHostSchedule("darwin", files)).toEqual({
     darwinContracts: true,
+    localArtifactContracts: true,
     localInvariantFiles: files,
+    remoteArtifactContracts: false,
     remoteInvariantFiles: [],
   });
 });
@@ -14,7 +16,9 @@ test("Darwin runs native files and kqueue contracts locally", () => {
 test("Linux runs its supported native files locally without Darwin contracts", () => {
   expect(sandboxHostSchedule("linux", files)).toEqual({
     darwinContracts: false,
+    localArtifactContracts: true,
     localInvariantFiles: files,
+    remoteArtifactContracts: false,
     remoteInvariantFiles: [],
   });
 });
@@ -22,7 +26,9 @@ test("Linux runs its supported native files locally without Darwin contracts", (
 test("other hosts retain native-file coverage in Linux Sandboxes", () => {
   expect(sandboxHostSchedule("win32", files)).toEqual({
     darwinContracts: false,
+    localArtifactContracts: false,
     localInvariantFiles: [],
+    remoteArtifactContracts: true,
     remoteInvariantFiles: files,
   });
 });

--- a/tests/harness/vercel-e2e.test.ts
+++ b/tests/harness/vercel-e2e.test.ts
@@ -73,6 +73,13 @@ import { MOCK_PROJECT_LINK, startMockVercelApi, type RecordedRequest } from "../
 const repoRoot = join(import.meta.dirname, "../..");
 const cacheDir = join(repoRoot, "node_modules/.cache/scriptc-tests");
 const sanitize = process.env["SCRIPTC_SAN"] === "1";
+const executionTag = [
+  sanitize ? "san" : "plain",
+  process.env["SCRIPTC_TEST_RUN_ID"] ?? `pid-${process.pid}`,
+  process.env["SCRIPTC_TEST_SHARD"] ?? "all",
+]
+  .join("-")
+  .replace(/[^a-zA-Z0-9_.-]+/g, "-");
 
 const vercelRoot = process.env["SCRIPTC_VERCEL_ROOT"] ?? join(homedir(), "Developer/vercel-scratch");
 const vercelEntry = join(vercelRoot, "node_modules/vercel/dist/index.js");
@@ -86,6 +93,7 @@ let refusedUrl = "";
 let jailCapture = "";
 let driverBinary = "";
 let probeBinary = "";
+const driverBuildPaths = new Set<string>();
 /** What the compiled leg reached in beforeAll: "loaded" once the island
  * serves the CLI's builtins, else the caught load error — today
  * "caught:ReferenceError: the island does not provide the 'node:https'
@@ -129,12 +137,14 @@ async function buildDriver(name: string, entrySource: (rel: string) => string): 
   // realpath: macOS's tmpdir is a symlink (/var → /private/var), and the
   // relative import back to the scratch install must survive Node
   // resolving the entry at its REAL path.
-  const dir = join(realpathSync(tmpdir()), `scriptc-vercel-e2e-${name}`);
+  const dir = join(realpathSync(tmpdir()), `scriptc-vercel-e2e-${name}-${executionTag}`);
+  driverBuildPaths.add(dir);
   mkdirSync(dir, { recursive: true });
   const rel = relative(dir, vercelEntry);
   const text = entrySource(rel.startsWith(".") ? rel : `./${rel}`);
   const key = hashInputs(text);
-  const outDir = join(cacheDir, `vercel-e2e-${name}-${key}`);
+  const outDir = join(cacheDir, `vercel-e2e-${name}-${key}-${executionTag}`);
+  driverBuildPaths.add(outDir);
   const entry = join(dir, "main.ts");
   writeFileSync(entry, text);
   writeFileSync(join(dir, "tsconfig.json"), DRIVER_TSCONFIG);
@@ -448,11 +458,15 @@ void go();
   }
 
   afterAll(async () => {
-    if (mockServer !== undefined) await new Promise<void>((resolve) => mockServer.close(() => resolve()));
-    // The endpoint-drift tripwire: every request any lane made resolved to
-    // a recorded route — a CLI/API drift 404s AND lands here, so it can
-    // never render as a silently-empty table (dns ls does exactly that).
-    expect(mockUnexpected.map((r) => `${r.method} ${r.path}${r.search}`)).toEqual([]);
+    try {
+      if (mockServer !== undefined) await new Promise<void>((resolve) => mockServer.close(() => resolve()));
+      // The endpoint-drift tripwire: every request any lane made resolved to
+      // a recorded route — a CLI/API drift 404s AND lands here, so it can
+      // never render as a silently-empty table (dns ls does exactly that).
+      expect(mockUnexpected.map((r) => `${r.method} ${r.path}${r.search}`)).toEqual([]);
+    } finally {
+      for (const path of driverBuildPaths) rmSync(path, { recursive: true, force: true });
+    }
   });
 
   test("the network jail was verified before any CLI ran", () => {

--- a/tests/harness/vercel-e2e.test.ts
+++ b/tests/harness/vercel-e2e.test.ts
@@ -66,6 +66,7 @@ import { homedir, tmpdir } from "node:os";
 import { basename, join, relative } from "node:path";
 import { afterAll, beforeAll, describe, expect, test } from "vitest";
 import { compile } from "@scriptc/compiler";
+import { shardSelect } from "./shard.js";
 import { jailEnv, refusedLoopbackUrl } from "./net-jail.js";
 import { MOCK_PROJECT_LINK, startMockVercelApi, type RecordedRequest } from "../fixtures/vercel-e2e/mock-vercel-api.js";
 
@@ -280,6 +281,77 @@ async function runCase(args: string[], opts: RunOptions = {}): Promise<void> {
   }
 }
 
+interface CliCase {
+  name: string;
+  args: string[];
+  opts?: RunOptions;
+}
+
+// The acceptance commands are platform-neutral and independent once the
+// shared driver and mock are ready. Sandbox runs split them locally because
+// the external Vercel CLI oracle is deliberately not uploaded; ordinary
+// `pnpm test` leaves SCRIPTC_TEST_SHARD unset and runs every command.
+const allCliCases: CliCase[] = [
+  { name: "whoami", args: ["whoami"] },
+  { name: "whoami with an invalid token", args: ["whoami"], opts: { tokenBase: "badfaketoken" } },
+  { name: "teams ls", args: ["teams", "ls"] },
+  { name: "ls (deployments)", args: ["ls"] },
+  { name: "project ls", args: ["project", "ls"] },
+  { name: "domains ls", args: ["domains", "ls"] },
+  { name: "dns ls", args: ["dns", "ls"] },
+  { name: "alias ls", args: ["alias", "ls"] },
+  { name: "certs ls", args: ["certs", "ls"] },
+  { name: "--version", args: ["--version"] },
+  { name: "help", args: ["help"] },
+  { name: "help alias", args: ["help", "alias"] },
+  { name: "env ls", args: ["env", "ls"], opts: { linked: true } },
+  { name: "env ls production", args: ["env", "ls", "production"], opts: { linked: true } },
+  {
+    name: "env ls --format json",
+    args: ["env", "ls", "--format", "json"],
+    opts: { linked: true },
+  },
+  { name: "env ls without a linked project", args: ["env", "ls"] },
+  {
+    name: "inspect a deployment",
+    args: ["inspect", "mock-app-abc123defg-mock-team.vercel.app"],
+  },
+  {
+    name: "logs for a deployment over a fixed window",
+    args: [
+      "logs",
+      "mock-app-abc123defg-mock-team.vercel.app",
+      "--since",
+      "2024-01-01T00:00:00.000Z",
+      "--until",
+      "2024-01-02T12:00:00.000Z",
+    ],
+  },
+  { name: "domains inspect", args: ["domains", "inspect", "mock-example.com"] },
+  { name: "teams switch", args: ["teams", "switch", "second-team"] },
+  {
+    name: "env add",
+    args: ["env", "add", "MOCK_API_TOKEN", "production", "--value", "supersecretvalue", "--yes"],
+    opts: { linked: true },
+  },
+  {
+    name: "env rm",
+    args: ["env", "rm", "NEXT_PUBLIC_BASE_URL", "production", "--yes"],
+    opts: { linked: true },
+  },
+  { name: "dns add", args: ["dns", "add", "mock-example.com", "api", "A", "76.76.21.42"] },
+  { name: "dns rm", args: ["dns", "rm", "rec_mock0000000000000000000002", "--yes"] },
+  {
+    name: "alias set",
+    args: ["alias", "set", "mock-app-abc123defg-mock-team.vercel.app", "staging-mock.vercel.app"],
+  },
+  { name: "alias rm", args: ["alias", "rm", "mock-app.vercel.app", "--yes"] },
+  { name: "project add", args: ["project", "add", "fresh-mock-project"] },
+];
+const selectedCliCases = new Set(
+  shardSelect<CliCase>(allCliCases, ({ name }) => name).map(({ name }) => name),
+);
+
 /* ── the suite ───────────────────────────────────────────────────────── */
 
 // The describe name is deliberately FLAVOR-FREE (unlike the real-CLI suite):
@@ -402,127 +474,15 @@ void go();
     expect(compiledLegProbe).toBe("loaded");
   }, 240_000);
 
-  test("whoami", async () => {
-    await runCase(["whoami"]);
-  }, 240_000);
-
-  test("whoami with an invalid token", async () => {
-    await runCase(["whoami"], { tokenBase: "badfaketoken" });
-  }, 240_000);
-
-  test("teams ls", async () => {
-    await runCase(["teams", "ls"]);
-  }, 240_000);
-
-  test("ls (deployments)", async () => {
-    await runCase(["ls"]);
-  }, 240_000);
-
-  test("project ls", async () => {
-    await runCase(["project", "ls"]);
-  }, 240_000);
-
-  test("domains ls", async () => {
-    await runCase(["domains", "ls"]);
-  }, 240_000);
-
-  test("dns ls", async () => {
-    await runCase(["dns", "ls"]);
-  }, 240_000);
-
-  test("alias ls", async () => {
-    await runCase(["alias", "ls"]);
-  }, 240_000);
-
-  test("certs ls", async () => {
-    await runCase(["certs", "ls"]);
-  }, 240_000);
-
-  /* ── no-network surfaces: the banner, the version pin, the full help
-   * tree (rendered against a non-TTY stderr in both lanes) ────────────── */
-
-  test("--version", async () => {
-    await runCase(["--version"]);
-  }, 240_000);
-
-  test("help", async () => {
-    await runCase(["help"]);
-  }, 240_000);
-
-  test("help alias", async () => {
-    await runCase(["help", "alias"]);
-  }, 240_000);
-
-  /* ── the linked-project env surface (the .vercel/project.json link) ─── */
-
-  test("env ls", async () => {
-    await runCase(["env", "ls"], { linked: true });
-  }, 240_000);
-
-  test("env ls production", async () => {
-    await runCase(["env", "ls", "production"], { linked: true });
-  }, 240_000);
-
-  test("env ls --format json", async () => {
-    await runCase(["env", "ls", "--format", "json"], { linked: true });
-  }, 240_000);
-
-  test("env ls without a linked project", async () => {
-    await runCase(["env", "ls"]);
-  }, 240_000);
-
-  /* ── single-deployment surfaces ──────────────────────────────────────── */
-
-  test("inspect a deployment", async () => {
-    await runCase(["inspect", "mock-app-abc123defg-mock-team.vercel.app"]);
-  }, 240_000);
-
-  // --since/--until pin the request-logs window to fixed epochs; without
-  // them the CLI queries wall-clock "now" and the endpoint trace (which
-  // embeds startDate/endDate) would never be snapshot-stable.
-  test("logs for a deployment over a fixed window", async () => {
-    await runCase(["logs", "mock-app-abc123defg-mock-team.vercel.app", "--since", "2024-01-01T00:00:00.000Z", "--until", "2024-01-02T12:00:00.000Z"]);
-  }, 240_000);
-
-  test("domains inspect", async () => {
-    await runCase(["domains", "inspect", "mock-example.com"]);
-  }, 240_000);
-
-  // A local-state mutation only: the switch validates against GET /v1/teams
-  // and then writes the run's own --global-config; no API mutation happens.
-  test("teams switch", async () => {
-    await runCase(["teams", "switch", "second-team"]);
-  }, 240_000);
-
-  /* ── mutations against the mock (the jail guarantees the CLI can never
-   * reach real infrastructure; every write lands in the mock and its JSON
-   * body is pinned in the endpoint trace) ─────────────────────────────── */
-
-  test("env add", async () => {
-    await runCase(["env", "add", "MOCK_API_TOKEN", "production", "--value", "supersecretvalue", "--yes"], { linked: true });
-  }, 240_000);
-
-  test("env rm", async () => {
-    await runCase(["env", "rm", "NEXT_PUBLIC_BASE_URL", "production", "--yes"], { linked: true });
-  }, 240_000);
-
-  test("dns add", async () => {
-    await runCase(["dns", "add", "mock-example.com", "api", "A", "76.76.21.42"]);
-  }, 240_000);
-
-  test("dns rm", async () => {
-    await runCase(["dns", "rm", "rec_mock0000000000000000000002", "--yes"]);
-  }, 240_000);
-
-  test("alias set", async () => {
-    await runCase(["alias", "set", "mock-app-abc123defg-mock-team.vercel.app", "staging-mock.vercel.app"]);
-  }, 240_000);
-
-  test("alias rm", async () => {
-    await runCase(["alias", "rm", "mock-app.vercel.app", "--yes"]);
-  }, 240_000);
-
-  test("project add", async () => {
-    await runCase(["project", "add", "fresh-mock-project"]);
-  }, 240_000);
+  /* The network jail guarantees every mutating command lands in the mock;
+   * its request body is pinned alongside stdout, stderr, and exit status. */
+  for (const { args, name, opts } of allCliCases) {
+    // Register the other shards as skipped so Vitest knows their snapshots
+    // are intentional; filtering the definitions entirely makes every
+    // partial run report the other shard's snapshots as obsolete.
+    const shardTest = selectedCliCases.has(name) ? test : test.skip;
+    shardTest(name, async () => {
+      await runCase(args, opts);
+    }, 240_000);
+  }
 });

--- a/tests/harness/worktree-files.test.ts
+++ b/tests/harness/worktree-files.test.ts
@@ -2,7 +2,7 @@ import { execFileSync } from "node:child_process";
 import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join, parse } from "node:path";
+import { join } from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, expect, test } from "vitest";
 import {
@@ -53,8 +53,13 @@ test("workspace reset removes image manifests but retains the dependency cache",
   );
 });
 
+test("workspace reset keeps Linux Sandbox paths POSIX on every host", () => {
+  const { command, args } = workspaceResetCommand("/workspace");
+
+  expect(command).toBe("find");
+  expect(args[0]).toBe("/workspace");
+});
+
 test("workspace reset refuses the filesystem root", () => {
-  expect(() => workspaceResetCommand(parse(process.cwd()).root)).toThrow(
-    "refusing to reset a filesystem root",
-  );
+  expect(() => workspaceResetCommand("/")).toThrow("refusing to reset a filesystem root");
 });

--- a/tests/harness/worktree-files.test.ts
+++ b/tests/harness/worktree-files.test.ts
@@ -1,0 +1,32 @@
+import { writeFileSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Readable } from "node:stream";
+import { afterEach, expect, test } from "vitest";
+import { filterExistingWorktreePaths } from "../../scripts/worktree-files.mjs";
+
+const roots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+test("archive path filtering omits unstaged deletions across stream chunks", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scriptc-worktree-files-"));
+  roots.push(root);
+  writeFileSync(join(root, "kept.ts"), "");
+  writeFileSync(join(root, "blocking"), "");
+
+  const input = Readable.from([
+    Buffer.from("ke"),
+    Buffer.from("pt.ts\0deleted.ts\0block"),
+    Buffer.from("ing/child.ts\0"),
+  ]);
+  const chunks: Buffer[] = [];
+  for await (const chunk of input.pipe(filterExistingWorktreePaths(root))) {
+    chunks.push(Buffer.from(chunk));
+  }
+
+  expect(Buffer.concat(chunks)).toEqual(Buffer.from("kept.ts\0"));
+});

--- a/tests/harness/worktree-files.test.ts
+++ b/tests/harness/worktree-files.test.ts
@@ -1,10 +1,14 @@
-import { writeFileSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { join, parse } from "node:path";
 import { Readable } from "node:stream";
 import { afterEach, expect, test } from "vitest";
-import { filterExistingWorktreePaths } from "../../scripts/worktree-files.mjs";
+import {
+  filterExistingWorktreePaths,
+  workspaceResetCommand,
+} from "../../scripts/worktree-files.mjs";
 
 const roots: string[] = [];
 
@@ -29,4 +33,28 @@ test("archive path filtering omits unstaged deletions across stream chunks", asy
   }
 
   expect(Buffer.concat(chunks)).toEqual(Buffer.from("kept.ts\0"));
+});
+
+test("workspace reset removes image manifests but retains the dependency cache", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scriptc-worktree-reset-"));
+  roots.push(root);
+  mkdirSync(join(root, "packages", "cli"), { recursive: true });
+  mkdirSync(join(root, "node_modules", ".pnpm"), { recursive: true });
+  writeFileSync(join(root, "package.json"), "stale root manifest");
+  writeFileSync(join(root, "packages", "cli", "package.json"), "stale package manifest");
+  writeFileSync(join(root, "node_modules", ".pnpm", "cache"), "cached dependencies");
+
+  const { command, args } = workspaceResetCommand(root);
+  execFileSync(command, args);
+
+  expect(readdirSync(root)).toEqual(["node_modules"]);
+  expect(readFileSync(join(root, "node_modules", ".pnpm", "cache"), "utf8")).toBe(
+    "cached dependencies",
+  );
+});
+
+test("workspace reset refuses the filesystem root", () => {
+  expect(() => workspaceResetCommand(parse(process.cwd()).root)).toThrow(
+    "refusing to reset a filesystem root",
+  );
 });


### PR DESCRIPTION
- Add a custom Node 24 test image with tenant-neutral VCR configuration.
- Shard differential suites across disposable Sandboxes while preserving host-specific coverage.
- Load local agent credentials safely and document the validation workflow.