### PR TITLE
feat(compiler): improve global crypto diagnostic and remove opaque token

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -923,6 +923,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
             WeakRef: "deref()-after-collect exposes GC timing — genuinely dynamic; hold a strong reference instead",
             FinalizationRegistry: "finalization callbacks expose GC timing — genuinely dynamic; release resources explicitly instead",
             eval: "runtime code evaluation cannot be compiled ahead of time",
+            crypto: "the Web Crypto API (globalThis.crypto) has no static lowering; import named exports from 'node:crypto' instead — e.g. `import { randomUUID } from \"node:crypto\"`",
           };
           L.noLowering(expr.text, expr, globalHints[expr.text], sym ?? undefined);
         }

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -1825,7 +1825,7 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
    * the one split surface: its five CALL members fence by name, while
    * the rest (`Console` — the suite's constructor-identity probe) have
    * no surface to lose and bind tokens. */
-  const TOKEN_OPAQUE_GLOBALS: ReadonlySet<string> = new Set(["crypto"]);
+  const TOKEN_OPAQUE_GLOBALS: ReadonlySet<string> = new Set([]);
   const CONSOLE_CALL_MEMBERS: ReadonlySet<string> = new Set(["log", "info", "debug", "error", "warn"]);
 
 /** `const { subtle } = globalThis.crypto`, `const { Console } = console`,


### PR DESCRIPTION
## Summary

Improve the developer experience when using the global Web Crypto API (`crypto.randomUUID()`) in TypeScript files by adding a clear diagnostic hint pointing to the supported alternative.

## Changes

- Add `crypto` to the `globalHints` map in `lower-exprs.ts` with a hint guiding users to import from `node:crypto` instead of using the global Web Crypto API.
- Remove `crypto` from `TOKEN_OPAQUE_GLOBALS` in `lower-stmts.ts` so that destructuring patterns on `crypto` receive the standard global fence diagnostic (with the new hint) rather than an opaque token.

## Motivation

Previously, using `crypto.randomUUID()` in a TypeScript file produced a generic error with no guidance. Now it shows an actionable hint:

> The Web Crypto API (globalThis.crypto) has no static lowering; import named exports from 'node:crypto' instead — e.g. `import { randomUUID } from "node:crypto"`

The correct TypeScript-idiomatic approach (`import { randomUUID } from "node:crypto"`) is already fully supported by scriptc with a dedicated lowering.

## Testing

All existing tests pass: 251 passed, 7 skipped (12 files).