### PR TITLE
feat(compiler): support new URL(url, base) with string literals

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-classes.ts
+++ b/packages/compiler/src/frontend/lowering/lower-classes.ts
@@ -5004,11 +5004,30 @@ export function lowerNew(L: Lowerer, expr: ts.NewExpression): IrExpr {
       }
       if (symbol && symbol.name === "URL" && L.isStdlibSymbol(symbol)) {
         const args = expr.arguments ?? [];
+        if (args.length === 2) {
+          const urlExpr = L.lowerExpr(args[0]!);
+          const baseExpr = L.lowerExpr(args[1]!);
+          if (urlExpr.kind === "strLit" && baseExpr.kind === "strLit") {
+            try {
+              const resolved = new URL(urlExpr.value, baseExpr.value).href;
+              return { kind: "libCall", fn: "url.new", args: [{ kind: "strLit", value: resolved, type: STRING, loc }], type: URL_T, loc };
+            } catch {
+              L.noLowering("new URL with an unresolvable base URL", expr, "the base argument must be a valid absolute URL");
+              return { kind: "libCall", fn: "url.new", args: [L.lowerExprExpecting(args[0]!, STRING)], type: URL_T, loc };
+            }
+          }
+          L.noLowering(
+            "new URL with a non-literal argument",
+            expr,
+            "compile-time string literals for both url and base are required; resolve relative inputs against a base yourself, or use --dynamic for runtime URL resolution",
+          );
+          return { kind: "libCall", fn: "url.new", args: [L.lowerExprExpecting(args[0]!, STRING)], type: URL_T, loc };
+        }
         if (args.length !== 1) {
           L.noLowering(
             `new URL with ${args.length} argument${args.length === 1 ? "" : "s"}`,
             expr,
-            "one absolute-URL string is the supported form (resolve relative inputs against a base yourself)",
+            "one absolute-URL string or two string literals (url + base) are the supported forms",
             symbol,
           );
         }


### PR DESCRIPTION
## Summary

Support the two-argument `new URL(url, base)` form when both arguments are compile-time string literals. The URL is resolved at compile time using Node's built-in URL class, and a single `url.new` libcall is emitted with the resolved href.

## Details

Previously, any `new URL` call with more than one argument was fenced with `noLowering`. This PR:
- Detects when both `url` and `base` are string literals → resolves at compile time
- Preserves the fence for non-literal arguments with an improved error message
- For invalid base URLs, emits a diagnostic similar to Node's TypeError

The non-literal case (e.g. `new URL(request.url, \"http://localhost\")`) remains unsupported and suggests `--dynamic` as a workaround.

## Testing

All existing tests pass: 251 passed, 7 skipped (12 files).