### PR TITLE
fix: lower HTTPS request callbacks in LLVM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to scriptc will be documented in this file.
 
 - **Top-level `await` compiles across the program's ESM graph.** Module evaluation follows Node 24's dependency ordering, one-time promise caching, cycle rooting, rejection precedence, and unsettled-module exit status 13 in both the LLVM and C backends. Dynamic imports of compiled modules await the same evaluation verdict.
 
+### Fixes
+
+- **`https.request(options, responseCallback)` compiles on the LLVM backend.** The options-object row now lowers the TLS verification and CA arguments through the same runtime ABI as the C backend, including response-callback ownership and event-loop liveness. The already-supported `http.request(options, responseCallback)` row is pinned alongside it.
+
 ## 0.0.17
 
 ### Fixes

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -777,7 +777,7 @@ const USES_TIMERS_LIB_FNS = new Set<string>([
   "fs.existsChk",
   "http.createServer", "http.createServerEmpty",
   "http.request", "http.requestCb", "http.requestUrl", "http.requestUrlCb",
-  "https.requestUrl", "https.requestUrlCb",
+  "https.request", "https.requestCb", "https.requestUrl", "https.requestUrlCb",
   "http.requestConn", "http.requestConnCb",
   "http.agentNew", "http.requestAgent", "http.requestAgentCb",
   // The dyn-async slice (emit-exprs.ts's markings): fiber parks, the
@@ -11604,14 +11604,17 @@ class LlEmitter {
     }
     if (e.fn === "http.request" || e.fn === "http.requestCb" || e.fn === "http.requestUrl" || e.fn === "http.requestUrlCb" ||
         e.fn === "http.requestAgent" || e.fn === "http.requestAgentCb" ||
+        e.fn === "https.request" || e.fn === "https.requestCb" ||
         e.fn === "https.requestUrl" || e.fn === "https.requestUrlCb") {
       // The https URL row is the http one with the TLS entry point — same
-      // three arguments, same response-callback adapter. (The https
-      // OPTIONS forms are a separate, wider row and are not here yet.)
+      // three arguments, same response-callback adapter. The https options
+      // row is wider: rejectUnauthorized stays an i1, while its ScrStr or
+      // ScrBytes CA value expands to the runtime's raw pointer + length.
       const isTls = e.fn.startsWith("https.");
-      const isUrl = isTls || e.fn.startsWith("http.requestUrl");
+      const isUrl = e.fn.includes("requestUrl");
+      const isTlsOptions = isTls && !isUrl;
       const isAgent = e.fn.startsWith("http.requestAgent");
-      const cbIdx = isUrl ? 3 : isAgent ? 8 : 7;
+      const cbIdx = isUrl ? 3 : isTlsOptions ? 9 : isAgent ? 8 : 7;
       const hasCb = e.fn.endsWith("Cb");
       const args = e.args.map((a) => this.emitExpr(a));
       let cb = "null";
@@ -11626,14 +11629,40 @@ class LlEmitter {
         adapter = `@${sym}`;
       }
       const head = args.slice(0, cbIdx);
-      const decls = head.map((a) => (this.llType(a.type) === "i1" ? "i1 zeroext" : this.llType(a.type)));
-      const entry = isTls ? "scr_https_request_url"
+      const entry = isTlsOptions ? "scr_https_request"
+        : isTls ? "scr_https_request_url"
         : isUrl ? "scr_http_request_url"
         : isAgent ? "scr_http_request_agent" : "scr_http_request";
-      this.declare(`declare ptr @${entry}(${[...decls, "ptr", "ptr"].join(", ")})`);
+      let callArgs = head.map((a) => `${this.llType(a.type)} ${a.name}`);
+      if (isTlsOptions) {
+        const ca = args[8]!;
+        const caLenPtr = B.tmp();
+        const caLen = B.tmp();
+        let caData: string;
+        if (ca.type.kind === "string") {
+          caData = B.tmp();
+          B.line(`${caLenPtr} = getelementptr inbounds %ScrStr, ptr ${ca.name}, i64 0, i32 1`);
+          B.line(`${caLen} = load i64, ptr ${caLenPtr}`);
+          B.line(`${caData} = getelementptr inbounds i8, ptr ${ca.name}, i64 24`);
+        } else if (ca.type.kind === "bytes" && ca.type.elem === "u8") {
+          const caDataPtr = B.tmp();
+          caData = B.tmp();
+          B.line(`${caLenPtr} = getelementptr inbounds i8, ptr ${ca.name}, i64 8`);
+          B.line(`${caLen} = load i64, ptr ${caLenPtr}`);
+          B.line(`${caDataPtr} = getelementptr inbounds i8, ptr ${ca.name}, i64 24`);
+          B.line(`${caData} = load ptr, ptr ${caDataPtr}`);
+        } else {
+          throw new Error(`llvm emitter bug: ${e.fn} CA is not a string or Buffer`);
+        }
+        callArgs = [...callArgs.slice(0, 8), `ptr ${caData}`, `i64 ${caLen}`];
+        this.declare(`declare ptr @scr_https_request(ptr, double, ptr, ptr, double, ptr, i1 zeroext, i1 zeroext, ptr, i64, ptr, ptr)`);
+      } else {
+        const decls = head.map((a) => (this.llType(a.type) === "i1" ? "i1 zeroext" : this.llType(a.type)));
+        this.declare(`declare ptr @${entry}(${[...decls, "ptr", "ptr"].join(", ")})`);
+      }
       const t = B.tmp();
       B.line(
-        `${t} = call ptr @${entry}(${[...head.map((a) => `${this.llType(a.type)} ${a.name}`), `ptr ${cb}`, `ptr ${adapter}`].join(", ")})`,
+        `${t} = call ptr @${entry}(${[...callArgs, `ptr ${cb}`, `ptr ${adapter}`].join(", ")})`,
       );
       const out = this.own({ name: t, type: e.type });
       if (MAY_THROW_LIB_FNS.has(e.fn)) this.emitPendingCheck();

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -3579,12 +3579,14 @@ function validateFunction(
           }
           break;
         }
-        if (e.fn === "http.requestCb" || e.fn === "http.requestUrlCb" || e.fn === "http.clientOnResponse" ||
+        if (e.fn === "http.requestCb" || e.fn === "https.requestCb" ||
+            e.fn === "http.requestUrlCb" || e.fn === "http.clientOnResponse" ||
             e.fn === "http.requestAgentCb" || e.fn === "https.requestAgentCb" ||
             e.fn === "https.requestUrlCb") {
           // The response listener: void, no params or exactly (res: httpReq).
           const cbT = e.args[
             e.fn === "http.requestCb" ? 7
+            : e.fn === "https.requestCb" ? 9
             : e.fn === "http.requestUrlCb" || e.fn === "https.requestUrlCb" ? 3
             : e.fn === "http.requestAgentCb" ? 8
             : e.fn === "https.requestAgentCb" ? 10

--- a/tests/corpus/2672-http-request-response-callback.ts
+++ b/tests/corpus/2672-http-request-response-callback.ts
@@ -1,0 +1,33 @@
+// The options-object response callback is part of request(), not just the
+// URL-string row. Exercise both clients against a released local port: the
+// callback must compile even though connection refusal keeps it from firing.
+import * as net from "node:net";
+import * as http from "node:http";
+import * as https from "node:https";
+
+const probe = net.createServer();
+probe.listen(0, () => {
+  const port = probe.address().port;
+  probe.close(() => {
+    const plain = http.request(
+      { hostname: "127.0.0.1", port, path: "/", method: "GET" },
+      () => console.log("unexpected http response"),
+    );
+    plain.on("error", () => console.log("http refused"));
+    plain.on("close", () => {
+      const secure = https.request(
+        {
+          hostname: "127.0.0.1",
+          port,
+          path: "/",
+          method: "GET",
+          rejectUnauthorized: false,
+        },
+        () => console.log("unexpected https response"),
+      );
+      secure.on("error", () => console.log("https refused"));
+      secure.end();
+    });
+    plain.end();
+  });
+});

--- a/tests/harness/llvm-differential.test.ts
+++ b/tests/harness/llvm-differential.test.ts
@@ -58,6 +58,11 @@ const TIER_FLOOR = [
   "401-mutual-recursion.ts",
 ];
 
+/** Fixed backend gaps whose corpus programs must remain in the LLVM tier. */
+const TIER_REGRESSIONS = [
+  "2672-http-request-response-callback.ts",
+];
+
 interface RunResult {
   stdout: Buffer;
   stderr: Buffer;
@@ -297,6 +302,12 @@ describe(`llvm differential corpus (${files.length} programs${sanitize ? ", sani
     // Under a shard, only the floor programs THIS slice ran can be asserted
     // (same key as the corpus split above); the shard union covers all six.
     for (const name of shardSelect(TIER_FLOOR, (n) => n)) {
+      expect(claimed, `${name} regressed out of the LLVM tier`).toContain(name);
+    }
+  });
+
+  test("fixed tier regressions stay claimed", () => {
+    for (const name of shardSelect(TIER_REGRESSIONS, (n) => n)) {
       expect(claimed, `${name} regressed out of the LLVM tier`).toContain(name);
     }
   });


### PR DESCRIPTION
- Lower the HTTPS options row through the runtime ABI with callback ownership and loop liveness.
- Pin HTTP and HTTPS response callbacks with differential and tier-regression coverage.