### PR TITLE
Support numeric iterators in for-of

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-modules.ts
+++ b/packages/compiler/src/frontend/lowering/lower-modules.ts
@@ -15,7 +15,7 @@ import { BOOL, DYN, IrClassDef, IrExpr, IrFunction, IrGlobal, IrRecordShape, IrS
 import { ENTRY_NAME, PoisonError, boundIdentifiersOf, dynFallbackType, dynUndefinedExpr, importCallHandleType, newFnCtx, uncheckedOverloadHandleCall } from "./lowerer.js";
 import { builtinMemberRequireDecl, builtinNamespaceDestructureModuleOf, createRequireBindingDecl, createRequireNamespaceDecl, createRequireSpecOf, isPromisifyCall } from "./lower-builtins.js";
 import { bindingContextualGenericFnNodeOf, bindingGenericFnAliasInfoOf, bindingGenericFnInfoOf, bindingGenericFnNodeOf, deadUnmappableBinding, implicitLocalFnInfoOf, implicitLocalFnNodeOf, nullishGenericBindingUnitOf } from "./lower-calls.js";
-import { isVarDeclared, provenanceElidedConstDecl } from "./lower-stmts.js";
+import { isVarDeclared, numericIteratorSourceOf, provenanceElidedConstDecl } from "./lower-stmts.js";
 import { streamClassAliasDecl } from "./lower-stream.js";
 import { stdlibGlobalAliasDecl } from "./surfaces.js";
 import { collectNamespaceStmt, nsPathPrefix, trapDeclRootOf } from "./lower-namespaces.js";
@@ -1068,6 +1068,19 @@ export function collectGlobals(L: Lowerer, sf: ts.SourceFile, topStmts: ts.State
         // probes below would otherwise claim the call-initializer shape
         // and put its fences on the build.
         if (provenanceElidedConstDecl(L, decl)) continue;
+        // A stored built-in numeric value iterator has no first-class
+        // global representation. Its same-%init for-of uses are backed by
+        // hidden source/cursor/done locals registered when the declaration
+        // lowers; skip the unmappable iterator global here so collection
+        // does not fence that statically closed protocol path.
+        // Cross-function or exported uses still fence at reference sites.
+        if (
+          isConst &&
+          ts.isIdentifier(decl.name) &&
+          numericIteratorSourceOf(L, decl.initializer) !== null
+        ) {
+          continue;
+        }
         // The trap/nullish/dead classification probes below resolve
         // symbols INSIDE the initializer, and resolution can fence (the
         // cross-block merged-namespace SC1090, resolveValueSymbol →

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -910,17 +910,109 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
         if (builtinNamespaceDestructureModuleOf(L, decl) !== null) return [];
         return L.lowerDestructuringDecl(decl, isLet);
       }
-      // A STORED matchAll drain (`const rows = s.matchAll(re)`): the drain
-      // runs through matchAllInto with a hidden companion index array so a
-      // later for-of over `rows` in the same function can serve `m.index`.
-      // Plain local consts only — module globals, TDZ-predeclared consts,
-      // and annotated non-drain types keep the ordinary path (and stored-
-      // row .index keeps its fence).
+      // STORED protocol values with statically closed representations:
+      // numeric value iterators retain source/cursor/done hidden locals; a
+      // matchAll drain retains its companion index array so a later
+      // for-of can serve `m.index`. Both are const-only interceptions.
+      const numericIterator = lowerNumericIteratorDecl(L, decl, isConst);
+      if (numericIterator) return numericIterator;
       const drained = lowerMatchAllDrainDecl(L, decl, isConst);
       if (drained) return drained;
       const lowered = L.lowerVarDecl(decl, isLet);
       return lowered ? [lowered] : [];
     });
