### PR TITLE
Compose integer slots with optional numbers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,13 @@ All notable changes to scriptc will be documented in this file.
 
 ## Unreleased
 
+### Fixes
+
+- **Library integer slots compose with optional numbers.** A declared `number | null` or optional-number slot projects as `optional<i64>` and proves only its present numeric values across records, tagged-message payloads, and helper parameters/returns. When two sidecar paths collapse to the same structurally interned record field, the build now refuses with both paths instead of silently overwriting one proof obligation.
+
 <!-- release:start -->
+
+## 0.0.18
 
 ### Features
 
@@ -13,15 +19,14 @@ All notable changes to scriptc will be documented in this file.
 ### Fixes
 
 - **`https.request(options, responseCallback)` compiles on the LLVM backend.** The options-object row now lowers the TLS verification and CA arguments through the same runtime ABI as the C backend, including response-callback ownership and event-loop liveness. The already-supported `http.request(options, responseCallback)` row is pinned alongside it.
-- **Library integer slots compose with optional numbers.** A declared `number | null` or optional-number slot projects as `optional<i64>` and proves only its present numeric values across records, tagged-message payloads, and helper parameters/returns. When two sidecar paths collapse to the same structurally interned record field, the build now refuses with both paths instead of silently overwriting one proof obligation.
+
+<!-- release:end -->
 
 ## 0.0.17
 
 ### Fixes
 
 - **The CLI builds and runs programs on Windows.** TypeScript's virtual filesystem now sees consistently slash-normalized Windows paths, default executable names carry the required `.exe` suffix for both native and cross-target Windows builds, and the workspace build command survives Windows shell quoting. A Windows CI lane pins the path regressions and drives `scriptc run` end to end.
-
-<!-- release:end -->
 
 ## 0.0.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ All notable changes to scriptc will be documented in this file.
 ### Fixes
 
 - **`https.request(options, responseCallback)` compiles on the LLVM backend.** The options-object row now lowers the TLS verification and CA arguments through the same runtime ABI as the C backend, including response-callback ownership and event-loop liveness. The already-supported `http.request(options, responseCallback)` row is pinned alongside it.
+- **Library integer slots compose with optional numbers.** A declared `number | null` or optional-number slot projects as `optional<i64>` and proves only its present numeric values across records, tagged-message payloads, and helper parameters/returns. When two sidecar paths collapse to the same structurally interned record field, the build now refuses with both paths instead of silently overwriting one proof obligation.
 
 ## 0.0.17
 

--- a/packages/compiler/src/frontend/lib-contract.ts
+++ b/packages/compiler/src/frontend/lib-contract.ts
@@ -38,7 +38,7 @@ export type ContractTypeShape =
   | { k: "text" }
   | { k: "bytes" }
   | { k: "void" }
-  | { k: "absent" } // `null` / `undefined` type constituents
+  | { k: "absent"; unit: "null" | "undefined" }
   | { k: "ref"; name: string }
   | { k: "array"; elem: ContractTypeShape }
   | { k: "tuple"; elems: ContractTypeShape[] }
@@ -153,7 +153,7 @@ export function typeShape(file: ts.SourceFile, node: ts.TypeNode): ContractTypeS
     case ts.SyntaxKind.VoidKeyword:
       return { k: "void" };
     case ts.SyntaxKind.UndefinedKeyword:
-      return { k: "absent" };
+      return { k: "absent", unit: "undefined" };
     default:
       break;
   }
