### PR TITLE
Support array copying and Uint8Array iteration

### DIFF
--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -54,6 +54,10 @@ export interface CcOptions {
    * JSContext there). Off = regex-free: the command line is exactly the
    * historical one, so regex-free binaries cannot change by a byte. */
   regex?: boolean;
+  /** The program uses one of the copying/typed-array bridge intrinsics
+   * implemented in scr_copying.c (index.ts detects them on the IR).
+   * Off keeps that optional TU out of unrelated binaries. */
+  copying?: boolean;
   /** The embedded npm graph references fetch (index.ts detects it on the
    * IR): compiles the NATIVE fetch bridge (scr_fetch.c over scr_net +
    * scr_tls + scr_http's client parser + zlib — the socket units join
@@ -737,6 +741,7 @@ export interface LibArchiveOptions {
   searchParams?: boolean;
   emitter?: boolean;
   zlib?: boolean;
+  copying?: boolean;
 }
 
 export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> {
@@ -764,6 +769,7 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
     ...(opts.searchParams ? ["scr_url_params.c"] : []),
     ...(opts.emitter ? ["scr_events_emitter.c", "scr_dyn_handle.c"] : []),
     ...(opts.zlib ? ["scr_zlib.c"] : []),
+    ...(opts.copying ? ["scr_copying.c"] : []),
   ];
   const cflags = [
     "-std=c11",
@@ -1095,6 +1101,7 @@ export async function compileC(opts: CcOptions): Promise<void> {
     "-Wno-deprecated-declarations", // ucontext fibers (scr_async.c)
     "-I", rtDir,
     ...RUNTIME_SOURCES.map((f) => rt(join(rtDir, f))),
+    ...(opts.copying ? [rt(join(rtDir, "scr_copying.c"))] : []),
     // win32 targets compile the libc-shim TU (stpcpy, arc4random_buf,
     // gmtime_r, strcasestr — the _WIN32 block in scr_runtime.h declares
     // them) and link advapi32 (the CSPRNG RtlGenRandom/SystemFunction036,

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -916,6 +916,27 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             const end = e.args[1] ? E.emitExpr(e.args[1]).name : "INFINITY";
             return E.newTemp(e.type, `scr_arr_slice(${r.name}, ${start}, ${end})`);
           }
+          case "toReversed":
+            return E.newTemp(e.type, `scr_arr_to_reversed(${r.name})`);
+          case "toSpliced": {
+            const start = E.emitExpr(e.args[0]!);
+            const count = E.emitExpr(e.args[1]!);
+            const items = E.emitExpr(e.args[2]!);
+            return E.newTemp(
+              e.type,
+              `scr_arr_to_spliced(${r.name}, ${start.name}, ${count.name}, ${items.name})`,
+            );
+          }
+          case "with": {
+            const index = E.emitExpr(e.args[0]!);
+            const value = E.emitExpr(e.args[1]!);
+            const out = E.newTemp(
+              e.type,
+              `scr_arr_with_${acc}(${r.name}, ${index.name}, ${value.name})`,
+            );
+            E.emitPendingCheck();
+            return out;
+          }
           case "splice": {
             // The removal splice: the removed elements come back as a
             // fresh +1 array, their ownership MOVED out of the receiver
@@ -1036,6 +1057,23 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
               e.type,
               `scr_bytes_subarray(${r.name}, ${args[0]?.name ?? "0"}, ${args[1]?.name ?? "INFINITY"})`,
             );
+          case "toReversed":
+            return E.newTemp(e.type, `scr_bytes_to_reversed(${r.name})`);
+          case "with": {
+            const out = E.newTemp(
+              e.type,
+              `scr_bytes_with(${r.name}, ${args[0]!.name}, ${args[1]!.name})`,
+            );
+            E.emitPendingCheck();
+            return out;
+          }
+          case "join":
+            return E.newTemp(
+              e.type,
+              `scr_bytes_join(${r.name}, ${args[0]!.name})`,
+            );
+          case "toArray":
+            return E.newTemp(e.type, `scr_bytes_to_arr(${r.name})`);
           case "setFrom": {
             // dst.set(src, offset?) — void; throws Node's RangeError on
             // overflow (may-throw seed).

--- a/packages/compiler/src/backend/emission/may-throw.ts
+++ b/packages/compiler/src/backend/emission/may-throw.ts
@@ -1,7 +1,7 @@
 /* Cheap whole-module may-throw analysis (see computeMayThrow). Pure function
  * of the IR module; the emitter consults the result to place unwind checks. */