+  }
+
+/** The numeric indexed source of a built-in value-iterator expression:
+   * `numbers.values()` or the equivalent
+   * `numbers[Symbol.iterator]()`, where numbers is number[] or one of the
+   * represented typed arrays (including Uint8Array). This is deliberately
+   * a syntax + provenance test rather than a mapping for the iterator
+   * object: it has observable mutable protocol state, represented by
+   * hidden locals only while a stored binding stays in one function. */
+  export function numericIteratorSourceOf(L: Lowerer, expr: ts.Expression | undefined): ts.Expression | null {
+    if (expr === undefined) return null;
+    let init = expr;
+    while (ts.isParenthesizedExpression(init)) init = init.expression;
+    if (!ts.isCallExpression(init) || init.questionDotToken || init.arguments.length !== 0) return null;
+
+    let receiver: ts.Expression | null = null;
+    if (
+      ts.isPropertyAccessExpression(init.expression) &&
+      !init.expression.questionDotToken &&
+      init.expression.name.text === "values" &&
+      L.isStdlibMember(init.expression)
+    ) {
+      receiver = init.expression.expression;
+    } else if (
+      ts.isElementAccessExpression(init.expression) &&
+      !init.expression.questionDotToken &&
+      init.expression.argumentExpression !== undefined
+    ) {
+      let key = init.expression.argumentExpression;
+      while (ts.isParenthesizedExpression(key)) key = key.expression;
+      if (
+        ts.isPropertyAccessExpression(key) &&
+        L.stdlibGlobalMember(key, "Symbol") === "iterator"
+      ) {
+        receiver = init.expression.expression;
+      }
+    }
+    if (receiver === null) return null;
+    const sourceT = L.mapTypeOf(L.typeOf(receiver));
+    return (
+      (sourceT?.kind === "array" && sourceT.elem.kind === "f64") ||
+      sourceT?.kind === "bytes"
+    ) ? receiver : null;
+  }
+
+/** A stored numeric value iterator does not become a first-class IR
+   * value. Its standard-library provenance proves the built-in iterator
+   * shape, so the declaration snapshots the indexed source and initializes
+   * the exact mutable protocol state:
+   *
+   *   const %source = numbers; let %index = 0; let %done = false;
+   *
+   * A same-function for-of resolves the binding symbol through
+   * numericIterators and drives these locals. Other value uses retain the
+   * iterator-object fence. */
+  function lowerNumericIteratorDecl(
+    L: Lowerer,
+    decl: ts.VariableDeclaration,
+    isConst: boolean,
+  ): IrStmt[] | null {
+    if (!isConst || !ts.isIdentifier(decl.name)) return null;
+    const sourceNode = numericIteratorSourceOf(L, decl.initializer);
+    if (sourceNode === null) return null;
+    const sym = L.checker.getSymbolAtLocation(decl.name);
+    if (!sym || L.tdzPredeclared.has(sym)) return null;
+    const source = L.lowerExpr(sourceNode);
+    if (
+      !(
+        (source.type.kind === "array" && source.type.elem.kind === "f64") ||
+        source.type.kind === "bytes"
+      )
+    ) {
+      L.badType(sourceNode, L.typeOf(sourceNode));
+    }
+    const loc = locOf(decl);
+    const indexedSource = L.declareHiddenLocal("%numiterSource", source.type);
+    const index = L.declareHiddenLocal("%numiterIndex", F64);
+    const done = L.declareHiddenLocal("%numiterDone", BOOL);
+    index.mutable = true;
+    done.mutable = true;
+    L.numericIterators.set(sym, {
+      sourceLocalId: indexedSource.id,
+      sourceType: source.type,
+      indexLocalId: index.id,
+      doneLocalId: done.id,
+      ctx: L.ctx,
+    });
+    return [
+      { kind: "varDecl", localId: indexedSource.id, init: source, loc },
+      { kind: "varDecl", localId: index.id, init: { kind: "numLit", value: 0, type: F64, loc }, loc },
+      { kind: "varDecl", localId: done.id, init: { kind: "boolLit", value: false, type: BOOL, loc }, loc },
+    ];
   }
 
 /** The stored-drain interception behind lowerVarStatement: lowers
@@ -5597,6 +5689,21 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
       }
       L.unsupported("SC1070", stmt, "'for await' (async iteration over anything but process.stdin and readable streams)");
     }
+    // A stored numeric value iterator declared in this function keeps its
+    // built-in protocol state in hidden locals (lowerVarStatement). The
+    // iterator's own [Symbol.iterator]() returns itself, so for-of resumes
+    // that cursor rather than starting another indexed-source walk.
+    {
+      let src: ts.Expression = stmt.expression;
+      while (ts.isParenthesizedExpression(src)) src = src.expression;
+      if (ts.isIdentifier(src)) {
+        const sym = L.resolveValueSymbol(src);
+        const state = sym ? L.numericIterators.get(sym) : undefined;
+        if (state?.ctx === L.ctx) {
+          return lowerForOfStoredNumericIterator(L, stmt, state, labels);
+        }
+      }
+    }
     // `for (const k of m.keys())` / `.values()` / `.entries()`: the
     // iterator methods consumed DIRECTLY by a for-of head ride the
     // container's live walk — exactly `for..of m` with the projection
@@ -5675,18 +5782,21 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         }
       }
     }
-    // `for (v of xs.values())` over an ARRAY receiver: Array.prototype
-    // .values() iterates the array's elements exactly — the iterator
-    // object never needs to exist, so the loop runs over the receiver
-    // itself (matchAll's eager-drain stance). Only the DIRECT for-of
-    // position unwraps; a stored iterator value keeps its fence.
-    let iterSrc: ts.Expression = stmt.expression;
-    {
+    // A DIRECT built-in value-iterator expression needs no first-class
+    // iterator object. The numeric recognizer covers number[] / typed
+    // arrays and both values/default spellings; retain the established
+    // generic Array.prototype.values() unwrap for every other T[] too.
+    // Stored numeric values took the retained-state path above.
+    let iterSrc = numericIteratorSourceOf(L, stmt.expression);
+    if (iterSrc === null) {
       let e: ts.Expression = stmt.expression;
       while (ts.isParenthesizedExpression(e)) e = e.expression;
       if (
-        ts.isCallExpression(e) && !e.questionDotToken && e.arguments.length === 0 &&
-        ts.isPropertyAccessExpression(e.expression) && !e.expression.questionDotToken &&
+        ts.isCallExpression(e) &&
+        !e.questionDotToken &&
+        e.arguments.length === 0 &&
+        ts.isPropertyAccessExpression(e.expression) &&
+        !e.expression.questionDotToken &&
         e.expression.name.text === "values" &&
         L.isStdlibMember(e.expression) &&
         L.mapTypeOf(L.typeOf(e.expression.expression))?.kind === "array"
@@ -5694,7 +5804,16 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         iterSrc = e.expression.expression;
       }
     }
+    iterSrc ??= stmt.expression;
     let iterable = L.lowerExpr(iterSrc);
+    if (iterable.type.kind === "bytes") {
+      return lowerForOfBytes(
+        L,
+        stmt,
+        iterable as IrExpr & { type: IrType & { kind: "bytes" } },
+        labels,
+      );
+    }
     if (iterable.type.kind !== "array") {
       // The lib types strings as iterable too, so those for-ofs typecheck;
       // only arrays, Maps, and Sets have a lowering. Named specifically —
@@ -5916,6 +6035,211 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
       const local = L.declareLocal(decl.name, decl.name.text, iterable.type.elem, isLet);
       const body = L.inCtl("loop", () => L.lowerScopedBlock(stmt.statement), labels);
       return { kind: "forOf", localId: local.id, iterable, body, ...(labels && { labels }), loc: locOf(stmt) };
+    } finally {
+      L.scopes.pop();
+    }
+  }
+
+/** Direct for-of over a represented typed array. The implicit iterator is
+   * unobservable, so instantiate its source/cursor/done state as ordinary
+   * hidden locals and share the retained numeric-iterator driver. */
+  function lowerForOfBytes(
+    L: Lowerer,
+    stmt: ts.ForOfStatement,
+    iterable: IrExpr & { type: IrType & { kind: "bytes" } },
+    labels?: string[],
+  ): IrStmt {
+    const loc = locOf(stmt);
+    const source = L.declareHiddenLocal("%numiterSource", iterable.type);
+    const index = L.declareHiddenLocal("%numiterIndex", F64);
+    const done = L.declareHiddenLocal("%numiterDone", BOOL);
+    index.mutable = true;
+    done.mutable = true;
+    const loop = lowerForOfStoredNumericIterator(
+      L,
+      stmt,
+      {
+        sourceLocalId: source.id,
+        sourceType: iterable.type,
+        indexLocalId: index.id,
+        doneLocalId: done.id,
+      },
+      labels,
+    );
+    return {
+      kind: "block",
+      body: [
+        { kind: "varDecl", localId: source.id, init: iterable, loc },
+        { kind: "varDecl", localId: index.id, init: { kind: "numLit", value: 0, type: F64, loc }, loc },
+        { kind: "varDecl", localId: done.id, init: { kind: "boolLit", value: false, type: BOOL, loc }, loc },
+        loop,
+      ],
+      loc,
+    };
+  }
+
+/** Drive a stored built-in numeric value iterator through its retained
+   * protocol state. Unlike the ordinary array for-of IR, the cursor
+   * advances BEFORE the source body: breaking or returning from the body
+   * leaves the iterator positioned at the next element. Natural
+   * exhaustion sets the sticky done bit; breaking early does not.
+   *
+   *   while (true) {
+   *     if (%done) break;
+   *     if (%index >= %source.length) { %done = true; break; }
+   *     const value = %source[%index];
+   *     %index += 1;
+   *     <assign/bind head>; <body>
+   *   }
+   */
+  function lowerForOfStoredNumericIterator(
+    L: Lowerer,
+    stmt: ts.ForOfStatement,
+    state: {
+      sourceLocalId: string;
+      sourceType: IrType;
+      indexLocalId: string;
+      doneLocalId: string;
+    },
+    labels?: string[],
+  ): IrStmt {
+    let exprTarget: { id: string; type: IrType } | null = null;
+    let exprTargetNode: ts.Identifier | null = null;
+    if (!ts.isVariableDeclarationList(stmt.initializer)) {
+      let target: ts.Node = stmt.initializer;
+      while (ts.isParenthesizedExpression(target)) target = target.expression;
+      if (ts.isIdentifier(target)) {
+        exprTarget = L.resolveWritable(target);
+        exprTargetNode = target;
+      }
+      if (!exprTarget) {
+        L.unsupported(
+          "SC1090",
+          stmt.initializer,
+          "for-of over a stored numeric iterator assigning anything but a pre-declared identifier",
+        );
+      }
+    }
+    const list = ts.isVariableDeclarationList(stmt.initializer) ? stmt.initializer : null;
+    if (list && (list.flags & ts.NodeFlags.Using) !== 0) {
+      L.unsupported("SC1090", list, "'using' declarations (dispose-at-scope-exit semantics)");
+    }
+    const isLet = list !== null && (list.flags & ts.NodeFlags.Let) !== 0;
+    const decl = list ? list.declarations[0]! : null;
+    if (decl && !ts.isIdentifier(decl.name)) L.unsupported("SC1031", decl.name);
+
+    const loc = locOf(stmt);
+    const sourceT = state.sourceType;
+    if (
+      !(
+        (sourceT.kind === "array" && sourceT.elem.kind === "f64") ||
+        sourceT.kind === "bytes"
+      )
+    ) {
+      throw new Error("internal: retained numeric iterator has a non-numeric source");
+    }
+    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
+    const indexRef = (): IrExpr => ref(state.indexLocalId, F64);
+    const doneRef = (): IrExpr => ref(state.doneLocalId, BOOL);
+    const sourceRef = (): IrExpr => ref(state.sourceLocalId, sourceT);
+    const sourceLength = (): IrExpr => sourceT.kind === "array"
+      ? {
+          kind: "arrIntrinsic",
+          method: "length",
+          receiver: sourceRef(),
+          args: [],
+          type: F64,
+          loc,
+        }
+      : {
+          kind: "bytesIntrinsic",
+          method: "length",
+          receiver: sourceRef(),
+          args: [],
+          type: F64,
+          loc,
+        };
+    const sourceValue = (): IrExpr => sourceT.kind === "array"
+      ? { kind: "arrayGet", arr: sourceRef(), index: indexRef(), type: F64, loc }
+      : {
+          kind: "bytesIntrinsic",
+          method: "get",
+          receiver: sourceRef(),
+          args: [indexRef()],
+          type: F64,
+          loc,
+        };
+    const one: IrExpr = { kind: "numLit", value: 1, type: F64, loc };
+
+    L.scopes.push(new Map());
+    try {
+      const varTarget = exprTarget ?? (decl ? forOfVarTarget(L, decl) : null);
+      const value = varTarget
+        ? L.declareHiddenLocal("%numiterValue", F64)
+        : L.declareLocal(decl!.name as ts.Identifier, (decl!.name as ts.Identifier).text, F64, isLet);
+      const valueRef: IrExpr = ref(value.id, F64);
+      const blame: ts.Node = decl?.name ?? exprTargetNode ?? stmt.initializer;
+      const head: IrStmt[] = [
+        {
+          kind: "if",
+          cond: doneRef(),
+          then: [{ kind: "break", loc }],
+          else_: null,
+          loc,
+        },
+        {
+          kind: "if",
+          cond: {
+            kind: "bin",
+            op: ">=",
+            left: indexRef(),
+            right: sourceLength(),
+            type: BOOL,
+            loc,
+          },
+          then: [
+            {
+              kind: "assign",
+              localId: state.doneLocalId,
+              value: { kind: "boolLit", value: true, type: BOOL, loc },
+              loc,
+            },
+            { kind: "break", loc },
+          ],
+          else_: null,
+          loc,
+        },
+        {
+          kind: "varDecl",
+          localId: value.id,
+          init: sourceValue(),
+          loc,
+        },
+        {
+          kind: "assign",
+          localId: state.indexLocalId,
+          value: { kind: "bin", op: "+", left: indexRef(), right: one, type: F64, loc },
+          loc,
+        },
+        ...(varTarget
+          ? [
+              {
+                kind: "assign",
+                localId: varTarget.id,
+                value: L.coerceInto(blame, valueRef, varTarget.type),
+                loc,
+              } satisfies IrStmt,
+            ]
+          : []),
+      ];
+      const body = L.inCtl("loop", () => L.lowerScopedBlock(stmt.statement), labels);
+      return {
+        kind: "while",
+        cond: { kind: "boolLit", value: true, type: BOOL, loc },
+        body: [...head, ...body],
+        ...(labels && { labels }),
+        loc,
+      };
     } finally {
       L.scopes.pop();
     }

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -958,6 +958,17 @@ export class Lowerer {
    * (the ctx guard keeps hidden locals out of closures — a cross-function
    * walk falls back to the plain array walk and the fence). */
   readonly matchAllDrainIndexes = new Map<ts.Symbol, { idxsLocalId: string; ctx: FnCtx }>();
+  /** STORED numeric value iterators: `const it = numbers.values()` (and
+   * the equivalent `[Symbol.iterator]()` spelling) over number[] or a
+   * represented typed array has no first-class IR value, so its statically
+   * known protocol state lives in hidden source/cursor/done locals. A
+   * later for-of in the SAME function reads and advances them.
+   * `doneLocalId` is sticky: once next() observes the end, later source
+   * changes do not revive the exhausted iterator, exactly like Node. */
+  readonly numericIterators = new Map<
+    ts.Symbol,
+    { sourceLocalId: string; sourceType: IrType; indexLocalId: string; doneLocalId: string; ctx: FnCtx }
+  >();
   chainCounter = 0;
   /** Keyed by program-wide qualified class name (what IR object types carry). */
   readonly classes = new Map<string, ClassInfo>();

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -5452,6 +5452,12 @@
    ],
    "diags": []
   },