@@ -161,7 +161,7 @@ export function typeShape(file: ts.SourceFile, node: ts.TypeNode): ContractTypeS
   if (ts.isLiteralTypeNode(node)) {
     const lit = node.literal;
     if (ts.isStringLiteral(lit)) return { k: "stringLit", text: lit.text };
-    if (lit.kind === ts.SyntaxKind.NullKeyword) return { k: "absent" };
+    if (lit.kind === ts.SyntaxKind.NullKeyword) return { k: "absent", unit: "null" };
     return { k: "unsupported", text: node.getText(file) };
   }
   if (ts.isArrayTypeNode(node)) return { k: "array", elem: typeShape(file, node.elementType) };

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1108,6 +1108,7 @@ function sidecarRecordMatcher(
       case "bool":
       case "nullT":
       case "undefinedT":
+      case "dyn":
         return actual.kind === pattern.kind;
       case "bytes":
         return actual.kind === "bytes" && actual.elem === pattern.elem;

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -3,8 +3,8 @@ import { basename, dirname, join, resolve } from "node:path";
 import { CcCompileError, compileC, compileLibArchive, resolveCc, targetPlatform } from "./backend/cc.js";
 import { emitModule } from "./backend/emission/emitter.js";
 import { emitLlvmModule, LlvmUnsupportedError } from "./backend/llvm/emitter.js";
-import { checkerPanicDiag, ffiNativeBuildDiag, libAsyncExportDiag, libAsyncSurfaceDiag, libExportUnresolvedDiag, libGenericExportDiag, libIntBoundaryDiag, libNpmIneligibleDiag, libUnmappableSignatureDiag, iceDiag, isCheckerPanic, LIB_INBOUND_BYTES_TRAP_CODE, LIB_RUNTIME_TRAP_CODES, type ScrDiagnostic } from "./diagnostics/diagnostic.js";
-import { checkLibraryIntegerSlots, classSeed, hasIntSlots, type FnIntSlots, type IntSlotConfig } from "./library/int-infer.js";
+import { checkerPanicDiag, ffiNativeBuildDiag, libAsyncExportDiag, libAsyncSurfaceDiag, libExportUnresolvedDiag, libGenericExportDiag, libIntBoundaryDiag, libNpmIneligibleDiag, libSidecarDiag, libUnmappableSignatureDiag, iceDiag, isCheckerPanic, LIB_INBOUND_BYTES_TRAP_CODE, LIB_RUNTIME_TRAP_CODES, type ScrDiagnostic } from "./diagnostics/diagnostic.js";
+import { checkLibraryIntegerSlots, classSeed, hasIntSlots, numberCarrierKind, type FnIntSlots, type IntSlotConfig } from "./library/int-infer.js";
 import { loadLibraryProfile, profileRemediation, profileTeaching, type LibraryProfile } from "./library/profile.js";
 import { decorateLibraryRefusals, evaluateLibraryFences } from "./library/fence-eval.js";
 import { assembleTrapTeaching } from "./library/trap-teaching.js";
@@ -1049,14 +1049,20 @@ function libraryIntSlotConfig(profile: LibraryProfile): IntSlotConfig {
 /** Merge the sidecar-resolved integer slots (ask 4) into the inference
  * config: helper slots key by function name and IR parameter index (the
  * projection already shifted past the model receiver); record-field
- * slots map onto every interned IR shape whose field-name set matches
- * the projected record's — shapes intern structurally, so a same-shaped
- * second type shares the obligation (a sound over-approximation). A
+ * slots map onto every interned IR shape whose field-name set and numeric
+ * optionality match the projected record's. Shapes intern structurally, so
+ * a same-shaped second type shares the obligation (a sound
+ * over-approximation); two DECLARED paths resolving to the same shape-field
+ * key refuse because overwriting either attestation would be unsound. A
  * record fact that matches no shape binds nothing: no compiled code
  * constructs the type (the contract surface — init/update/subscriptions
  * and every helper — is force-lowered whenever integer slots are
  * declared, so this is genuine vacuity, not dead-stripping). */
-function mergeSidecarIntSlots(cfg: IntSlotConfig, facts: SidecarIntegerSlotFacts, mod: IrModule): IntSlotConfig {
+function mergeSidecarIntSlots(
+  cfg: IntSlotConfig,
+  facts: SidecarIntegerSlotFacts,
+  mod: IrModule,
+): { ok: true; config: IntSlotConfig } | { ok: false; diagnostic: ScrDiagnostic } {
   for (const h of facts.helpers) {
     const fn = mod.functions.find((f) => f.name === h.fnName);
     const arity = Math.max(fn?.params.length ?? 0, (h.index ?? 0) + 1);
@@ -1100,16 +1106,27 @@ function mergeSidecarIntSlots(cfg: IntSlotConfig, facts: SidecarIntegerSlotFacts
         (names.length === wantedSansKind.size && names.every((n: string) => wantedSansKind.has(n)));
       if (!matches) continue;
       const target = shape.fields.find((f) => f.name === r.targetField);
-      if (target === undefined || target.type.kind !== "f64") continue;
+      if (target === undefined || numberCarrierKind(target.type, mod) !== (r.optional ? "optional" : "plain")) continue;
       let m = cfg.records.get(shape.id);
       if (m === undefined) {
         m = new Map();
         cfg.records.set(shape.id, m);
       }
+      const existing = m.get(r.targetField);
+      if (existing !== undefined && existing.path !== r.path) {
+        return {
+          ok: false,
+          diagnostic: libSidecarDiag(
+            `integer slots '${existing.path}' (${existing.cls}) and '${r.path}' (${r.cls}) collapse to the same lowered record field '${r.targetField}' — their proof obligations cannot be kept distinct`,
+            r.loc,
+            "kind-tagged union arms and structurally identical records may share one lowered shape — give the colliding payloads distinct structural shapes, or integer-class at most one of these slots",
+          ),
+        };
+      }
       m.set(r.targetField, { cls: r.cls, path: r.path });
     }
   }
-  return cfg;
+  return { ok: true, config: cfg };
 }
 
 export async function compileLibrary(opts: CompileLibraryOptions): Promise<CompileLibraryResult> {
@@ -1286,7 +1303,9 @@ export async function compileLibrary(opts: CompileLibraryOptions): Promise<Compi
       return fail(violations.map((v) => iceDiag(`sidecar self-check failed — ${v}`, { file: entryPath, start: 0, end: 0 })));
     }
     sidecarJson = built.json;
-    intCfg = mergeSidecarIntSlots(intCfg, built.integerSlotFacts, mod);
+    const merged = mergeSidecarIntSlots(intCfg, built.integerSlotFacts, mod);
+    if (!merged.ok) return fail([merged.diagnostic]);
+    intCfg = merged.config;
   }
 
   // Ask 4: the integer-boundary inference — every value that can reach a

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1063,9 +1063,8 @@ function sidecarRecordMatcher(
   const recordMatches = (
     pattern: SidecarIrRecordPattern,
     shape: IrRecordShape,
-    depth: number,
   ): boolean => {
-    if (depth > 64 || shape.tuple === true || shape.indexValue !== undefined) return false;
+    if (shape.tuple === true || shape.indexValue !== undefined) return false;
     const variants = [pattern.fields];
     if (pattern.kindMayBeOmitted === true) {
       variants.push(pattern.fields.filter((field) => field.name !== "kind"));
@@ -1075,7 +1074,7 @@ function sidecarRecordMatcher(
         fields.length === shape.fields.length &&
         fields.every((field) => {
           const actual = shape.fields.find((candidate) => candidate.name === field.name);
-          return actual !== undefined && typeMatches(field.type, actual.type, depth + 1);
+          return actual !== undefined && typeMatches(field.type, actual.type);
         }),
     );
   };
@@ -1083,14 +1082,13 @@ function sidecarRecordMatcher(
   const unionMatches = (
     patterns: SidecarIrTypePattern[],
     actual: IrType[],
-    depth: number,
   ): boolean => {
     if (patterns.length !== actual.length) return false;
     const used = new Set<number>();
     const visit = (index: number): boolean => {
       if (index === patterns.length) return true;
       for (let i = 0; i < actual.length; i++) {
-        if (used.has(i) || !typeMatches(patterns[index]!, actual[i]!, depth + 1)) continue;
+        if (used.has(i) || !typeMatches(patterns[index]!, actual[i]!)) continue;
         used.add(i);
         if (visit(index + 1)) return true;
         used.delete(i);
@@ -1103,9 +1101,7 @@ function sidecarRecordMatcher(
   const typeMatches = (
     pattern: SidecarIrTypePattern,
     actual: IrType,
-    depth: number,
   ): boolean => {
-    if (depth > 64) return false;
     switch (pattern.kind) {
       case "f64":
       case "string":
@@ -1116,21 +1112,21 @@ function sidecarRecordMatcher(
       case "bytes":
         return actual.kind === "bytes" && actual.elem === pattern.elem;
       case "array":
-        return actual.kind === "array" && typeMatches(pattern.elem, actual.elem, depth + 1);
+        return actual.kind === "array" && typeMatches(pattern.elem, actual.elem);
       case "record": {
         if (actual.kind !== "record") return false;
         const shape = records.get(actual.shapeId);
-        return shape !== undefined && recordMatches(pattern, shape, depth + 1);
+        return shape !== undefined && recordMatches(pattern, shape);
       }
       case "union": {
         if (actual.kind !== "union") return false;
         const union = unions.get(actual.unionId);
-        return union !== undefined && unionMatches(pattern.arms, union.arms, depth + 1);
+        return union !== undefined && unionMatches(pattern.arms, union.arms);
       }
     }
   };
 
-  return (pattern, shape) => recordMatches(pattern, shape, 0);
+  return (pattern, shape) => recordMatches(pattern, shape);
 }
 
 /** Merge the sidecar-resolved integer slots (ask 4) into the inference

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -15,11 +15,13 @@ import {
   compilerReleaseVersion,
   libraryIdentityHashes,
   type SidecarIntegerSlotFacts,
+  type SidecarIrRecordPattern,
+  type SidecarIrTypePattern,
 } from "./library/sidecar.js";
 import { validateSidecar } from "./library/sidecar-validate.js";
 import { entryFunctionExports, type EntryExportInfo } from "./frontend/lib-exports.js";
 import { entryContractFacts, type ContractFacts } from "./frontend/lib-contract.js";
-import { moduleLibAsyncSurface, moduleLibNondeterministicSurface, moduleEmbedsBuiltin, moduleEmbedsCompressedNpm, moduleUsesAssert, moduleUsesCopying, moduleUsesDc, moduleUsesDgram, moduleUsesDynAsync, moduleUsesDynInvoke, moduleUsesEmitter, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesInspect, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesQs, moduleUsesRegex, moduleUsesSearchParams, moduleUsesStream, moduleUsesSymbol, moduleUsesTls, moduleUsesTlsCa, moduleUsesZlib, type IrLibSection, type IrModule, type IrType, type SrcLoc } from "./ir/nodes.js";
+import { moduleLibAsyncSurface, moduleLibNondeterministicSurface, moduleEmbedsBuiltin, moduleEmbedsCompressedNpm, moduleUsesAssert, moduleUsesCopying, moduleUsesDc, moduleUsesDgram, moduleUsesDynAsync, moduleUsesDynInvoke, moduleUsesEmitter, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesInspect, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesQs, moduleUsesRegex, moduleUsesSearchParams, moduleUsesStream, moduleUsesSymbol, moduleUsesTls, moduleUsesTlsCa, moduleUsesZlib, type IrLibSection, type IrModule, type IrRecordShape, type IrType, type SrcLoc } from "./ir/nodes.js";
 import { serializeModule } from "./ir/serialize.js";
 import { validateModule } from "./ir/validate.js";
 import { canonicalBuiltinModule, checkPreflight, isNodeTypesPath, loadProgram, locOf, requiresOf, resolveNpmImport, type LoadResult } from "./frontend/program.js";
@@ -1046,14 +1048,99 @@ function libraryIntSlotConfig(profile: LibraryProfile): IntSlotConfig {
   return cfg;
 }
 
+/** Match the sidecar syntax's exact structural type projection against the
+ * frontend's interned IR registries. The pattern deliberately mirrors
+ * ShapeRegistry's identity: every field name and recursively mapped field
+ * type participates. Tagged payload records additionally accept omission
+ * of their `kind` field because the lowering may carry that discriminant
+ * only in the surrounding union tag. */
+function sidecarRecordMatcher(
+  mod: IrModule,
+): (pattern: SidecarIrRecordPattern, shape: IrRecordShape) => boolean {
+  const records = new Map((mod.records ?? []).map((shape) => [shape.id, shape]));
+  const unions = new Map((mod.unions ?? []).map((union) => [union.id, union]));
+
+  const recordMatches = (
+    pattern: SidecarIrRecordPattern,
+    shape: IrRecordShape,
+    depth: number,
+  ): boolean => {
+    if (depth > 64 || shape.tuple === true || shape.indexValue !== undefined) return false;
+    const variants = [pattern.fields];
+    if (pattern.kindMayBeOmitted === true) {
+      variants.push(pattern.fields.filter((field) => field.name !== "kind"));
+    }
+    return variants.some(
+      (fields) =>
+        fields.length === shape.fields.length &&
+        fields.every((field) => {
+          const actual = shape.fields.find((candidate) => candidate.name === field.name);
+          return actual !== undefined && typeMatches(field.type, actual.type, depth + 1);
+        }),
+    );
+  };
+
+  const unionMatches = (
+    patterns: SidecarIrTypePattern[],
+    actual: IrType[],
+    depth: number,
+  ): boolean => {
+    if (patterns.length !== actual.length) return false;
+    const used = new Set<number>();
+    const visit = (index: number): boolean => {
+      if (index === patterns.length) return true;
+      for (let i = 0; i < actual.length; i++) {
+        if (used.has(i) || !typeMatches(patterns[index]!, actual[i]!, depth + 1)) continue;
+        used.add(i);
+        if (visit(index + 1)) return true;
+        used.delete(i);
+      }
+      return false;
+    };
+    return visit(0);
+  };
+
+  const typeMatches = (
+    pattern: SidecarIrTypePattern,
+    actual: IrType,
+    depth: number,
+  ): boolean => {
+    if (depth > 64) return false;
+    switch (pattern.kind) {
+      case "f64":
+      case "string":
+      case "bool":
+      case "nullT":
+      case "undefinedT":
+        return actual.kind === pattern.kind;
+      case "bytes":
+        return actual.kind === "bytes" && actual.elem === pattern.elem;
+      case "array":
+        return actual.kind === "array" && typeMatches(pattern.elem, actual.elem, depth + 1);
+      case "record": {
+        if (actual.kind !== "record") return false;
+        const shape = records.get(actual.shapeId);
+        return shape !== undefined && recordMatches(pattern, shape, depth + 1);
+      }
+      case "union": {
+        if (actual.kind !== "union") return false;
+        const union = unions.get(actual.unionId);
+        return union !== undefined && unionMatches(pattern.arms, union.arms, depth + 1);
+      }
+    }
+  };
+
+  return (pattern, shape) => recordMatches(pattern, shape, 0);
+}
+
 /** Merge the sidecar-resolved integer slots (ask 4) into the inference
  * config: helper slots key by function name and IR parameter index (the
  * projection already shifted past the model receiver); record-field
- * slots map onto every interned IR shape whose field-name set and numeric
- * optionality match the projected record's. Shapes intern structurally, so
- * a same-shaped second type shares the obligation (a sound
- * over-approximation); two DECLARED paths resolving to the same shape-field
- * key refuse because overwriting either attestation would be unsound. A
+ * slots map onto every interned IR shape whose complete structural field
+ * signature matches the projected record's. Shapes intern structurally,
+ * so a same-shaped second type shares the obligation; two DECLARED paths
+ * resolving to the same shape-field key refuse because overwriting either
+ * attestation would be unsound. A
  * record fact that matches no shape binds nothing: no compiled code
  * constructs the type (the contract surface — init/update/subscriptions
  * and every helper — is force-lowered whenever integer slots are
@@ -1063,6 +1150,7 @@ function mergeSidecarIntSlots(
   facts: SidecarIntegerSlotFacts,
   mod: IrModule,
 ): { ok: true; config: IntSlotConfig } | { ok: false; diagnostic: ScrDiagnostic } {
+  const recordMatches = sidecarRecordMatcher(mod);
   for (const h of facts.helpers) {
     const fn = mod.functions.find((f) => f.name === h.fnName);
     const arity = Math.max(fn?.params.length ?? 0, (h.index ?? 0) + 1);
@@ -1093,20 +1181,10 @@ function mergeSidecarIntSlots(
     }
   }
   for (const r of facts.records) {
-    const wanted = new Set(r.fieldNames);
-    const wantedSansKind = new Set(r.fieldNames.filter((n) => n !== "kind"));
     for (const shape of mod.records ?? []) {
-      if (shape.tuple === true || shape.indexValue !== undefined) continue;
-      const names = shape.fields.map((f) => f.name);
-      if (names.some((n) => n.startsWith("%"))) continue;
-      // The union discriminant may or may not materialize as a shape
-      // field depending on the arm's lowering; match either spelling.
-      const matches =
-        (names.length === wanted.size && names.every((n) => wanted.has(n))) ||
-        (names.length === wantedSansKind.size && names.every((n: string) => wantedSansKind.has(n)));
-      if (!matches) continue;
+      if (!recordMatches(r.shape, shape)) continue;
       const target = shape.fields.find((f) => f.name === r.targetField);
-      if (target === undefined || numberCarrierKind(target.type, mod) !== (r.optional ? "optional" : "plain")) continue;
+      if (target === undefined || numberCarrierKind(target.type, mod) === null) continue;
       let m = cfg.records.get(shape.id);
       if (m === undefined) {
         m = new Map();

--- a/packages/compiler/src/library/int-infer.test.ts
+++ b/packages/compiler/src/library/int-infer.test.ts
@@ -24,6 +24,7 @@ const F64 = { kind: "f64" } as const;
 const BOOL = { kind: "bool" } as const;
 const VOID = { kind: "void" } as const;
 const MODEL = { kind: "record", shapeId: "model-shape" } as const;
+const OPTIONAL_NUMBER = { kind: "union", unionId: "optional-number" } as const;
 
 const num = (value: number, spelling?: string): IrExpr =>
   spelling === undefined
@@ -326,6 +327,71 @@ describe("the domain's edges beyond the corpus", () => {
     expect(vs[0]!.outcome).toBe("refuse");
     expect(vs[0]!.obligation).toBe("range");
     expect(vs[0]!.detail).toContain(`[${SAFE_MIN}, ${SAFE_MAX}]`);
+  });
+
+  test("a matching unit tag makes an optional return vacuous", () => {
+    const x: IrExpr = { kind: "varRef", localId: "x.0", type: OPTIONAL_NUMBER, loc };
+    const one: IrExpr = {
+      kind: "unionWrap",
+      unionId: OPTIONAL_NUMBER.unionId,
+      tag: 0,
+      value: num(1),
+      type: OPTIONAL_NUMBER,
+      loc,
+    };
+    const mod: IrModule = {
+      irVersion: 3,
+      sourceFile: "optional.ts",
+      functions: [{
+        name: "normalize",
+        params: [{ localId: "x.0", name: "x", type: OPTIONAL_NUMBER }],
+        returnType: OPTIONAL_NUMBER,
+        locals: [{ id: "x.0", name: "x", type: OPTIONAL_NUMBER, mutable: true }],
+        body: [
+          {
+            kind: "if",
+            cond: {
+              kind: "unionIsTag",
+              unionId: OPTIONAL_NUMBER.unionId,
+              tag: 1,
+              negated: false,
+              value: x,
+              type: BOOL,
+              loc,
+            },
+            then: [{ kind: "return", value: x, loc }],
+            else_: null,
+            loc,
+          },
+          { kind: "return", value: one, loc },
+        ],
+        loc,
+      }],
+      unions: [{
+        id: OPTIONAL_NUMBER.unionId,
+        arms: [F64, { kind: "nullT" }],
+      }],
+      entry: "normalize",
+    };
+    const cfg: IntSlotConfig = {
+      fns: new Map([[
+        "normalize",
+        {
+          fnName: "normalize",
+          params: [null],
+          paramPaths: [null],
+          ret: "u64",
+          retPath: "helpers.normalize.return",
+          paramSeeds: [null],
+        },
+      ]]),
+      records: new Map(),
+    };
+    const vs = checkLibraryIntegerSlots(mod, cfg);
+    expect(vs).toHaveLength(2);
+    expect(vs.every((v) => v.outcome === "prove")).toBe(true);
+    expect(Number.isNaN(vs[0]!.provenLo)).toBe(true);
+    expect(vs[1]!.provenLo).toBe(1);
   });
 
   test("a guard that only excludes NaN still refuses on the unbounded range", () => {

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -76,6 +76,7 @@ import type {
   IrModule,
   IrNumBinOp,
   IrStmt,
+  IrType,
   SrcLoc,
 } from "../ir/nodes.js";
 
@@ -436,6 +437,25 @@ export interface IntSlotConfig {
   records: Map<string, Map<string, { cls: IntClass; path: string }>>;
 }
 
+/** The IR representations whose PRESENT values can carry one number slot.
+ * A bare f64 is plain; a union of exactly one f64 arm and one or more
+ * null/undefined arms is optional. The abstract interpreter tracks the
+ * possible f64 arm values and treats unit arms as the empty numeric set. */
+export function numberCarrierKind(t: IrType, mod: IrModule): "plain" | "optional" | null {
+  if (t.kind === "f64") return "plain";
+  if (t.kind !== "union") return null;
+  const def = mod.unions?.find((u) => u.id === t.unionId);
+  if (def === undefined) return null;
+  let numbers = 0;
+  let units = 0;
+  for (const arm of def.arms) {
+    if (arm.kind === "f64") numbers++;
+    else if (arm.kind === "nullT" || arm.kind === "undefinedT") units++;
+    else return null;
+  }
+  return numbers === 1 && units > 0 ? "optional" : null;
+}
+
 export function hasIntSlots(cfg: IntSlotConfig): boolean {
   if (cfg.records.size > 0) return true;
   for (const f of cfg.fns.values()) {
@@ -752,7 +772,7 @@ class FnAnalyzer {
     const env: Env = new Map();
     const slots = this.cfg.fns.get(fn.name);
     fn.params.forEach((p, i) => {
-      if (p.type.kind !== "f64") return;
+      if (!this.bindingCarriesNumber(p.localId)) return;
       const declared = slots?.params[i] ?? null;
       const seed = slots?.paramSeeds[i] ?? null;
       if (declared !== null) env.set(p.localId, classSeed(declared));
@@ -787,13 +807,13 @@ class FnAnalyzer {
         if (s.init === null) return env;
         const v = this.evalExpr(s.init, env);
         this.clearPathsRootedAt(env, s.localId);
-        if (this.bindingIsF64(s.localId)) env.set(s.localId, v);
+        if (this.bindingCarriesNumber(s.localId)) env.set(s.localId, v);
         return env;
       }
       case "assign": {
         const v = this.evalExpr(s.value, env);
         this.clearPathsRootedAt(env, s.localId);
-        if (this.bindingIsF64(s.localId)) env.set(s.localId, v);
+        if (this.bindingCarriesNumber(s.localId)) env.set(s.localId, v);
         return env;
       }
       case "exprStmt":
@@ -825,7 +845,7 @@ class FnAnalyzer {
         return this.execLoop(env, { cond: s.cond, body: s.body, labels: s.labels ?? [], doWhile: true });
       case "forOf": {
         this.evalExpr(s.iterable, env);
-        const elemF64 = this.bindingIsF64(s.localId);
+        const elemF64 = this.bindingCarriesNumber(s.localId);
         return this.execLoop(env, {
           body: s.body,
           labels: s.labels ?? [],
@@ -1000,7 +1020,7 @@ class FnAnalyzer {
     };
     tryBody.forEach(visitStmt);
     for (const id of assigned) {
-      if (this.bindingIsF64(id)) out.set(id, { ...TOP });
+      if (this.bindingCarriesNumber(id)) out.set(id, { ...TOP });
     }
     // Globals: any callee may have written before the throw.
     for (const k of [...out.keys()]) {
@@ -1216,6 +1236,8 @@ class FnAnalyzer {
       case "recordGet":
       case "fieldGet":
         return this.staticAccessPath(e) !== null;
+      case "unionNarrow":
+        return this.isPure(e.value);
       case "bin":
         return this.isPure(e.left) && this.isPure(e.right);
       case "unary":
@@ -1235,13 +1257,17 @@ class FnAnalyzer {
       case "numLit":
         return constVal(e.value, e.spelling);
       case "varRef":
-        return e.type.kind === "f64" ? envGet(env, e.localId) : { ...TOP };
+        return this.bindingCarriesNumber(e.localId) ? envGet(env, e.localId) : { ...TOP };
       case "recordGet": {
         const slot = this.cfg.records.get(e.shapeId)?.get(e.field);
-        if (slot === undefined || e.type.kind !== "f64") return { ...TOP };
+        if (slot === undefined || numberCarrierKind(e.type, this.mod) === null) return { ...TOP };
         const key = this.pathKey(e, slot.cls);
         return key === null ? classSeed(slot.cls) : envGet(env, key);
       }
+      case "unionNarrow":
+        return e.type.kind === "f64" && numberCarrierKind(e.value.type, this.mod) === "optional"
+          ? this.evalPure(e.value, env)
+          : { ...TOP };
       case "unary":
         if (e.op === "-") return transferNeg(this.evalPure(e.operand, env));
         if (e.op === "~") return transferBitNot(this.evalPure(e.operand, env));
@@ -1272,6 +1298,8 @@ class FnAnalyzer {
         if (base === null) return null;
         return { rootId: base.rootId, steps: [...base.steps, ["record", e.shapeId, e.field]] };
       }
+      case "unionNarrow":
+        return this.staticAccessPath(e.value);
       case "fieldGet": {
         const base = this.staticAccessPath(e.obj);
         if (base === null) return null;
@@ -1295,7 +1323,10 @@ class FnAnalyzer {
 
   private refinementKey(e: IrExpr, allowPaths: boolean): string | null {
     if (e.kind === "varRef") return e.localId;
-    if (!allowPaths || e.kind !== "recordGet" || e.type.kind !== "f64") return null;
+    if (e.kind === "unionNarrow" && e.type.kind === "f64") {
+      return this.refinementKey(e.value, allowPaths);
+    }
+    if (!allowPaths || e.kind !== "recordGet" || numberCarrierKind(e.type, this.mod) === null) return null;
     const slot = this.cfg.records.get(e.shapeId)?.get(e.field);
     return slot === undefined ? null : this.pathKey(e, slot.cls);
   }
@@ -1316,6 +1347,8 @@ class FnAnalyzer {
       case "recordGet":
       case "fieldGet":
         return this.staticAccessPath(e) !== null;
+      case "unionNarrow":
+        return this.stablePathGuard(e.value);
       case "bin":
       case "logical":
         return this.stablePathGuard(e.left) && this.stablePathGuard(e.right);
@@ -1350,15 +1383,19 @@ class FnAnalyzer {
     }
   }
 
-  private bindingIsF64(id: string): boolean {
-    return this.f64Bindings.has(id);
+  private bindingCarriesNumber(id: string): boolean {
+    return this.numberBindings.has(id);
   }
-  private f64Bindings = new Set<string>();
+  private numberBindings = new Set<string>();
 
   seedBindings(fn: IrFunction, mod: IrModule): void {
-    this.f64Bindings = new Set();
-    for (const l of fn.locals) if (l.type.kind === "f64" && l.boxed !== true) this.f64Bindings.add(l.id);
-    for (const g of mod.globals ?? []) if (g.type.kind === "f64") this.f64Bindings.add(g.id);
+    this.numberBindings = new Set();
+    for (const l of fn.locals) {
+      if (numberCarrierKind(l.type, mod) !== null && l.boxed !== true) this.numberBindings.add(l.id);
+    }
+    for (const g of mod.globals ?? []) {
+      if (numberCarrierKind(g.type, mod) !== null) this.numberBindings.add(g.id);
+    }
   }
 
   /** Evaluate an expression over the environment, applying the side
@@ -1380,7 +1417,7 @@ class FnAnalyzer {
       case "chainRecv":
         return { ...TOP };
       case "varRef":
-        return e.type.kind === "f64" && this.bindingIsF64(e.localId) ? envGet(env, e.localId) : { ...TOP };
+        return this.bindingCarriesNumber(e.localId) ? envGet(env, e.localId) : { ...TOP };
       case "bin": {
         const a = this.evalExpr(e.left, env);
         const b = this.evalExpr(e.right, env);
@@ -1395,15 +1432,15 @@ class FnAnalyzer {
         return { ...TOP };
       }
       case "incDec": {
-        const old = this.bindingIsF64(e.localId) ? envGet(env, e.localId) : { ...TOP };
+        const old = this.bindingCarriesNumber(e.localId) ? envGet(env, e.localId) : { ...TOP };
         const next = transferAdd(old, constVal(e.op === "+" ? 1 : -1));
-        if (this.bindingIsF64(e.localId)) env.set(e.localId, next);
+        if (this.bindingCarriesNumber(e.localId)) env.set(e.localId, next);
         return e.prefix ? next : old;
       }
       case "assignExpr": {
         const v = this.evalExpr(e.value, env);
         this.clearPathsRootedAt(env, e.localId);
-        if (this.bindingIsF64(e.localId)) env.set(e.localId, v);
+        if (this.bindingCarriesNumber(e.localId)) env.set(e.localId, v);
         return v;
       }
       case "ternary": {
@@ -1419,18 +1456,18 @@ class FnAnalyzer {
       case "logical":
       case "nullish":
       case "orDefault": {
-        this.evalExpr(e.left, env);
+        const left = this.evalExpr(e.left, env);
         const rightEnv = cloneEnv(env);
-        this.evalExpr(e.right, rightEnv);
+        const right = this.evalExpr(e.right, rightEnv);
         mergeInto(env, joinEnv(env, rightEnv));
-        return { ...TOP };
+        return numberCarrierKind(e.type, this.mod) !== null ? join(left, right) : { ...TOP };
       }
       case "optChain": {
         this.evalExpr(e.receiver, env);
         const bodyEnv = cloneEnv(env);
-        this.evalExpr(e.body, bodyEnv);
+        const body = this.evalExpr(e.body, bodyEnv);
         mergeInto(env, joinEnv(env, bodyEnv));
-        return { ...TOP };
+        return numberCarrierKind(e.type, this.mod) !== null ? body : { ...TOP };
       }
       case "seqExpr": {
         // Expression-position statements: no jumps can escape them.
@@ -1459,6 +1496,19 @@ class FnAnalyzer {
         this.havocCall(e.callee, env);
         if (slots?.ret != null) return classSeed(slots.ret);
         return { ...TOP };
+      }
+      case "unionWrap": {
+        const value = this.evalExpr(e.value, env);
+        if (numberCarrierKind(e.type, this.mod) !== "optional") return { ...TOP };
+        // Unit arms are absence, not an integer crossing. The one f64 arm
+        // contributes its abstract value unchanged.
+        return e.value.type.kind === "f64" ? value : BOTTOM;
+      }
+      case "unionNarrow": {
+        const value = this.evalExpr(e.value, env);
+        return e.type.kind === "f64" && numberCarrierKind(e.value.type, this.mod) === "optional"
+          ? value
+          : { ...TOP };
       }
       case "libCall": {
         const math = this.evalMath(e, env, true);
@@ -1495,7 +1545,9 @@ class FnAnalyzer {
         for (const f of e.fields) {
           const v = this.evalExpr(f.value, env);
           const slot = slotMap?.get(f.name);
-          if (slot !== undefined && f.value.type.kind === "f64") this.emit(v, slot.path, slot.cls, f.value.loc);
+          if (slot !== undefined && numberCarrierKind(f.value.type, this.mod) !== null) {
+            this.emit(v, slot.path, slot.cls, f.value.loc);
+          }
         }
         return { ...TOP };
       }
@@ -1508,7 +1560,7 @@ class FnAnalyzer {
         // — instead of a spurious may-be-NaN wholeness refusal).
         this.evalExpr(e.obj, env);
         const slot = this.cfg.records.get(e.shapeId)?.get(e.field);
-        if (slot !== undefined && e.type.kind === "f64") {
+        if (slot !== undefined && numberCarrierKind(e.type, this.mod) !== null) {
           const key = this.pathKey(e, slot.cls);
           return key === null ? classSeed(slot.cls) : envGet(env, key);
         }

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -1173,6 +1173,24 @@ class FnAnalyzer {
         );
         return joinEnv(viaLeft, viaRight);
       }
+      case "unionIsTag": {
+        const unionType: IrType = { kind: "union", unionId: cond.unionId };
+        if (numberCarrierKind(unionType, this.mod) !== "optional") return env;
+        const def = this.mod.unions?.find((u) => u.id === cond.unionId);
+        const arm = def?.arms[cond.tag];
+        const key = this.refinementKey(cond.value, allowPaths);
+        if (arm === undefined || key === null) return env;
+        const tagMatches = cond.negated ? !branch : branch;
+        // The abstract value describes only PRESENT f64 inhabitants. A
+        // branch selecting a unit arm has no numeric inhabitants; likewise
+        // a branch excluding the optional carrier's sole f64 arm.
+        if ((tagMatches && arm.kind !== "f64") || (!tagMatches && arm.kind === "f64")) {
+          const out = cloneEnv(env);
+          out.set(key, { ...BOTTOM });
+          return out;
+        }
+        return env;
+      }
       case "bin": {
         if (!CMP_OPS.has(cond.op)) return env;
         if (cond.left.type.kind !== "f64" || cond.right.type.kind !== "f64") return env;
@@ -1358,6 +1376,8 @@ class FnAnalyzer {
       case "recordGet":
       case "fieldGet":
         return this.staticAccessPath(e) !== null;
+      case "unionIsTag":
+        return this.stablePathGuard(e.value);
       case "unionNarrow":
         return this.stablePathGuard(e.value);
       case "bin":

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -897,12 +897,23 @@ class FnAnalyzer {
         clearPathFacts(env);
         return env;
       }
-      case "recordKeySet":
+      case "recordKeySet": {
         this.evalExpr(s.obj, env);
         this.evalExpr(s.key, env);
-        this.evalExpr(s.value, env);
+        const v = this.evalExpr(s.value, env);
+        // A runtime key can dispatch to any declared field of the shape.
+        // overflowOnly proves a literal key names no declared field; every
+        // other keyed write must therefore discharge every integer slot it
+        // could select. Multiple classified fields intentionally emit
+        // independent obligations (their classes and paths may differ).
+        if (s.overflowOnly !== true) {
+          for (const slot of this.cfg.records.get(s.shapeId)?.values() ?? []) {
+            this.emit(v, slot.path, slot.cls, s.loc);
+          }
+        }
         clearPathFacts(env);
         return env;
+      }
       case "recordKeyDelete":
         this.evalExpr(s.obj, env);
         this.evalExpr(s.key, env);

--- a/packages/compiler/src/library/profile.ts
+++ b/packages/compiler/src/library/profile.ts
@@ -158,11 +158,12 @@ export interface LibrarySidecarConfig {
   sourceHash: "module-graph";
   /** Ask 4's declared integer boundary slots, keyed by the sidecar's slot
    * path grammar (`Msg.count`, `Point.x`, `helpers.clamp.params[0]`,
-   * `helpers.clamp.return`). Each named slot must resolve to a NUMBER
-   * slot of the projected contract (refused at sidecar build otherwise),
-   * is spelled i64 in the emitted document's TypeRef/descriptor (the
-   * frozen format-1 type vocabulary has no u64 — unsigned-ness is a
-   * boundary-slot refinement, not a type-table concept), joins
+   * `helpers.clamp.return`). Each named slot must resolve to a bare or
+   * optional NUMBER slot of the projected contract (refused at sidecar
+   * build otherwise), is spelled i64 (or optional<i64>) in the emitted
+   * document's TypeRef/descriptor (the frozen format-1 type vocabulary has
+   * no u64 — unsigned-ness is a boundary-slot refinement, not a type-table
+   * concept), joins
    * `integer_slots` with its DECLARED class ({i64, u64} — the u64
    * declaration is the stricter obligation, and the attestation records
    * the class whose proof was discharged), and obligates every

--- a/packages/compiler/src/library/sidecar-validate.ts
+++ b/packages/compiler/src/library/sidecar-validate.ts
@@ -317,7 +317,10 @@ export function validateSidecar(doc: unknown): string[] {
         }
         case "scalar": {
           const t = d["type"];
-          walkRef(t, `msg arm '${armName}' scalar payload`, null, null);
+          // Scalar optionals can carry the msg arm's integer-classed number
+          // slot (optional<i64>); slices still clear the path in walkRef
+          // because format 1 has no slice-element slot grammar.
+          walkRef(t, `msg arm '${armName}' scalar payload`, null, `${msgName}.${armName}`);
           if (isDict(t) && (t["kind"] === "node" || t["kind"] === "value" || t["kind"] === "void")) {
             bad("V7", `msg arm '${armName}': scalar descriptors carry a non-record, non-void TypeRef`);
           }

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -714,6 +714,51 @@ class Projector {
     }
   }
 
+  /** Record a number_bytes obligation for every composed occurrence of the
+   * wire-selected discriminant. Unlike a scalar descriptor, number_bytes
+   * exposes both source field names, so a later same-named arm must retain
+   * those names and the required number-then-bytes family. Text and bytes
+   * are the same sidecar bytes payload but distinct IR shapes; compatible
+   * occurrences therefore each need their own structural inference fact. */
+  private recordIntegerNumberBytesArmFacts(
+    unionName: string,
+    armName: string,
+    numberField: string,
+    bytesField: string,
+    cls: "i64" | "u64",
+    path: string,
+    loc: SrcLoc,
+  ): void {
+    for (const arm of this.allUnionArms(unionName, loc)) {
+      if (arm.name !== armName) continue;
+      const [number, bytes] = arm.fields;
+      const compatible =
+        arm.fields.length === 2 &&
+        number !== undefined &&
+        bytes !== undefined &&
+        !number.optional &&
+        !bytes.optional &&
+        number.name === numberField &&
+        bytes.name === bytesField &&
+        number.shape.k === "number" &&
+        (bytes.shape.k === "text" || bytes.shape.k === "bytes");
+      if (!compatible) {
+        throw new SidecarError(
+          `integer slot '${path}' (${cls}) selects number_bytes payload fields '${numberField}' and '${bytesField}', but another composed '${armName}' arm does not have the same required number-then-bytes fields`,
+          arm.loc,
+        );
+      }
+      this.pendingIntRecordFacts.push({
+        fields: arm.fields,
+        tagged: true,
+        targetField: numberField,
+        cls,
+        path,
+        loc: arm.loc,
+      });
+    }
+  }
+
   /** Project a syntactic field to a TypeRef, tabling every named type it
    * references. `container`/`member` seed synthesized names. */
   fieldRef(field: ContractField, container: string): TypeRef {
@@ -919,14 +964,15 @@ class Projector {
         const slotPath = `${msgName}.${arm.name}.${first.name}`;
         const numRef = this.intify({ kind: "f64" }, slotPath, first.loc);
         if (numRef.kind === "i64") {
-          this.pendingIntRecordFacts.push({
-            fields,
-            tagged: true,
-            targetField: first.name,
-            cls: this.intConsumed.get(slotPath)!,
-            path: slotPath,
-            loc: first.loc,
-          });
+          this.recordIntegerNumberBytesArmFacts(
+            msgName,
+            arm.name,
+            first.name,
+            second.name,
+            this.intConsumed.get(slotPath)!,
+            slotPath,
+            first.loc,
+          );
         }
         return { kind: "number_bytes", number_field: first.name, number_class: numRef.kind as "f64" | "i64", bytes_field: second.name };
       }

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -254,7 +254,7 @@ type Classified =
  * string discriminant field while others use only the surrounding union
  * tag. */
 export type SidecarIrTypePattern =
-  | { kind: "f64" | "string" | "bool" | "nullT" | "undefinedT" }
+  | { kind: "f64" | "string" | "bool" | "nullT" | "undefinedT" | "dyn" }
   | { kind: "bytes"; elem: "u8" }
   | { kind: "array"; elem: SidecarIrTypePattern }
   | SidecarIrRecordPattern
@@ -490,10 +490,18 @@ class Projector {
       case "union":
         return this.irUnionPattern(shape.parts.map((part) => this.irTypePattern(part, loc)));
       case "object":
-        return this.irRecordPattern(shape.fields);
+        // A declared `{}` annotation is TypeScript's top non-nullish type,
+        // not the inferred shape of an empty object literal. The frontend
+        // therefore lowers it to dyn (types.ts's declared-empty rule).
+        return shape.fields.length === 0
+          ? { kind: "dyn" }
+          : this.irRecordPattern(shape.fields);
       case "ref": {
         const resolved = this.resolve(shape.name, loc);
         if (resolved.c.c === "enum") return { kind: "string" };
+        if (resolved.c.c === "struct" && resolved.c.fields.length === 0) {
+          return { kind: "dyn" };
+        }
         if (this.irPatterning.has(resolved.name)) {
           throw new SidecarError(
             `the contract type graph is cyclic through '${resolved.name}' — recursive contract types cannot encode`,

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -236,6 +236,8 @@ type TaggedPart =
   | { p: "arm"; name: string; fields: ContractField[]; loc: SrcLoc }
   | { p: "ref"; name: string; loc: SrcLoc };
 
+type TaggedArm = { name: string; fields: ContractField[]; loc: SrcLoc };
+
 type Classified =
   | { c: "struct"; storage: "node" | "value"; fields: ContractField[]; decl: ContractTypeDecl; index: number }
   | { c: "enum"; members: string[]; decl: ContractTypeDecl; index: number }
@@ -340,8 +342,10 @@ class Projector {
   private readonly multiSite = new Map<string, string[]>();
   private readonly table = new Map<string, TableEntry>();
   private readonly inProgress = new Set<string>();
-  private readonly flatArms = new Map<string, { name: string; fields: ContractField[]; loc: SrcLoc }[]>();
+  private readonly flatArms = new Map<string, TaggedArm[]>();
+  private readonly allFlatArms = new Map<string, TaggedArm[]>();
   private readonly flattening = new Set<string>();
+  private readonly allFlattening = new Set<string>();
   private readonly irPatterning = new Set<string>();
   private synthCounter = 0;
   /** The profile's declared integer slots (ask 4), by slot path; entries
@@ -461,37 +465,7 @@ class Projector {
    * whenever their payload shapes differ. irUnionPattern performs the
    * frontend's structural deduplication after this walk. */
   private irTaggedArmPatterns(unionName: string, loc: SrcLoc): SidecarIrRecordPattern[] {
-    const c = this.lookup(unionName, loc);
-    if (c.c !== "tagged") {
-      throw new SidecarError(`'${unionName}' is not a kind-tagged union of object literals`, c.decl.loc);
-    }
-    const out: SidecarIrRecordPattern[] = [];
-    for (const part of c.parts) {
-      if (part.p === "arm") {
-        out.push(this.irRecordPattern(part.fields, true));
-        continue;
-      }
-      const resolved = this.resolve(part.name, part.loc);
-      if (resolved.c.c !== "tagged") {
-        throw new SidecarError(
-          `constituent '${part.name}' of union '${unionName}' is not a kind-tagged union — only kind-tagged unions compose by reference`,
-          part.loc,
-        );
-      }
-      if (this.irPatterning.has(resolved.name)) {
-        throw new SidecarError(
-          `union composition is cyclic through '${resolved.name}' — a union cannot spread itself`,
-          part.loc,
-        );
-      }
-      this.irPatterning.add(resolved.name);
-      try {
-        out.push(...this.irTaggedArmPatterns(resolved.name, part.loc));
-      } finally {
-        this.irPatterning.delete(resolved.name);
-      }
-    }
-    return out;
+    return this.allUnionArms(unionName, loc).map((arm) => this.irRecordPattern(arm.fields, true));
   }
 
   /** Convert a sidecar-supported syntactic type into the exact structural
@@ -649,6 +623,97 @@ class Projector {
     }
   }
 
+  /** Every source constituent of a composed tagged union, including later
+   * occurrences of an already-seen discriminant name. The wire table keeps
+   * first occurrence, but structural matching and integer obligations must
+   * retain all shapes the frontend can lower under that discriminant. */
+  private allUnionArms(unionName: string, loc: SrcLoc): TaggedArm[] {
+    const memo = this.allFlatArms.get(unionName);
+    if (memo !== undefined) return memo;
+    if (this.allFlattening.has(unionName)) {
+      throw new SidecarError(`union composition is cyclic through '${unionName}' — a union cannot spread itself`, loc);
+    }
+    const c = this.lookup(unionName, loc);
+    if (c.c !== "tagged") {
+      throw new SidecarError(`'${unionName}' is not a kind-tagged union of object literals`, c.decl.loc);
+    }
+    this.allFlattening.add(unionName);
+    try {
+      const out: TaggedArm[] = [];
+      for (const part of c.parts) {
+        if (part.p === "arm") {
+          out.push({ name: part.name, fields: part.fields, loc: part.loc });
+          continue;
+        }
+        const r = this.resolve(part.name, part.loc);
+        if (r.c.c !== "tagged") {
+          throw new SidecarError(
+            `constituent '${part.name}' of union '${unionName}' is not a kind-tagged union — only kind-tagged unions compose by reference`,
+            part.loc,
+          );
+        }
+        out.push(...this.allUnionArms(r.name, part.loc));
+      }
+      this.allFlatArms.set(unionName, out);
+      return out;
+    } finally {
+      this.allFlattening.delete(unionName);
+    }
+  }
+
+  /** Record one integer obligation for every lowered structural arm carrying
+   * the wire-selected discriminant. A composed union can repeat an arm name
+   * with a different payload field name; the sidecar's scalar descriptor
+   * omits that source name, so each compatible record shape must prove the
+   * same boundary slot. Incompatible later payloads refuse rather than let a
+   * non-integer value ride an integer-attested wire arm. */
+  private recordIntegerUnionArmFacts(
+    unionName: string,
+    armName: string,
+    intifiedRef: TypeRef,
+    cls: "i64" | "u64",
+    path: string,
+    loc: SrcLoc,
+  ): void {
+    const selectedOptional =
+      intifiedRef.kind === "optional" && intifiedRef.inner.kind === "i64";
+    if (intifiedRef.kind !== "i64" && !selectedOptional) {
+      throw new Error(`sidecar pattern bug: integer arm '${path}' has ref '${intifiedRef.kind}'`);
+    }
+    for (const arm of this.allUnionArms(unionName, loc)) {
+      if (arm.name !== armName) continue;
+      if (arm.fields.length !== 1) {
+        throw new SidecarError(
+          `integer slot '${path}' (${cls}) selects a scalar ${selectedOptional ? "optional " : ""}number payload, but another composed '${armName}' arm has ${arm.fields.length === 0 ? "no payload" : `${arm.fields.length} payload fields`}`,
+          arm.loc,
+        );
+      }
+      const field = arm.fields[0]!;
+      const ref = this.fieldRef(field, unionName);
+      const candidateOptional = ref.kind === "optional" && ref.inner.kind === "f64";
+      if (ref.kind !== "f64" && !candidateOptional) {
+        throw new SidecarError(
+          `integer slot '${path}' (${cls}) selects a scalar ${selectedOptional ? "optional " : ""}number payload, but another composed '${armName}' arm projects as '${ref.kind}'`,
+          arm.loc,
+        );
+      }
+      if (!selectedOptional && candidateOptional) {
+        throw new SidecarError(
+          `integer slot '${path}' (${cls}) selects a required number payload, but another composed '${armName}' arm makes that payload optional`,
+          arm.loc,
+        );
+      }
+      this.pendingIntRecordFacts.push({
+        fields: arm.fields,
+        tagged: true,
+        targetField: field.name,
+        cls,
+        path,
+        loc: arm.loc,
+      });
+    }
+  }
+
   /** Project a syntactic field to a TypeRef, tabling every named type it
    * references. `container`/`member` seed synthesized names. */
   fieldRef(field: ContractField, container: string): TypeRef {
@@ -779,16 +844,14 @@ class Projector {
         const before = this.intConsumed.has(slotPath);
         payload = this.intify(payload, slotPath, arm.loc);
         if (!before && this.intConsumed.has(slotPath)) {
-          // The one intifiable arm shape is a single number payload
-          // field; its IR record carries the 'kind' discriminant too.
-          this.pendingIntRecordFacts.push({
-            fields: arm.fields,
-            tagged: true,
-            targetField: arm.fields[0]!.name,
-            cls: this.intConsumed.get(slotPath)!,
-            path: slotPath,
-            loc: arm.loc,
-          });
+          this.recordIntegerUnionArmFacts(
+            name,
+            arm.name,
+            payload,
+            this.intConsumed.get(slotPath)!,
+            slotPath,
+            arm.loc,
+          );
         }
         entry.arms.push({ name: arm.name, payload });
       }
@@ -877,14 +940,14 @@ class Projector {
       const before = this.intConsumed.has(slotPath);
       ref = this.intify(ref, slotPath, arm.loc);
       if (!before && this.intConsumed.has(slotPath)) {
-        this.pendingIntRecordFacts.push({
-          fields,
-          tagged: true,
-          targetField: fields[0]!.name,
-          cls: this.intConsumed.get(slotPath)!,
-          path: slotPath,
-          loc: arm.loc,
-        });
+        this.recordIntegerUnionArmFacts(
+          msgName,
+          arm.name,
+          ref,
+          this.intConsumed.get(slotPath)!,
+          slotPath,
+          arm.loc,
+        );
       }
       switch (ref.kind) {
         case "bytes":

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -245,6 +245,25 @@ type Classified =
   | { c: "alias"; target: string; decl: ContractTypeDecl; index: number }
   | { c: "unsupported"; why: string; computed?: "conditional" | "mapped"; decl: ContractTypeDecl; index: number };
 
+/** The sidecar syntax's exact IR-shape projection. Record integer facts
+ * carry this structural pattern into the post-lowering join so it can use
+ * the same field-name AND field-type identity as ShapeRegistry. Tagged
+ * payload records admit omission of `kind`: some lowering paths retain the
+ * string discriminant field while others use only the surrounding union
+ * tag. */
+export type SidecarIrTypePattern =
+  | { kind: "f64" | "string" | "bool" | "nullT" | "undefinedT" }
+  | { kind: "bytes"; elem: "u8" }
+  | { kind: "array"; elem: SidecarIrTypePattern }
+  | SidecarIrRecordPattern
+  | { kind: "union"; arms: SidecarIrTypePattern[] };
+
+export interface SidecarIrRecordPattern {
+  kind: "record";
+  fields: { name: string; type: SidecarIrTypePattern }[];
+  kindMayBeOmitted?: true;
+}
+
 function classify(decl: ContractTypeDecl, index: number): Classified {
   const s = decl.shape;
   if (s.k === "unsupported") {
@@ -322,8 +341,8 @@ class Projector {
   private readonly intDeclared = new Map<string, "i64" | "u64">();
   readonly intConsumed = new Map<string, "i64" | "u64">();
   /** The record-field slots' resolution facts for the inference: the
-   * containing record's full projected field-name list plus the target
-   * field (ir shapes intern structurally by field names). */
+   * containing record's complete projected IR shape plus the target field
+   * (IR shapes intern structurally by field names and field types). */
   readonly intRecordFacts: SidecarIntegerSlotFacts["records"] = [];
 
   constructor(
@@ -367,21 +386,102 @@ class Projector {
 
   /** intify for a struct field (declared or synthesized), recording the
    * record-resolution fact the inference maps onto interned IR shapes. */
-  intifyStructField(ref: TypeRef, container: string, field: string, allFields: string[], loc: SrcLoc): TypeRef {
+  intifyStructField(ref: TypeRef, container: string, field: string, allFields: ContractField[], loc: SrcLoc): TypeRef {
     const slotPath = `${container}.${field}`;
     const before = this.intConsumed.has(slotPath);
     const out = this.intify(ref, slotPath, loc);
     if (!before && this.intConsumed.has(slotPath)) {
       this.intRecordFacts.push({
-        fieldNames: allFields,
+        shape: this.irRecordPattern(allFields),
         targetField: field,
-        optional: out.kind === "optional",
         cls: this.intConsumed.get(slotPath)!,
         path: slotPath,
         loc,
       });
     }
     return out;
+  }
+
+  /** Canonical union constructor mirroring the frontend: nested unions
+   * flatten, structurally repeated arms collapse, and one surviving arm is
+   * just that arm. */
+  private irUnionPattern(arms: SidecarIrTypePattern[]): SidecarIrTypePattern {
+    const flat: SidecarIrTypePattern[] = [];
+    for (const arm of arms) {
+      if (arm.kind === "union") flat.push(...arm.arms);
+      else flat.push(arm);
+    }
+    const unique = new Map<string, SidecarIrTypePattern>();
+    for (const arm of flat) unique.set(JSON.stringify(arm), arm);
+    const canonical = [...unique.entries()]
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([, arm]) => arm);
+    if (canonical.length === 0) throw new Error("sidecar pattern bug: empty union");
+    return canonical.length === 1 ? canonical[0]! : { kind: "union", arms: canonical };
+  }
+
+  private irFieldPattern(field: ContractField): SidecarIrTypePattern {
+    const inner = this.irTypePattern(field.shape, field.loc);
+    return field.optional
+      ? this.irUnionPattern([inner, { kind: "undefinedT" }])
+      : inner;
+  }
+
+  private irRecordPattern(fields: ContractField[], tagged = false): SidecarIrRecordPattern {
+    const projected = fields.map((field) => ({
+      name: field.name,
+      type: this.irFieldPattern(field),
+    }));
+    if (tagged) projected.push({ name: "kind", type: { kind: "string" } });
+    projected.sort((a, b) => (a.name < b.name ? -1 : a.name > b.name ? 1 : 0));
+    return {
+      kind: "record",
+      fields: projected,
+      ...(tagged ? { kindMayBeOmitted: true as const } : {}),
+    };
+  }
+
+  /** Convert a sidecar-supported syntactic type into the exact structural
+   * IR pattern the frontend maps it to. Projection has already refused
+   * unsupported shapes before an integer fact is recorded, so the default
+   * cases are internal consistency checks. */
+  private irTypePattern(shape: ContractTypeShape, loc: SrcLoc): SidecarIrTypePattern {
+    switch (shape.k) {
+      case "number":
+        return { kind: "f64" };
+      case "text":
+      case "stringLit":
+        return { kind: "string" };
+      case "bool":
+        return { kind: "bool" };
+      case "bytes":
+        return { kind: "bytes", elem: "u8" };
+      case "absent":
+        return { kind: shape.unit === "null" ? "nullT" : "undefinedT" };
+      case "array":
+        return { kind: "array", elem: this.irTypePattern(shape.elem, loc) };
+      case "union":
+        return this.irUnionPattern(shape.parts.map((part) => this.irTypePattern(part, loc)));
+      case "object":
+        return this.irRecordPattern(shape.fields);
+      case "ref": {
+        const resolved = this.resolve(shape.name, loc);
+        switch (resolved.c.c) {
+          case "struct":
+            return this.irRecordPattern(resolved.c.fields);
+          case "enum":
+            return { kind: "string" };
+          case "tagged":
+            return this.irUnionPattern(
+              this.unionArms(resolved.name, loc).map((arm) => this.irRecordPattern(arm.fields, true)),
+            );
+        }
+      }
+      case "void":
+      case "tuple":
+      case "unsupported":
+        throw new Error(`sidecar pattern bug: unsupported ${shape.k} shape reached an integer record fact`);
+    }
   }
 
   /** A declared slot path that the whole projection never spelled: the
@@ -602,7 +702,7 @@ class Projector {
           seen.add(f.name);
           entry.fields.push({
             name: f.name,
-            type: this.intifyStructField(this.fieldRef(f, name), name, f.name, c.fields.map((x) => x.name), f.loc),
+            type: this.intifyStructField(this.fieldRef(f, name), name, f.name, c.fields, f.loc),
           });
         }
         this.table.set(name, { kind: "struct", entry, anchor: c.index, sub: -1 });
@@ -621,9 +721,8 @@ class Projector {
           // The one intifiable arm shape is a single number payload
           // field; its IR record carries the 'kind' discriminant too.
           this.intRecordFacts.push({
-            fieldNames: [...arm.fields.map((f) => f.name), "kind"],
+            shape: this.irRecordPattern(arm.fields, true),
             targetField: arm.fields[0]!.name,
-            optional: payload.kind === "optional",
             cls: this.intConsumed.get(slotPath)!,
             path: slotPath,
             loc: arm.loc,
@@ -669,7 +768,7 @@ class Projector {
       seen.add(f.name);
       entry.fields.push({
         name: f.name,
-        type: this.intifyStructField(this.fieldRef(f, name), name, f.name, fields.map((x) => x.name), f.loc),
+        type: this.intifyStructField(this.fieldRef(f, name), name, f.name, fields, f.loc),
       });
     }
     return name;
@@ -696,9 +795,8 @@ class Projector {
         const numRef = this.intify({ kind: "f64" }, slotPath, first.loc);
         if (numRef.kind === "i64") {
           this.intRecordFacts.push({
-            fieldNames: [first.name, second.name, "kind"],
+            shape: this.irRecordPattern(fields, true),
             targetField: first.name,
-            optional: false,
             cls: this.intConsumed.get(slotPath)!,
             path: slotPath,
             loc: first.loc,
@@ -717,9 +815,8 @@ class Projector {
       ref = this.intify(ref, slotPath, arm.loc);
       if (!before && this.intConsumed.has(slotPath)) {
         this.intRecordFacts.push({
-          fieldNames: [fields[0]!.name, "kind"],
+          shape: this.irRecordPattern(fields, true),
           targetField: fields[0]!.name,
-          optional: ref.kind === "optional",
           cls: this.intConsumed.get(slotPath)!,
           path: slotPath,
           loc: arm.loc,
@@ -778,15 +875,14 @@ export interface SidecarBuildInput {
  * the facts the boundary inference maps onto lowered IR: helper slots by
  * function name and IR parameter index (the schema's helper param index
  * skips the model receiver, so `index` is already shifted +1), and
- * record-field slots by the containing record's projected field-name
- * list plus the target field (IR record shapes intern structurally by
- * field name, so the list is the join key). */
+ * record-field slots by the containing record's complete structural IR
+ * pattern plus the target field (IR record shapes intern by both field
+ * names and field types, so the full signature is the join key). */
 export interface SidecarIntegerSlotFacts {
   helpers: { fnName: string; kind: "param" | "return"; index?: number; cls: "i64" | "u64"; path: string }[];
   records: {
-    fieldNames: string[];
+    shape: SidecarIrRecordPattern;
     targetField: string;
-    optional: boolean;
     cls: "i64" | "u64";
     path: string;
     loc: SrcLoc;

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -264,6 +264,15 @@ export interface SidecarIrRecordPattern {
   kindMayBeOmitted?: true;
 }
 
+interface PendingIntegerRecordFact {
+  fields: ContractField[];
+  tagged: boolean;
+  targetField: string;
+  cls: "i64" | "u64";
+  path: string;
+  loc: SrcLoc;
+}
+
 function classify(decl: ContractTypeDecl, index: number): Classified {
   const s = decl.shape;
   if (s.k === "unsupported") {
@@ -333,6 +342,7 @@ class Projector {
   private readonly inProgress = new Set<string>();
   private readonly flatArms = new Map<string, { name: string; fields: ContractField[]; loc: SrcLoc }[]>();
   private readonly flattening = new Set<string>();
+  private readonly irPatterning = new Set<string>();
   private synthCounter = 0;
   /** The profile's declared integer slots (ask 4), by slot path; entries
    * move to `intConsumed` as the projection spells them — a declared path
@@ -342,8 +352,10 @@ class Projector {
   readonly intConsumed = new Map<string, "i64" | "u64">();
   /** The record-field slots' resolution facts for the inference: the
    * containing record's complete projected IR shape plus the target field
-   * (IR shapes intern structurally by field names and field types). */
-  readonly intRecordFacts: SidecarIntegerSlotFacts["records"] = [];
+   * (IR shapes intern structurally by field names and field types). Pattern
+   * construction is deferred until the whole contract graph has projected,
+   * so an invalid later sibling still takes its ordinary SidecarError path. */
+  private readonly pendingIntRecordFacts: PendingIntegerRecordFact[] = [];
 
   constructor(
     readonly facts: ContractFacts,
@@ -391,8 +403,9 @@ class Projector {
     const before = this.intConsumed.has(slotPath);
     const out = this.intify(ref, slotPath, loc);
     if (!before && this.intConsumed.has(slotPath)) {
-      this.intRecordFacts.push({
-        shape: this.irRecordPattern(allFields),
+      this.pendingIntRecordFacts.push({
+        fields: allFields,
+        tagged: false,
         targetField: field,
         cls: this.intConsumed.get(slotPath)!,
         path: slotPath,
@@ -466,21 +479,31 @@ class Projector {
         return this.irRecordPattern(shape.fields);
       case "ref": {
         const resolved = this.resolve(shape.name, loc);
-        switch (resolved.c.c) {
-          case "struct":
-            return this.irRecordPattern(resolved.c.fields);
-          case "enum":
-            return { kind: "string" };
-          case "tagged":
-            return this.irUnionPattern(
-              this.unionArms(resolved.name, loc).map((arm) => this.irRecordPattern(arm.fields, true)),
-            );
+        if (resolved.c.c === "enum") return { kind: "string" };
+        if (this.irPatterning.has(resolved.name)) {
+          throw new SidecarError(
+            `the contract type graph is cyclic through '${resolved.name}' — recursive contract types cannot encode`,
+            loc,
+          );
+        }
+        this.irPatterning.add(resolved.name);
+        try {
+          return resolved.c.c === "struct"
+            ? this.irRecordPattern(resolved.c.fields)
+            : this.irUnionPattern(
+                this.unionArms(resolved.name, loc).map((arm) => this.irRecordPattern(arm.fields, true)),
+              );
+        } finally {
+          this.irPatterning.delete(resolved.name);
         }
       }
       case "void":
       case "tuple":
       case "unsupported":
-        throw new Error(`sidecar pattern bug: unsupported ${shape.k} shape reached an integer record fact`);
+        throw new SidecarError(
+          `an integer-slot record contains a shape outside the sidecar's structural vocabulary (${shape.k})`,
+          loc,
+        );
     }
   }
 
@@ -720,8 +743,9 @@ class Projector {
         if (!before && this.intConsumed.has(slotPath)) {
           // The one intifiable arm shape is a single number payload
           // field; its IR record carries the 'kind' discriminant too.
-          this.intRecordFacts.push({
-            shape: this.irRecordPattern(arm.fields, true),
+          this.pendingIntRecordFacts.push({
+            fields: arm.fields,
+            tagged: true,
             targetField: arm.fields[0]!.name,
             cls: this.intConsumed.get(slotPath)!,
             path: slotPath,
@@ -794,8 +818,9 @@ class Projector {
         const slotPath = `${msgName}.${arm.name}.${first.name}`;
         const numRef = this.intify({ kind: "f64" }, slotPath, first.loc);
         if (numRef.kind === "i64") {
-          this.intRecordFacts.push({
-            shape: this.irRecordPattern(fields, true),
+          this.pendingIntRecordFacts.push({
+            fields,
+            tagged: true,
             targetField: first.name,
             cls: this.intConsumed.get(slotPath)!,
             path: slotPath,
@@ -814,8 +839,9 @@ class Projector {
       const before = this.intConsumed.has(slotPath);
       ref = this.intify(ref, slotPath, arm.loc);
       if (!before && this.intConsumed.has(slotPath)) {
-        this.intRecordFacts.push({
-          shape: this.irRecordPattern(fields, true),
+        this.pendingIntRecordFacts.push({
+          fields,
+          tagged: true,
           targetField: fields[0]!.name,
           cls: this.intConsumed.get(slotPath)!,
           path: slotPath,
@@ -844,6 +870,15 @@ class Projector {
     // Everything else — bytes-first pairs, three-plus fields, optional
     // payload fields — tables a synthesized record (family 5).
     return { kind: "record", name: this.tableSynthesized(msgName, arm.name, fields, arm.loc) };
+  }
+
+  /** Materialize structural join patterns only after normal sidecar
+   * projection has validated every field reachable from these facts. */
+  finishedIntRecordFacts(): SidecarIntegerSlotFacts["records"] {
+    return this.pendingIntRecordFacts.map(({ fields, tagged, ...fact }) => ({
+      shape: this.irRecordPattern(fields, tagged),
+      ...fact,
+    }));
   }
 
   /** The finished type table, each array in declaration order (synthesized
@@ -1071,6 +1106,7 @@ export function buildSidecar(input: SidecarBuildInput): SidecarBuildResult {
     // Every declared integer slot must have been spelled by now — the
     // whole contract (model, msg, helpers, channels) is projected.
     projector.checkIntConsumed();
+    const intRecordFacts = projector.finishedIntRecordFacts();
 
     const doc: SidecarDoc = {
       format: SIDECAR_FORMAT,
@@ -1130,7 +1166,7 @@ export function buildSidecar(input: SidecarBuildInput): SidecarBuildResult {
       ok: true,
       doc,
       json: JSON.stringify(doc, null, 2) + "\n",
-      integerSlotFacts: { helpers: helperIntFacts, records: projector.intRecordFacts },
+      integerSlotFacts: { helpers: helperIntFacts, records: intRecordFacts },
     };
   } catch (e) {
     if (e instanceof SidecarRefusal) {

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -30,9 +30,10 @@
  *
  * Integer slots (ask 4): the profile's `sidecar.integer_slots` declares
  * specific number slots i64/u64 by slot path; the projection spells each
- * declared slot's TypeRef/descriptor `i64` (the frozen format-1
- * vocabulary — u64 is the stricter compile-time obligation over the same
- * wire spelling), refuses paths that resolve to no plain number slot,
+ * declared slot's TypeRef/descriptor `i64`, nested under `optional` when
+ * the TypeScript slot is optional (the frozen format-1 vocabulary — u64 is
+ * the stricter compile-time obligation over the same wire spelling), and
+ * refuses paths that resolve to no bare or optional number slot,
  * and emits `integer_slots` as the resolved-decision list, in profile
  * declaration order, each entry recording the DECLARED class ({i64, u64}
  * — the flattening is TypeRef-only). The list is an ATTESTATION (schema
@@ -323,7 +324,7 @@ class Projector {
   /** The record-field slots' resolution facts for the inference: the
    * containing record's full projected field-name list plus the target
    * field (ir shapes intern structurally by field names). */
-  readonly intRecordFacts: { fieldNames: string[]; targetField: string; cls: "i64" | "u64"; path: string }[] = [];
+  readonly intRecordFacts: SidecarIntegerSlotFacts["records"] = [];
 
   constructor(
     readonly facts: ContractFacts,
@@ -338,22 +339,30 @@ class Projector {
   }
 
   /** Spell a projected slot i64 when the profile declared it (ask 4).
-   * Only a PLAIN NUMBER slot can be integer-declared: optionals, slices,
-   * and named types refuse — the declaration must match the wire shape
-   * the schema freezes. The document spells i64 for both classes (the
-   * frozen format-1 vocabulary has no u64; u64 is the stricter
-   * compile-time obligation over the same wire spelling). */
+   * A NUMBER slot may be bare or optional: optional<number> composes the
+   * schema's two existing constructors as optional<i64>, and the proof
+   * applies only to its present numeric arm. Slices and named types still
+   * refuse — the declaration must match the wire shape the schema freezes.
+   * The document spells i64 for both classes (the frozen format-1
+   * vocabulary has no u64; u64 is the stricter compile-time obligation
+   * over the same wire spelling). */
   intify(ref: TypeRef, slotPath: string, loc: SrcLoc): TypeRef {
     const cls = this.intDeclared.get(slotPath);
     if (cls === undefined) return ref;
-    if (ref.kind !== "f64") {
+    if (ref.kind === "f64") {
+      this.intConsumed.set(slotPath, cls);
+      return { kind: "i64" };
+    }
+    if (ref.kind === "optional" && ref.inner.kind === "f64") {
+      this.intConsumed.set(slotPath, cls);
+      return { kind: "optional", inner: { kind: "i64" } };
+    }
+    {
       throw new SidecarError(
-        `the profile declares integer slot '${slotPath}' (${cls}), but that slot is not a plain number slot (it projects as '${ref.kind}')`,
+        `the profile declares integer slot '${slotPath}' (${cls}), but that slot is not a number or optional number slot (it projects as '${ref.kind}')`,
         loc,
       );
     }
-    this.intConsumed.set(slotPath, cls);
-    return { kind: "i64" };
   }
 
   /** intify for a struct field (declared or synthesized), recording the
@@ -366,8 +375,10 @@ class Projector {
       this.intRecordFacts.push({
         fieldNames: allFields,
         targetField: field,
+        optional: out.kind === "optional",
         cls: this.intConsumed.get(slotPath)!,
         path: slotPath,
+        loc,
       });
     }
     return out;
@@ -612,8 +623,10 @@ class Projector {
           this.intRecordFacts.push({
             fieldNames: [...arm.fields.map((f) => f.name), "kind"],
             targetField: arm.fields[0]!.name,
+            optional: payload.kind === "optional",
             cls: this.intConsumed.get(slotPath)!,
             path: slotPath,
+            loc: arm.loc,
           });
         }
         entry.arms.push({ name: arm.name, payload });
@@ -685,8 +698,10 @@ class Projector {
           this.intRecordFacts.push({
             fieldNames: [first.name, second.name, "kind"],
             targetField: first.name,
+            optional: false,
             cls: this.intConsumed.get(slotPath)!,
             path: slotPath,
+            loc: first.loc,
           });
         }
         return { kind: "number_bytes", number_field: first.name, number_class: numRef.kind as "f64" | "i64", bytes_field: second.name };
@@ -694,19 +709,21 @@ class Projector {
     }
     if (fields.length === 1 && !fields[0]!.optional) {
       let ref = this.fieldRef(fields[0]!, msgName);
-      if (ref.kind === "f64") {
-        // A plain number payload is an ask-4 declarable slot: `<msg>.<arm>`.
-        const slotPath = `${msgName}.${arm.name}`;
-        const before = this.intConsumed.has(slotPath);
-        ref = this.intify(ref, slotPath, arm.loc);
-        if (!before && this.intConsumed.has(slotPath)) {
-          this.intRecordFacts.push({
-            fieldNames: [fields[0]!.name, "kind"],
-            targetField: fields[0]!.name,
-            cls: this.intConsumed.get(slotPath)!,
-            path: slotPath,
-          });
-        }
+      // A bare or optional number payload is an ask-4 declarable slot:
+      // `<msg>.<arm>`. Calling intify for every one-field family also makes
+      // a declaration targeting a non-number refuse at the precise arm.
+      const slotPath = `${msgName}.${arm.name}`;
+      const before = this.intConsumed.has(slotPath);
+      ref = this.intify(ref, slotPath, arm.loc);
+      if (!before && this.intConsumed.has(slotPath)) {
+        this.intRecordFacts.push({
+          fieldNames: [fields[0]!.name, "kind"],
+          targetField: fields[0]!.name,
+          optional: ref.kind === "optional",
+          cls: this.intConsumed.get(slotPath)!,
+          path: slotPath,
+          loc: arm.loc,
+        });
       }
       switch (ref.kind) {
         case "bytes":
@@ -766,7 +783,14 @@ export interface SidecarBuildInput {
  * field name, so the list is the join key). */
 export interface SidecarIntegerSlotFacts {
   helpers: { fnName: string; kind: "param" | "return"; index?: number; cls: "i64" | "u64"; path: string }[];
-  records: { fieldNames: string[]; targetField: string; cls: "i64" | "u64"; path: string }[];
+  records: {
+    fieldNames: string[];
+    targetField: string;
+    optional: boolean;
+    cls: "i64" | "u64";
+    path: string;
+    loc: SrcLoc;
+  }[];
 }
 
 export type SidecarBuildResult =

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -454,6 +454,46 @@ class Projector {
     };
   }
 
+  /** Flatten a tagged union for IR identity, preserving every source
+   * constituent. This is deliberately separate from unionArms(): the
+   * sidecar's wire table is first-discriminant-name-wins, while the
+   * frontend's structural union interner retains later same-named arms
+   * whenever their payload shapes differ. irUnionPattern performs the
+   * frontend's structural deduplication after this walk. */
+  private irTaggedArmPatterns(unionName: string, loc: SrcLoc): SidecarIrRecordPattern[] {
+    const c = this.lookup(unionName, loc);
+    if (c.c !== "tagged") {
+      throw new SidecarError(`'${unionName}' is not a kind-tagged union of object literals`, c.decl.loc);
+    }
+    const out: SidecarIrRecordPattern[] = [];
+    for (const part of c.parts) {
+      if (part.p === "arm") {
+        out.push(this.irRecordPattern(part.fields, true));
+        continue;
+      }
+      const resolved = this.resolve(part.name, part.loc);
+      if (resolved.c.c !== "tagged") {
+        throw new SidecarError(
+          `constituent '${part.name}' of union '${unionName}' is not a kind-tagged union — only kind-tagged unions compose by reference`,
+          part.loc,
+        );
+      }
+      if (this.irPatterning.has(resolved.name)) {
+        throw new SidecarError(
+          `union composition is cyclic through '${resolved.name}' — a union cannot spread itself`,
+          part.loc,
+        );
+      }
+      this.irPatterning.add(resolved.name);
+      try {
+        out.push(...this.irTaggedArmPatterns(resolved.name, part.loc));
+      } finally {
+        this.irPatterning.delete(resolved.name);
+      }
+    }
+    return out;
+  }
+
   /** Convert a sidecar-supported syntactic type into the exact structural
    * IR pattern the frontend maps it to. Projection has already refused
    * unsupported shapes before an integer fact is recorded, so the default
@@ -490,9 +530,7 @@ class Projector {
         try {
           return resolved.c.c === "struct"
             ? this.irRecordPattern(resolved.c.fields)
-            : this.irUnionPattern(
-                this.unionArms(resolved.name, loc).map((arm) => this.irRecordPattern(arm.fields, true)),
-              );
+            : this.irUnionPattern(this.irTaggedArmPatterns(resolved.name, loc));
         } finally {
           this.irPatterning.delete(resolved.name);
         }

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -660,6 +660,33 @@ export function update(m: Model, msg: Msg): Model { return m; }
     expect(validateSidecar(doc)).toEqual([]);
   });
 
+  test("duplicate-name composed union arms keep a containing record integer obligation live", async () => {
+    const source = `export type First =
+  | { kind: "dup"; a: number }
+  | { kind: "firstOnly" };
+export type Second =
+  | { kind: "dup"; b: string }
+  | { kind: "secondOnly" };
+export type Nested = First | Second;
+export interface Model { value: number; nested: Nested; }
+export type Msg = { kind: "noop" } | { kind: "other" };
+export function init(): Model {
+  return { value: 0.5, nested: { kind: "dup", b: "" } };
+}
+export function update(m: Model, msg: Msg): Model { return m; }
+`;
+    const r = await buildCase(
+      "sidecar-int-composed-duplicate-arm-shape",
+      source,
+      sidecarProfile([{ slot: "Model.value", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Model.value'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
   test("null- and undefined-optional integer fields remain distinct IR shapes", async () => {
     const source = `export interface A { value: number | null; }
 export interface B { value: number | undefined; }

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -625,6 +625,30 @@ export function replace(m: Model, id: number): Model {
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 
+  test("a unit-tag branch makes an optional integer return vacuous", async () => {
+    const source = `export interface Model { value: number; }
+export type Msg = { kind: "noop" } | { kind: "other" };
+export function init(): Model { return { value: 0 }; }
+export function update(m: Model, msg: Msg): Model { return m; }
+export function normalize(m: Model, x: number | null): number | null {
+  if (x === null) return x;
+  return 1;
+}
+`;
+    const r = await buildCase(
+      "sidecar-optional-int-unit-branch",
+      source,
+      sidecarProfile(
+        [{ slot: "helpers.normalize.return", class: "u64" }],
+        { exports: [] },
+      ),
+    );
+    expect(r.ok, r.ok ? "" : r.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n")).toBe(true);
+    if (!r.ok) return;
+    const doc = JSON.parse(readFileSync(r.sidecarPath!, "utf8")) as unknown;
+    expect(validateSidecar(doc)).toEqual([]);
+  });
+
   test("same-named fields with different field types remain distinct integer shapes", async () => {
     const source = `export interface A { value: number; extra: string; }
 export interface B { value: number; extra: boolean; }
@@ -717,6 +741,57 @@ export function update(m: Model, msg: Msg): Model {
     expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
     expect(r.diagnostics[0]!.message).toContain("'Nested.dup'");
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
+  test("same-named composed number_bytes arms each keep the integer obligation live", async () => {
+    const source = `export type First =
+  | { kind: "dup"; n: number; payload: string }
+  | { kind: "firstOnly" };
+export type Second =
+  | { kind: "dup"; n: number; payload: Uint8Array }
+  | { kind: "secondOnly" };
+export type Msg = First | Second;
+export interface Model { value: number; }
+export function init(): Model { return { value: 0 }; }
+export function update(m: Model, msg: Msg): Model {
+  const later: Msg = { kind: "dup", n: 0.5, payload: new Uint8Array(0) };
+  return later.n > 0 ? m : m;
+}
+`;
+    const r = await buildCase(
+      "sidecar-int-composed-duplicate-number-bytes",
+      source,
+      sidecarProfile([{ slot: "Msg.dup.n", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Msg.dup.n'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
+  test("a composed number_bytes arm cannot change the selected wire field names", async () => {
+    const source = `export type First =
+  | { kind: "dup"; n: number; a: string }
+  | { kind: "firstOnly" };
+export type Second =
+  | { kind: "dup"; n: number; b: string }
+  | { kind: "secondOnly" };
+export type Msg = First | Second;
+export interface Model { value: number; }
+export function init(): Model { return { value: 0 }; }
+export function update(m: Model, msg: Msg): Model { return m; }
+`;
+    const r = await buildCase(
+      "sidecar-int-composed-number-bytes-fields",
+      source,
+      sidecarProfile([{ slot: "Msg.dup.n", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4009"]);
+    expect(r.diagnostics[0]!.message).toContain("'Msg.dup.n'");
+    expect(r.diagnostics[0]!.message).toContain("same required number-then-bytes fields");
   });
 
   test("computed record writes check every optional integer field they can select", async () => {

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -625,6 +625,72 @@ export function replace(m: Model, id: number): Model {
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 
+  test("same-named fields with different field types remain distinct integer shapes", async () => {
+    const source = `export interface A { value: number; extra: string; }
+export interface B { value: number; extra: boolean; }
+export interface Model { a: A; b: B; }
+export type Msg = { kind: "noop" } | { kind: "other" };
+export function init(): Model {
+  return {
+    a: { value: 1, extra: "" },
+    b: { value: 2, extra: false },
+  };
+}
+export function update(m: Model, msg: Msg): Model { return m; }
+`;
+    const slots = [
+      { slot: "A.value", class: "u64" },
+      { slot: "B.value", class: "i64" },
+    ];
+    const r = await buildCase(
+      "sidecar-int-distinct-shapes",
+      source,
+      sidecarProfile(slots, { exports: [] }),
+    );
+    expect(r.ok, r.ok ? "" : r.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n")).toBe(true);
+    if (!r.ok) return;
+    const doc = JSON.parse(readFileSync(r.sidecarPath!, "utf8")) as {
+      integer_slots: { slot: string; class: string }[];
+      types: { structs: { name: string; fields: { name: string; type: { kind: string } }[] }[] };
+    };
+    expect(doc.integer_slots).toEqual(slots);
+    for (const name of ["A", "B"]) {
+      expect(doc.types.structs.find((s) => s.name === name)!.fields.find((f) => f.name === "value")!.type).toEqual({ kind: "i64" });
+    }
+    expect(validateSidecar(doc)).toEqual([]);
+  });
+
+  test("null- and undefined-optional integer fields remain distinct IR shapes", async () => {
+    const source = `export interface A { value: number | null; }
+export interface B { value: number | undefined; }
+export interface Model { a: A; b: B; }
+export type Msg = { kind: "noop" } | { kind: "other" };
+export function init(): Model {
+  return {
+    a: { value: null },
+    b: { value: undefined },
+  };
+}
+export function update(m: Model, msg: Msg): Model { return m; }
+`;
+    const slots = [
+      { slot: "A.value", class: "u64" },
+      { slot: "B.value", class: "i64" },
+    ];
+    const r = await buildCase(
+      "sidecar-int-distinct-optional-shapes",
+      source,
+      sidecarProfile(slots, { exports: [] }),
+    );
+    expect(r.ok, r.ok ? "" : r.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n")).toBe(true);
+    if (!r.ok) return;
+    const doc = JSON.parse(readFileSync(r.sidecarPath!, "utf8")) as {
+      integer_slots: { slot: string; class: string }[];
+    };
+    expect(doc.integer_slots).toEqual(slots);
+    expect(validateSidecar(doc)).toEqual([]);
+  });
+
   test("same-shaped tagged-union integer slots refuse instead of overwriting an obligation", async () => {
     const source = `export interface Model { value: number; }
 export type Msg = { kind: "first"; id: number } | { kind: "second"; id: number };

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -879,6 +879,27 @@ export function update(m: Model, msg: Msg): Model { return m }
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 
+  test("declared empty-object siblings do not make a live integer obligation vacuous", async () => {
+    const source = `export interface Empty {}
+export interface Model { value: number; inline: {}; named: Empty }
+export type Msg = { kind: "noop" } | { kind: "other" }
+export function init(): Model {
+  return { value: 0.5, inline: {}, named: {} }
+}
+export function update(m: Model, msg: Msg): Model { return m }
+`;
+    const r = await buildCase(
+      "sidecar-int-empty-object-sibling",
+      source,
+      sidecarProfile([{ slot: "Model.value", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Model.value'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
   test.each([
     {
       name: "an unsupported later sibling",

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -560,6 +560,97 @@ describe("ask-4 sidecar-declared slots", () => {
     expect(validateSidecar(doc)).toEqual([]);
   });
 
+  test("optional numbers compose with integer classes across records, msg arms, and helpers", async () => {
+    const source = `export interface Model { maybeId: number | null; }
+export type Msg = { kind: "set"; id: number | null } | { kind: "clear" };
+export function init(): Model { return { maybeId: null }; }
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "clear") return { maybeId: null };
+  return { maybeId: msg.id };
+}
+export function normalize(m: Model, id: number | null): number | null { return id; }
+`;
+    const slots = [
+      { slot: "Model.maybeId", class: "u64" },
+      { slot: "Msg.set", class: "u64" },
+      { slot: "helpers.normalize.params[0]", class: "u64" },
+      { slot: "helpers.normalize.return", class: "u64" },
+    ];
+    const r = await buildCase("sidecar-optional-int", source, sidecarProfile(slots, { exports: [] }));
+    expect(r.ok, r.ok ? "" : r.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n")).toBe(true);
+    if (!r.ok) return;
+    const doc = JSON.parse(readFileSync(r.sidecarPath!, "utf8")) as {
+      integer_slots: { slot: string; class: string }[];
+      types: { structs: { name: string; fields: { name: string; type: unknown }[] }[] };
+      msg: { arms: { name: string; payload: { kind: string; type?: unknown } }[] };
+      model_helpers: { name: string; params: unknown[]; returns: unknown }[];
+    };
+    const optionalI64 = { kind: "optional", inner: { kind: "i64" } };
+    expect(doc.integer_slots).toEqual(slots);
+    expect(doc.types.structs.find((s) => s.name === "Model")!.fields).toEqual([
+      { name: "maybeId", type: optionalI64 },
+    ]);
+    expect(doc.msg.arms.find((a) => a.name === "set")!.payload).toEqual({
+      kind: "scalar",
+      type: optionalI64,
+    });
+    const helper = doc.model_helpers.find((h) => h.name === "normalize")!;
+    expect(helper.params).toEqual([optionalI64]);
+    expect(helper.returns).toEqual(optionalI64);
+    expect(validateSidecar(doc)).toEqual([]);
+  });
+
+  test("an optional record integer slot checks its present numeric arm", async () => {
+    const source = `export interface Model { maybeId: number | null; }
+export type Msg = { kind: "clear" } | { kind: "noop" };
+export function init(): Model { return { maybeId: null }; }
+export function update(m: Model, msg: Msg): Model { return m; }
+export function replace(m: Model, id: number): Model {
+  if (id >= 0 && id <= 100) return { maybeId: id * 0.5 };
+  return { maybeId: null };
+}
+`;
+    const r = await buildCase(
+      "sidecar-optional-int-refuse",
+      source,
+      sidecarProfile([{ slot: "Model.maybeId", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(
+      r.diagnostics.map((d) => d.code),
+      r.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n"),
+    ).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Model.maybeId'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
+  test("same-shaped tagged-union integer slots refuse instead of overwriting an obligation", async () => {
+    const source = `export interface Model { value: number; }
+export type Msg = { kind: "first"; id: number } | { kind: "second"; id: number };
+export function init(): Model { return { value: 0 }; }
+export function update(m: Model, msg: Msg): Model { return m; }
+`;
+    const r = await buildCase(
+      "sidecar-int-shape-collision",
+      source,
+      sidecarProfile(
+        [
+          { slot: "Msg.first", class: "u64" },
+          { slot: "Msg.second", class: "i64" },
+        ],
+        { exports: [] },
+      ),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4009"]);
+    expect(r.diagnostics[0]!.message).toContain("'Msg.first' (u64)");
+    expect(r.diagnostics[0]!.message).toContain("'Msg.second' (i64)");
+    expect(r.diagnostics[0]!.message).toContain("same lowered record field");
+    expect(r.diagnostics[0]!.hint).toContain("structurally identical");
+  });
+
   test("an unproven update write into a declared model field refuses by slot path", async () => {
     // The model-slot prove-or-refuse gate: a declared Model field class
     // obligates every write the contract surface performs — init and
@@ -762,7 +853,7 @@ export function update(m: Model, msg: Msg): Model {
     expect(r.ok).toBe(false);
     if (r.ok) return;
     expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4009"]);
-    expect(r.diagnostics[0]!.message).toContain("not a plain number slot");
+    expect(r.diagnostics[0]!.message).toContain("not a number or optional number slot");
   });
 
   test("a profile teaching rides an integer refusal as the attributed note", async () => {

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -691,6 +691,64 @@ export function update(m: Model, msg: Msg): Model { return m; }
     expect(validateSidecar(doc)).toEqual([]);
   });
 
+  test("deep structural record matching keeps a live integer obligation", async () => {
+    const depth = 40;
+    const declarations = Array.from({ length: depth + 1 }, (_, i) =>
+      i === depth
+        ? `export interface N${i} { leaf: string }`
+        : `export interface N${i} { next: N${i + 1} }`,
+    ).join("\n");
+    let nested = `{ leaf: "" }`;
+    for (let i = depth - 1; i >= 0; i--) nested = `{ next: ${nested} }`;
+    const source = `${declarations}
+export interface Model { value: number; nested: N0 }
+export type Msg = { kind: "noop" } | { kind: "other" }
+export function init(): Model { return { value: 0.5, nested: ${nested} } }
+export function update(m: Model, msg: Msg): Model { return m }
+`;
+    const r = await buildCase(
+      "sidecar-int-deep-shape",
+      source,
+      sidecarProfile([{ slot: "Model.value", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Model.value'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
+  test.each([
+    {
+      name: "an unsupported later sibling",
+      evidence: "tuple",
+      source: `export interface Model { value: number; pair: [number, number] }
+export type Msg = { kind: "noop" } | { kind: "other" }
+export function init(): Model { return { value: 0, pair: [1, 2] } }
+export function update(m: Model, msg: Msg): Model { return m }
+`,
+    },
+    {
+      name: "a recursive later sibling",
+      evidence: "cyclic",
+      source: `export interface Model { value: number; next: Model | null }
+export type Msg = { kind: "noop" } | { kind: "other" }
+export function init(): Model { throw new Error("unreachable") }
+export function update(m: Model, msg: Msg): Model { return m }
+`,
+    },
+  ])("integer pattern construction preserves the SC4009 refusal for $name", async ({ name, evidence, source }) => {
+    const r = await buildCase(
+      `sidecar-int-invalid-shape-${name.replaceAll(" ", "-")}`,
+      source,
+      sidecarProfile([{ slot: "Model.value", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4009"]);
+    expect(r.diagnostics[0]!.message).toContain(evidence);
+  });
+
   test("same-shaped tagged-union integer slots refuse instead of overwriting an obligation", async () => {
     const source = `export interface Model { value: number; }
 export type Msg = { kind: "first"; id: number } | { kind: "second"; id: number };

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -687,6 +687,65 @@ export function update(m: Model, msg: Msg): Model { return m; }
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 
+  test("same-named composed optional-number arms each keep the integer obligation live", async () => {
+    const source = `export type First =
+  | { kind: "dup"; a: number | null }
+  | { kind: "firstOnly" };
+export type Second =
+  | { kind: "dup"; b: number | null }
+  | { kind: "secondOnly" };
+export type Nested = First | Second;
+export interface Model { nested: Nested; }
+export type Msg = { kind: "fractional" } | { kind: "noop" };
+export function init(): Model {
+  return { nested: { kind: "dup", a: 1 } };
+}
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "fractional") {
+    return { nested: { kind: "dup", b: 0.5 } };
+  }
+  return m;
+}
+`;
+    const r = await buildCase(
+      "sidecar-int-composed-duplicate-optional-arm",
+      source,
+      sidecarProfile([{ slot: "Nested.dup", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Nested.dup'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
+  test("computed record writes check every optional integer field they can select", async () => {
+    const source = `export interface Model {
+  maybe: number | null;
+  other: number | null;
+}
+export type Msg = { kind: "fractional" } | { kind: "noop" };
+export function init(): Model { return { maybe: null, other: null }; }
+function write(m: Model, key: keyof Model, value: number | null): void {
+  m[key] = value;
+}
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "fractional") write(m, "maybe", 0.5);
+  return m;
+}
+`;
+    const r = await buildCase(
+      "sidecar-optional-int-computed-write",
+      source,
+      sidecarProfile([{ slot: "Model.maybe", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Model.maybe'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
   test("null- and undefined-optional integer fields remain distinct IR shapes", async () => {
     const source = `export interface A { value: number | null; }
 export interface B { value: number | undefined; }


### PR DESCRIPTION
- Project declared optional-number slots as optional<i64> and prove present numeric values across library boundaries.
- Refuse structurally colliding tagged-union obligations with an attributed SC4009 diagnostic.