### PR TITLE
Project readonly arrays in contract sidecars

### DIFF
--- a/packages/compiler/src/frontend/lib-contract.ts
+++ b/packages/compiler/src/frontend/lib-contract.ts
@@ -158,6 +158,13 @@ export function typeShape(file: ts.SourceFile, node: ts.TypeNode): ContractTypeS
       break;
   }
   if (ts.isParenthesizedTypeNode(node)) return typeShape(file, node.type);
+  // `readonly T[]` is the same contract shape as `T[]`: readonly is a
+  // checker-only view, and format 1 has one mutability-neutral slice
+  // spelling. Preserve the wrapped shape so readonly tuples still reach
+  // the projector's explicit tuple refusal.
+  if (ts.isTypeOperatorNode(node) && node.operator === ts.SyntaxKind.ReadonlyKeyword) {
+    return typeShape(file, node.type);
+  }
   if (ts.isLiteralTypeNode(node)) {
     const lit = node.literal;
     if (ts.isStringLiteral(lit)) return { k: "stringLit", text: lit.text };
@@ -195,7 +202,7 @@ export function typeShape(file: ts.SourceFile, node: ts.TypeNode): ContractTypeS
     if (!ts.isIdentifier(node.typeName)) return { k: "unsupported", text: node.getText(file) };
     const name = node.typeName.text;
     if (name === "Uint8Array" && (node.typeArguments?.length ?? 0) === 0) return { k: "bytes" };
-    if (name === "Array" && node.typeArguments?.length === 1) {
+    if ((name === "Array" || name === "ReadonlyArray") && node.typeArguments?.length === 1) {
       return { k: "array", elem: typeShape(file, node.typeArguments[0]!) };
     }
     if ((node.typeArguments?.length ?? 0) > 0) return { k: "unsupported", text: node.getText(file) };

--- a/packages/compiler/src/frontend/lib-contract.ts
+++ b/packages/compiler/src/frontend/lib-contract.ts
@@ -105,6 +105,8 @@ export interface ContractFacts {
 }
 
 const CONVENTION_CONSTS = new Set(["modelUnbound", "msgUnbound", "appearanceMsg", "chromeMsg", "envMsgs"]);
+const CONTRACT_GLOBAL_TYPES = new Set(["Array", "ReadonlyArray", "Uint8Array"]);
+const moduleTypeBindings = new WeakMap<ts.SourceFile, Set<string>>();
 
 function locOf(file: ts.SourceFile, node: ts.Node): SrcLoc {
   return { file: file.fileName, start: node.getStart(), end: node.end };
@@ -119,6 +121,54 @@ function propName(name: ts.Node): string | null {
   if (ts.isIdentifier(name)) return name.text;
   if (ts.isStringLiteral(name)) return name.text;
   return null;
+}
+
+/** Module-local type bindings which hide same-spelled globals. The contract
+ * reader deliberately has no checker, but blindly recognizing `Array`,
+ * `ReadonlyArray`, or `Uint8Array` by text can publish a slice/bytes contract
+ * for a user-declared record. Imports and declarations are module-scoped
+ * regardless of statement order, so one syntax-tree pass is sufficient. */
+function localTypeBindings(file: ts.SourceFile): Set<string> {
+  const cached = moduleTypeBindings.get(file);
+  if (cached !== undefined) return cached;
+  const names = new Set<string>();
+  const add = (name: ts.Identifier | undefined): void => {
+    if (name !== undefined && CONTRACT_GLOBAL_TYPES.has(name.text)) names.add(name.text);
+  };
+  for (const stmt of file.statements) {
+    if (
+      ts.isInterfaceDeclaration(stmt) ||
+      ts.isTypeAliasDeclaration(stmt) ||
+      ts.isClassDeclaration(stmt) ||
+      ts.isEnumDeclaration(stmt)
+    ) {
+      add(stmt.name);
+      continue;
+    }
+    if (ts.isImportEqualsDeclaration(stmt)) {
+      add(stmt.name);
+      continue;
+    }
+    if (!ts.isImportDeclaration(stmt) || stmt.importClause === undefined) continue;
+    const clause = stmt.importClause;
+    add(clause.name);
+    if (clause.namedBindings === undefined) continue;
+    if (ts.isNamespaceImport(clause.namedBindings)) add(clause.namedBindings.name);
+    else for (const el of clause.namedBindings.elements) add(el.name);
+  }
+  moduleTypeBindings.set(file, names);
+  return names;
+}
+
+/** Whether a bare type name reaches the ambient global rather than a local
+ * declaration/import or a type parameter in an enclosing declaration. */
+function isUnshadowedGlobalType(file: ts.SourceFile, node: ts.TypeNode, name: string): boolean {
+  if (localTypeBindings(file).has(name)) return false;
+  for (let scope = node.parent; scope !== undefined && scope !== file; scope = scope.parent) {
+    const params = (scope as ts.Node & { typeParameters?: readonly ts.TypeParameterDeclaration[] }).typeParameters;
+    if (params?.some((p) => p.name.text === name) === true) return false;
+  }
+  return true;
 }
 
 function shapeOfMembers(file: ts.SourceFile, members: readonly ts.Node[], onBad: (text: string) => void): ContractField[] {
@@ -201,8 +251,9 @@ export function typeShape(file: ts.SourceFile, node: ts.TypeNode): ContractTypeS
   if (ts.isTypeReferenceNode(node)) {
     if (!ts.isIdentifier(node.typeName)) return { k: "unsupported", text: node.getText(file) };
     const name = node.typeName.text;
-    if (name === "Uint8Array" && (node.typeArguments?.length ?? 0) === 0) return { k: "bytes" };
-    if ((name === "Array" || name === "ReadonlyArray") && node.typeArguments?.length === 1) {
+    const global = CONTRACT_GLOBAL_TYPES.has(name) && isUnshadowedGlobalType(file, node, name);
+    if (global && name === "Uint8Array" && (node.typeArguments?.length ?? 0) === 0) return { k: "bytes" };
+    if (global && (name === "Array" || name === "ReadonlyArray") && node.typeArguments?.length === 1) {
       return { k: "array", elem: typeShape(file, node.typeArguments[0]!) };
     }
     if ((node.typeArguments?.length ?? 0) > 0) return { k: "unsupported", text: node.getText(file) };

--- a/tests/harness/library-contract.test.ts
+++ b/tests/harness/library-contract.test.ts
@@ -843,6 +843,62 @@ export function boot(): number {
       { name: "inspect", params: [slice, slice], returns: slice, arena: true },
     ]);
   });
+
+  test.each(["Array", "ReadonlyArray"])("a local %s<T> alias is not mistaken for the global array type", async (name) => {
+    const diags = await sidecarRefusal(`export type ${name}<T> = { value: T };
+export interface Model { item: ${name}<number>; }
+export type Msg = { kind: "keep" } | { kind: "alsoKeep" };
+export function init(): Model { return { item: { value: 1 } }; }
+export function update(m: Model, msg: Msg): Model { return m; }
+let state = init();
+export function boot(): number {
+  state = update(state, { kind: "keep" });
+  return state.item.value;
+}
+`);
+    expect(diags[0]!.code).toBe("SC4009");
+    expect(diags[0]!.message).toContain(`${name}<number>`);
+  });
+
+  test("an imported ReadonlyArray binding is not mistaken for the global array type", async () => {
+    const diags = await sidecarRefusal(
+      `import type { Box as ReadonlyArray } from "./box.ts";
+export interface Model { item: ReadonlyArray<number>; }
+export type Msg = { kind: "keep" } | { kind: "alsoKeep" };
+export function init(): Model { return { item: { value: 1 } }; }
+export function update(m: Model, msg: Msg): Model { return m; }
+let state = init();
+export function boot(): number {
+  state = update(state, { kind: "keep" });
+  return state.item.value;
+}
+`,
+      {},
+      { "box.ts": "export type Box<T> = { value: T };\n" },
+    );
+    expect(diags[0]!.code).toBe("SC4009");
+    expect(diags[0]!.message).toContain("ReadonlyArray<number>");
+  });
+
+  test("a local Uint8Array interface remains a named record", async () => {
+    const doc = await sidecarProjection(`export interface Uint8Array { value: number; }
+export interface Model { data: Uint8Array; }
+export type Msg = { kind: "keep" } | { kind: "alsoKeep" };
+export function init(): Model { return { data: { value: 1 } }; }
+export function update(m: Model, msg: Msg): Model { return m; }
+let state = init();
+export function boot(): number {
+  state = update(state, { kind: "keep" });
+  return state.data.value;
+}
+`);
+    expect(doc.types.structs.find((s) => s.name === "Uint8Array")?.fields).toEqual([
+      { name: "value", type: { kind: "f64" } },
+    ]);
+    expect(doc.types.structs.find((s) => s.name === "Model")?.fields).toEqual([
+      { name: "data", type: { kind: "node", name: "Uint8Array" } },
+    ]);
+  });
 });
 
 describe("SC4009: contract sidecar refusals", () => {

--- a/tests/harness/library-contract.test.ts
+++ b/tests/harness/library-contract.test.ts
@@ -706,6 +706,47 @@ describe("the V1-V14 validator", () => {
   });
 });
 
+/* ── Focused sidecar projection fixtures ───────────────────────────────── */
+
+let projectionCounter = 0;
+
+async function sidecarProjection(source: string): Promise<SidecarDoc> {
+  const outDir = join(cacheDir, `projection-${projectionCounter++}`);
+  mkdirSync(outDir, { recursive: true });
+  const entry = join(outDir, "lib.ts");
+  writeFileSync(entry, source);
+  const profile = {
+    profile_format: 1,
+    name: "sidecar-projection-fixture",
+    entry: "lib.ts",
+    emission: "c",
+    abi: {
+      prefix: "kp_",
+      init_symbol: "kp_init",
+      sink_register_symbol: "kp_set_panic_sink",
+      collect_symbol: null,
+      result_reset_symbol: null,
+    },
+    exports: [{ export: "boot", symbol: "kp_boot", params: [], returns: "f64" }],
+    sidecar: {
+      wire_version: 1,
+      abi_version: 1,
+      snapshot_format: 1,
+      build_id_symbol: "kp_build_id",
+      abi_version_symbol: "kp_abi_version",
+      model: "Model",
+      msg: "Msg",
+    },
+  };
+  const profilePath = join(outDir, "profile.json");
+  writeFileSync(profilePath, JSON.stringify(profile));
+  const result = await compileLibrary({ profilePath, outDir });
+  if (!result.ok) {
+    throw new Error(result.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n"));
+  }
+  return JSON.parse(readFileSync(result.sidecarPath!, "utf8")) as SidecarDoc;
+}
+
 /* ── SC4009: unprojectable designations refuse, never guess ────────────── */
 
 let refusalCounter = 0;
@@ -758,6 +799,51 @@ export function update(m: Model, msg: Msg): Model { return { count: m.count + 1 
 let state = init();
 export function boot(): number { state = update(state, { kind: "tick" }); return state.count; }
 `;
+
+describe("contract sidecar array spellings", () => {
+  test("readonly T[] and ReadonlyArray<T> project identically to T[]", async () => {
+    const doc = await sidecarProjection(`export interface Model {
+  plainIds: number[];
+  readonlyIds: readonly number[];
+  genericIds: ReadonlyArray<number>;
+  maybeIds?: readonly number[];
+}
+export type Msg =
+  | { kind: "replace"; ids: ReadonlyArray<number> }
+  | { kind: "keep" };
+export function init(): Model {
+  return { plainIds: [1], readonlyIds: [2], genericIds: [3] };
+}
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "keep") return m;
+  return { plainIds: msg.ids.slice(), readonlyIds: msg.ids, genericIds: m.genericIds };
+}
+export function inspect(m: Model, left: readonly number[], right: ReadonlyArray<number>): readonly number[] {
+  return [m.plainIds.length, left.length, right.length];
+}
+let state = init();
+export function boot(): number {
+  state = update(state, { kind: "replace", ids: [4, 5] });
+  return state.readonlyIds.length;
+}
+`);
+    const slice = { kind: "slice", elem: { kind: "f64" } } as const;
+    const model = doc.types.structs.find((s) => s.name === "Model");
+    expect(model?.fields).toEqual([
+      { name: "plainIds", type: slice },
+      { name: "readonlyIds", type: slice },
+      { name: "genericIds", type: slice },
+      { name: "maybeIds", type: { kind: "optional", inner: slice } },
+    ]);
+    expect(doc.msg.arms).toEqual([
+      { name: "replace", payload: { kind: "scalar", type: slice } },
+      { name: "keep", payload: { kind: "void" } },
+    ]);
+    expect(doc.model_helpers).toEqual([
+      { name: "inspect", params: [slice, slice], returns: slice, arena: true },
+    ]);
+  });
+});
 
 describe("SC4009: contract sidecar refusals", () => {
   test("a model designation naming nothing refuses", async () => {


### PR DESCRIPTION
- Treat readonly T[] and ReadonlyArray<T> as mutability-neutral slices.
- Cover model, message, optional, and helper projections across readonly spellings.