+  "<repo>/tests/corpus/2668-stored-number-array-iterator.ts": {
+   "order": [
+    "<repo>/tests/corpus/2668-stored-number-array-iterator.ts"
+   ],
+   "diags": []
+  },
   "<repo>/tests/corpus/300-if-else.ts": {
    "order": [
     "<repo>/tests/corpus/300-if-else.ts"

--- a/tests/corpus/2668-stored-number-array-iterator.ts
+++ b/tests/corpus/2668-stored-number-array-iterator.ts
@@ -1,0 +1,87 @@
+// Stored ArrayIterator<number> values consumed by for-of. The iterator
+// keeps its cursor across loops, advances before the body runs, observes
+// live array growth until it is exhausted, and stays exhausted after that
+// even if the source grows again. Node is the byte-for-byte oracle.
+const numbers = [10, 20, 30];
+const values = numbers.values();
+
+for (const n of values) {
+  console.log("first", n);
+  if (n === 10) break;
+}
+
+numbers.push(40);
+for (const n of values) {
+  if (n === 30) continue;
+  console.log("resume", n);
+}
+
+numbers.push(50);
+for (const n of values) console.log("exhausted", n);
+
+// The default array iterator is the same values protocol. A pre-declared
+// head is assigned per step, and a break leaves the cursor ready to resume.
+const viaSymbol = [1, 2, 3][Symbol.iterator]();
+let current = 0;
+for (current of viaSymbol) {
+  console.log("symbol", current);
+  break;
+}
+for (current of viaSymbol) console.log("symbol-rest", current);
+console.log("last", current);
+
+// Growth while a loop is active is visible because ArrayIterator.next()
+// re-reads the source length for each step.
+const liveNumbers = [7];
+const liveValues = liveNumbers.values();
+for (const n of liveValues) {
+  console.log("live", n);
+  if (n < 9) liveNumbers.push(n + 1);
+}
+
+// Function-local iterator state is independent per call, and the source
+// expression is evaluated exactly once when the iterator is created.
+function makeNumbers(limit: number): number[] {
+  console.log("make", limit);
+  return [limit, limit + 1];
+}
+function walkLocal(limit: number): number {
+  const localValues = makeNumbers(limit).values();
+  let sum = 0;
+  for (const n of localValues) sum += n;
+  return sum;
+}
+console.log("local", walkLocal(4), walkLocal(8));
+
+// Uint8Array uses the same numeric value-iterator protocol. Direct
+// iteration evaluates the source once and observes element writes that
+// happen before a later index is visited.
+function makeBytes(): Uint8Array {
+  console.log("make-bytes");
+  return new Uint8Array([250, 2, 3]);
+}
+const directBytes = makeBytes();
+for (const byte of directBytes) {
+  console.log("byte", byte);
+  if (byte === 250) directBytes[1] = 8;
+}
+
+// Stored typed-array iterators retain their cursor across loops just like
+// stored number[] iterators.
+const byteValues = new Uint8Array([11, 12, 13]).values();
+for (const byte of byteValues) {
+  console.log("byte-first", byte);
+  break;
+}
+for (const byte of byteValues) console.log("byte-rest", byte);
+for (const byte of byteValues) console.log("byte-exhausted", byte);
+
+// Both direct and stored default-iterator spellings yield numbers.
+for (const byte of new Uint8Array([21, 22]).values()) {
+  console.log("byte-direct-values", byte);
+}
+for (const byte of new Uint8Array([31, 32])[Symbol.iterator]()) {
+  console.log("byte-direct-symbol", byte);
+}
+const byteSymbol = new Uint8Array([41, 42])[Symbol.iterator]();
+for (const byte of byteSymbol) console.log("byte-symbol", byte);


### PR DESCRIPTION
- Lower number-array and typed-array value iterators statically.
- Preserve stored iterator cursor and exhaustion state across loops.
- Add Node differential coverage for arrays and Uint8Array.