### PR TITLE
feat(compiler): add HeadersInit to island ambient types

### DIFF
--- a/packages/compiler/src/frontend/types.ts
+++ b/packages/compiler/src/frontend/types.ts
@@ -15,7 +15,7 @@ export { typeKey };
  * signal), so under --dynamic they map to island handles (jsval) exactly
  * like npm-declared types. Checked with declaration provenance in mapType;
  * consumed by the lowerer's badType for the static-build wording. */
-export const ISLAND_AMBIENT_TYPES = ["Response", "RequestInit", "AbortSignal", "Headers"] as const;
+export const ISLAND_AMBIENT_TYPES = ["Response", "RequestInit", "AbortSignal", "Headers", "HeadersInit"] as const;
 
 /** The frontend's record-shape interner. Records are monomorphic structural
  * shapes: fields sorted by name form the canonical identity, and two types


### PR DESCRIPTION
## Summary

Add `HeadersInit` to `ISLAND_AMBIENT_TYPES` alongside the already-present `Headers`, `RequestInit`, `AbortSignal`, and `Response`. This ensures scriptc recognizes the TypeScript type alias as an island type rather than trying to lower it to a C struct.

All existing tests pass: 251 passed, 7 skipped (12 files).