### PR TITLE
feat: add static Array.toSorted support

### DIFF
--- a/docs/src/app/limitations/page.mdx
+++ b/docs/src/app/limitations/page.mdx
@@ -70,7 +70,7 @@ const who = process.argv.length > 2 ? process.argv[2] : "world";
 
 **Process shape** — `process.argv[0]` is `"scriptc"` and `argv[1]` is the binary's path (positions line up with Node; `argv[2]` onward are your args). The uncaught-exception stderr line reads `Uncaught <value>` instead of Node's stack-trace block (exit code and pre-throw stdout are identical). Runtime errors carry `message` and Node's `code`, but not `errno`/`syscall`/`path`.
 
-**Comparator call sequences differ in `sort`** (stable insertion sort here, TimSort in V8 — sorted results are byte-identical for consistent comparators), and **`localeCompare` compares code units**, not ICU collation.
+**Comparator call sequences differ in `sort` and `toSorted`** (stable insertion sort here, TimSort in V8 — sorted results are byte-identical for consistent comparators), and **`localeCompare` compares code units**, not ICU collation.
 
 ## Dynamic-tier limits
 

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -566,7 +566,8 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
       case "strCmp": {
         const l = E.emitExpr(e.left);
         const r = E.emitExpr(e.right);
-        return E.newTemp(e.type, `scr_str_cmp(${l.name}, ${r.name}) ${e.op} 0`);
+        const fn = e.utf16 === true ? "scr_str_cmp_u16" : "scr_str_cmp";
+        return E.newTemp(e.type, `${fn}(${l.name}, ${r.name}) ${e.op} 0`);
       }
       case "toString": {
         const v = E.emitExpr(e.operand);

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -4092,11 +4092,12 @@ class LlEmitter {
       case "strCmp": {
         const l = this.emitExpr(e.left);
         const r = this.emitExpr(e.right);
-        this.declare(`declare i32 @scr_str_cmp(ptr, ptr)`);
+        const fn = e.utf16 === true ? "scr_str_cmp_u16" : "scr_str_cmp";
+        this.declare(`declare i32 @${fn}(ptr, ptr)`);
         const c = B.tmp();
         const t = B.tmp();
         const pred = { "<": "slt", "<=": "sle", ">": "sgt", ">=": "sge" }[e.op];
-        B.line(`${c} = call i32 @scr_str_cmp(ptr ${l.name}, ptr ${r.name})`);
+        B.line(`${c} = call i32 @${fn}(ptr ${l.name}, ptr ${r.name})`);
         B.line(`${t} = icmp ${pred} i32 ${c}, 0`);
         return { name: t, type: e.type };
       }

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -1390,10 +1390,11 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
    * comparator calls differs from V8's TimSort (SEMANTICS.md); results are
    * identical for consistent comparators. The comparator-less form lowers for
    * STRING elements only — JS's default converts every element to string and
-   * compares UTF-16 units, which for strings is the relational operator the
-   * compiler already has (an interned synthesized comparator); for numbers
-   * that default is the notorious string sort ([10, 9, 1] → [1, 10, 9]),
-   * deliberately fenced toward an explicit comparator. */
+   * compares UTF-16 units, so the interned synthesized comparator selects the
+   * runtime's code-unit ordering rather than scriptc's documented code-point
+   * relational operators. For numbers that default is the notorious string
+   * sort ([10, 9, 1] → [1, 10, 9]), deliberately fenced toward an explicit
+   * comparator. */
   export function lowerArraySortCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,
     elem: IrType,
@@ -1410,7 +1411,7 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
       if (!helper) {
         helper = `%arr.${method}.${L.arrHofHelpers.size}`;
         L.arrHofHelpers.set(key, helper);
-        L.liftedFns.push(buildArraySortFn(helper, STRING, 2, copyFirst, loc));
+        L.liftedFns.push(buildArraySortFn(helper, STRING, 2, copyFirst, null, loc));
       }
       const fnArg: IrExpr = { kind: "closure", fnName: cmp, captures: [], type: fnT, loc };
       return { kind: "call", callee: helper, args: [receiver, fnArg], type: arrT, loc };
@@ -1443,7 +1444,18 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
     if (!helper) {
       helper = `%arr.${method}.${L.arrHofHelpers.size}`;
       L.arrHofHelpers.set(key, helper);
-      L.liftedFns.push(buildArraySortFn(helper, elem, arity, copyFirst, loc));
+      const undefinedTag =
+        elem.kind === "union" ? L.armTag(elem.unionId, UNDEFINED_T) : -1;
+      L.liftedFns.push(
+        buildArraySortFn(
+          helper,
+          elem,
+          arity,
+          copyFirst,
+          undefinedTag >= 0 ? undefinedTag : null,
+          loc,
+        ),
+      );
     }
     return { kind: "call", callee: helper, args: [receiver, fnArg], type: arrT, loc };
   }
@@ -1452,9 +1464,9 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
    *
    *   (a, b) => a < b ? -1 : a > b ? 1 : 0
    *
-   * For strings, the spec's default (ToString both, compare UTF-16 units)
-   * IS the relational operator, so this synthesized comparator makes
-   * `xs.sort()` exactly `xs.sort((a, b) => ...)`. */
+   * The dedicated UTF-16 comparison flag keeps this exact across
+   * supplementary-plane code points and U+E000..U+FFFF, where the runtime's
+   * ordinary code-point relational order deliberately differs. */
   function defaultStringCmpHelper(L: Lowerer, loc: SrcLoc): string {
     const key = "sortCmpStr";
     const existing = L.arrHofHelpers.get(key);
@@ -1464,7 +1476,7 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
     const ref = (localId: string): IrExpr => ({ kind: "varRef", localId, type: STRING, loc });
     const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
     const cmp = (op: "<" | ">"): IrExpr => ({
-      kind: "strCmp", op, left: ref("a.0"), right: ref("b.0"), type: BOOL, loc,
+      kind: "strCmp", op, left: ref("a.0"), right: ref("b.0"), utf16: true, type: BOOL, loc,
     });
     const body: IrStmt[] = [
       {
@@ -1500,10 +1512,12 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
 /** The insertion-sort loop, from existing IR nodes:
    *
    *   n = a.length;
-   *   for (i = 1; i < n; i++) {
-   *     v = a[i]; j = i - 1;
-   *     while (j >= 0) {
-   *       if (f(a[j], v) > 0) { a[j + 1] = a[j]; j = j - 1; } else break;
+    *   for (i = 1; i < n; i++) {
+    *     v = a[i]; j = i - 1;
+    *     while (j >= 0) {
+    *       if (CompareArrayElements(a[j], v, f) > 0) {
+    *         a[j + 1] = a[j]; j = j - 1;
+    *       } else break;
    *     }
    *     a[j + 1] = v;
    *   }
@@ -1514,6 +1528,7 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
     elem: IrType,
     arity: number,
     copyFirst: boolean,
+    undefinedTag: number | null,
     loc: SrcLoc,
   ): IrFunction {
     const arrT = arrayOf(elem);
@@ -1523,26 +1538,81 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
     const j = ref("j.0", F64);
     const at = (index: IrExpr): IrExpr => ({ kind: "arrayGet", arr: ref("a.0", arrT), index, type: elem, loc });
     const jPlus1: IrExpr = { kind: "bin", op: "+", left: j, right: num(1), type: F64, loc };
+    const isUndefined = (value: IrExpr): IrExpr | null => {
+      if (elem.kind === "union" && undefinedTag !== null) {
+        return {
+          kind: "unionIsTag",
+          unionId: elem.unionId,
+          tag: undefinedTag,
+          negated: false,
+          value,
+          type: BOOL,
+          loc,
+        };
+      }
+      if (elem.kind === "jsval") {
+        return {
+          kind: "jsOp",
+          op: "eq",
+          args: [
+            value,
+            { kind: "jsOp", op: "undefLit", args: [], type: JSVAL, loc },
+          ],
+          type: BOOL,
+          loc,
+        };
+      }
+      return null;
+    };
+    const compareGreater: IrExpr = {
+      kind: "bin",
+      op: ">",
+      left: {
+        kind: "callValue",
+        callee: ref("f.0", fnT),
+        args: [at(j), ref("v.0", elem)].slice(0, arity),
+        type: F64,
+        loc,
+      },
+      right: num(0),
+      type: BOOL,
+      loc,
+    };
+    const leftUndefined = isUndefined(at(j));
+    const valueUndefined = isUndefined(ref("v.0", elem));
+    // CompareArrayElements: undefined always sinks and never reaches the
+    // user comparator. Ternaries preserve that callback suppression.
+    const shouldShift: IrExpr =
+      leftUndefined !== null && valueUndefined !== null
+        ? {
+            kind: "ternary",
+            cond: leftUndefined,
+            then: {
+              kind: "unary",
+              op: "!",
+              operand: valueUndefined,
+              type: BOOL,
+              loc,
+            },
+            else_: {
+              kind: "ternary",
+              cond: valueUndefined,
+              then: { kind: "boolLit", value: false, type: BOOL, loc },
+              else_: compareGreater,
+              type: BOOL,
+              loc,
+            },
+            type: BOOL,
+            loc,
+          }
+        : compareGreater;
     const shiftLoop: IrStmt = {
       kind: "while",
       cond: { kind: "bin", op: ">=", left: j, right: num(0), type: BOOL, loc },
       body: [
         {
           kind: "if",
-          cond: {
-            kind: "bin",
-            op: ">",
-            left: {
-              kind: "callValue",
-              callee: ref("f.0", fnT),
-              args: [at(j), ref("v.0", elem)].slice(0, arity),
-              type: F64,
-              loc,
-            },
-            right: num(0),
-            type: BOOL,
-            loc,
-          },
+          cond: shouldShift,
           then: [
             { kind: "arraySet", arr: ref("a.0", arrT), index: jPlus1, value: at(j), loc },
             { kind: "assign", localId: "j.0", value: { kind: "bin", op: "-", left: j, right: num(1), type: F64, loc }, loc },

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -110,7 +110,9 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
         elem = receiver.type.elem;
       }
     }
-    if (name === "sort") return lowerArraySortCall(L, call, access, elem, receiverIr);
+    if (name === "sort" || name === "toSorted") {
+      return lowerArraySortCall(L, call, access, elem, receiverIr);
+    }
 
     // The lib declares wider call forms than the lowered surface —
     // indexOf/includes take a fromIndex, join's separator is optional, the
@@ -1375,46 +1377,50 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
     return name;
   }
 
-/** `a.sort(cmp)` — in-place, returns the receiver (JS's `this`), desugared
-   * to an interned synthetic function like the other array HOFs. The loop
-   * is a binary-free INSERTION sort: stable (equal-comparing elements keep
-   * their source order, which is what Node's stable TimSort produces for
-   * any consistent comparator) and JS-faithful on the comparator contract —
-   * an element moves left only while cmp(left, v) > 0, so a NaN or 0
-   * result holds position exactly like the spec's "treat as equal". The
-   * SEQUENCE of comparator calls differs from V8's TimSort (SEMANTICS.md);
-   * results are identical for consistent comparators. The comparator-less
-   * form lowers for STRING elements only — JS's default converts every
-   * element to string and compares UTF-16 units, which for strings is the
-   * relational operator the compiler already has (an interned synthesized
-   * comparator); for numbers that default is the notorious string sort
-   * ([10, 9, 1] → [1, 10, 9]), deliberately fenced toward an explicit
-   * comparator. */
+/** `a.sort(cmp)` / `a.toSorted(cmp)`, desugared to an interned synthetic
+   * function like the other array HOFs. sort mutates and returns the receiver;
+   * toSorted takes its shallow snapshot INSIDE the helper, after the receiver
+   * and comparator expressions have both been evaluated, then sorts and
+   * returns that copy without touching the receiver. The loop is a
+   * binary-free INSERTION sort: stable (equal-comparing elements keep their
+   * source order, which is what Node's stable TimSort produces for any
+   * consistent comparator) and JS-faithful on the comparator contract — an
+   * element moves left only while cmp(left, v) > 0, so a NaN or 0 result holds
+   * position exactly like the spec's "treat as equal". The SEQUENCE of
+   * comparator calls differs from V8's TimSort (SEMANTICS.md); results are
+   * identical for consistent comparators. The comparator-less form lowers for
+   * STRING elements only — JS's default converts every element to string and
+   * compares UTF-16 units, which for strings is the relational operator the
+   * compiler already has (an interned synthesized comparator); for numbers
+   * that default is the notorious string sort ([10, 9, 1] → [1, 10, 9]),
+   * deliberately fenced toward an explicit comparator. */
   export function lowerArraySortCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,
     elem: IrType,
     arrT: IrType & { kind: "array" },): IrExpr {
     const loc = locOf(call);
+    const method = access.name.text === "toSorted" ? "toSorted" : "sort";
+    const copyFirst = method === "toSorted";
     if (call.arguments.length === 0 && elem.kind === "string") {
       const receiver = L.lowerExpr(access.expression);
       const cmp = defaultStringCmpHelper(L, loc);
       const fnT = funcOf([STRING, STRING], F64);
-      const key = `sort:${typeKey(STRING)}:2`;
+      const key = `${method}:${typeKey(STRING)}:2`;
       let helper = L.arrHofHelpers.get(key);
       if (!helper) {
-        helper = `%arr.sort.${L.arrHofHelpers.size}`;
+        helper = `%arr.${method}.${L.arrHofHelpers.size}`;
         L.arrHofHelpers.set(key, helper);
-        L.liftedFns.push(buildArraySortFn(helper, STRING, 2, loc));
+        L.liftedFns.push(buildArraySortFn(helper, STRING, 2, copyFirst, loc));
       }
       const fnArg: IrExpr = { kind: "closure", fnName: cmp, captures: [], type: fnT, loc };
       return { kind: "call", callee: helper, args: [receiver, fnArg], type: arrT, loc };
     }
     if (call.arguments.length !== 1) {
       L.noLowering(
-        `.sort with ${call.arguments.length} arguments`,
+        `.${method} with ${call.arguments.length} arguments`,
         call,
         "the default string-conversion ordering lowers only for string[] — pass a comparator: " +
-          "sort((a, b) => a - b) for numbers",
+          `${method}((a, b) => a - b) for numbers`,
       );
     }
     const receiver = L.lowerExpr(access.expression);
@@ -1432,12 +1438,12 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
       L.badType(argNode, L.typeOf(argNode));
     }
     const arity = fnArg.type.params.length;
-    const key = `sort:${typeKey(elem)}:${arity}`;
+    const key = `${method}:${typeKey(elem)}:${arity}`;
     let helper = L.arrHofHelpers.get(key);
     if (!helper) {
-      helper = `%arr.sort.${L.arrHofHelpers.size}`;
+      helper = `%arr.${method}.${L.arrHofHelpers.size}`;
       L.arrHofHelpers.set(key, helper);
-      L.liftedFns.push(buildArraySortFn(helper, elem, arity, loc));
+      L.liftedFns.push(buildArraySortFn(helper, elem, arity, copyFirst, loc));
     }
     return { kind: "call", callee: helper, args: [receiver, fnArg], type: arrT, loc };
   }
@@ -1503,7 +1509,13 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
    *   }
    *   return a;
    */
-  function buildArraySortFn(name: string, elem: IrType, arity: number, loc: SrcLoc): IrFunction {
+  function buildArraySortFn(
+    name: string,
+    elem: IrType,
+    arity: number,
+    copyFirst: boolean,
+    loc: SrcLoc,
+  ): IrFunction {
     const arrT = arrayOf(elem);
     const fnT = funcOf([elem, elem].slice(0, arity), F64);
     const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
@@ -1542,6 +1554,21 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
       loc,
     };
     const body: IrStmt[] = [
+      ...(copyFirst
+        ? [{
+            kind: "assign" as const,
+            localId: "a.0",
+            value: {
+              kind: "arrIntrinsic" as const,
+              method: "slice" as const,
+              receiver: ref("a.0", arrT),
+              args: [],
+              type: arrT,
+              loc,
+            },
+            loc,
+          }]
+        : []),
       readLenStmt(arrT, loc),
       {
         kind: "for",

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -282,6 +282,7 @@ export const ARRAY_METHODS = new Set([
   "includes",
   "join",
   "slice",
+  "toSorted",
 ]);
 
 /** The lowered Map<K, V> method surface. Like ARRAY_METHODS, membership is

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -3958,7 +3958,10 @@ export type IrExpr =
   | { kind: "logical"; op: "&&" | "||"; left: IrExpr; right: IrExpr; type: IrType; loc: SrcLoc }
   | { kind: "strConcat"; left: IrExpr; right: IrExpr; type: IrType; loc: SrcLoc }
   | { kind: "strEq"; negated: boolean; left: IrExpr; right: IrExpr; type: IrType; loc: SrcLoc }
-  | { kind: "strCmp"; op: IrStrCmpOp; left: IrExpr; right: IrExpr; type: IrType; loc: SrcLoc }
+  /** String ordering. Ordinary source comparisons omit `utf16` and retain
+   * scriptc's documented code-point order; the default Array sort comparator
+   * sets it to request ECMAScript's UTF-16 code-unit order. */
+  | { kind: "strCmp"; op: IrStrCmpOp; left: IrExpr; right: IrExpr; utf16?: boolean; type: IrType; loc: SrcLoc }
   /** f64|bool → string, JS-exact (Number::toString / "true"/"false").
    * Union operands dispatch through the per-union ToString helper (arms
    * fenced to unit/string/f64/bool by the frontend); a CAUGHT operand is

--- a/packages/compiler/surface-manifest.json
+++ b/packages/compiler/surface-manifest.json
@@ -1985,6 +1985,12 @@
       "status": "static"
     },
     {
+      "id": "stdlib.array.toSorted",
+      "kind": "stdlib",
+      "name": "Array.prototype.toSorted",
+      "status": "static"
+    },
+    {
       "id": "stdlib.date.UTC",
       "kind": "stdlib",
       "name": "Date.UTC",

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -5440,6 +5440,18 @@
    ],
    "diags": []
   },
+  "<repo>/tests/corpus/2666-array-to-sorted.ts": {
+   "order": [
+    "<repo>/tests/corpus/2666-array-to-sorted.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2667-array-to-sorted-any.ts": {
+   "order": [
+    "<repo>/tests/corpus/2667-array-to-sorted-any.ts"
+   ],
+   "diags": []
+  },
   "<repo>/tests/corpus/300-if-else.ts": {
    "order": [
     "<repo>/tests/corpus/300-if-else.ts"

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -317,6 +317,10 @@ bool scr_str_eq(ScrStr *a, ScrStr *b);
  * <0, 0, >0. */
 int scr_str_cmp(ScrStr *a, ScrStr *b);
 
+/* ECMAScript string-list ordering: compare UTF-16 code units even though
+ * ScrStr stores well-formed UTF-8. Returns <0, 0, >0. */
+int scr_str_cmp_u16(ScrStr *a, ScrStr *b);
+
 /* ── class objects (classes as first-class values) ────────────────────
  * The class STATIC side as a runtime value: one emitted IMMORTAL static
  * per class the program takes as a value (`const X = C`, class

--- a/packages/runtime/src/scr_string.c
+++ b/packages/runtime/src/scr_string.c
@@ -198,6 +198,64 @@ int scr_str_cmp(ScrStr *a, ScrStr *b) {
   return a->len < b->len ? -1 : (a->len > b->len ? 1 : 0);
 }
 
+/* UTF-16 code-unit comparison over well-formed UTF-8 (the default
+ * Array.sort/toSorted and URLSearchParams.sort order). Byte order ALMOST
+ * matches — the exception is U+E000..U+FFFF (3-byte UTF-8, single high code
+ * units) vs supplementary code points (4-byte UTF-8, surrogate pairs
+ * 0xD800..0xDFFF): bytes put the 4-byte form last, code units put it first.
+ * Decode code points and compare their leading UTF-16 units. */
+static uint32_t scr_str_lead_u16(const unsigned char *s, size_t len,
+                                size_t *adv) {
+  unsigned char b = s[0];
+  uint32_t cp;
+  size_t n;
+  if (b < 0x80) {
+    cp = b; n = 1;
+  } else if ((b & 0xe0) == 0xc0) {
+    cp = b & 0x1fu; n = 2;
+  } else if ((b & 0xf0) == 0xe0) {
+    cp = b & 0x0fu; n = 3;
+  } else {
+    cp = b & 0x07u; n = 4;
+  }
+  if (n > len) n = len; /* defensive: strings are well-formed by contract */
+  for (size_t i = 1; i < n; i++) cp = (cp << 6) | (s[i] & 0x3fu);
+  *adv = n;
+  if (cp >= 0x10000) return 0xd800 + ((cp - 0x10000) >> 10);
+  return cp;
+}
+
+int scr_str_cmp_u16(ScrStr *a, ScrStr *b) {
+  size_t ia = 0, ib = 0;
+  while (ia < a->len && ib < b->len) {
+    size_t na, nb;
+    uint32_t ua = scr_str_lead_u16(
+        (const unsigned char *)a->data + ia, a->len - ia, &na);
+    uint32_t ub = scr_str_lead_u16(
+        (const unsigned char *)b->data + ib, b->len - ib, &nb);
+    if (ua != ub) return ua < ub ? -1 : 1;
+    /* Equal leading units: equal whole code points (both single units or
+     * both pairs with equal highs — lows only differ if cps differ). */
+    if (na == 4 && nb == 4) {
+      uint32_t cpa = 0, cpb = 0;
+      for (size_t i = 0; i < 4; i++) {
+        cpa = (cpa << 6) |
+              (i == 0 ? (unsigned char)a->data[ia] & 0x07u
+                      : (unsigned char)a->data[ia + i] & 0x3fu);
+        cpb = (cpb << 6) |
+              (i == 0 ? (unsigned char)b->data[ib] & 0x07u
+                      : (unsigned char)b->data[ib + i] & 0x3fu);
+      }
+      if (cpa != cpb) return cpa < cpb ? -1 : 1;
+    }
+    ia += na;
+    ib += nb;
+  }
+  if (ia < a->len) return 1;
+  if (ib < b->len) return -1;
+  return 0;
+}
+
 /* ── interned strings ─────────────────────────────────────────────────
  * The empty string and every single-character ASCII string are immortal
  * statics (same layout the emitter uses for literals): charAt/slice churn
@@ -1272,4 +1330,3 @@ ScrStr *scr_str_decode_uri_component(ScrStr *s) {
   }
   return out;
 }
-

--- a/packages/runtime/src/scr_url_params.c
+++ b/packages/runtime/src/scr_url_params.c
@@ -467,57 +467,6 @@ bool scr_sp_has_value(ScrSearchParams *sp, ScrStr *name, ScrStr *value) {
   return false;
 }
 
-/* UTF-16 code-unit comparison over well-formed UTF-8 (the spec's sort
- * order). Byte order ALMOST matches — the exception is U+E000..U+FFFF
- * (3-byte UTF-8, single high code units) vs supplementary code points
- * (4-byte UTF-8, surrogate pairs 0xD800..0xDFFF): bytes put the 4-byte
- * form last, code units put it first. Decode code points and compare
- * their leading UTF-16 units. */
-static uint32_t sp_lead_unit(const unsigned char *s, size_t len, size_t *adv) {
-  unsigned char b = s[0];
-  uint32_t cp;
-  size_t n;
-  if (b < 0x80) {
-    cp = b; n = 1;
-  } else if ((b & 0xe0) == 0xc0) {
-    cp = b & 0x1fu; n = 2;
-  } else if ((b & 0xf0) == 0xe0) {
-    cp = b & 0x0fu; n = 3;
-  } else {
-    cp = b & 0x07u; n = 4;
-  }
-  if (n > len) n = len; /* defensive: strings are well-formed by contract */
-  for (size_t i = 1; i < n; i++) cp = (cp << 6) | (s[i] & 0x3fu);
-  *adv = n;
-  if (cp >= 0x10000) return 0xd800 + ((cp - 0x10000) >> 10); /* high surrogate leads */
-  return cp;
-}
-
-static int sp_cmp_u16(const ScrStr *a, const ScrStr *b) {
-  size_t ia = 0, ib = 0;
-  while (ia < a->len && ib < b->len) {
-    size_t na, nb;
-    uint32_t ua = sp_lead_unit((const unsigned char *)a->data + ia, a->len - ia, &na);
-    uint32_t ub = sp_lead_unit((const unsigned char *)b->data + ib, b->len - ib, &nb);
-    if (ua != ub) return ua < ub ? -1 : 1;
-    /* Equal LEADING units: equal whole code points (both single units or
-     * both pairs with equal highs — lows only differ if cps differ). */
-    if (na == 4 && nb == 4) {
-      uint32_t cpa = 0, cpb = 0;
-      for (size_t i = 0; i < 4; i++) {
-        cpa = (cpa << 6) | ((i == 0 ? a->data[ia] & 0x07 : a->data[ia + i] & 0x3f));
-        cpb = (cpb << 6) | ((i == 0 ? b->data[ib] & 0x07 : b->data[ib + i] & 0x3f));
-      }
-      if (cpa != cpb) return cpa < cpb ? -1 : 1;
-    }
-    ia += na;
-    ib += nb;
-  }
-  if (ia < a->len) return 1;
-  if (ib < b->len) return -1;
-  return 0;
-}
-
 /* Stable insertion sort by name (lists are small; equal names keep their
  * relative order — the spec's stability requirement). */
 void scr_sp_sort(ScrSearchParams *sp) {
@@ -525,7 +474,7 @@ void scr_sp_sort(ScrSearchParams *sp) {
     ScrStr *n = sp->names[i];
     ScrStr *v = sp->vals[i];
     size_t j = i;
-    while (j > 0 && sp_cmp_u16(sp->names[j - 1], n) > 0) {
+    while (j > 0 && scr_str_cmp_u16(sp->names[j - 1], n) > 0) {
       sp->names[j] = sp->names[j - 1];
       sp->vals[j] = sp->vals[j - 1];
       j--;

--- a/tests/corpus/1536-string-array-sweep.ts
+++ b/tests/corpus/1536-string-array-sweep.ts
@@ -1,7 +1,8 @@
 // The surface-tail sweep trio: string.substring (clamp-and-swap, the
 // port-suffix idiom), array findIndex (first match or -1, index-aware
 // callbacks), and the comparator-less sort() on string[] (JS's default
-// UTF-16 ordering — for strings, the relational operator).
+// UTF-16 ordering — a dedicated comparator because relational operators use
+// scriptc's documented code-point order).
 const localAddr = "127.0.0.1.51823";
 const lastColon = localAddr.lastIndexOf(".");
 console.log(localAddr.substring(lastColon + 1));

--- a/tests/corpus/2666-array-to-sorted.ts
+++ b/tests/corpus/2666-array-to-sorted.ts
@@ -34,16 +34,15 @@ console.log(empty.toSorted().length, ["only"].toSorted().join(","));
 
 // Both the receiver expression and comparator expression are evaluated once,
 // left-to-right, before toSorted snapshots the receiver.
-let receiverEvals = 0;
-let comparatorEvals = 0;
+const evaluationOrder: string[] = [];
 const evaluated = (() => {
-  receiverEvals++;
+  evaluationOrder.push("receiver");
   return [3, 2, 1];
 })().toSorted((() => {
-  comparatorEvals++;
+  evaluationOrder.push("comparator");
   return (a: number, b: number) => a - b;
 })());
-console.log(evaluated.join(","), receiverEvals, comparatorEvals);
+console.log(evaluated.join(","), evaluationOrder.join(","));
 
 // Argument evaluation precedes the method body and therefore the snapshot.
 const argumentSource = [3, 2, 1];

--- a/tests/corpus/2666-array-to-sorted.ts
+++ b/tests/corpus/2666-array-to-sorted.ts
@@ -32,6 +32,22 @@ console.log(words.join(","));
 const empty: string[] = [];
 console.log(empty.toSorted().length, ["only"].toSorted().join(","));
 
+// Default ordering is UTF-16 code-unit order: supplementary pairs sort
+// before U+E000..U+FFFF even though UTF-8/code-point order reverses them.
+const utf16Ordered = ["\uE000", "\u{10000}"].toSorted();
+console.log(utf16Ordered[0]!.charCodeAt(0), utf16Ordered[1]!.charCodeAt(0));
+
+// Undefined values sink to the end without ever reaching compareFn.
+let optionalCalls = 0;
+const optionals: (number | undefined)[] = [undefined, 2, 1, undefined];
+const sortedOptionals = optionals.toSorted((a, b) => {
+  optionalCalls++;
+  if (a === undefined || b === undefined) throw new Error("undefined reached compareFn");
+  return a - b;
+});
+console.log(sortedOptionals.join(","), optionalCalls);
+console.log(optionals.join(","));
+
 // Both the receiver expression and comparator expression are evaluated once,
 // left-to-right, before toSorted snapshots the receiver.
 const evaluationOrder: string[] = [];

--- a/tests/corpus/2666-array-to-sorted.ts
+++ b/tests/corpus/2666-array-to-sorted.ts
@@ -1,0 +1,65 @@
+// Array.prototype.toSorted — the stable ordering of sort on a fresh shallow
+// snapshot. The receiver is not mutated, receiver/comparator expressions run
+// before the snapshot, and comparator mutations of the source cannot change
+// the values being sorted. Node is the oracle.
+
+const nums = [5, 1, 4, 1, 3];
+const ascending = nums.toSorted((a, b) => a - b);
+console.log(ascending.join(","));
+console.log(nums.join(","));
+
+// Stability: equal keys keep their source order.
+const entries = [
+  { key: "b", order: 1 },
+  { key: "a", order: 2 },
+  { key: "b", order: 3 },
+  { key: "a", order: 4 },
+];
+const byKey = entries.toSorted((a, b) => a.key.localeCompare(b.key));
+for (const entry of byKey) {
+  console.log(entry.key, entry.order);
+}
+console.log(entries.map((entry) => entry.order).join(","));
+
+// The copy is shallow: its record elements retain identity.
+byKey[0]!.order = 20;
+console.log(entries[1]!.order);
+
+// Comparator-less string ordering and empty/single-element arrays.
+const words = ["z", "alpha", "beta", "Alpha"];
+console.log(words.toSorted().join(","));
+console.log(words.join(","));
+const empty: string[] = [];
+console.log(empty.toSorted().length, ["only"].toSorted().join(","));
+
+// Both the receiver expression and comparator expression are evaluated once,
+// left-to-right, before toSorted snapshots the receiver.
+let receiverEvals = 0;
+let comparatorEvals = 0;
+const evaluated = (() => {
+  receiverEvals++;
+  return [3, 2, 1];
+})().toSorted((() => {
+  comparatorEvals++;
+  return (a: number, b: number) => a - b;
+})());
+console.log(evaluated.join(","), receiverEvals, comparatorEvals);
+
+// Argument evaluation precedes the method body and therefore the snapshot.
+const argumentSource = [3, 2, 1];
+const afterArgumentMutation = argumentSource.toSorted((() => {
+  argumentSource[0] = 0;
+  return (a: number, b: number) => a - b;
+})());
+console.log(afterArgumentMutation.join(","));
+
+// The method snapshots before its first comparator call. Mutating the source
+// during comparison therefore changes only the source.
+const source = [3, 1, 2];
+const snapshot = source.toSorted((a, b) => {
+  source[0] = 99;
+  if (source.length === 3) source.push(4);
+  return a - b;
+});
+console.log(snapshot.join(","));
+console.log(source.join(","));

--- a/tests/corpus/2667-array-to-sorted-any.ts
+++ b/tests/corpus/2667-array-to-sorted-any.ts
@@ -1,0 +1,29 @@
+// @dynamic
+// Explicit any[] stays a static array of engine handles. Array.toSorted must
+// still sink engine undefined values without invoking compareFn for them.
+
+const source: any[] = [undefined, 2, 1, undefined];
+let calls = 0;
+const sorted = source.toSorted((a: any, b: any) => {
+  calls++;
+  if (a === undefined || b === undefined) {
+    throw new Error("undefined reached compareFn");
+  }
+  return a - b;
+});
+
+console.log(
+  sorted.length,
+  `${sorted[0]}`,
+  `${sorted[1]}`,
+  `${sorted[2]}`,
+  `${sorted[3]}`,
+  calls,
+);
+console.log(
+  source.length,
+  `${source[0]}`,
+  `${source[1]}`,
+  `${source[2]}`,
+  `${source[3]}`,
+);


### PR DESCRIPTION
- Lower to the stable array sort helper over a shallow snapshot.
- Publish Array.prototype.toSorted in the static surface manifest.
- Cover stability, copy semantics, and evaluation order differentially.