-import type { IrBytesIntrinsicMethod, IrLibFn, IrModule } from "../../ir/nodes.js";
-import { MAY_THROW_BYTES_METHODS, MAY_THROW_LIB_FNS } from "../../ir/nodes.js";
+import type { IrArrIntrinsicMethod, IrBytesIntrinsicMethod, IrLibFn, IrModule } from "../../ir/nodes.js";
+import { MAY_THROW_ARR_METHODS, MAY_THROW_BYTES_METHODS, MAY_THROW_LIB_FNS } from "../../ir/nodes.js";
 
 /** Cheap may-throw analysis (cost discipline: functions that transitively
  * CANNOT throw pay for no pending-exception checks). A function may throw
@@ -176,6 +176,11 @@ export function computeMayThrow(mod: IrModule): { fns: Set<string>; indirect: bo
           // RangeErrors (Node's bounds discipline); the rest trap or
           // cannot fail.
           if (MAY_THROW_BYTES_METHODS.has(rec["method"] as IrBytesIntrinsicMethod)) {
+            f.throws = true;
+          }
+          break;
+        case "arrIntrinsic":
+          if (MAY_THROW_ARR_METHODS.has(rec["method"] as IrArrIntrinsicMethod)) {
             f.throws = true;
           }
           break;

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -8814,6 +8814,39 @@ class LlEmitter {
         B.line(`${t} = call ptr @scr_arr_slice(ptr ${r.name}, double ${start}, double ${end})`);
         return this.own({ name: t, type: e.type });
       }
+      case "toReversed": {
+        this.declare(`declare ptr @scr_arr_to_reversed(ptr)`);
+        const t = B.tmp();
+        B.line(`${t} = call ptr @scr_arr_to_reversed(ptr ${r.name})`);
+        return this.own({ name: t, type: e.type });
+      }
+      case "toSpliced": {
+        const start = this.emitExpr(e.args[0]!);
+        const count = this.emitExpr(e.args[1]!);
+        const items = this.emitExpr(e.args[2]!);
+        this.declare(`declare ptr @scr_arr_to_spliced(ptr, double, double, ptr)`);
+        const t = B.tmp();
+        B.line(
+          `${t} = call ptr @scr_arr_to_spliced(ptr ${r.name}, double ${start.name}, ` +
+            `double ${count.name}, ptr ${items.name})`,
+        );
+        return this.own({ name: t, type: e.type });
+      }
+      case "with": {
+        const index = this.emitExpr(e.args[0]!);
+        const value = this.emitExpr(e.args[1]!);
+        this.declare(
+          `declare ptr @scr_arr_with_${acc}(ptr, double, ${accArg})`,
+        );
+        const t = B.tmp();
+        B.line(
+          `${t} = call ptr @scr_arr_with_${acc}(ptr ${r.name}, double ${index.name}, ` +
+            `${accTy} ${value.name})`,
+        );
+        const out = this.own({ name: t, type: e.type });
+        this.emitPendingCheck();
+        return out;
+      }
       case "splice": {
         // The removal splice: removed elements come back as a fresh +1
         // array, ownership MOVED out of the receiver. An omitted count
@@ -9261,6 +9294,38 @@ class LlEmitter {
           "scr_bytes_subarray",
           "ptr (ptr, double, double)",
           `ptr ${r.name}, double ${args[0]?.name ?? f64Lit(0)}, double ${args[1]?.name ?? F64_INF}`,
+          true,
+          false,
+        );
+      case "toReversed":
+        return call(
+          "scr_bytes_to_reversed",
+          "ptr (ptr)",
+          `ptr ${r.name}`,
+          true,
+          false,
+        );
+      case "with":
+        return call(
+          "scr_bytes_with",
+          "ptr (ptr, double, double)",
+          `ptr ${r.name}, double ${args[0]!.name}, double ${args[1]!.name}`,
+          true,
+          true,
+        );
+      case "join":
+        return call(
+          "scr_bytes_join",
+          "ptr (ptr, ptr)",
+          `ptr ${r.name}, ptr ${args[0]!.name}`,
+          true,
+          false,
+        );
+      case "toArray":
+        return call(
+          "scr_bytes_to_arr",
+          "ptr (ptr)",
+          `ptr ${r.name}`,
           true,
           false,
         );

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -20,6 +20,18 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
  * An effectful `void e` is exact in this context: evaluate e, then produce
  * undefined, instead of hitting value-position void's general fence. */
 function lowerStaticallyUndefinedArg(L: Lowerer, node: ts.Expression): IrExpr | null {
+  const peelErasableWrappers = (value: ts.Expression): ts.Expression => {
+    let expr = value;
+    while (
+      ts.isParenthesizedExpression(expr) ||
+      ts.isAsExpression(expr) ||
+      ts.isTypeAssertion(expr) ||
+      ts.isSatisfiesExpression(expr)
+    ) {
+      expr = expr.expression;
+    }
+    return expr;
+  };
   let expr = node;
   while (ts.isParenthesizedExpression(expr)) expr = expr.expression;
   if (
@@ -29,11 +41,22 @@ function lowerStaticallyUndefinedArg(L: Lowerer, node: ts.Expression): IrExpr | 
   ) {
     return null;
   }
-  if (ts.isVoidExpression(expr)) {
+  // TypeScript erases `as`, angle-bracket assertions, and `satisfies`.
+  // Peel them only for the void recognition: a non-void assertion still
+  // lowers through the ordinary path below, preserving the checked-dynamic
+  // cast discipline. Nested voids add no effects of their own, so the one
+  // innermost operand carries the complete runtime evaluation.
+  expr = peelErasableWrappers(expr);
+  let sawVoid = false;
+  while (ts.isVoidExpression(expr)) {
+    sawVoid = true;
+    expr = peelErasableWrappers(expr.expression);
+  }
+  if (sawVoid) {
     // The caller discards this token before producing the parameter
     // default, so the operand itself carries exactly the required effects;
     // no bare undefined value needs to enter the IR.
-    return L.lowerExpr(expr.expression);
+    return L.lowerExpr(expr);
   }
   return L.lowerExpr(node);
 }

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -210,14 +210,17 @@ function lowerOptionalDefaultArg(
         type: F64,
         loc,
       };
-      const deleteCount = call.arguments[1]
-        ? lowerOptionalDefaultArg(
-            L,
-            call.arguments[1],
-            F64,
-            deleteCountDefault,
-          )
-        : { kind: "numLit" as const, value: Infinity, type: F64, loc };
+      const deleteCount =
+        call.arguments.length === 0
+          ? { kind: "numLit" as const, value: 0, type: F64, loc }
+          : call.arguments[1]
+            ? lowerOptionalDefaultArg(
+                L,
+                call.arguments[1],
+                F64,
+                deleteCountDefault,
+              )
+            : { kind: "numLit" as const, value: Infinity, type: F64, loc };
       const items: IrExpr = {
         kind: "arrayLit",
         elems: call.arguments.slice(2).map((arg) =>

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -13,6 +13,20 @@ import { DYN_DISPATCH_METHODS, islandPrimitiveExit } from "./lower-calls.js";
 import { typeKey } from "../types.js";
 import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
 
+/** True only for an `undefined`-typed identifier with the standard
+ * spelling (parentheses ignored). Optional builtin parameters use this to
+ * distinguish an explicit undefined from a numeric/string value; a user
+ * binding that shadows the spelling with another type does not match. */
+function stdlibUndefinedArg(L: Lowerer, node: ts.Expression): boolean {
+  let expr = node;
+  while (ts.isParenthesizedExpression(expr)) expr = expr.expression;
+  return (
+    ts.isIdentifier(expr) &&
+    expr.text === "undefined" &&
+    (L.typeOf(expr).flags & ts.TypeFlags.Undefined) !== 0
+  );
+}
+
 /** Ambient array method calls. `push`/`pop`/`indexOf`/`includes`/`join`
    * lower to arrIntrinsic; the HOF family — `map`/`filter`/`forEach`/
    * `find`/`some`/`every`/`flatMap`/`reduce`/`reduceRight` — desugars to a
@@ -112,6 +126,68 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
     }
     if (name === "sort" || name === "toSorted") {
       return lowerArraySortCall(L, call, access, elem, receiverIr);
+    }
+    if (name === "toReversed") {
+      if (call.arguments.length !== 0) {
+        L.noLowering(`.toReversed with ${call.arguments.length} arguments`, call);
+      }
+      return {
+        kind: "arrIntrinsic",
+        method: "toReversed",
+        receiver: L.lowerExpr(access.expression),
+        args: [],
+        type: receiverIr,
+        loc,
+      };
+    }
+    if (name === "with") {
+      if (call.arguments.length !== 2 || call.arguments.some(ts.isSpreadElement)) {
+        L.noLowering(`.with with ${call.arguments.length} arguments`, call);
+      }
+      const receiver = L.lowerExpr(access.expression);
+      const index = L.lowerExprExpecting(call.arguments[0]!, F64);
+      const value = L.coerceInto(
+        call.arguments[1]!,
+        L.lowerExpr(call.arguments[1]!),
+        elem,
+      );
+      return {
+        kind: "arrIntrinsic",
+        method: "with",
+        receiver,
+        args: [index, value],
+        type: receiverIr,
+        loc,
+      };
+    }
+    if (name === "toSpliced") {
+      if (call.arguments.some(ts.isSpreadElement)) {
+        L.unsupported("SC1090", call, "spread arguments to Array.toSpliced");
+      }
+      const receiver = L.lowerExpr(access.expression);
+      const start = call.arguments[0]
+        ? L.lowerExprExpecting(call.arguments[0], F64)
+        : { kind: "numLit" as const, value: 0, type: F64, loc };
+      const deleteCount = call.arguments[1]
+        ? stdlibUndefinedArg(L, call.arguments[1])
+          ? { kind: "numLit" as const, value: NaN, type: F64, loc }
+          : L.lowerExprExpecting(call.arguments[1], F64)
+        : { kind: "numLit" as const, value: Infinity, type: F64, loc };
+      const items: IrExpr = {
+        kind: "arrayLit",
+        elems: call.arguments.slice(2).map((arg) =>
+          L.coerceInto(arg, L.lowerExpr(arg), elem)),
+        type: receiverIr,
+        loc,
+      };
+      return {
+        kind: "arrIntrinsic",
+        method: "toSpliced",
+        receiver,
+        args: [start, deleteCount, items],
+        type: receiverIr,
+        loc,
+      };
     }
 
     // The lib declares wider call forms than the lowered surface —
@@ -1675,6 +1751,280 @@ import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
         { id: "v.0", name: "v", type: elem, mutable: false },
         { id: "j.0", name: "j", type: F64, mutable: true },
       ],
+      body,
+      loc,
+    };
+  }
+
+/** Uint8Array.prototype.toSorted. The receiver/comparator expressions are
+ * evaluated before entering the helper; the helper snapshots with
+ * TypedArray.prototype.slice before its first comparison, then performs
+ * the same stable insertion walk as Array.toSorted. Uint8Array's default
+ * comparator is numeric ascending, so its comparator-less form needs no
+ * string-conversion machinery. */
+  function lowerBytesToSortedCall(
+    L: Lowerer,
+    call: ts.CallExpression,
+    access: ts.PropertyAccessExpression,
+    bytesT: IrType & { kind: "bytes" },
+  ): IrExpr {
+    const loc = locOf(call);
+    if (call.arguments.length > 1 || call.arguments.some(ts.isSpreadElement)) {
+      L.noLowering(`.toSorted with ${call.arguments.length} arguments on Uint8Array`, call);
+    }
+    const receiver = L.lowerExpr(access.expression);
+    if (
+      call.arguments.length === 0 ||
+      stdlibUndefinedArg(L, call.arguments[0]!)
+    ) {
+      const key = "bytes.toSorted:u8:default";
+      let helper = L.arrHofHelpers.get(key);
+      if (!helper) {
+        helper = `%bytes.toSorted.${L.arrHofHelpers.size}`;
+        L.arrHofHelpers.set(key, helper);
+        L.liftedFns.push(buildBytesSortFn(helper, 0, false, loc));
+      }
+      return { kind: "call", callee: helper, args: [receiver], type: bytesT, loc };
+    }
+    const argNode = call.arguments[0]!;
+    const fnArg = L.lowerExpr(argNode);
+    if (
+      fnArg.type.kind !== "func" ||
+      fnArg.type.params.length > 2 ||
+      !fnArg.type.params.every((p) => p.kind === "f64") ||
+      fnArg.type.ret.kind !== "f64"
+    ) {
+      L.badType(argNode, L.typeOf(argNode));
+    }
+    const arity = fnArg.type.params.length;
+    const key = `bytes.toSorted:u8:${arity}`;
+    let helper = L.arrHofHelpers.get(key);
+    if (!helper) {
+      helper = `%bytes.toSorted.${L.arrHofHelpers.size}`;
+      L.arrHofHelpers.set(key, helper);
+      L.liftedFns.push(buildBytesSortFn(helper, arity, true, loc));
+    }
+    return {
+      kind: "call",
+      callee: helper,
+      args: [receiver, fnArg],
+      type: bytesT,
+      loc,
+    };
+  }
+
+  function buildBytesSortFn(
+    name: string,
+    arity: number,
+    hasComparator: boolean,
+    loc: SrcLoc,
+  ): IrFunction {
+    const bytesT = BYTES_U8;
+    const fnT = funcOf([F64, F64].slice(0, arity), F64);
+    const ref = (localId: string, type: IrType): IrExpr => ({
+      kind: "varRef",
+      localId,
+      type,
+      loc,
+    });
+    const num = (value: number): IrExpr => ({
+      kind: "numLit",
+      value,
+      type: F64,
+      loc,
+    });
+    const j = ref("j.0", F64);
+    const at = (index: IrExpr): IrExpr => ({
+      kind: "bytesIntrinsic",
+      method: "get",
+      receiver: ref("a.0", bytesT),
+      args: [index],
+      type: F64,
+      loc,
+    });
+    const jPlus1: IrExpr = {
+      kind: "bin",
+      op: "+",
+      left: j,
+      right: num(1),
+      type: F64,
+      loc,
+    };
+    const compare: IrExpr = hasComparator
+      ? {
+          kind: "callValue",
+          callee: ref("f.0", fnT),
+          args: [at(j), ref("v.0", F64)].slice(0, arity),
+          type: F64,
+          loc,
+        }
+      : {
+          kind: "bin",
+          op: "-",
+          left: at(j),
+          right: ref("v.0", F64),
+          type: F64,
+          loc,
+        };
+    const shiftLoop: IrStmt = {
+      kind: "while",
+      cond: {
+        kind: "bin",
+        op: ">=",
+        left: j,
+        right: num(0),
+        type: BOOL,
+        loc,
+      },
+      body: [
+        {
+          kind: "if",
+          cond: {
+            kind: "bin",
+            op: ">",
+            left: compare,
+            right: num(0),
+            type: BOOL,
+            loc,
+          },
+          then: [
+            {
+              kind: "bytesSet",
+              arr: ref("a.0", bytesT),
+              index: jPlus1,
+              value: at(j),
+              loc,
+            },
+            {
+              kind: "assign",
+              localId: "j.0",
+              value: {
+                kind: "bin",
+                op: "-",
+                left: j,
+                right: num(1),
+                type: F64,
+                loc,
+              },
+              loc,
+            },
+          ],
+          else_: [{ kind: "break", loc }],
+          loc,
+        },
+      ],
+      loc,
+    };
+    const params: IrParam[] = [
+      { localId: "a.0", name: "a", type: bytesT },
+      ...(hasComparator
+        ? [{ localId: "f.0", name: "f", type: fnT }]
+        : []),
+    ];
+    const locals: IrLocal[] = [
+      { id: "a.0", name: "a", type: bytesT, mutable: true },
+      ...(hasComparator
+        ? [{ id: "f.0", name: "f", type: fnT, mutable: true }]
+        : []),
+      { id: "n.0", name: "n", type: F64, mutable: false },
+      { id: "i.0", name: "i", type: F64, mutable: true },
+      { id: "v.0", name: "v", type: F64, mutable: false },
+      { id: "j.0", name: "j", type: F64, mutable: true },
+    ];
+    const body: IrStmt[] = [
+      {
+        kind: "assign",
+        localId: "a.0",
+        value: {
+          kind: "bytesIntrinsic",
+          method: "slice",
+          receiver: ref("a.0", bytesT),
+          args: [],
+          type: bytesT,
+          loc,
+        },
+        loc,
+      },
+      {
+        kind: "varDecl",
+        localId: "n.0",
+        init: {
+          kind: "bytesIntrinsic",
+          method: "length",
+          receiver: ref("a.0", bytesT),
+          args: [],
+          type: F64,
+          loc,
+        },
+        loc,
+      },
+      {
+        kind: "for",
+        init: {
+          kind: "varDecl",
+          localId: "i.0",
+          init: num(1),
+          loc,
+        },
+        cond: {
+          kind: "bin",
+          op: "<",
+          left: ref("i.0", F64),
+          right: ref("n.0", F64),
+          type: BOOL,
+          loc,
+        },
+        update: {
+          kind: "assign",
+          localId: "i.0",
+          value: {
+            kind: "bin",
+            op: "+",
+            left: ref("i.0", F64),
+            right: num(1),
+            type: F64,
+            loc,
+          },
+          loc,
+        },
+        body: [
+          {
+            kind: "varDecl",
+            localId: "v.0",
+            init: at(ref("i.0", F64)),
+            loc,
+          },
+          {
+            kind: "varDecl",
+            localId: "j.0",
+            init: {
+              kind: "bin",
+              op: "-",
+              left: ref("i.0", F64),
+              right: num(1),
+              type: F64,
+              loc,
+            },
+            loc,
+          },
+          shiftLoop,
+          {
+            kind: "bytesSet",
+            arr: ref("a.0", bytesT),
+            index: jPlus1,
+            value: ref("v.0", F64),
+            loc,
+          },
+        ],
+        loc,
+      },
+      { kind: "return", value: ref("a.0", bytesT), loc },
+    ];
+    return {
+      name,
+      params,
+      returnType: bytesT,
+      locals,
       body,
       loc,
     };
@@ -3824,7 +4174,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     }
   }
 
-/** for-of over an ARRAY's keys()/entries() projections consumed directly
+/** for-of over an ARRAY/typed-array keys()/entries() projection consumed directly
    * by the head (`for (const [index, line] of lines.entries())` — the
    * dominant formatter idiom): the LIVE index walk — the length re-reads
    * every pass, exactly the array iterator's contract (elements appended
@@ -3837,11 +4187,15 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
    * [number, T] tuple record. Stored iterator OBJECTS keep their fence
    * (only the direct for-of position unwraps). */
   export function lowerForOfArrayIter(L: Lowerer, stmt: ts.ForOfStatement,
-    iterable: IrExpr & { type: IrType & { kind: "array" } },
+    iterable: IrExpr & {
+      type:
+        | (IrType & { kind: "array" })
+        | (IrType & { kind: "bytes" });
+    },
     proj: "keys" | "entries",): IrStmt {
     const loc = locOf(stmt);
     const arrT = iterable.type;
-    const elemT = arrT.elem;
+    const elemT = arrT.kind === "array" ? arrT.elem : F64;
     const yieldsPair = proj === "entries";
     if (!ts.isVariableDeclarationList(stmt.initializer)) {
       L.unsupported(
@@ -3865,7 +4219,23 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
       const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
       const keyRead = (): IrExpr => ref(i.id, F64);
-      const valRead = (): IrExpr => ({ kind: "arrayGet", arr: ref(arr.id, arrT), index: ref(i.id, F64), type: elemT, loc });
+      const valRead = (): IrExpr =>
+        arrT.kind === "array"
+          ? {
+              kind: "arrayGet",
+              arr: ref(arr.id, arrT),
+              index: ref(i.id, F64),
+              type: elemT,
+              loc,
+            }
+          : {
+              kind: "bytesIntrinsic",
+              method: "get",
+              receiver: ref(arr.id, arrT),
+              args: [ref(i.id, F64)],
+              type: F64,
+              loc,
+            };
 
       const binds: IrStmt[] = [];
       const isPlainIdent = (el: ts.ArrayBindingElement): el is ts.BindingElement & { name: ts.Identifier } =>
@@ -3953,7 +4323,24 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
           kind: "bin",
           op: "<",
           left: ref(i.id, F64),
-          right: { kind: "arrIntrinsic", method: "length", receiver: ref(arr.id, arrT), args: [], type: F64, loc },
+          right:
+            arrT.kind === "array"
+              ? {
+                  kind: "arrIntrinsic",
+                  method: "length",
+                  receiver: ref(arr.id, arrT),
+                  args: [],
+                  type: F64,
+                  loc,
+                }
+              : {
+                  kind: "bytesIntrinsic",
+                  method: "length",
+                  receiver: ref(arr.id, arrT),
+                  args: [],
+                  type: F64,
+                  loc,
+                },
           type: BOOL,
           loc,
         },
@@ -4858,6 +5245,56 @@ const BYTES_CTORS: Record<string, IrBytesElem | undefined> = {
     if (!L.isStdlibMember(access)) return null;
     const loc = locOf(call);
     const nArgs = call.arguments.length;
+    if (receiverIr.elem === "u8" && name === "toSorted") {
+      return lowerBytesToSortedCall(L, call, access, receiverIr);
+    }
+    if (receiverIr.elem === "u8" && name === "toReversed") {
+      if (nArgs !== 0) {
+        L.noLowering(`.toReversed with ${nArgs} arguments on Uint8Array`, call);
+      }
+      return {
+        kind: "bytesIntrinsic",
+        method: "toReversed",
+        receiver: L.lowerExpr(access.expression),
+        args: [],
+        type: receiverIr,
+        loc,
+      };
+    }
+    if (receiverIr.elem === "u8" && name === "with") {
+      if (nArgs !== 2 || call.arguments.some(ts.isSpreadElement)) {
+        L.noLowering(`.with with ${nArgs} arguments on Uint8Array`, call);
+      }
+      return {
+        kind: "bytesIntrinsic",
+        method: "with",
+        receiver: L.lowerExpr(access.expression),
+        args: [
+          L.lowerExprExpecting(call.arguments[0]!, F64),
+          L.lowerExprExpecting(call.arguments[1]!, F64),
+        ],
+        type: receiverIr,
+        loc,
+      };
+    }
+    if (receiverIr.elem === "u8" && name === "join") {
+      if (nArgs > 1 || call.arguments.some(ts.isSpreadElement)) {
+        L.noLowering(`.join with ${nArgs} arguments on Uint8Array`, call);
+      }
+      const separator = call.arguments[0]
+        ? stdlibUndefinedArg(L, call.arguments[0])
+          ? { kind: "strLit" as const, value: ",", type: STRING, loc }
+          : L.lowerExprExpecting(call.arguments[0], STRING)
+        : { kind: "strLit" as const, value: ",", type: STRING, loc };
+      return {
+        kind: "bytesIntrinsic",
+        method: "join",
+        receiver: L.lowerExpr(access.expression),
+        args: [separator],
+        type: STRING,
+        loc,
+      };
+    }
     if (name === "slice" || name === "subarray") {
       if (nArgs > 2) {
         L.noLowering(`.${name} with ${nArgs} arguments on typed arrays`, call);

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -6,25 +6,61 @@ import * as ts from "../ts7/adapter.js";
 import type { Lowerer } from "./lowerer.js";
 import { BOOL, BYTES_U8, CAUGHT, DYN, F64, IrBytesElem, IrBytesIntrinsicMethod, IrExpr, IrFunction, IrLocal, IrMapIntrinsicMethod, IrParam, IrRecordShape, IrSetIntrinsicMethod, IrStmt, IrType, JSVAL, STRING, SrcLoc, UNDEFINED_T, VOID, arrayOf, bytesOf, funcOf, isRefCounted, isSupportedIndexValue, isUnitType, typeEquals } from "../../ir/nodes.js";
 import { ARRAY_METHODS, MAP_METHODS, SET_COMBINE_METHODS, SET_METHODS, STR_METHODS } from "./surfaces.js";
-import { isRequireMainFilename, lowerDynObjectLiteral, probeLower, pureReemittable } from "./lower-exprs.js";
+import { droppableStatic, isRequireMainFilename, lowerDynObjectLiteral, probeLower, pureReemittable } from "./lower-exprs.js";
 import { forOfVarTarget, lowerDestructuringAssign } from "./lower-stmts.js";
 import { isJsSourceFile, locOf } from "../program.js";
 import { DYN_DISPATCH_METHODS, islandPrimitiveExit } from "./lower-calls.js";
 import { typeKey } from "../types.js";
 import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
 
-/** True only for an `undefined`-typed identifier with the standard
- * spelling (parentheses ignored). Optional builtin parameters use this to
- * distinguish an explicit undefined from a numeric/string value; a user
- * binding that shadows the spelling with another type does not match. */
-function stdlibUndefinedArg(L: Lowerer, node: ts.Expression): boolean {
+/** Lower an expression whose checker type is statically `undefined`/`void`.
+ * Optional builtin arguments use this before their ordinary expected-type
+ * coercion so every equivalent spelling (`undefined`, `void 0`, a typed
+ * binding, or an effectful call returning undefined) selects the default.
+ * An effectful `void e` is exact in this context: evaluate e, then produce
+ * undefined, instead of hitting value-position void's general fence. */
+function lowerStaticallyUndefinedArg(L: Lowerer, node: ts.Expression): IrExpr | null {
   let expr = node;
   while (ts.isParenthesizedExpression(expr)) expr = expr.expression;
-  return (
-    ts.isIdentifier(expr) &&
-    expr.text === "undefined" &&
-    (L.typeOf(expr).flags & ts.TypeFlags.Undefined) !== 0
-  );
+  if (
+    (L.typeOf(expr).flags &
+      (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) ===
+    0
+  ) {
+    return null;
+  }
+  if (ts.isVoidExpression(expr)) {
+    // The caller discards this token before producing the parameter
+    // default, so the operand itself carries exactly the required effects;
+    // no bare undefined value needs to enter the IR.
+    return L.lowerExpr(expr.expression);
+  }
+  return L.lowerExpr(node);
+}
+
+/** Preserve a statically-undefined argument's effects, then answer the
+ * optional parameter's already-lowered default value. */
+function defaultAfterUndefined(value: IrExpr, defaultValue: IrExpr): IrExpr {
+  if (droppableStatic(value)) return defaultValue;
+  return {
+    kind: "seqExpr",
+    stmts: [{ kind: "exprStmt", expr: value, loc: value.loc }],
+    result: defaultValue,
+    type: defaultValue.type,
+    loc: value.loc,
+  };
+}
+
+function lowerOptionalDefaultArg(
+  L: Lowerer,
+  node: ts.Expression,
+  expected: IrType,
+  defaultValue: IrExpr,
+): IrExpr {
+  const undefinedArg = lowerStaticallyUndefinedArg(L, node);
+  return undefinedArg
+    ? defaultAfterUndefined(undefinedArg, defaultValue)
+    : L.lowerExprExpecting(node, expected);
 }
 
 /** Ambient array method calls. `push`/`pop`/`indexOf`/`includes`/`join`
@@ -168,10 +204,19 @@ function stdlibUndefinedArg(L: Lowerer, node: ts.Expression): boolean {
       const start = call.arguments[0]
         ? L.lowerExprExpecting(call.arguments[0], F64)
         : { kind: "numLit" as const, value: 0, type: F64, loc };
+      const deleteCountDefault: IrExpr = {
+        kind: "numLit",
+        value: NaN,
+        type: F64,
+        loc,
+      };
       const deleteCount = call.arguments[1]
-        ? stdlibUndefinedArg(L, call.arguments[1])
-          ? { kind: "numLit" as const, value: NaN, type: F64, loc }
-          : L.lowerExprExpecting(call.arguments[1], F64)
+        ? lowerOptionalDefaultArg(
+            L,
+            call.arguments[1],
+            F64,
+            deleteCountDefault,
+          )
         : { kind: "numLit" as const, value: Infinity, type: F64, loc };
       const items: IrExpr = {
         kind: "arrayLit",
@@ -1773,10 +1818,10 @@ function stdlibUndefinedArg(L: Lowerer, node: ts.Expression): boolean {
       L.noLowering(`.toSorted with ${call.arguments.length} arguments on Uint8Array`, call);
     }
     const receiver = L.lowerExpr(access.expression);
-    if (
-      call.arguments.length === 0 ||
-      stdlibUndefinedArg(L, call.arguments[0]!)
-    ) {
+    const undefinedArg = call.arguments[0]
+      ? lowerStaticallyUndefinedArg(L, call.arguments[0])
+      : null;
+    if (call.arguments.length === 0 || undefinedArg) {
       const key = "bytes.toSorted:u8:default";
       let helper = L.arrHofHelpers.get(key);
       if (!helper) {
@@ -1784,7 +1829,35 @@ function stdlibUndefinedArg(L: Lowerer, node: ts.Expression): boolean {
         L.arrHofHelpers.set(key, helper);
         L.liftedFns.push(buildBytesSortFn(helper, 0, false, loc));
       }
-      return { kind: "call", callee: helper, args: [receiver], type: bytesT, loc };
+      if (!undefinedArg || droppableStatic(undefinedArg)) {
+        return { kind: "call", callee: helper, args: [receiver], type: bytesT, loc };
+      }
+      // The default helper takes no comparator argument. Snapshot the
+      // receiver into a hidden local so the discarded undefined argument
+      // still evaluates after the receiver and before the helper call.
+      const saved = L.declareHiddenLocal("%bytesSortRecv", bytesT);
+      const savedRef: IrExpr = {
+        kind: "varRef",
+        localId: saved.id,
+        type: bytesT,
+        loc,
+      };
+      return {
+        kind: "seqExpr",
+        stmts: [
+          { kind: "varDecl", localId: saved.id, init: receiver, loc },
+          { kind: "exprStmt", expr: undefinedArg, loc: undefinedArg.loc },
+        ],
+        result: {
+          kind: "call",
+          callee: helper,
+          args: [savedRef],
+          type: bytesT,
+          loc,
+        },
+        type: bytesT,
+        loc,
+      };
     }
     const argNode = call.arguments[0]!;
     const fnArg = L.lowerExpr(argNode);
@@ -5281,11 +5354,20 @@ const BYTES_CTORS: Record<string, IrBytesElem | undefined> = {
       if (nArgs > 1 || call.arguments.some(ts.isSpreadElement)) {
         L.noLowering(`.join with ${nArgs} arguments on Uint8Array`, call);
       }
+      const separatorDefault: IrExpr = {
+        kind: "strLit",
+        value: ",",
+        type: STRING,
+        loc,
+      };
       const separator = call.arguments[0]
-        ? stdlibUndefinedArg(L, call.arguments[0])
-          ? { kind: "strLit" as const, value: ",", type: STRING, loc }
-          : L.lowerExprExpecting(call.arguments[0], STRING)
-        : { kind: "strLit" as const, value: ",", type: STRING, loc };
+        ? lowerOptionalDefaultArg(
+            L,
+            call.arguments[0],
+            STRING,
+            separatorDefault,
+          )
+        : separatorDefault;
       return {
         kind: "bytesIntrinsic",
         method: "join",

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -3635,6 +3635,21 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
         if (src.type.kind === "string") {
           src = strCharsCall(L, src, locOf(el));
         }
+        // `[...typedArray]`: represented typed arrays are dense numeric
+        // iterables, so drain their elements into the fresh number[] that
+        // the surrounding array literal will copy. In particular this is
+        // the Uint8Array-to-Array bridge (`[...u8]`), with element values
+        // read rather than backing bytes for the wider typed-array kinds.
+        if (src.type.kind === "bytes" && type.elem.kind === "f64") {
+          src = {
+            kind: "bytesIntrinsic",
+            method: "toArray",
+            receiver: src,
+            args: [],
+            type: arrayOf(F64),
+            loc: locOf(el),
+          };
+        }
         // A same-family array whose ELEMENT lifts (string[] into a
         // (string | symbol)[] literal — per-element wrap/width copy):
         // the interned width helper reshapes before the spread copies.

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -3640,7 +3640,7 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
         // the surrounding array literal will copy. In particular this is
         // the Uint8Array-to-Array bridge (`[...u8]`), with element values
         // read rather than backing bytes for the wider typed-array kinds.
-        if (src.type.kind === "bytes" && type.elem.kind === "f64") {
+        if (src.type.kind === "bytes") {
           src = {
             kind: "bytesIntrinsic",
             method: "toArray",

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -1447,6 +1447,60 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
         });
         return;
       }
+      // Represented typed arrays are dense numeric iterables. Destructuring
+      // reads their elements in index order; a rest binding drains to a
+      // fresh number[] (never another typed array), exactly the iterator
+      // protocol's Array accumulation.
+      if (srcType.kind === "bytes") {
+        pattern.elements.forEach((el, i) => {
+          if (ts.isOmittedExpression(el) || el.name === undefined) return;
+          const loc = locOf(el);
+          if (el.dotDotDotToken) {
+            if (el.initializer) {
+              L.unsupported("SC1031", el, "defaults on rest elements");
+            }
+            const all: IrExpr = {
+              kind: "bytesIntrinsic",
+              method: "toArray",
+              receiver: srcRef(),
+              args: [],
+              type: arrayOf(F64),
+              loc,
+            };
+            const value: IrExpr = {
+              kind: "arrIntrinsic",
+              method: "slice",
+              receiver: all,
+              args: [{ kind: "numLit", value: i, type: F64, loc }],
+              type: arrayOf(F64),
+              loc,
+            };
+            L.bindPatternTarget(el.name, value, isLet, out);
+            return;
+          }
+          let value: IrExpr = {
+            kind: "bytesIntrinsic",
+            method: "get",
+            receiver: srcRef(),
+            args: [{ kind: "numLit", value: i, type: F64, loc }],
+            type: F64,
+            loc,
+          };
+          if (el.initializer) {
+            value = arrayPositionDefault(
+              L,
+              el,
+              value,
+              srcRef,
+              i,
+              F64,
+              out,
+            );
+          }
+          L.bindPatternTarget(el.name, value, isLet, out);
+        });
+        return;
+      }
       if (srcType.kind !== "array") {
         L.unsupported(
           "SC1031",
@@ -2130,11 +2184,29 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
     if (isUnitType(elemT)) {
       return L.lowerExprExpecting(init, bodyT);
     }
+    const source = srcRef();
+    const length: IrExpr = source.type.kind === "bytes"
+      ? {
+          kind: "bytesIntrinsic",
+          method: "length",
+          receiver: source,
+          args: [],
+          type: F64,
+          loc,
+        }
+      : {
+          kind: "arrIntrinsic",
+          method: "length",
+          receiver: source,
+          args: [],
+          type: F64,
+          loc,
+        };
     const inRange: IrExpr = {
       kind: "bin",
       op: "<",
       left: { kind: "numLit", value: index, type: F64, loc },
-      right: { kind: "arrIntrinsic", method: "length", receiver: srcRef(), args: [], type: F64, loc },
+      right: length,
       type: BOOL,
       loc,
     };
@@ -5529,8 +5601,8 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         loc,
       });
       elemsRef = () => ({ kind: "varRef", localId: iterTmp.id, type: srcType, loc });
-    } else if (srcType.kind !== "array" && !isTuple) {
-      if (elements.length === 0 && (srcType.kind === "string" || srcType.kind === "bytes" || srcType.kind === "map" || srcType.kind === "set")) {
+    } else if (srcType.kind !== "array" && srcType.kind !== "bytes" && !isTuple) {
+      if (elements.length === 0 && (srcType.kind === "string" || srcType.kind === "map" || srcType.kind === "set")) {
         // `[] = e` over a statically-iterable source: GetIterator +
         // immediate close — no user code can observe it, so evaluating
         // the RHS is the whole statement.
@@ -5557,6 +5629,16 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
           L.unsupported("SC1031", at, `destructuring the element ${i} the source tuple does not carry`);
         }
         return { kind: "recordGet", obj: tmpRef(), shapeId: (srcType as IrType & { kind: "record" }).shapeId, field: String(i), type: fieldType, loc: locOf(at) };
+      }
+      if (srcType.kind === "bytes") {
+        return {
+          kind: "bytesIntrinsic",
+          method: "get",
+          receiver: tmpRef(),
+          args: [{ kind: "numLit", value: i, type: F64, loc: locOf(at) }],
+          type: F64,
+          loc: locOf(at),
+        };
       }
       // Plain arrays read by index — a pattern wider than the runtime
       // array traps (the arrayGet discipline, divergence 4's policy; JS
@@ -5592,6 +5674,24 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
       // defaults on nested targets fence in the shared machinery).
       const readOf = (targetT: IrType | null): IrExpr => {
         if (isRest) {
+          if (srcType.kind === "bytes") {
+            const all: IrExpr = {
+              kind: "bytesIntrinsic",
+              method: "toArray",
+              receiver: tmpRef(),
+              args: [],
+              type: arrayOf(F64),
+              loc: locOf(el),
+            };
+            return {
+              kind: "arrIntrinsic",
+              method: "slice",
+              receiver: all,
+              args: [{ kind: "numLit", value: i, type: F64, loc: locOf(el) }],
+              type: arrayOf(F64),
+              loc: locOf(el),
+            };
+          }
           return isTuple
             ? tupleTailValue(L, el, tmpRef, srcType as IrType & { kind: "record" }, shape!, i, targetT)
             : { kind: "arrIntrinsic", method: "slice", receiver: tmpRef(), args: [{ kind: "numLit", value: i, type: F64, loc: locOf(el) }], type: srcType, loc: locOf(el) };
@@ -5630,7 +5730,19 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
           } else if (targetT !== null) {
             read = isTuple
               ? undefArmDefault(L, el, defaultNode, read, targetT)
-              : arrayPositionDefaultValue(L, el, defaultNode, read, tmpRef, i, (srcType as IrType & { kind: "array" }).elem, targetT, out);
+              : arrayPositionDefaultValue(
+                  L,
+                  el,
+                  defaultNode,
+                  read,
+                  tmpRef,
+                  i,
+                  srcType.kind === "bytes"
+                    ? F64
+                    : (srcType as IrType & { kind: "array" }).elem,
+                  targetT,
+                  out,
+                );
           }
         }
         return read;
@@ -5748,6 +5860,20 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
           const container = L.lowerExpr(src.expression.expression);
           if (container.type.kind === "array") {
             return lowerForOfArrayIter(L, stmt, container as IrExpr & { type: IrType & { kind: "array" } }, proj);
+          }
+        }
+        // Typed arrays expose the same live indexed iterator projections.
+        // Their fixed length makes the walk simpler, but the yielded keys
+        // and [key, numeric value] pairs are identical to Array's.
+        if (recv?.kind === "bytes" && (proj === "keys" || proj === "entries")) {
+          const container = L.lowerExpr(src.expression.expression);
+          if (container.type.kind === "bytes") {
+            return lowerForOfArrayIter(
+              L,
+              stmt,
+              container as IrExpr & { type: IrType & { kind: "bytes" } },
+              proj,
+            );
           }
         }
       }

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -282,7 +282,10 @@ export const ARRAY_METHODS = new Set([
   "includes",
   "join",
   "slice",
+  "toReversed",
+  "toSpliced",
   "toSorted",
+  "with",
 ]);
 
 /** The lowered Map<K, V> method surface. Like ARRAY_METHODS, membership is

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -19,7 +19,7 @@ import {
 import { validateSidecar } from "./library/sidecar-validate.js";
 import { entryFunctionExports, type EntryExportInfo } from "./frontend/lib-exports.js";
 import { entryContractFacts, type ContractFacts } from "./frontend/lib-contract.js";
-import { moduleLibAsyncSurface, moduleLibNondeterministicSurface, moduleEmbedsBuiltin, moduleEmbedsCompressedNpm, moduleUsesAssert, moduleUsesDc, moduleUsesDgram, moduleUsesDynAsync, moduleUsesDynInvoke, moduleUsesEmitter, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesInspect, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesQs, moduleUsesRegex, moduleUsesSearchParams, moduleUsesStream, moduleUsesSymbol, moduleUsesTls, moduleUsesTlsCa, moduleUsesZlib, type IrLibSection, type IrModule, type IrType, type SrcLoc } from "./ir/nodes.js";
+import { moduleLibAsyncSurface, moduleLibNondeterministicSurface, moduleEmbedsBuiltin, moduleEmbedsCompressedNpm, moduleUsesAssert, moduleUsesCopying, moduleUsesDc, moduleUsesDgram, moduleUsesDynAsync, moduleUsesDynInvoke, moduleUsesEmitter, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesInspect, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesQs, moduleUsesRegex, moduleUsesSearchParams, moduleUsesStream, moduleUsesSymbol, moduleUsesTls, moduleUsesTlsCa, moduleUsesZlib, type IrLibSection, type IrModule, type IrType, type SrcLoc } from "./ir/nodes.js";
 import { serializeModule } from "./ir/serialize.js";
 import { validateModule } from "./ir/validate.js";
 import { canonicalBuiltinModule, checkPreflight, isNodeTypesPath, loadProgram, locOf, requiresOf, resolveNpmImport, type LoadResult } from "./frontend/program.js";
@@ -727,6 +727,9 @@ export async function compile(entryPath: string, opts: CompileOptions): Promise<
       // The link switch for scr_regex.c + libregexp: detected on the IR, so
       // regex-free programs keep the historical (pinned) command line.
       regex: moduleUsesRegex(lowered.module),
+      // Array copying methods and the typed-array bridges live in one
+      // optional TU, linked only when one of their IR intrinsics survives.
+      copying: moduleUsesCopying(lowered.module),
       // The link switch for scr_fetch.c (the native bridge over scr_net +
       // scr_tls + scr_http's client parser + zlib — cc.ts implies those
       // units into the link): embedded npm code that references fetch gets
@@ -1341,6 +1344,7 @@ export async function compileLibrary(opts: CompileLibraryOptions): Promise<Compi
     searchParams: moduleUsesSearchParams(mod),
     emitter: moduleUsesEmitter(mod),
     zlib: moduleUsesZlib(mod),
+    copying: moduleUsesCopying(mod),
   });
 
   // The sidecar lands beside the compiled object, written by the same

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -1281,7 +1281,30 @@ export type IrStmt =
  * from the end, clamping; omitted args omitted from `args` — backends fill
  * 0 / +Infinity, the strIntrinsic convention); ref elements retain into
  * the fresh array. */
-export type IrArrIntrinsicMethod = "length" | "push" | "pushSpread" | "pop" | "indexOf" | "includes" | "join" | "slice" | "shift" | "splice";
+export type IrArrIntrinsicMethod =
+  | "length"
+  | "push"
+  | "pushSpread"
+  | "pop"
+  | "indexOf"
+  | "includes"
+  | "join"
+  | "slice"
+  | "shift"
+  | "splice"
+  /** ES2023 copying methods. `toSpliced` receives [start, deleteCount,
+   * itemsArray], with omitted arguments completed by the frontend;
+   * `with` receives [index, value] and throws Node's catchable RangeError
+   * when the relative index is out of range. */
+  | "toReversed"
+  | "toSpliced"
+  | "with";
+
+/** Array intrinsics whose runtime implementation can raise a catchable
+ * exception (rather than the static tier's deliberate index traps). */
+export const MAY_THROW_ARR_METHODS: ReadonlySet<IrArrIntrinsicMethod> = new Set([
+  "with",
+]);
 
 /** The Map method/property surface (mirrors ambient/scriptc.d.ts) plus the
  * iteration primitives behind the forEach desugar. `forEach` itself is NOT
@@ -1420,6 +1443,16 @@ export type IrBytesIntrinsicMethod =
   | "get"
   | "slice"
   | "subarray"
+  /** Fresh Uint8Array copying methods. `with` takes [index, value] and
+   * throws a catchable RangeError for an invalid relative index. */
+  | "toReversed"
+  | "with"
+  /** Uint8Array.prototype.join(separator), with the omitted separator
+   * completed to "," by the frontend. */
+  | "join"
+  /** Drain numeric typed-array elements into a fresh number[]. Used by
+   * array spread and typed-array destructuring rest. */
+  | "toArray"
   | "setFrom"
   | "toString"
   | "readNum"
@@ -1487,6 +1520,7 @@ export type IrBytesIntrinsicMethod =
 /** The bytesIntrinsic methods that can raise a catchable error — backends'
  * may-throw analyses seed on these exactly like MAY_THROW_LIB_FNS. */
 export const MAY_THROW_BYTES_METHODS: ReadonlySet<IrBytesIntrinsicMethod> = new Set([
+  "with",
   "setFrom",
   "readNum",
   "writeNum",
@@ -5517,6 +5551,43 @@ export function moduleUsesRegex(mod: IrModule): boolean {
     // RegExp.escape lives in scr_regex.c too (needing no engine — it
     // keeps the always-linked string TU out of hello-world's size class).
     if (kind === "libCall" && (v as { fn?: unknown }).fn === "regexp.escape") {
+      found = true;
+      return;
+    }
+    for (const key of Object.keys(v)) visit((v as Record<string, unknown>)[key]);
+  };
+  visit(mod);
+  return found;
+}
+
+/** True when the module contains an intrinsic whose implementation lives
+ * in scr_copying.c. This is the link switch that keeps the optional
+ * Array-copying and typed-array bridge TU out of unrelated binaries. */
+export function moduleUsesCopying(mod: IrModule): boolean {
+  let found = false;
+  const visit = (v: unknown): void => {
+    if (found || v === null || typeof v !== "object") return;
+    if (Array.isArray(v)) {
+      for (const item of v) visit(item);
+      return;
+    }
+    const node = v as { kind?: unknown; method?: unknown };
+    if (
+      node.kind === "arrIntrinsic" &&
+      (node.method === "toReversed" ||
+        node.method === "toSpliced" ||
+        node.method === "with")
+    ) {
+      found = true;
+      return;
+    }
+    if (
+      node.kind === "bytesIntrinsic" &&
+      (node.method === "toReversed" ||
+        node.method === "with" ||
+        node.method === "join" ||
+        node.method === "toArray")
+    ) {
       found = true;
       return;
     }

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -2241,6 +2241,14 @@ function validateFunction(
               ? { argTypes: [F64], minArgs: 1, result: F64 }
               : e.method === "slice" || e.method === "subarray"
                 ? { argTypes: [F64, F64], minArgs: 0, result: bytesOf(recv.elem) }
+                : e.method === "toReversed"
+                  ? { argTypes: [], minArgs: 0, result: bytesOf(recv.elem) }
+                : e.method === "with"
+                  ? { argTypes: [F64, F64], minArgs: 2, result: bytesOf(recv.elem) }
+                  : e.method === "join"
+                    ? { argTypes: [STRING], minArgs: 1, result: STRING }
+                    : e.method === "toArray"
+                      ? { argTypes: [], minArgs: 0, result: arrayOf(F64) }
                 : e.method === "setFrom"
                   ? { argTypes: [bytesOf(recv.elem), F64], minArgs: 1, result: VOID }
                   : e.method === "toString"
@@ -2305,10 +2313,16 @@ function validateFunction(
                   ? { argTypes: [elem], result: BOOL }
                   : e.method === "join"
                     ? { argTypes: [STRING], result: STRING }
-                    : e.method === "slice"
-                      ? { argTypes: [F64, F64], result: e.receiver.type }
-                      : e.method === "splice"
-                        ? { argTypes: [F64, F64], result: e.receiver.type }
+                : e.method === "slice"
+                  ? { argTypes: [F64, F64], result: e.receiver.type }
+                  : e.method === "toReversed"
+                    ? { argTypes: [], result: e.receiver.type }
+                    : e.method === "toSpliced"
+                      ? { argTypes: [F64, F64, e.receiver.type], result: e.receiver.type }
+                      : e.method === "with"
+                        ? { argTypes: [F64, elem], result: e.receiver.type }
+                  : e.method === "splice"
+                    ? { argTypes: [F64, F64], result: e.receiver.type }
                         : e.method === "shift"
                           ? { argTypes: [], result: e.type } // union-checked below
                           : { argTypes: [], result: F64 }; // length

--- a/packages/compiler/surface-manifest.json
+++ b/packages/compiler/surface-manifest.json
@@ -1985,9 +1985,27 @@
       "status": "static"
     },
     {
+      "id": "stdlib.array.toReversed",
+      "kind": "stdlib",
+      "name": "Array.prototype.toReversed",
+      "status": "static"
+    },
+    {
       "id": "stdlib.array.toSorted",
       "kind": "stdlib",
       "name": "Array.prototype.toSorted",
+      "status": "static"
+    },
+    {
+      "id": "stdlib.array.toSpliced",
+      "kind": "stdlib",
+      "name": "Array.prototype.toSpliced",
+      "status": "static"
+    },
+    {
+      "id": "stdlib.array.with",
+      "kind": "stdlib",
+      "name": "Array.prototype.with",
       "status": "static"
     },
     {

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -5458,6 +5458,24 @@
    ],
    "diags": []
   },
+  "<repo>/tests/corpus/2669-array-copying-methods.ts": {
+   "order": [
+    "<repo>/tests/corpus/2669-array-copying-methods.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2670-uint8array-copy-iterate.ts": {
+   "order": [
+    "<repo>/tests/corpus/2670-uint8array-copy-iterate.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2671-array-copying-js.cjs": {
+   "order": [
+    "<repo>/tests/corpus/2671-array-copying-js.cjs"
+   ],
+   "diags": []
+  },
   "<repo>/tests/corpus/300-if-else.ts": {
    "order": [
     "<repo>/tests/corpus/300-if-else.ts"

--- a/packages/runtime/src/scr_bytes.c
+++ b/packages/runtime/src/scr_bytes.c
@@ -1503,4 +1503,3 @@ double scr_bytes_write_var(ScrBytes *b, double value, double offset, double byte
   }
   return offset + (double)width;
 }
-

--- a/packages/runtime/src/scr_copying.c
+++ b/packages/runtime/src/scr_copying.c
@@ -1,0 +1,157 @@
+#include "scr_runtime.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdint.h>
+
+/* ES2023 Array/TypedArray copying methods and the typed-array-to-number[]
+ * bridge live in their own archive member. Programs that do not use this
+ * surface therefore pull in none of it — the static binary size contract. */
+
+static uint64_t copying_slot_from_ptr(void *p) {
+  return (uint64_t)(uintptr_t)p;
+}
+
+static void *copying_slot_to_ptr(uint64_t slot) {
+  return (void *)(uintptr_t)slot;
+}
+
+static bool copying_elem_is_ref(ScrElemKind kind) {
+  return kind == SCR_ELEM_STR || kind == SCR_ELEM_ARR ||
+         kind == SCR_ELEM_BYTES || kind == SCR_ELEM_REF;
+}
+
+static ScrArr *copying_arr_new_like(const ScrArr *a, size_t cap) {
+  return a->elem == SCR_ELEM_REF
+             ? scr_arr_new_ref(a->elem_retain, a->elem_release,
+                               a->elem_trace, cap ? cap : 1)
+             : scr_arr_new(a->elem, cap ? cap : 1);
+}
+
+static uint64_t copying_arr_retain_slot(const ScrArr *a, uint64_t slot) {
+  if (!copying_elem_is_ref(a->elem)) return slot;
+  void *p = copying_slot_to_ptr(slot);
+  if (a->elem == SCR_ELEM_STR) p = scr_str_retain((ScrStr *)p);
+  else if (a->elem == SCR_ELEM_ARR) p = scr_arr_retain((ScrArr *)p);
+  else if (a->elem == SCR_ELEM_BYTES) p = scr_bytes_retain((ScrBytes *)p);
+  else p = a->elem_retain(p);
+  return copying_slot_from_ptr(p);
+}
+
+static void copying_arr_copy_slot(ScrArr *out, const ScrArr *src, size_t i) {
+  out->data[out->len++] = copying_arr_retain_slot(src, src->data[i]);
+}
+
+ScrArr *scr_arr_to_reversed(const ScrArr *a) {
+  ScrArr *out = copying_arr_new_like(a, a->len);
+  for (size_t i = a->len; i > 0; i--) {
+    copying_arr_copy_slot(out, a, i - 1);
+  }
+  return out;
+}
+
+ScrArr *scr_arr_to_spliced(const ScrArr *a, double start,
+                           double delete_count, const ScrArr *items) {
+  double len = (double)a->len;
+  double s0 = isnan(start) ? 0 : trunc(start);
+  if (s0 < 0) s0 += len;
+  size_t from = s0 <= 0 ? 0 : s0 >= len ? a->len : (size_t)s0;
+  double avail = len - (double)from;
+  double d0 = isnan(delete_count) ? 0 : trunc(delete_count);
+  size_t ndelete =
+      d0 <= 0 ? 0 : d0 >= avail ? (size_t)avail : (size_t)d0;
+  if (items->len > SIZE_MAX - (a->len - ndelete)) {
+    scr_trap("scriptc: out of memory\n");
+  }
+  size_t out_len = a->len - ndelete + items->len;
+  ScrArr *out = copying_arr_new_like(a, out_len);
+  for (size_t i = 0; i < from; i++) copying_arr_copy_slot(out, a, i);
+  for (size_t i = 0; i < items->len; i++) {
+    out->data[out->len++] =
+        copying_arr_retain_slot(a, items->data[i]);
+  }
+  for (size_t i = from + ndelete; i < a->len; i++) {
+    copying_arr_copy_slot(out, a, i);
+  }
+  return out;
+}
+
+static bool copying_arr_with_index(const ScrArr *a, double index,
+                                   size_t *out) {
+  double rel = isnan(index) ? 0 : trunc(index);
+  double actual = rel >= 0 ? rel : (double)a->len + rel;
+  if (!(actual >= 0) || actual >= (double)a->len) {
+    char num[32];
+    size_t numlen = scr_f64_to_str(index, num);
+    char msg[80];
+    int mlen = snprintf(msg, sizeof msg, "Invalid index : %.*s",
+                        (int)numlen, num);
+    scr_throw_error_msg(SCR_ERR_RANGE, msg, (size_t)mlen);
+    return false;
+  }
+  *out = (size_t)actual;
+  return true;
+}
+
+ScrArr *scr_arr_with_f64(ScrArr *a, double index, double value) {
+  size_t i;
+  if (!copying_arr_with_index(a, index, &i)) return NULL;
+  ScrArr *out = scr_arr_slice(a, 0, INFINITY);
+  scr_arr_set_f64(out, (double)i, value);
+  return out;
+}
+
+ScrArr *scr_arr_with_bool(ScrArr *a, double index, bool value) {
+  size_t i;
+  if (!copying_arr_with_index(a, index, &i)) return NULL;
+  ScrArr *out = scr_arr_slice(a, 0, INFINITY);
+  scr_arr_set_bool(out, (double)i, value);
+  return out;
+}
+
+ScrArr *scr_arr_with_ref(ScrArr *a, double index, void *value) {
+  size_t i;
+  if (!copying_arr_with_index(a, index, &i)) return NULL;
+  ScrArr *out = scr_arr_slice(a, 0, INFINITY);
+  uint64_t retained =
+      copying_arr_retain_slot(a, copying_slot_from_ptr(value));
+  scr_arr_set_ref(out, (double)i, copying_slot_to_ptr(retained));
+  return out;
+}
+
+ScrBytes *scr_bytes_to_reversed(const ScrBytes *b) {
+  ScrBytes *out = scr_bytes_new(b->elem, (double)b->len);
+  for (size_t i = 0; i < b->len; i++) {
+    scr_bytes_set(out, (double)i,
+                  scr_bytes_get(b, (double)(b->len - i - 1)));
+  }
+  return out;
+}
+
+ScrBytes *scr_bytes_with(const ScrBytes *b, double index, double value) {
+  double rel = isnan(index) ? 0 : trunc(index);
+  double actual = rel >= 0 ? rel : (double)b->len + rel;
+  if (!(actual >= 0) || actual >= (double)b->len) {
+    static const char msg[] = "Invalid typed array index";
+    scr_throw_error_msg(SCR_ERR_RANGE, msg, sizeof msg - 1);
+    return NULL;
+  }
+  ScrBytes *out = scr_bytes_copy(b);
+  scr_bytes_set(out, actual, value);
+  return out;
+}
+
+ScrArr *scr_bytes_to_arr(const ScrBytes *b) {
+  ScrArr *out = scr_arr_new(SCR_ELEM_F64, b->len ? b->len : 1);
+  for (size_t i = 0; i < b->len; i++) {
+    scr_arr_push_f64(out, scr_bytes_get(b, (double)i));
+  }
+  return out;
+}
+
+ScrStr *scr_bytes_join(const ScrBytes *b, const ScrStr *separator) {
+  ScrArr *values = scr_bytes_to_arr(b);
+  ScrStr *out = scr_arr_join(values, (ScrStr *)separator);
+  scr_arr_release(values);
+  return out;
+}

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -822,6 +822,16 @@ void scr_arr_set_ref(ScrArr *a, double i, void *v);
  * elements retain into the copy. Borrows a. */
 ScrArr *scr_arr_slice(ScrArr *a, double start, double end);
 
+/* ES2023 copying methods. All borrow their inputs and return fresh +1
+ * shallow copies. with() raises Node's catchable RangeError for an invalid
+ * relative index; the ref variant retains the borrowed replacement. */
+ScrArr *scr_arr_to_reversed(const ScrArr *a);
+ScrArr *scr_arr_to_spliced(const ScrArr *a, double start,
+                           double delete_count, const ScrArr *items);
+ScrArr *scr_arr_with_f64(ScrArr *a, double index, double value);
+ScrArr *scr_arr_with_bool(ScrArr *a, double index, bool value);
+ScrArr *scr_arr_with_ref(ScrArr *a, double index, void *value);
+
 /* push returns the new length (JS-exact); _ref takes ownership. */
 double scr_arr_push_f64(ScrArr *a, double v);
 double scr_arr_push_bool(ScrArr *a, bool v);
@@ -4463,6 +4473,17 @@ void scr_bytes_set(ScrBytes *b, double i, double v);
  * string/array slice (ToIntegerOrInfinity, negatives from the end); the
  * result is a fresh same-kind copy. Never throws. */
 ScrBytes *scr_bytes_slice(const ScrBytes *b, double start, double end); /* +1 */
+
+/* ES2023 typed-array copying methods. Both preserve the receiver's element
+ * kind and return a fresh +1 owner. with() raises Node's catchable
+ * "Invalid typed array index" RangeError for an invalid relative index. */
+ScrBytes *scr_bytes_to_reversed(const ScrBytes *b); /* +1 */
+ScrBytes *scr_bytes_with(const ScrBytes *b, double index, double value); /* +1 */
+
+/* Numeric typed-array iteration drained into number[], and Uint8Array.join.
+ * Inputs borrowed; results fresh +1. */
+ScrArr *scr_bytes_to_arr(const ScrBytes *b); /* +1 */
+ScrStr *scr_bytes_join(const ScrBytes *b, const ScrStr *separator); /* +1 */
 
 /* TypedArray.prototype.fill on non-u8 receivers: per-element fill with
  * the element write's coercion, slice-clamped relative indices; answers

--- a/tests/corpus/2669-array-copying-methods.ts
+++ b/tests/corpus/2669-array-copying-methods.ts
@@ -8,6 +8,23 @@ console.log(source.toSpliced(1, 2, 8, 9).join(","));
 console.log(source.toSpliced(-2, 1, 7).join(","));
 console.log(source.toSpliced(2).join(","));
 console.log(source.toSpliced(1, undefined).join(","));
+const missingDeleteCount: undefined = undefined;
+console.log(source.toSpliced(1, void 0).join(","));
+console.log(source.toSpliced(1, missingDeleteCount).join(","));
+const deleteOrder: string[] = [];
+const effectDefault = source.toSpliced(1, (() => {
+  deleteOrder.push("call");
+  return undefined;
+})());
+const voidEffectDefault = source.toSpliced(
+  1,
+  void deleteOrder.push("void"),
+);
+console.log(
+  effectDefault.join(","),
+  voidEffectDefault.join(","),
+  deleteOrder.join(","),
+);
 console.log(source.toSpliced(NaN, 0, 6).join(","));
 console.log(source.join(","));
 

--- a/tests/corpus/2669-array-copying-methods.ts
+++ b/tests/corpus/2669-array-copying-methods.ts
@@ -1,0 +1,57 @@
+// The ES2023 non-mutating Array copying methods. Node 24 is the oracle for
+// index coercion, insertion/removal, evaluation order, and RangeError text.
+
+const source = [1, 2, 3, 4];
+console.log(source.toReversed().join(","), source.join(","));
+
+console.log(source.toSpliced(1, 2, 8, 9).join(","));
+console.log(source.toSpliced(-2, 1, 7).join(","));
+console.log(source.toSpliced(2).join(","));
+console.log(source.toSpliced(1, undefined).join(","));
+console.log(source.toSpliced(NaN, 0, 6).join(","));
+console.log(source.join(","));
+
+console.log(source.with(1, 8).join(","));
+console.log(source.with(-1, 9).join(","));
+console.log(source.with(1.9, 7).join(","));
+console.log(source.with(NaN, 6).join(","));
+console.log(source.join(","));
+
+for (const index of [4, -5, Infinity]) {
+  try {
+    source.with(index, 0);
+  } catch (err) {
+    const e = err as Error;
+    console.log(e.name, e.message);
+  }
+}
+
+const order: string[] = [];
+const evaluated = (() => {
+  order.push("receiver");
+  return [1, 2, 3];
+})().with((() => {
+  order.push("index");
+  return 1;
+})(), (() => {
+  order.push("value");
+  return 5;
+})());
+console.log(evaluated.join(","), order.join(","));
+
+const records = [{ n: 1 }, { n: 2 }];
+const copied = records.toReversed();
+copied[0]!.n = 20;
+console.log(records[1]!.n, copied[1] === records[0]);
+
+const inserted = { n: 3 };
+const splicedRecords = records.toSpliced(1, 0, inserted);
+const replacement = { n: 4 };
+const withRecord = records.with(0, replacement);
+console.log(
+  splicedRecords.length,
+  splicedRecords[0] === records[0],
+  splicedRecords[1] === inserted,
+  withRecord[0] === replacement,
+  withRecord[1] === records[1],
+);

--- a/tests/corpus/2669-array-copying-methods.ts
+++ b/tests/corpus/2669-array-copying-methods.ts
@@ -20,9 +20,19 @@ const voidEffectDefault = source.toSpliced(
   1,
   void deleteOrder.push("void"),
 );
+const assertedVoidEffectDefault = source.toSpliced(
+  1,
+  (void deleteOrder.push("asserted")) as undefined,
+);
+const nestedVoidEffectDefault = source.toSpliced(
+  1,
+  void (void deleteOrder.push("nested")),
+);
 console.log(
   effectDefault.join(","),
   voidEffectDefault.join(","),
+  assertedVoidEffectDefault.join(","),
+  nestedVoidEffectDefault.join(","),
   deleteOrder.join(","),
 );
 console.log(source.toSpliced(NaN, 0, 6).join(","));

--- a/tests/corpus/2670-uint8array-copy-iterate.ts
+++ b/tests/corpus/2670-uint8array-copy-iterate.ts
@@ -6,6 +6,23 @@ const ascending = source.toSorted((a, b) => a - b);
 console.log(ascending.join(","), source.join(","));
 console.log(source.toSorted().join(","));
 console.log(source.toSorted(undefined).join(","));
+const missing: undefined = undefined;
+console.log(source.toSorted(void 0).join(","));
+console.log(source.toSorted(missing).join(","));
+const sortOrder: string[] = [];
+const defaultSorted = (() => {
+  sortOrder.push("receiver");
+  return source;
+})().toSorted((() => {
+  sortOrder.push("argument");
+  return undefined;
+})());
+const voidDefaultSorted = source.toSorted(void sortOrder.push("void"));
+console.log(
+  defaultSorted.join(","),
+  voidDefaultSorted.join(","),
+  sortOrder.join(","),
+);
 console.log(source.toReversed().join(","), source.join(","));
 console.log(source.with(1, -1).join(","), source.join(","));
 console.log(source.with(-1, 260).join(","));
@@ -46,3 +63,11 @@ console.log("sum", sum);
 
 console.log(new Uint8Array().join("-"));
 console.log(source.join(), source.join(undefined), source.join("-"), source.join(""));
+console.log(source.join(void 0), source.join(missing));
+const joinOrder: string[] = [];
+const defaultJoined = source.join((() => {
+  joinOrder.push("call");
+  return undefined;
+})());
+const voidDefaultJoined = source.join(void joinOrder.push("void"));
+console.log(defaultJoined, voidDefaultJoined, joinOrder.join(","));

--- a/tests/corpus/2670-uint8array-copy-iterate.ts
+++ b/tests/corpus/2670-uint8array-copy-iterate.ts
@@ -18,9 +18,21 @@ const defaultSorted = (() => {
   return undefined;
 })());
 const voidDefaultSorted = source.toSorted(void sortOrder.push("void"));
+const assertedVoidDefaultSorted = source.toSorted(
+  (void sortOrder.push("asserted")) as undefined,
+);
+const satisfiesVoidDefaultSorted = source.toSorted(
+  (void sortOrder.push("satisfies")) satisfies undefined,
+);
+const nestedVoidDefaultSorted = source.toSorted(
+  void (void sortOrder.push("nested")),
+);
 console.log(
   defaultSorted.join(","),
   voidDefaultSorted.join(","),
+  assertedVoidDefaultSorted.join(","),
+  satisfiesVoidDefaultSorted.join(","),
+  nestedVoidDefaultSorted.join(","),
   sortOrder.join(","),
 );
 console.log(source.toReversed().join(","), source.join(","));
@@ -73,4 +85,16 @@ const defaultJoined = source.join((() => {
   return undefined;
 })());
 const voidDefaultJoined = source.join(void joinOrder.push("void"));
-console.log(defaultJoined, voidDefaultJoined, joinOrder.join(","));
+const assertedVoidDefaultJoined = source.join(
+  (void joinOrder.push("asserted")) as undefined,
+);
+const nestedVoidDefaultJoined = source.join(
+  void (void joinOrder.push("nested")),
+);
+console.log(
+  defaultJoined,
+  voidDefaultJoined,
+  assertedVoidDefaultJoined,
+  nestedVoidDefaultJoined,
+  joinOrder.join(","),
+);

--- a/tests/corpus/2670-uint8array-copy-iterate.ts
+++ b/tests/corpus/2670-uint8array-copy-iterate.ts
@@ -49,6 +49,9 @@ const spread = [...source];
 spread[0] = 99;
 console.log(spread.join(","), source.join(","));
 
+const widened: (number | string)[] = [...source, "tail"];
+console.log(widened.join(","));
+
 const [a, b, , d] = source;
 console.log(a, b, d);
 

--- a/tests/corpus/2670-uint8array-copy-iterate.ts
+++ b/tests/corpus/2670-uint8array-copy-iterate.ts
@@ -1,0 +1,48 @@
+// Uint8Array copying methods, array conversion/destructuring, iterator
+// projections, and join. Every output is compared byte-for-byte with Node 24.
+
+const source = new Uint8Array([5, 1, 4, 1, 3]);
+const ascending = source.toSorted((a, b) => a - b);
+console.log(ascending.join(","), source.join(","));
+console.log(source.toSorted().join(","));
+console.log(source.toSorted(undefined).join(","));
+console.log(source.toReversed().join(","), source.join(","));
+console.log(source.with(1, -1).join(","), source.join(","));
+console.log(source.with(-1, 260).join(","));
+console.log(source.with(1.9, 8).join(","));
+console.log(source.with(NaN, 9).join(","));
+
+const snapshotSource = new Uint8Array([3, 1, 2]);
+const snapshotSorted = snapshotSource.toSorted((a, b) => {
+  snapshotSource[0] = 0;
+  return a - b;
+});
+console.log(snapshotSorted.join(","), snapshotSource.join(","));
+
+for (const index of [source.length, -source.length - 1, Infinity]) {
+  try {
+    source.with(index, 0);
+  } catch (err) {
+    const e = err as Error;
+    console.log(e.name, e.message);
+  }
+}
+
+const spread = [...source];
+spread[0] = 99;
+console.log(spread.join(","), source.join(","));
+
+const [a, b, , d] = source;
+console.log(a, b, d);
+
+for (const [i, value] of source.entries()) console.log("entry", i, value);
+for (const key of source.keys()) console.log("key", key);
+for (const value of source.values()) console.log("value", value);
+
+const values = source.values();
+let sum = 0;
+for (const value of values) sum += value;
+console.log("sum", sum);
+
+console.log(new Uint8Array().join("-"));
+console.log(source.join(), source.join(undefined), source.join("-"), source.join(""));

--- a/tests/corpus/2671-array-copying-js.cjs
+++ b/tests/corpus/2671-array-copying-js.cjs
@@ -1,0 +1,9 @@
+// JavaScript permits the zero-argument Array.prototype.toSpliced form even
+// though TypeScript's declaration requires `start`. It returns a fresh
+// shallow copy; it must not share the one-argument form's delete-to-end
+// default.
+
+const source = [1, 2, 3];
+const copied = source.toSpliced();
+copied[0] = 9;
+console.log(copied.join(","), source.join(","));


### PR DESCRIPTION
- Add static Array and Uint8Array copying, sorting, and join surfaces.
- Lower Uint8Array spread, destructuring, and iterator methods across C and LLVM.
- Pin Node 24 semantics with differential coverage and runtime size gating.