### PR TITLE
Add sparse array support

### DIFF
--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -45,12 +45,15 @@ function streamTypedRefCommitAdapter(
       `  size_t sc_target_len = sc_target->len;`,
       `  size_t sc_target_cap = sc_target->cap;`,
       `  uint64_t *sc_target_data = sc_target->data;`,
+      `  uint8_t *sc_target_present = sc_target->present;`,
       `  sc_target->len = sc_next->len;`,
       `  sc_target->cap = sc_next->cap;`,
       `  sc_target->data = sc_next->data;`,
+      `  sc_target->present = sc_next->present;`,
       `  sc_next->len = sc_target_len;`,
       `  sc_next->cap = sc_target_cap;`,
       `  sc_next->data = sc_target_data;`,
+      `  sc_next->present = sc_target_present;`,
       `  scr_arr_release(sc_next);`,
       `}`,
       ``,
@@ -200,6 +203,7 @@ function streamTypedRefAdapter(
     lines.push(
       `  ScrDyn *d = scr_dyn_new_arr();`,
       `  for (size_t sc_i = 0; sc_i < v->len; sc_i++) {`,
+      `    if (!scr_arr_has(v, (double)sc_i)) { scr_dyn_arr_push_hole(d); continue; }`,
     );
     if (elem.kind === "f64") {
       lines.push(

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -1250,6 +1250,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
         const arr = E.newTemp(e.type, E.arrNewC(elem, e.elems.length));
         const acc = elemAccess(elem);
         const spreadSet = new Set(e.spreads ?? []);
+        const holeSet = new Set(e.holes ?? []);
         e.elems.forEach((el, i) => {
           const v = E.emitExpr(el);
           if (spreadSet.has(i)) {
@@ -1263,16 +1264,19 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           }
           if (acc === "ref") E.moveTemp(v);
           E.line(`scr_arr_push_${acc}(${arr.name}, ${v.name});`);
+          if (holeSet.has(i)) {
+            let fill = "NULL";
+            if (elem.kind === "union") {
+              const def = E.unionsById.get(elem.unionId);
+              const tag = def ? def.arms.findIndex((a) => a.kind === "undefinedT") : -1;
+              if (tag >= 0) fill = E.unitInstanceRef(elem.unionId, tag);
+            }
+            E.line(`scr_arr_delete(${arr.name}, scr_arr_len(${arr.name}) - 1, ${fill});`);
+          }
         });
         return arr;
       }
       case "arrayNewLen": {
-        // Mapper-less Array.from({ length: n }): a length-n array of
-        // ABSENT slots — the interned undefined arm for unions carrying
-        // one (immortal: pushing owes no retain), NULL for every other
-        // ref element kind (assign before reading — SEMANTICS.md 46). The
-        // `i <= n - 1` bound is ToLength for the lengths that terminate:
-        // fractions truncate, negative/NaN produce an empty array.
         if (e.type.kind !== "array") throw new Error("emitter bug: arrayNewLen of non-array type");
         const elem = e.type.elem;
         const n = E.emitExpr(e.length);
@@ -1283,13 +1287,23 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           const tag = def ? def.arms.findIndex((a) => a.kind === "undefinedT") : -1;
           if (tag >= 0) fill = E.unitInstanceRef(elem.unionId, tag);
         }
-        const i = `sc_i${E.tempCounter++}`;
-        E.line(`for (double ${i} = 0; ${i} <= ${n.name} - 1; ${i} += 1) {`);
-        E.indent++;
-        E.line(`scr_arr_push_${elemAccess(elem)}(${arr.name}, ${fill});`);
-        E.indent--;
-        E.line(`}`);
+        if (e.sparse) {
+          E.line(`scr_arr_set_sparse_len(${arr.name}, ${n.name}, ${fill});`);
+          E.emitPendingCheck();
+        } else {
+          const i = `sc_i${E.tempCounter++}`;
+          E.line(`for (double ${i} = 0; ${i} <= ${n.name} - 1; ${i} += 1) {`);
+          E.indent++;
+          E.line(`scr_arr_push_${elemAccess(elem)}(${arr.name}, ${fill});`);
+          E.indent--;
+          E.line(`}`);
+        }
         return arr;
+      }
+      case "arrayHas": {
+        const arr = E.emitExpr(e.arr);
+        const idx = E.emitExpr(e.index);
+        return E.newTemp(e.type, `scr_arr_has(${arr.name}, ${idx.name})`);
       }
       case "arrayGet": {
         const arr = E.emitExpr(e.arr);
@@ -1298,7 +1312,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
         // Ref-element reads return +1 (the runtime retains); newTemp
         // registers the owned temp in the frame like any other.
         const acc = elemAccess(e.arr.type.elem);
-        return E.newTemp(e.type, `scr_arr_get_${acc}(${arr.name}, ${idx.name})`);
+        return E.newTemp(e.type, `scr_arr_get_${e.dense ? "dense_" : ""}${acc}(${arr.name}, ${idx.name})`);
       }
       case "arrIntrinsic": {
         const r = E.emitExpr(e.receiver);
@@ -1338,6 +1352,18 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             E.indent--;
             E.line(`}`);
             return E.newTemp(e.type, `scr_arr_len(${r.name})`);
+          }
+          case "appendSparse": {
+            const src = E.emitExpr(e.args[0]!);
+            let fill = "NULL";
+            if (e.receiver.type.elem.kind === "union") {
+              const def = E.unionsById.get(e.receiver.type.elem.unionId);
+              const tag = def ? def.arms.findIndex((a) => a.kind === "undefinedT") : -1;
+              if (tag >= 0) fill = E.unitInstanceRef(e.receiver.type.elem.unionId, tag);
+            }
+            const result = E.newTemp(e.type, `scr_arr_append_sparse(${r.name}, ${src.name}, ${fill})`);
+            E.emitPendingCheck();
+            return result;
           }
           case "pop":
             // Ownership of a refcounted element moves OUT of the array to

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -2556,7 +2556,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           e.key === "length"
             ? "true"
             : /^(0|[1-9][0-9]*)$/.test(e.key) && Number(e.key) <= Number.MAX_SAFE_INTEGER
-              ? `${d.name}->v.arr.len > ${e.key}`
+              ? `scr_dyn_arr_has_index(${d.name}, ${e.key})`
               : "false";
         const test = `(${d.name}->kind == SCR_DYN_OBJ ? (${objTest}) : ${d.name}->kind == SCR_DYN_ARR ? (${arrTest}) : scr_dyn_isl_fence(${d.name}, "'in'"))`;
         return E.fallibleTemp(e.type, e.negated ? `!${test}` : test);

--- a/packages/compiler/src/backend/emission/emit-stmts.ts
+++ b/packages/compiler/src/backend/emission/emit-stmts.ts
@@ -360,8 +360,16 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
         const idx = E.emitExpr(s.index);
         const v = E.emitExpr(s.value);
         if (s.arr.type.kind !== "array") throw new Error("emitter bug: arraySet on non-array");
-        const acc = elemAccess(s.arr.type.elem);
+        const elem = s.arr.type.elem;
+        const acc = elemAccess(elem);
         if (acc === "ref") E.moveTemp(v);
+        if (elem.kind === "union") {
+          const tag = E.undefinedArmTag(elem);
+          if (tag >= 0) {
+            E.line(`scr_arr_set_ref_fill(${arr.name}, ${idx.name}, ${v.name}, ${E.unitInstanceRef(elem.unionId, tag)});${E.srcComment(s.loc)}`);
+            break;
+          }
+        }
         E.line(`scr_arr_set_${acc}(${arr.name}, ${idx.name}, ${v.name});${E.srcComment(s.loc)}`);
         break;
       }

--- a/packages/compiler/src/backend/emission/emit-stmts.ts
+++ b/packages/compiler/src/backend/emission/emit-stmts.ts
@@ -365,6 +365,31 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
         E.line(`scr_arr_set_${acc}(${arr.name}, ${idx.name}, ${v.name});${E.srcComment(s.loc)}`);
         break;
       }
+      case "arrayDelete": {
+        const arr = E.emitExpr(s.arr);
+        const idx = E.emitExpr(s.index);
+        let fill = "NULL";
+        if (s.arr.type.kind === "array" && s.arr.type.elem.kind === "union") {
+          const def = E.unionsById.get(s.arr.type.elem.unionId);
+          const tag = def ? def.arms.findIndex((a) => a.kind === "undefinedT") : -1;
+          if (tag >= 0) fill = E.unitInstanceRef(s.arr.type.elem.unionId, tag);
+        }
+        E.line(`scr_arr_delete(${arr.name}, ${idx.name}, ${fill});${E.srcComment(s.loc)}`);
+        break;
+      }
+      case "arraySetLength": {
+        const arr = E.emitExpr(s.arr);
+        const length = E.emitExpr(s.length);
+        let fill = "NULL";
+        if (s.arr.type.kind === "array" && s.arr.type.elem.kind === "union") {
+          const def = E.unionsById.get(s.arr.type.elem.unionId);
+          const tag = def ? def.arms.findIndex((a) => a.kind === "undefinedT") : -1;
+          if (tag >= 0) fill = E.unitInstanceRef(s.arr.type.elem.unionId, tag);
+        }
+        E.line(`scr_arr_set_sparse_len(${arr.name}, ${length.name}, ${fill});${E.srcComment(s.loc)}`);
+        E.emitPendingCheck();
+        break;
+      }
       case "bytesSet": {
         // Typed-array element write: same evaluation order as arraySet;
         // the value is a scalar (the runtime coerces JS-exactly), so no

--- a/packages/compiler/src/backend/emission/emit-walkers.ts
+++ b/packages/compiler/src/backend/emission/emit-walkers.ts
@@ -260,6 +260,7 @@ import { OVERFLOW_MEMBER } from "./emit-shapes.js";
       `  size_t n = (size_t)scr_arr_len(a);`,
       `  for (size_t i = 0; i < n; i++) {`,
       `    if (i) for (size_t j = 0; j < sep->len; j++) scr_jb_putc(&b, sep->data[j]);`,
+      `    if (!scr_arr_has(a, (double)i)) continue;`,
       `    ScrUnion *u = (ScrUnion *)scr_arr_get_ref(a, (double)i);`,
       ...(unitTags.length > 0
         ? [`    if (${unitTags.map((t) => `u->tag == ${t}`).join(" || ")}) { scr_union_release(u); continue; }`]
@@ -1197,12 +1198,15 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
             `      size_t sc_old_len = sc_cached->len;`,
             `      size_t sc_old_cap = sc_cached->cap;`,
             `      uint64_t *sc_old_data = sc_cached->data;`,
+            `      uint8_t *sc_old_present = sc_cached->present;`,
             `      sc_cached->len = sc_out->len;`,
             `      sc_cached->cap = sc_out->cap;`,
             `      sc_cached->data = sc_out->data;`,
+            `      sc_cached->present = sc_out->present;`,
             `      sc_out->len = sc_old_len;`,
             `      sc_out->cap = sc_old_cap;`,
             `      sc_out->data = sc_old_data;`,
+            `      sc_out->present = sc_old_present;`,
             `      scr_arr_release(sc_out);`,
             `      return sc_cached;`,
             `    }`,

--- a/packages/compiler/src/backend/emission/emit-walkers.ts
+++ b/packages/compiler/src/backend/emission/emit-walkers.ts
@@ -6,7 +6,7 @@
  * interning ORDER is part of the emitted C, so the registries stay on
  * CEmitter and these functions only consult them through it. */
 import type { CEmitter } from "./emitter.js";
-import { DYN_HANDLE_KINDS, IrType, isRefCounted, typeEquals, typeKey } from "../../ir/nodes.js";
+import { DYN_CONVERTIBLE_HANDLE_KINDS, IrType, isRefCounted, typeEquals, typeKey } from "../../ir/nodes.js";
 import { cDecl, cStringLiteral, cType, elemAccess, releaseCallC, retainCallC, vAdapters } from "./emit-types.js";
 import { mangleField, mangleRecordNew, mangleRecordStruct } from "../mangle.js";
 import { OVERFLOW_MEMBER } from "./emit-shapes.js";
@@ -65,7 +65,7 @@ import { OVERFLOW_MEMBER } from "./emit-shapes.js";
       default: {
         // Runtime HANDLE targets name the class ("expected
         // IncomingMessage at $, got string").
-        const h = DYN_HANDLE_KINDS.get(t.kind);
+        const h = DYN_CONVERTIBLE_HANDLE_KINDS.get(t.kind);
         if (h) return h.cls;
         throw new Error(`emitter bug: dynDesc of non-JSON type ${t.kind}`);
       }
@@ -798,6 +798,10 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
         if (t.elem !== "u8") throw new Error(`emitter bug: dynMatch of bytes<${t.elem}>`);
         d.push(`  return d->kind == SCR_DYN_BYTES;`);
         break;
+      case "func":
+        // Any boxed function can adapt through dynCheck's per-target shim.
+        d.push(`  return d->kind == SCR_DYN_FUNC;`);
+        break;
       case "record": {
         const shape = E.recordsById.get(t.shapeId);
         if (!shape) throw new Error(`emitter bug: dynCheck of unknown shape ${t.shapeId}`);
@@ -808,7 +812,12 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
           const byIndex = [...shape.fields].sort((a, b) => Number(a.name) - Number(b.name));
           d.push(`  if (d->kind != SCR_DYN_ARR || d->v.arr.len != ${byIndex.length}) return false;`);
           byIndex.forEach((f, i) => {
-            d.push(`  if (!${E.dynMatchHelper(f.type)}(d->v.arr.items[${i}])) return false;`);
+            d.push(`  {`);
+            d.push(`    ScrDyn *e = scr_dyn_arr_at(d, ${i}.0);`);
+            d.push(`    bool ok = ${E.dynMatchHelper(f.type)}(e);`);
+            d.push(`    scr_dyn_release(e);`);
+            d.push(`    if (!ok) return false;`);
+            d.push(`  }`);
           });
           d.push(`  return true;`);
           break;
@@ -855,6 +864,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
         const m = E.dynMatchHelper(t.elem);
         d.push(`  if (d->kind != SCR_DYN_ARR) return false;`);
         d.push(`  for (size_t i = 0; i < d->v.arr.len; i++) {`);
+        d.push(`    if (!scr_dyn_arr_has_index(d, i)) continue;`);
         d.push(`    if (!${m}(d->v.arr.items[i])) return false;`);
         d.push(`  }`);
         d.push(`  return true;`);
@@ -1095,7 +1105,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
     d.push(`        if (k->data[i] < '0' || k->data[i] > '9' || idx > (SIZE_MAX - 9) / 10) { digits = false; break; }`);
     d.push(`        idx = idx * 10 + (size_t)(k->data[i] - '0');`);
     d.push(`      }`);
-    d.push(`      if (digits && d->kind == SCR_DYN_ARR && idx < d->v.arr.len) return scr_dyn_retain(d->v.arr.items[idx]);`);
+    d.push(`      if (digits && d->kind == SCR_DYN_ARR && idx < d->v.arr.len) return scr_dyn_arr_at(d, (double)idx);`);
     d.push(`      if (digits && d->kind == SCR_DYN_STR && (double)idx < scr_str_utf16_len(d->v.str)) {`);
     d.push(`        ScrStr *c = scr_str_char_at(d->v.str, (double)idx);`);
     d.push(`        ScrDyn *r = scr_dyn_new_str(c);`);
@@ -1266,7 +1276,9 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
           byIndex.forEach((f, i) => {
             d.push(`  {`);
             d.push(`    ScrDynPath p = { path, NULL, ${i} };`);
-            d.push(`    r->${mangleField(f.name)} = ${E.dynCheckHelper(f.type)}(d->v.arr.items[${i}], &p);`);
+            d.push(`    ScrDyn *e = scr_dyn_arr_at(d, ${i}.0);`);
+            d.push(`    r->${mangleField(f.name)} = ${E.dynCheckHelper(f.type)}(e, &p);`);
+            d.push(`    scr_dyn_release(e);`);
             d.push(`    if (scr_exc_pending()) { ${rel("r")}; return NULL; }`);
             d.push(`  }`);
           });
@@ -1348,13 +1360,21 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
       case "array": {
         const elem = t.elem;
         const c = E.dynCheckHelper(elem);
+        let fill = "NULL";
+        if (elem.kind === "union") {
+          const tag = E.undefinedArmTag(elem);
+          if (tag >= 0) fill = E.unitInstanceRef(elem.unionId, tag);
+        }
         d.push(`  if (d->kind != SCR_DYN_ARR) { scr_dyn_check_fail(path, ${want}, d); return NULL; }`);
-        d.push(`  ScrArr *a = ${E.arrNewC(elem, "d->v.arr.len")};`);
+        d.push(`  ScrArr *a = ${E.arrNewC(elem, "0")};`);
+        d.push(`  scr_arr_set_sparse_len(a, (double)d->v.arr.len, ${fill});`);
+        d.push(`  if (scr_exc_pending()) { scr_arr_release(a); return NULL; }`);
         d.push(`  for (size_t i = 0; i < d->v.arr.len; i++) {`);
+        d.push(`    if (!scr_dyn_arr_has_index(d, i)) continue;`);
         d.push(`    ScrDynPath p = { path, NULL, i };`);
         d.push(`    ${cDecl(elem, "e")} = ${c}(d->v.arr.items[i], &p);`);
         d.push(`    if (scr_exc_pending()) { scr_arr_release(a); return NULL; }`);
-        d.push(`    scr_arr_push_${elemAccess(elem)}(a, e);`);
+        d.push(`    scr_arr_set_${elemAccess(elem)}(a, (double)i, e);`);
         d.push(`  }`);
         d.push(`  return a;`);
         break;
@@ -1460,7 +1480,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
         // Runtime HANDLE targets: a tag-checked reference unwrap (+1 —
         // identity, no copy; the runtime throws the path-annotated
         // TypeError on any other kind or tag).
-        const h = DYN_HANDLE_KINDS.get(t.kind);
+        const h = DYN_CONVERTIBLE_HANDLE_KINDS.get(t.kind);
         if (h) {
           d.push(`  return (${cType(t).trim()})scr_dyn_handle_unbox(d, ${h.tag}, path, ${want});`);
           break;
@@ -1627,6 +1647,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
         if (cyclicArr) d.push(`  scr_dyn_from_enter(v);`);
         d.push(`  ScrDyn *d = scr_dyn_new_arr();`);
         d.push(`  for (size_t i = 0; i < v->len; i++) {`);
+        d.push(`    if (!scr_arr_has(v, (double)i)) { scr_dyn_arr_push_hole(d); continue; }`);
         if (elem.kind === "f64") {
           d.push(`    scr_dyn_arr_push(d, scr_dyn_new_num(scr_arr_get_f64(v, (double)i)));`);
         } else if (elem.kind === "bool") {
@@ -1683,7 +1704,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
         // Runtime HANDLE kinds box by REFERENCE (identity — no copy):
         // scr_dyn_new_handle retains the borrowed operand through the
         // tag's installed ops.
-        const h = DYN_HANDLE_KINDS.get(t.kind);
+        const h = DYN_CONVERTIBLE_HANDLE_KINDS.get(t.kind);
         if (h) {
           d.push(`  return scr_dyn_new_handle(v, ${h.tag});`);
           break;

--- a/packages/compiler/src/backend/emission/emit-walkers.ts
+++ b/packages/compiler/src/backend/emission/emit-walkers.ts
@@ -678,6 +678,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
         d.push(`  scr_jb_putc(b, '[');`);
         d.push(`  for (size_t i = 0; i < v->len; i++) {`);
         d.push(`    if (i > 0) scr_jb_putc(b, ',');`);
+        d.push(`    if (!scr_arr_has(v, (double)i)) { scr_jb_puts(b, "null"); continue; }`);
         if (cyclic) d.push(`    scr_jb_edge_idx(b, i);`);
         if (elem.kind === "f64") {
           d.push(`    ${w}(b, scr_arr_get_f64(v, (double)i));`);

--- a/packages/compiler/src/backend/emission/may-throw.ts
+++ b/packages/compiler/src/backend/emission/may-throw.ts
@@ -171,6 +171,12 @@ export function computeMayThrow(mod: IrModule): { fns: Set<string>; indirect: bo
           if (source && source.type?.kind === "f64") f.throws = true;
           break;
         }
+        case "arrayNewLen":
+          if (rec["sparse"] === true) f.throws = true;
+          break;
+        case "arraySetLength":
+          f.throws = true;
+          break;
         case "bytesIntrinsic":
           // setFrom and the numeric read/write families throw catchable
           // RangeErrors (Node's bounds discipline); the rest trap or

--- a/packages/compiler/src/backend/llvm/dyn.ts
+++ b/packages/compiler/src/backend/llvm/dyn.ts
@@ -668,6 +668,7 @@ export class LlDyn {
                 { index: 1, type: "i64" as const, name: "length" },
                 { index: 2, type: "i64" as const, name: "capacity" },
                 { index: 7, type: "ptr" as const, name: "data" },
+                { index: 8, type: "ptr" as const, name: "present" },
               ];
           members.forEach((member) => {
             const cachedPtr = B.tmp();

--- a/packages/compiler/src/backend/llvm/dyn.ts
+++ b/packages/compiler/src/backend/llvm/dyn.ts
@@ -22,7 +22,7 @@
  *   ScrBytes { rc +0; len +8; elem +16; data +24 }.
  *   ScrDynPath { parent, key, index } — the %ScrDynPath type. */
 import type { IrType } from "../../ir/nodes.js";
-import { DYN_HANDLE_KINDS, isRefCounted, typeKey } from "../../ir/nodes.js";
+import { DYN_CONVERTIBLE_HANDLE_KINDS, isRefCounted, typeKey } from "../../ir/nodes.js";
 import { mangleRecordNew, mangleRecordStruct } from "../mangle.js";
 import { BlockBuilder } from "./blocks.js";
 import { arrNewCall, elemAccess, llFieldType, releaseSym, traceAdapter, traceArg, vAdapters } from "./shapes.js";
@@ -30,14 +30,6 @@ import { LlvmUnsupportedError } from "./unsupported.js";
 import type { WalkerHost } from "./walkers.js";
 
 /** ScrDynKind values (scr_runtime.h). */
-/** ScrDynHandleTag numeric values (scr_runtime.h's enum order). */
-export const DYN_HANDLE_TAG_NUM: Record<string, number> = {
-  httpReq: 0,
-  httpRes: 1,
-  netSocket: 2,
-  netServer: 3,
-};
-
 export const DK = {
   NULL: 0,
   BOOL: 1,
@@ -319,7 +311,7 @@ export class LlDyn {
       case "func":
         return "function";
       default: {
-        const h = DYN_HANDLE_KINDS.get(t.kind);
+        const h = DYN_CONVERTIBLE_HANDLE_KINDS.get(t.kind);
         if (h) return h.cls;
         throw new Error(`llvm emitter bug: dynDesc of non-JSON type ${t.kind}`);
       }
@@ -397,6 +389,10 @@ export class LlDyn {
         if (t.elem !== "u8") throw new Error(`llvm emitter bug: dynMatch of bytes<${t.elem}>`);
         kindIs(DK.BYTES);
         break;
+      case "func":
+        // Any boxed function can adapt through dynCheck's per-target shim.
+        kindIs(DK.FUNC);
+        break;
       case "record": {
         const shape = this.host.recordsById.get(t.shapeId);
         if (!shape) throw new Error(`llvm emitter bug: dynCheck of unknown shape ${t.shapeId}`);
@@ -416,11 +412,14 @@ export class LlDyn {
           const l2 = B.newLabel("dm.l");
           B.condBr(lenOk, l2, fail);
           B.startBlock(l2);
-          const items = this.itemsOf(B, "%d");
+          this.host.declare(`declare ptr @scr_dyn_arr_at(ptr, double)`);
+          this.host.declare(`declare void @scr_dyn_release(ptr)`);
           for (const [i, f] of byIndex.entries()) {
-            const e = this.itemAt(B, items, `${i}`);
+            const e = B.tmp();
             const m = B.tmp();
+            B.line(`${e} = call ptr @scr_dyn_arr_at(ptr %d, double ${f64Lit(i)})`);
             B.line(`${m} = call zeroext i1 @${this.dynMatchHelper(f.type)}(ptr ${e})`);
+            B.line(`call void @scr_dyn_release(ptr ${e})`);
             const ln = B.newLabel("dm.i");
             B.condBr(m, ln, fail);
             B.startBlock(ln);
@@ -509,7 +508,16 @@ export class LlDyn {
         B.startBlock(l0);
         const n = this.lenOf(B, "%d");
         const items = this.itemsOf(B, "%d");
-        this.i64Loop(B, "dm.el", n, (i) => {
+        this.host.declare(`declare zeroext i1 @scr_dyn_arr_has_index(ptr, i64)`);
+        this.i64Loop(B, "dm.el", n, (i, brNext) => {
+          const present = B.tmp();
+          B.line(`${present} = call zeroext i1 @scr_dyn_arr_has_index(ptr %d, i64 ${i})`);
+          const lCheck = B.newLabel("dm.ep");
+          const lSkip = B.newLabel("dm.eh");
+          B.condBr(present, lCheck, lSkip);
+          B.startBlock(lSkip);
+          brNext();
+          B.startBlock(lCheck);
           const e = this.itemAt(B, items, i);
           const ok = B.tmp();
           B.line(`${ok} = call zeroext i1 @${m}(ptr ${e})`);
@@ -843,12 +851,15 @@ export class LlDyn {
           B.terminate(`ret ptr null`);
           B.startBlock(lGo);
           B.line(`%r0 = call ptr @${mangleRecordNew(t.shapeId)}()`);
-          const items = this.itemsOf(B, "%d");
+          host.declare(`declare ptr @scr_dyn_arr_at(ptr, double)`);
+          host.declare(`declare void @scr_dyn_release(ptr)`);
           byIndex.forEach((f, i) => {
             setPath(null, `${i}`);
-            const e = this.itemAt(B, items, `${i}`);
+            const e = B.tmp();
             const v = B.tmp();
+            B.line(`${e} = call ptr @scr_dyn_arr_at(ptr %d, double ${f64Lit(i)})`);
             B.line(`${v} = call ${this.valTy(f.type)} @${this.dynCheckHelper(f.type)}(ptr ${e}, ptr ${pathSlot})`);
+            B.line(`call void @scr_dyn_release(ptr ${e})`);
             storeInto(f.name, f.type, v);
             this.pendingBail(B, "dct", releaseR, "ptr null");
           });
@@ -981,16 +992,36 @@ export class LlDyn {
         requireKind(DK.ARR, "dca");
         const n = this.lenOf(B, "%d");
         const a = B.tmp();
-        B.line(`${a} = ${arrNewCall(host, elem, n)}`);
+        B.line(`${a} = ${arrNewCall(host, elem, "0")}`);
+        let fill = "null";
+        if (elem.kind === "union") {
+          const tag = host.undefinedArmTag(elem);
+          if (tag >= 0) fill = host.unitInstanceRef(elem.unionId, tag);
+        }
+        host.declare(`declare void @scr_arr_set_sparse_len(ptr, double, ptr)`);
+        const nDouble = B.tmp();
+        B.line(`${nDouble} = uitofp i64 ${n} to double`);
+        B.line(`call void @scr_arr_set_sparse_len(ptr ${a}, double ${nDouble}, ptr ${fill})`);
+        this.pendingBail(B, "dca", () => {
+          host.declare(`declare void @scr_arr_release(ptr)`);
+          B.line(`call void @scr_arr_release(ptr ${a})`);
+        }, "ptr null");
         const items = this.itemsOf(B, "%d");
         const pathSlot = "%dcp";
         B.entryAllocas.push(`${pathSlot} = alloca %ScrDynPath`);
         const acc = elemAccess(elem);
         const accTy = acc === "f64" ? "double" : acc === "bool" ? "i1" : "ptr";
-        host.declare(
-          `declare double @scr_arr_push_${acc}(ptr, ${acc === "bool" ? "i1 zeroext" : accTy})`,
-        );
-        this.i64Loop(B, "dca", n, (i) => {
+        host.declare(`declare void @scr_arr_set_${acc}(ptr, double, ${acc === "bool" ? "i1 zeroext" : accTy})`);
+        host.declare(`declare zeroext i1 @scr_dyn_arr_has_index(ptr, i64)`);
+        this.i64Loop(B, "dca", n, (i, brNext) => {
+          const present = B.tmp();
+          B.line(`${present} = call zeroext i1 @scr_dyn_arr_has_index(ptr %d, i64 ${i})`);
+          const lCheck = B.newLabel("dca.p");
+          const lSkip = B.newLabel("dca.h");
+          B.condBr(present, lCheck, lSkip);
+          B.startBlock(lSkip);
+          brNext();
+          B.startBlock(lCheck);
           const pp = B.tmp();
           const kp = B.tmp();
           const ip = B.tmp();
@@ -1007,8 +1038,9 @@ export class LlDyn {
             host.declare(`declare void @scr_arr_release(ptr)`);
             B.line(`call void @scr_arr_release(ptr ${a})`);
           }, "ptr null");
-          const pushed = B.tmp();
-          B.line(`${pushed} = call double @scr_arr_push_${acc}(ptr ${a}, ${accTy} ${v})`);
+          const index = B.tmp();
+          B.line(`${index} = uitofp i64 ${i} to double`);
+          B.line(`call void @scr_arr_set_${acc}(ptr ${a}, double ${index}, ${accTy} ${v})`);
         });
         B.terminate(`ret ptr ${a}`);
         break;
@@ -1181,11 +1213,11 @@ export class LlDyn {
         // Runtime HANDLE targets: a tag-checked reference unwrap (+1 —
         // identity, no copy; the runtime throws the path-annotated
         // TypeError on any other kind or tag).
-        const h = DYN_HANDLE_KINDS.get(t.kind);
+        const h = DYN_CONVERTIBLE_HANDLE_KINDS.get(t.kind);
         if (h) {
           host.declare(`declare ptr @scr_dyn_handle_unbox(ptr, i32, ptr, ptr)`);
           const r = B.tmp();
-          B.line(`${r} = call ptr @scr_dyn_handle_unbox(ptr %d, i32 ${DYN_HANDLE_TAG_NUM[t.kind]}, ptr %path, ptr ${want})`);
+          B.line(`${r} = call ptr @scr_dyn_handle_unbox(ptr %d, i32 ${h.tagNum}, ptr %path, ptr ${want})`);
           B.terminate(`ret ptr ${r}`);
           break;
         }
@@ -1432,7 +1464,9 @@ export class LlDyn {
         const elem = t.elem;
         host.declare(`declare ptr @scr_dyn_new_arr()`);
         host.declare(`declare void @scr_dyn_arr_push(ptr, ptr)`);
+        host.declare(`declare void @scr_dyn_arr_push_hole(ptr)`);
         host.declare(`declare double @scr_arr_len(ptr)`);
+        host.declare(`declare zeroext i1 @scr_arr_has(ptr, double)`);
         // Cycle-capable arrays guard the deep copy like records above.
         const cyclicArr = traceAdapter(host, t) !== null;
         if (cyclicArr) {
@@ -1449,6 +1483,9 @@ export class LlDyn {
         B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
         const lc = B.newLabel("tda.c");
         const lb = B.newLabel("tda.b");
+        const lp = B.newLabel("tda.p");
+        const lh = B.newLabel("tda.h");
+        const ln = B.newLabel("tda.n");
         const le = B.newLabel("tda.e");
         B.br(lc);
         B.startBlock(lc);
@@ -1458,6 +1495,13 @@ export class LlDyn {
         B.line(`${cont} = fcmp olt double ${i}, ${len}`);
         B.condBr(cont, lb, le);
         B.startBlock(lb);
+        const present = B.tmp();
+        B.line(`${present} = call zeroext i1 @scr_arr_has(ptr %v, double ${i})`);
+        B.condBr(present, lp, lh);
+        B.startBlock(lh);
+        B.line(`call void @scr_dyn_arr_push_hole(ptr ${d})`);
+        B.br(ln);
+        B.startBlock(lp);
         if (elem.kind === "f64" || elem.kind === "bool") {
           const acc = elem.kind;
           const accTy = elem.kind === "f64" ? "double" : "i1";
@@ -1482,6 +1526,8 @@ export class LlDyn {
           B.line(`call void @scr_dyn_arr_push(ptr ${d}, ptr ${conv})`);
           B.line(`call void ${releaseSym(host, elem)}(ptr ${e})`);
         }
+        B.br(ln);
+        B.startBlock(ln);
         const i2 = B.tmp();
         B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
         B.line(`store double ${i2}, ptr ${iSlot}`);
@@ -1580,11 +1626,11 @@ export class LlDyn {
         // Runtime HANDLE kinds box by REFERENCE (identity — no copy):
         // scr_dyn_new_handle retains the borrowed operand through the
         // tag's installed ops.
-        const h = DYN_HANDLE_KINDS.get(t.kind);
+        const h = DYN_CONVERTIBLE_HANDLE_KINDS.get(t.kind);
         if (h) {
           host.declare(`declare ptr @scr_dyn_new_handle(ptr, i32)`);
           const r = B.tmp();
-          B.line(`${r} = call ptr @scr_dyn_new_handle(ptr %v, i32 ${DYN_HANDLE_TAG_NUM[t.kind]})`);
+          B.line(`${r} = call ptr @scr_dyn_new_handle(ptr %v, i32 ${h.tagNum})`);
           B.terminate(`ret ptr ${r}`);
           break;
         }
@@ -2501,9 +2547,11 @@ export class LlDyn {
         const lHit = B.newLabel("kg.ah");
         B.condBr(inR, lHit, lMiss);
         B.startBlock(lHit);
-        const items = this.itemsOf(B, "%d");
-        const e = this.itemAt(B, items, idx);
-        const r = this.retainDyn(B, e);
+        host.declare(`declare ptr @scr_dyn_arr_at(ptr, double)`);
+        const idxArrD = B.tmp();
+        const r = B.tmp();
+        B.line(`${idxArrD} = uitofp i64 ${idx} to double`);
+        B.line(`${r} = call ptr @scr_dyn_arr_at(ptr %d, double ${idxArrD})`);
         B.terminate(`ret ptr ${r}`);
         B.startBlock(lStr);
         host.declare(`declare ptr @scr_str_char_at(ptr, double)`);

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -3169,9 +3169,18 @@ class LlEmitter {
         const idx = this.emitExpr(s.index);
         const v = this.emitExpr(s.value);
         if (s.arr.type.kind !== "array") throw new Error("llvm emitter bug: arraySet on non-array");
-        const acc = elemAccess(s.arr.type.elem);
+        const elem = s.arr.type.elem;
+        const acc = elemAccess(elem);
         if (acc === "ref") this.moveTemp(v);
         const argTy = acc === "f64" ? "double" : acc === "bool" ? "i1" : "ptr";
+        if (elem.kind === "union") {
+          const tag = this.undefinedArmTag(elem);
+          if (tag >= 0) {
+            this.declare(`declare void @scr_arr_set_ref_fill(ptr, double, ptr, ptr)`);
+            B.line(`call void @scr_arr_set_ref_fill(ptr ${arr.name}, double ${idx.name}, ptr ${v.name}, ptr ${this.unitInstanceRef(elem.unionId, tag)})`);
+            break;
+          }
+        }
         this.declare(`declare void @scr_arr_set_${acc}(ptr, double, ${argTy === "i1" ? "i1 zeroext" : argTy})`);
         B.line(`call void @scr_arr_set_${acc}(ptr ${arr.name}, double ${idx.name}, ${argTy} ${v.name})`);
         break;
@@ -10148,6 +10157,12 @@ class LlEmitter {
         `  %next_data = load ptr, ptr %next_data_ptr`,
         `  store ptr %next_data, ptr %target_data_ptr`,
         `  store ptr %target_data, ptr %next_data_ptr`,
+        `  %target_present_ptr = getelementptr inbounds %ScrArr, ptr %target, i64 0, i32 8`,
+        `  %next_present_ptr = getelementptr inbounds %ScrArr, ptr %next, i64 0, i32 8`,
+        `  %target_present = load ptr, ptr %target_present_ptr`,
+        `  %next_present = load ptr, ptr %next_present_ptr`,
+        `  store ptr %next_present, ptr %target_present_ptr`,
+        `  store ptr %target_present, ptr %next_present_ptr`,
         `  call void @scr_arr_release(ptr %next)`,
         `  br label %done`,
         `done:`,
@@ -10416,7 +10431,9 @@ class LlEmitter {
       const elem = t.elem;
       this.declare(`declare ptr @scr_dyn_new_arr()`);
       this.declare(`declare void @scr_dyn_arr_push(ptr, ptr)`);
+      this.declare(`declare void @scr_dyn_arr_push_hole(ptr)`);
       this.declare(`declare double @scr_arr_len(ptr)`);
+      this.declare(`declare zeroext i1 @scr_arr_has(ptr, double)`);
       const out = B.tmp();
       B.line(`${out} = call ptr @scr_dyn_new_arr()`);
       const len = B.tmp();
@@ -10426,6 +10443,9 @@ class LlEmitter {
       B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
       const condition = B.newLabel("strm.c");
       const body = B.newLabel("strm.b");
+      const present = B.newLabel("strm.p");
+      const hole = B.newLabel("strm.h");
+      const next = B.newLabel("strm.n");
       const done = B.newLabel("strm.e");
       B.br(condition);
       B.startBlock(condition);
@@ -10435,6 +10455,13 @@ class LlEmitter {
       B.line(`${more} = fcmp olt double ${index}, ${len}`);
       B.condBr(more, body, done);
       B.startBlock(body);
+      const has = B.tmp();
+      B.line(`${has} = call zeroext i1 @scr_arr_has(ptr %p, double ${index})`);
+      B.condBr(has, present, hole);
+      B.startBlock(hole);
+      B.line(`call void @scr_dyn_arr_push_hole(ptr ${out})`);
+      B.br(next);
+      B.startBlock(present);
       let value: string;
       if (elem.kind === "f64" || elem.kind === "bool") {
         const valueTy = elem.kind === "f64" ? "double" : "i1";
@@ -10453,9 +10480,11 @@ class LlEmitter {
       if (isRefCounted(elem)) {
         B.line(`call void ${releaseSym(this, elem)}(ptr ${value})`);
       }
-      const next = B.tmp();
-      B.line(`${next} = fadd double ${index}, ${f64Lit(1)}`);
-      B.line(`store double ${next}, ptr ${iSlot}`);
+      B.br(next);
+      B.startBlock(next);
+      const nextIndex = B.tmp();
+      B.line(`${nextIndex} = fadd double ${index}, ${f64Lit(1)}`);
+      B.line(`store double ${nextIndex}, ptr ${iSlot}`);
       B.br(condition);
       B.startBlock(done);
       B.terminate(`ret ptr ${out}`);

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -1322,10 +1322,10 @@ class LlEmitter {
       `%ScrClosure = type { i64, ptr, i64, ptr }`,
       `%ScrRegex = type { i64, ptr, ptr, ptr }`,
       // ScrArr mirror { rc, len, cap, elem(i32+pad), elem_retain,
-      // elem_release, elem_trace, data } — the immortal tagged-template
-      // strings objects lay out through it (nothing GEPs into live heap
-      // arrays; those stay behind the runtime's own entry points).
-      `%ScrArr = type { i64, i64, i64, i32, ptr, ptr, ptr, ptr }`,
+      // elem_release, elem_trace, data, present } — the immortal tagged-
+      // template strings objects lay out through it (nothing GEPs into live
+      // heap arrays; those stay behind the runtime's own entry points).
+      `%ScrArr = type { i64, i64, i64, i32, ptr, ptr, ptr, ptr, ptr }`,
       // The runtime error prefix { rc, vt, name, message, code } and the
       // class-object shape { rc, pre, post, ctor, name } — field reads on
       // builtin errors and classval loads GEP through these.
@@ -1398,7 +1398,7 @@ class LlEmitter {
       const n = inst.slots.length;
       out.push(
         `@${inst.sym}_data = internal constant [${n} x ptr] [ ${inst.slots.map((s) => `ptr ${s}`).join(", ")} ]`,
-        `@${inst.sym} = internal global %ScrArr { i64 -1, i64 ${n}, i64 ${n}, i32 2, ptr null, ptr null, ptr null, ptr @${inst.sym}_data }`,
+        `@${inst.sym} = internal global %ScrArr { i64 -1, i64 ${n}, i64 ${n}, i32 2, ptr null, ptr null, ptr null, ptr @${inst.sym}_data, ptr null }`,
       );
     }
     if (this.templateStringsInstances.size > 0) out.push(``);
@@ -3176,6 +3176,31 @@ class LlEmitter {
         B.line(`call void @scr_arr_set_${acc}(ptr ${arr.name}, double ${idx.name}, ${argTy} ${v.name})`);
         break;
       }
+      case "arrayDelete": {
+        const arr = this.emitExpr(s.arr);
+        const idx = this.emitExpr(s.index);
+        let fill = "null";
+        if (s.arr.type.kind === "array" && s.arr.type.elem.kind === "union") {
+          const tag = this.undefinedArmTag(s.arr.type.elem);
+          if (tag >= 0) fill = this.unitInstanceRef(s.arr.type.elem.unionId, tag);
+        }
+        this.declare(`declare zeroext i1 @scr_arr_delete(ptr, double, ptr)`);
+        B.line(`call i1 @scr_arr_delete(ptr ${arr.name}, double ${idx.name}, ptr ${fill})`);
+        break;
+      }
+      case "arraySetLength": {
+        const arr = this.emitExpr(s.arr);
+        const length = this.emitExpr(s.length);
+        let fill = "null";
+        if (s.arr.type.kind === "array" && s.arr.type.elem.kind === "union") {
+          const tag = this.undefinedArmTag(s.arr.type.elem);
+          if (tag >= 0) fill = this.unitInstanceRef(s.arr.type.elem.unionId, tag);
+        }
+        this.declare(`declare void @scr_arr_set_sparse_len(ptr, double, ptr)`);
+        B.line(`call void @scr_arr_set_sparse_len(ptr ${arr.name}, double ${length.name}, ptr ${fill})`);
+        this.emitPendingCheck();
+        break;
+      }
       case "bytesSet": {
         // Typed-array element write: same evaluation order as arraySet;
         // the value is a scalar (the runtime coerces JS-exactly), so no
@@ -4254,6 +4279,7 @@ class LlEmitter {
         const out = this.own({ name: arr, type: e.type });
         const acc = elemAccess(elem);
         const spreadSet = new Set(e.spreads ?? []);
+        const holeSet = new Set(e.holes ?? []);
         e.elems.forEach((el, i) => {
           const v = this.emitExpr(el);
           if (spreadSet.has(i)) {
@@ -4262,15 +4288,24 @@ class LlEmitter {
           }
           if (acc === "ref") this.moveTemp(v);
           this.arrPush(arr, acc, v.name);
+          if (holeSet.has(i)) {
+            this.declare(`declare double @scr_arr_len(ptr)`);
+            this.declare(`declare zeroext i1 @scr_arr_delete(ptr, double, ptr)`);
+            const len = B.tmp();
+            const idx = B.tmp();
+            B.line(`${len} = call double @scr_arr_len(ptr ${arr})`);
+            B.line(`${idx} = fsub double ${len}, ${f64Lit(1)}`);
+            let fill = "null";
+            if (elem.kind === "union") {
+              const tag = this.undefinedArmTag(elem);
+              if (tag >= 0) fill = this.unitInstanceRef(elem.unionId, tag);
+            }
+            B.line(`call i1 @scr_arr_delete(ptr ${arr}, double ${idx}, ptr ${fill})`);
+          }
         });
         return out;
       }
       case "arrayNewLen": {
-        // Mapper-less Array.from({ length: n }): a length-n array of
-        // ABSENT slots — the interned undefined arm for unions carrying
-        // one (immortal: pushing owes no retain), NULL for every other ref
-        // element kind. The `i <= n - 1` bound is ToLength for the lengths
-        // that terminate: fractions truncate, negative/NaN → empty.
         if (e.type.kind !== "array") throw new Error("llvm emitter bug: arrayNewLen of non-array type");
         const elem = e.type.elem;
         const n = this.emitExpr(e.length);
@@ -4283,29 +4318,43 @@ class LlEmitter {
           const tag = this.undefinedArmTag(elem);
           if (tag >= 0) fill = this.unitInstanceRef(elem.unionId, tag);
         }
-        const iSlot = B.slot();
-        B.entryAllocas.push(`${iSlot} = alloca double`);
-        B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
-        const lc = B.newLabel("anl.c");
-        const lb = B.newLabel("anl.b");
-        const le = B.newLabel("anl.e");
-        const bound = B.tmp();
-        B.line(`${bound} = fsub double ${n.name}, ${f64Lit(1)}`);
-        B.br(lc);
-        B.startBlock(lc);
-        const i = B.tmp();
-        const cont = B.tmp();
-        B.line(`${i} = load double, ptr ${iSlot}`);
-        B.line(`${cont} = fcmp ole double ${i}, ${bound}`);
-        B.condBr(cont, lb, le);
-        B.startBlock(lb);
-        this.arrPush(arr, acc, fill);
-        const i2 = B.tmp();
-        B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
-        B.line(`store double ${i2}, ptr ${iSlot}`);
-        B.br(lc);
-        B.startBlock(le);
+        if (e.sparse) {
+          this.declare(`declare void @scr_arr_set_sparse_len(ptr, double, ptr)`);
+          B.line(`call void @scr_arr_set_sparse_len(ptr ${arr}, double ${n.name}, ptr ${acc === "ref" ? fill : "null"})`);
+          this.emitPendingCheck();
+        } else {
+          const iSlot = B.slot();
+          B.entryAllocas.push(`${iSlot} = alloca double`);
+          B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
+          const lc = B.newLabel("anl.c");
+          const lb = B.newLabel("anl.b");
+          const le = B.newLabel("anl.e");
+          const bound = B.tmp();
+          B.line(`${bound} = fsub double ${n.name}, ${f64Lit(1)}`);
+          B.br(lc);
+          B.startBlock(lc);
+          const i = B.tmp();
+          const cont = B.tmp();
+          B.line(`${i} = load double, ptr ${iSlot}`);
+          B.line(`${cont} = fcmp ole double ${i}, ${bound}`);
+          B.condBr(cont, lb, le);
+          B.startBlock(lb);
+          this.arrPush(arr, acc, fill);
+          const i2 = B.tmp();
+          B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
+          B.line(`store double ${i2}, ptr ${iSlot}`);
+          B.br(lc);
+          B.startBlock(le);
+        }
         return out;
+      }
+      case "arrayHas": {
+        const arr = this.emitExpr(e.arr);
+        const idx = this.emitExpr(e.index);
+        this.declare(`declare zeroext i1 @scr_arr_has(ptr, double)`);
+        const t = B.tmp();
+        B.line(`${t} = call i1 @scr_arr_has(ptr ${arr.name}, double ${idx.name})`);
+        return { name: t, type: e.type };
       }
       case "arrayGet": {
         const arr = this.emitExpr(e.arr);
@@ -4315,9 +4364,9 @@ class LlEmitter {
         // the owned temp in the frame like any other.
         const acc = elemAccess(e.arr.type.elem);
         const accTy = acc === "f64" ? "double" : acc === "bool" ? "i1" : "ptr";
-        this.declare(`declare ${acc === "bool" ? "zeroext i1" : accTy} @scr_arr_get_${acc}(ptr, double)`);
+        this.declare(`declare ${acc === "bool" ? "zeroext i1" : accTy} @scr_arr_get_${e.dense ? "dense_" : ""}${acc}(ptr, double)`);
         const t = B.tmp();
-        B.line(`${t} = call ${accTy} @scr_arr_get_${acc}(ptr ${arr.name}, double ${idx.name})`);
+        B.line(`${t} = call ${accTy} @scr_arr_get_${e.dense ? "dense_" : ""}${acc}(ptr ${arr.name}, double ${idx.name})`);
         return this.own({ name: t, type: e.type });
       }
       case "arrIntrinsic":
@@ -8839,6 +8888,19 @@ class LlEmitter {
         this.declare(`declare double @scr_arr_len(ptr)`);
         const t = B.tmp();
         B.line(`${t} = call double @scr_arr_len(ptr ${r.name})`);
+        return { name: t, type: e.type };
+      }
+      case "appendSparse": {
+        const src = this.emitExpr(e.args[0]!);
+        let fill = "null";
+        if (elem.kind === "union") {
+          const tag = this.undefinedArmTag(elem);
+          if (tag >= 0) fill = this.unitInstanceRef(elem.unionId, tag);
+        }
+        this.declare(`declare double @scr_arr_append_sparse(ptr, ptr, ptr)`);
+        const t = B.tmp();
+        B.line(`${t} = call double @scr_arr_append_sparse(ptr ${r.name}, ptr ${src.name}, ptr ${fill})`);
+        this.emitPendingCheck();
         return { name: t, type: e.type };
       }
       case "pop": {

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -6409,13 +6409,10 @@ class LlEmitter {
         if (e.key === "length") {
           B.line(`store i1 true, ptr ${slot}`);
         } else if (/^(0|[1-9][0-9]*)$/.test(e.key) && Number(e.key) <= Number.MAX_SAFE_INTEGER) {
-          const lenp = B.tmp();
-          const len = B.tmp();
-          const inR = B.tmp();
-          B.line(`${lenp} = getelementptr inbounds i8, ptr ${d.name}, i64 16 ; ->v.arr.len`);
-          B.line(`${len} = load i64, ptr ${lenp}`);
-          B.line(`${inR} = icmp ugt i64 ${len}, ${e.key}`);
-          B.line(`store i1 ${inR}, ptr ${slot}`);
+          this.declare(`declare zeroext i1 @scr_dyn_arr_has_index(ptr, i64)`);
+          const hasIndex = B.tmp();
+          B.line(`${hasIndex} = call zeroext i1 @scr_dyn_arr_has_index(ptr ${d.name}, i64 ${e.key})`);
+          B.line(`store i1 ${hasIndex}, ptr ${slot}`);
         }
         B.br(lj);
         // An ISLAND-held receiver fences loudly (Node asks the real

--- a/packages/compiler/src/backend/llvm/walkers.ts
+++ b/packages/compiler/src/backend/llvm/walkers.ts
@@ -467,6 +467,17 @@ export class LlWalkers {
     this.putc(B, "%b", "44"); // ','
     B.br(lj);
     B.startBlock(lj);
+    host.declare(`declare zeroext i1 @scr_arr_has(ptr, double)`);
+    const present = B.tmp();
+    const lp = B.newLabel("jwa.p");
+    const lh = B.newLabel("jwa.h");
+    const ln = B.newLabel("jwa.n");
+    B.line(`${present} = call i1 @scr_arr_has(ptr %v, double ${i})`);
+    B.condBr(present, lp, lh);
+    B.startBlock(lh);
+    this.puts(B, "%b", "null");
+    B.br(ln);
+    B.startBlock(lp);
     if (cyclic) {
       const idx = B.tmp();
       B.line(`${idx} = fptoui double ${i} to i64`);
@@ -487,6 +498,8 @@ export class LlWalkers {
       B.line(`call void @${w}(ptr %b, ptr ${v})`);
       B.line(`call void ${releaseSym(host, elem)}(ptr ${v})`);
     }
+    B.br(ln);
+    B.startBlock(ln);
     const i2 = B.tmp();
     B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
     B.line(`store double ${i2}, ptr ${iSlot}`);

--- a/packages/compiler/src/backend/llvm/walkers.ts
+++ b/packages/compiler/src/backend/llvm/walkers.ts
@@ -874,6 +874,7 @@ export class LlWalkers {
     host.declare(`declare void @scr_jb_init(ptr)`);
     host.declare(`declare ptr @scr_jb_finish(ptr)`);
     host.declare(`declare double @scr_arr_len(ptr)`);
+    host.declare(`declare zeroext i1 @scr_arr_has(ptr, double)`);
     host.declare(`declare ptr @scr_arr_get_ref(ptr, double)`);
     host.declare(`declare void @scr_union_release(ptr)`);
     host.declare(`declare void @scr_str_release(ptr)`);
@@ -900,13 +901,18 @@ export class LlWalkers {
     // `if (i) put sep bytes` — separators between elements only.
     const nz = B.tmp();
     const lsep = B.newLabel("uj.s");
-    const lel = B.newLabel("uj.v");
+    const lhas = B.newLabel("uj.h");
+    const lval = B.newLabel("uj.v");
     B.line(`${nz} = fcmp ogt double ${i}, ${f64Lit(0)}`);
-    B.condBr(nz, lsep, lel);
+    B.condBr(nz, lsep, lhas);
     B.startBlock(lsep);
     this.putScrStr(B, buf, "%sep");
-    B.br(lel);
-    B.startBlock(lel);
+    B.br(lhas);
+    B.startBlock(lhas);
+    const present = B.tmp();
+    B.line(`${present} = call i1 @scr_arr_has(ptr %a, double ${i})`);
+    B.condBr(present, lval, ln);
+    B.startBlock(lval);
     const u = B.tmp();
     B.line(`${u} = call ptr @scr_arr_get_ref(ptr %a, double ${i}) ; element (+1)`);
     if (unitTags.length > 0) {

--- a/packages/compiler/src/frontend/lowering/array-density.ts
+++ b/packages/compiler/src/frontend/lowering/array-density.ts
@@ -1,0 +1,166 @@
+import * as ts from "../ts7/adapter.js";
+import type { IrType } from "../../ir/nodes.js";
+import type { Lowerer } from "./lowerer.js";
+
+/** A hole can be read as JavaScript undefined only when the element slot has
+ * an actual undefined value. */
+export function arrayElementCanRepresentUndefined(L: Lowerer, elem: IrType): boolean {
+  if (elem.kind === "jsval" || elem.kind === "dyn" || elem.kind === "undefinedT") return true;
+  return elem.kind === "union" &&
+    (L.unions.get(elem.unionId)?.arms.some((arm) => arm.kind === "undefinedT") ?? false);
+}
+
+export function requireArrayGetSafe(
+  L: Lowerer,
+  source: ts.Expression,
+  elem: IrType,
+  blame: ts.Node,
+  construct: string,
+): void {
+  if (arrayElementCanRepresentUndefined(L, elem) || !arrayExprIsProvablySparse(L, source)) return;
+  L.unsupported(
+    "SC1090",
+    blame,
+    `${construct} on a sparse '${L.fmt({ kind: "array", elem })}' value ` +
+      `(a hole must be observed as undefined, which '${L.fmt(elem)}' element slots cannot represent - ` +
+      "use an undefined-capable element type or a dense array)",
+  );
+}
+
+function stripWrappers(expr: ts.Expression): ts.Expression {
+  let value = expr;
+  while (
+    ts.isParenthesizedExpression(value) || ts.isNonNullExpression(value) ||
+    ts.isAsExpression(value) || ts.isTypeAssertion(value) || ts.isSatisfiesExpression(value)
+  ) {
+    value = value.expression;
+  }
+  return value;
+}
+
+function isAssignmentOperator(kind: ts.SyntaxKind): boolean {
+  return kind >= ts.SyntaxKind.FirstAssignment && kind <= ts.SyntaxKind.LastAssignment;
+}
+
+function isWriteTarget(node: ts.Expression): boolean {
+  let value = node;
+  let parent = value.parent;
+  while (
+    parent &&
+    (ts.isParenthesizedExpression(parent) || ts.isNonNullExpression(parent) ||
+      ts.isAsExpression(parent) || ts.isTypeAssertion(parent) || ts.isSatisfiesExpression(parent))
+  ) {
+    value = parent;
+    parent = parent.parent;
+  }
+  if (!parent) return false;
+  if (ts.isDeleteExpression(parent) && parent.expression === value) return true;
+  if (
+    (ts.isPrefixUnaryExpression(parent) || ts.isPostfixUnaryExpression(parent)) &&
+    parent.operand === value &&
+    (parent.operator === ts.SyntaxKind.PlusPlusToken || parent.operator === ts.SyntaxKind.MinusMinusToken)
+  ) {
+    return true;
+  }
+  return ts.isBinaryExpression(parent) && parent.left === value && isAssignmentOperator(parent.operatorToken.kind);
+}
+
+const READ_ONLY_ARRAY_METHODS = new Set([
+  "at", "concat", "entries", "every", "filter", "find", "findIndex", "findLast",
+  "findLastIndex", "flat", "flatMap", "forEach", "includes", "indexOf", "join", "keys",
+  "lastIndexOf", "map", "reduce", "reduceRight", "slice", "some", "toReversed", "toSorted",
+  "toSpliced", "values", "with",
+]);
+
+function symbolUsePreservesSparsity(L: Lowerer, node: ts.Identifier): boolean {
+  const parent = node.parent;
+  if (
+    (ts.isVariableDeclaration(parent) || ts.isParameter(parent) || ts.isBindingElement(parent) ||
+      ts.isFunctionDeclaration(parent)) && parent.name === node
+  ) {
+    return true;
+  }
+  if (ts.isPropertyAccessExpression(parent) && parent.expression === node) {
+    if (isWriteTarget(parent)) return false;
+    if (parent.name.text === "length") return true;
+    return ts.isCallExpression(parent.parent) && parent.parent.expression === parent &&
+      READ_ONLY_ARRAY_METHODS.has(parent.name.text);
+  }
+  if (ts.isElementAccessExpression(parent) && parent.expression === node) {
+    return !isWriteTarget(parent);
+  }
+  if ((ts.isForOfStatement(parent) || ts.isForInStatement(parent)) && parent.expression === node) return true;
+  if (ts.isSpreadElement(parent) && parent.expression === node) return true;
+  if (ts.isBinaryExpression(parent)) {
+    if (parent.right === node && parent.operatorToken.kind === ts.SyntaxKind.InKeyword) return true;
+    return !isAssignmentOperator(parent.operatorToken.kind) &&
+      (parent.operatorToken.kind === ts.SyntaxKind.EqualsEqualsToken ||
+        parent.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken ||
+        parent.operatorToken.kind === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+        parent.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken);
+  }
+  return parent.kind === ts.SyntaxKind.TypeQuery;
+}
+
+function symbolUsesPreserveSparsity(
+  L: Lowerer,
+  symbol: ts.Symbol,
+  file: ts.SourceFile,
+  before: number,
+): boolean {
+  let safe = true;
+  const visit = (node: ts.Node): void => {
+    if (!safe) return;
+    if (
+      ts.isIdentifier(node) && node.pos < before &&
+      node.text === symbol.name && L.resolveValueSymbol(node) === symbol
+    ) {
+      safe = symbolUsePreservesSparsity(L, node);
+      if (!safe) return;
+    }
+    node.forEachChild(visit);
+  };
+  file.forEachChild(visit);
+  return safe;
+}
+
+function isSparseArrayInitializer(L: Lowerer, source: ts.Expression): boolean {
+  const value = stripWrappers(source);
+  if (ts.isArrayLiteralExpression(value)) return value.elements.some(ts.isOmittedExpression);
+  if (!ts.isCallExpression(value) && !ts.isNewExpression(value)) return false;
+  const callee = value.expression;
+  if (
+    !ts.isIdentifier(callee) || callee.text !== "Array" ||
+    !L.isStdlibSymbol(L.resolveValueSymbol(callee) ?? undefined)
+  ) {
+    return false;
+  }
+  const args = value.arguments ?? [];
+  if (args.length !== 1) return false;
+  const length = stripWrappers(args[0]!);
+  return ts.isNumericLiteral(length) && Number.isInteger(Number(length.text)) && Number(length.text) > 0;
+}
+
+/** Prove only the narrow case needed to fence unrepresentable hole reads.
+ * Unknown provenance deliberately keeps the historical lowering behavior. */
+function arrayExprIsProvablySparse(L: Lowerer, source: ts.Expression): boolean {
+  const value = stripWrappers(source);
+  if (isSparseArrayInitializer(L, value)) return true;
+  if (!ts.isIdentifier(value)) return false;
+  const symbol = L.resolveValueSymbol(value);
+  if (!symbol) return false;
+  const declarations = L.checker.declarationsOf(symbol);
+  const declaration = declarations.length === 1 ? declarations[0] : undefined;
+  if (!declaration || !ts.isVariableDeclaration(declaration) || !declaration.initializer) return false;
+  const list = declaration.parent;
+  const statement = list.parent;
+  if (
+    !ts.isVariableDeclarationList(list) || list.declarations.length !== 1 ||
+    !ts.isVariableStatement(statement) ||
+    (ts.getCombinedModifierFlags(statement) & ts.ModifierFlags.Export) !== 0 ||
+    declaration.end > value.pos || !isSparseArrayInitializer(L, declaration.initializer)
+  ) {
+    return false;
+  }
+  return symbolUsesPreserveSparsity(L, symbol, declaration.getSourceFile(), value.pos);
+}

--- a/packages/compiler/src/frontend/lowering/lib-boundary.ts
+++ b/packages/compiler/src/frontend/lowering/lib-boundary.ts
@@ -38,7 +38,7 @@
  * cleanly before. The validator stays the backstop for anything else. */
 import type { Lowerer } from "./lowerer.js";
 import { PoisonError } from "./lowerer.js";
-import { canAdaptDynFuncTo, canMarshalTypedFuncIntoIsland, DYN, IrExpr, IrType, JSVAL, SrcLoc, STRING, isUnitType, typeEquals } from "../../ir/nodes.js";
+import { canAdaptDynFuncTo, canDynCheckTo, canMarshalTypedFuncIntoIsland, DYN, IrExpr, IrType, JSVAL, SrcLoc, STRING, isUnitType, typeEquals } from "../../ir/nodes.js";
 import { LIB_FN_SIGS, REGEX_INTRINSIC_SIGS, STR_INTRINSIC_SIGS } from "../../ir/validate.js";
 import { unionMismatchDiag, unsupportedDiag } from "../../diagnostics/diagnostic.js";
 
@@ -48,17 +48,10 @@ import { unionMismatchDiag, unsupportedDiag } from "../../diagnostics/diagnostic
  * callback flowing into setTimeout's `() => void` slot adapts through
  * the per-target shim). */
 function dynCheckable(L: Lowerer, want: IrType): boolean {
-  if (L.jsonSafe(want)) return true;
-  if (want.kind === "bytes" && want.elem === "u8") return true;
-  if (want.kind === "object" && want.className === "%Error") return true;
-  if (want.kind === "func") {
-    return canAdaptDynFuncTo(want, (id) => L.shapes.get(id), (id) => L.unions.get(id));
-  }
-  if (want.kind === "union") {
-    const def = L.unions.get(want.unionId);
-    return !!def && def.arms.every((a) => a.kind === "undefinedT" || L.jsonSafe(a));
-  }
-  return false;
+  const getRecord = (id: string) => L.shapes.get(id);
+  const getUnion = (id: string) => L.unions.get(id);
+  return canDynCheckTo(want, getRecord, getUnion) ||
+    (want.kind === "func" && canAdaptDynFuncTo(want, getRecord, getUnion));
 }
 
 /** The checked coercion for one argument slot, or the named fence. Returns

--- a/packages/compiler/src/frontend/lowering/lower-assert.ts
+++ b/packages/compiler/src/frontend/lowering/lower-assert.ts
@@ -26,7 +26,7 @@ import type { Lowerer } from "./lowerer.js";
 import { jsFuncNameOf, own } from "./lowerer.js";
 import { NARROW_FIRST } from "./surfaces.js";
 import { typeReachesItself } from "./lower-inspect.js";
-import { BOOL, CAUGHT, DYN, DYN_HANDLE_KINDS, F64, IrExpr, IrLibFn, IrStmt, IrType, REGEX, RUNTIME_ERROR_CLASSES, STRING, SrcLoc, VOID, isUnitType, typeEquals, typeKey } from "../../ir/nodes.js";
+import { BOOL, CAUGHT, DYN, DYN_CONVERTIBLE_HANDLE_KINDS, F64, IrExpr, IrLibFn, IrStmt, IrType, REGEX, RUNTIME_ERROR_CLASSES, STRING, SrcLoc, VOID, isUnitType, typeEquals, typeKey } from "../../ir/nodes.js";
 
 /** node:assert/strict binds the loose NAMES to the strict comparisons —
  * Node's own aliasing (`strict.equal === assert.strictEqual`). */
@@ -273,7 +273,7 @@ function lowerAssertEqual(
         // strict compare is honest: assert.strictEqual(this, server) —
         // the ambient-receiver suite shape. The runtime's deep arm
         // answers same-handle only (its documented stance).
-        DYN_HANDLE_KINDS.has(k) ||
+        DYN_CONVERTIBLE_HANDLE_KINDS.has(k) ||
         // %Error crosses as the checked-dynamic tree's error encoding ({%error, name,
         // message, code?}) through scr_dyn_from_error's IDENTITY CACHE —
         // one error instance is ONE dyn node however it crosses. Strict

--- a/packages/compiler/src/frontend/lowering/lower-assert.ts
+++ b/packages/compiler/src/frontend/lowering/lower-assert.ts
@@ -1340,15 +1340,26 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
     case "array": {
       const len = (arr: IrExpr): IrExpr => ({ kind: "arrIntrinsic", method: "length", receiver: arr, args: [], type: F64, loc });
       const at = (arr: IrExpr, i: IrExpr): IrExpr => ({ kind: "arrayGet", arr, index: i, type: t.elem, loc });
+      const has = (arr: IrExpr, i: IrExpr): IrExpr => ({ kind: "arrayHas", arr, index: i, type: BOOL, loc });
+      const i = (): IrExpr => ref("i.0", F64);
       locals.push({ id: "i.0", name: "i", type: F64, mutable: true });
       body = [
         bailIf(neq(len(a()), len(b()))),
         {
           kind: "for",
           init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-          cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: len(a()), type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
-          body: [bailIf(not(deq(t.elem, at(a(), ref("i.0", F64)), at(b(), ref("i.0", F64)))))],
+          cond: { kind: "bin", op: "<", left: i(), right: len(a()), type: BOOL, loc },
+          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: num(1), type: F64, loc }, loc },
+          body: [
+            bailIf(neq(has(a(), i()), has(b(), i()))),
+            {
+              kind: "if",
+              cond: has(a(), i()),
+              then: [bailIf(not(deq(t.elem, at(a(), i()), at(b(), i()))))],
+              else_: null,
+              loc,
+            },
+          ],
           loc,
         },
         ret(boolLit(true)),

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -32,6 +32,7 @@ import { CRYPTO_CIPHERS, CRYPTO_CONSTANTS, CRYPTO_CURVES, CRYPTO_HASHES } from "
 import { timerStyleCallback } from "./lower-calls.js";
 import { registerHttpClientFnBinding } from "./lower-server.js";
 import { BOOL, BYTES_U8, CHILD_T, CHILDSTREAM_T, DYN, F64, FSWATCHER_T, PROCSTREAM_T, IrExpr, IrFunction, IrLibFn, IrLocal, IrStmt, IrType, JSVAL, NULL_T, SEARCH_PARAMS_T, SPAWNRES_T, STRING, SrcLoc, UNDEFINED_T, VOID, arrayOf, canBoxFuncIntoDyn, canConvertToDyn, funcOf, isUnitType, typeEquals, typeKey } from "../../ir/nodes.js";
+import { requireArrayGetSafe } from "./array-density.js";
 
 
 
@@ -1326,6 +1327,10 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
       if (spread) {
         if (expr.arguments.length === 1) {
           // The whole-array form forwards the operand directly (no copy).
+          const sourceType = L.mapTypeOf(L.typeOf(spread.expression));
+          if (sourceType?.kind === "array") {
+            requireArrayGetSafe(L, spread.expression, sourceType.elem, spread, "array argument spread");
+          }
           const packed = L.lowerExprExpecting(spread.expression, arrayOf(STRING));
           return { kind: "libCall", fn: fn.fn, args: [packed], type: fn.result, loc };
         }
@@ -1333,6 +1338,13 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         // tmpdir.resolve: plain arguments and spread arrays pack into one
         // fresh string[] (arrayLit's spread positions copy element-wise,
         // JS-exact; a dyn spread source rides the validated extraction).
+        for (const arg of expr.arguments) {
+          if (!ts.isSpreadElement(arg)) continue;
+          const sourceType = L.mapTypeOf(L.typeOf(arg.expression));
+          if (sourceType?.kind === "array") {
+            requireArrayGetSafe(L, arg.expression, sourceType.elem, arg, "array argument spread");
+          }
+        }
         const elems = expr.arguments.map((a) =>
           ts.isSpreadElement(a)
             ? L.lowerExprExpecting(a.expression, arrayOf(STRING))
@@ -6415,6 +6427,7 @@ type TextCodecCtor = {
         return { kind: "libCall", fn: "string.fromCharCode", args: [packed], type: STRING, loc };
       }
       const packed = L.lowerExprExpecting(spread.expression, arrayOf(F64));
+      requireArrayGetSafe(L, spread.expression, F64, spread, "array argument spread");
       return { kind: "libCall", fn: "string.fromCharCode", args: [packed], type: STRING, loc };
     }
     const elems = call.arguments.map((a) => L.lowerExprExpecting(a, F64));

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -27,6 +27,7 @@ import { ambientNsRootOf, ambientUndefReadType, ambientUndefVarRootOf, ambientUn
 import { declSymbolOf } from "./lower-modules.js";
 import { expandoMemberRead } from "./lower-expando.js";
 import { npmStaticPackageOfPath } from "../npm-static.js";
+import { requireArrayGetSafe } from "./array-density.js";
 
 /** How a parameter participates in CALL-SITE COMPLETION (the frontend
  * completes every call to the one full signature, so the IR and backends
@@ -478,6 +479,10 @@ export interface GenericInstance {
               a,
               `spreading '${L.fmt(src.type)}' into a '${L.fmt(restType)}' rest parameter (only a same-element-type array spreads)`,
             );
+          }
+          const sourceType = L.mapTypeOf(L.typeOf(a.expression));
+          if (sourceType?.kind === "array") {
+            requireArrayGetSafe(L, a.expression, sourceType.elem, a, "array argument spread");
           }
           spreads.push(i);
           return src;

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -2722,6 +2722,125 @@ export function lowerFfiCall(L: Lowerer, expr: ts.CallExpression): IrExpr | null
     };
   }
 
+export function refineJsArrayFillType(
+  L: Lowerer,
+  expr: ts.CallExpression | ts.NewExpression,
+  t: IrType | null,
+): IrType | null {
+  const ctx = L.checker.getContextualType(expr);
+  const contextual = ctx ? L.mapTypeOf(ctx) : null;
+  if (t?.kind !== "array" && contextual?.kind === "array") t = contextual;
+  const declaredElem = contextual?.kind === "array"
+    ? contextual.elem
+    : t?.kind === "array" ? t.elem : null;
+  const holesRepresentable = declaredElem?.kind === "union" &&
+    L.armTag(declaredElem.unionId, UNDEFINED_T) >= 0;
+  // Unannotated JS commonly allocates then fills by index (`var out =
+  // Array(n); for (...) out[i] = value`, Lodash's output-buffer idiom).
+  // The checker leaves the constructor at any[]; recover the element
+  // type only for an immediate canonical loop that fills every slot.
+  if (
+    isJsSourceFile(expr.getSourceFile()) &&
+    (t?.kind !== "array" || t.elem.kind === "jsval" || t.elem.kind === "dyn") &&
+    ts.isVariableDeclaration(expr.parent) && ts.isIdentifier(expr.parent.name) &&
+    !holesRepresentable
+  ) {
+    // An unresolvable binding would alias every other unresolvable
+    // indexed write (undefined === undefined) — require the symbol.
+    const binding = L.resolveValueSymbol(expr.parent.name);
+    const args = expr.arguments ?? [];
+    const lengthArg = args[0];
+    let inferredCompleteFill = false;
+    if (binding && args.length === 1 && lengthArg && ts.isIdentifier(lengthArg)) {
+      const declList = expr.parent.parent;
+      const declStmt = declList.parent;
+      const container = declStmt.parent;
+      if (
+        ts.isVariableDeclarationList(declList) && ts.isVariableStatement(declStmt) &&
+        declList.declarations.length === 1 &&
+        (ts.isBlock(container) || ts.isSourceFile(container))
+      ) {
+        const stmtIndex = container.statements.indexOf(declStmt);
+        const loop = container.statements[stmtIndex + 1];
+        const init = loop && ts.isForStatement(loop) && loop.initializer &&
+            ts.isVariableDeclarationList(loop.initializer) && loop.initializer.declarations.length === 1
+          ? loop.initializer.declarations[0]
+          : undefined;
+        const index = init && ts.isIdentifier(init.name) && init.initializer &&
+            ts.isNumericLiteral(init.initializer) && Number(init.initializer.text) === 0
+          ? L.resolveValueSymbol(init.name)
+          : undefined;
+        const condition = loop && ts.isForStatement(loop) ? loop.condition : undefined;
+        const increment = loop && ts.isForStatement(loop) ? loop.incrementor : undefined;
+        const bodyStmt = loop && ts.isForStatement(loop)
+          ? ts.isBlock(loop.statement) && loop.statement.statements.length === 1
+            ? loop.statement.statements[0]
+            : loop.statement
+          : undefined;
+        const write = bodyStmt && ts.isExpressionStatement(bodyStmt) &&
+            ts.isBinaryExpression(bodyStmt.expression) &&
+            bodyStmt.expression.operatorToken.kind === ts.SyntaxKind.EqualsToken
+          ? bodyStmt.expression
+          : undefined;
+        let mutatesLoopControl = false;
+        if (write && index) {
+          const visit = (n: ts.Node): void => {
+            if (ts.isCallExpression(n) || ts.isNewExpression(n)) {
+              mutatesLoopControl = true;
+            }
+            const operand = ts.isPrefixUnaryExpression(n) || ts.isPostfixUnaryExpression(n)
+              ? n.operand
+              : undefined;
+            const target = ts.isBinaryExpression(n) &&
+                n.operatorToken.kind >= ts.SyntaxKind.FirstAssignment &&
+                n.operatorToken.kind <= ts.SyntaxKind.LastAssignment
+              ? n.left
+              : operand;
+            if (
+              target && ts.isIdentifier(target) &&
+              (L.resolveValueSymbol(target) === index ||
+                L.resolveValueSymbol(target) === L.resolveValueSymbol(lengthArg) ||
+                L.resolveValueSymbol(target) === binding)
+            ) {
+              mutatesLoopControl = true;
+            }
+            ts.forEachChild(n, visit);
+          };
+          visit(write.right);
+        }
+        if (
+          index && condition && ts.isBinaryExpression(condition) &&
+          condition.operatorToken.kind === ts.SyntaxKind.LessThanToken &&
+          ts.isIdentifier(condition.left) && L.resolveValueSymbol(condition.left) === index &&
+          ts.isIdentifier(condition.right) &&
+          L.resolveValueSymbol(condition.right) === L.resolveValueSymbol(lengthArg) &&
+          increment && (ts.isPostfixUnaryExpression(increment) || ts.isPrefixUnaryExpression(increment)) &&
+          increment.operator === ts.SyntaxKind.PlusPlusToken && ts.isIdentifier(increment.operand) &&
+          L.resolveValueSymbol(increment.operand) === index && write && !mutatesLoopControl &&
+          ts.isElementAccessExpression(write.left) && ts.isIdentifier(write.left.expression) &&
+          L.resolveValueSymbol(write.left.expression) === binding &&
+          write.left.argumentExpression && ts.isIdentifier(write.left.argumentExpression) &&
+          L.resolveValueSymbol(write.left.argumentExpression) === index
+        ) {
+          const wt = L.mapTypeOf(L.typeOf(write.right));
+          if (wt && wt.kind !== "void" && !isUnitType(wt)) {
+            t = arrayOf(wt);
+            inferredCompleteFill = true;
+          }
+        }
+      }
+    }
+    if (!inferredCompleteFill) {
+      L.noLowering(
+        "Array whose indexed writes do not provably initialize every element",
+        expr,
+        "use an explicit element type that includes undefined",
+      );
+    }
+  }
+  return t;
+}
+
 export function lowerCall(L: Lowerer, expr: ts.CallExpression): IrExpr {
     const loc = locOf(expr);
 
@@ -3129,6 +3248,26 @@ export function lowerCall(L: Lowerer, expr: ts.CallExpression): IrExpr {
       L.isStdlibSymbol(L.resolveValueSymbol(expr.expression) ?? undefined)
     ) {
       return L.lowerComptime(expr);
+    }
+
+    // `Array(n)` is the constructor's sparse one-number form. Other call
+    // forms are ordinary packed element construction.
+    if (
+      ts.isIdentifier(expr.expression) &&
+      expr.expression.text === "Array" &&
+      L.isStdlibSymbol(L.resolveValueSymbol(expr.expression) ?? undefined)
+    ) {
+      if (expr.arguments.some(ts.isSpreadElement)) {
+        L.noLowering("Array with spread arguments", expr, "write the array literal: [...xs]");
+      }
+      let t = L.mapTypeOf(L.typeOf(expr));
+      t = refineJsArrayFillType(L, expr, t);
+      if (t?.kind !== "array") L.badType(expr, L.typeOf(expr));
+      if (expr.arguments.length === 1 && L.mapTypeOf(L.typeOf(expr.arguments[0]!))?.kind === "f64") {
+        return { kind: "arrayNewLen", length: L.lowerExpr(expr.arguments[0]!), sparse: true, type: t, loc };
+      }
+      const elems = expr.arguments.map((a) => L.lowerExprExpecting(a, t.elem));
+      return { kind: "arrayLit", elems, type: t, loc };
     }
 
     // The lib constructors-as-functions with STATIC conversion semantics:
@@ -7314,6 +7453,14 @@ export function lowerPromiseMethodCall(L: Lowerer, call: ts.CallExpression,
         if (key.type.kind !== "string") return null;
         return { kind: "libCall", fn: "dyn.hasOwn", args: [receiver, key], type: BOOL, loc };
       }
+      if (probed?.type.kind === "array") {
+        const receiver = L.lowerExpr(recvNode);
+        const index = L.lowerExpr(keyNode);
+        if (receiver.type.kind === "array" && index.type.kind === "f64") {
+          return { kind: "arrayHas", arr: receiver, index, type: BOOL, loc: locOf(call) };
+        }
+        return null;
+      }
       if (probed?.type.kind !== "record") return null;
       const shape = L.shapes.get(probed.type.shapeId);
       if (!shape || shape.tuple || shape.indexValue || shapeHasAccessorSlots(shape)) return null;
@@ -7352,6 +7499,51 @@ export function lowerPromiseMethodCall(L: Lowerer, call: ts.CallExpression,
       }
     }
     let argIr = L.mapTypeOf(L.typeOf(argNode));
+    if (argIr?.kind === "array" && member === "keys") {
+      const loc = locOf(call);
+      const arrT = argIr;
+      const resultT = arrayOf(STRING);
+      const key = `arr.keys:${typeKey(arrT)}`;
+      let helper = L.arrHofHelpers.get(key);
+      if (!helper) {
+        helper = `%arr.keys.${L.arrHofHelpers.size}`;
+        L.arrHofHelpers.set(key, helper);
+        const ref = (id: string, type: IrType): IrExpr => ({ kind: "varRef", localId: id, type, loc });
+        const i = ref("i.0", F64);
+        const a = ref("a.0", arrT);
+        const out = ref("out.0", resultT);
+        L.liftedFns.push({
+          name: helper,
+          params: [{ localId: "a.0", name: "a", type: arrT }],
+          returnType: resultT,
+          locals: [
+            { id: "a.0", name: "a", type: arrT, mutable: true },
+            { id: "out.0", name: "out", type: resultT, mutable: false },
+            { id: "i.0", name: "i", type: F64, mutable: true },
+          ],
+          body: [
+            { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: resultT, loc }, loc },
+            {
+              kind: "for",
+              init: { kind: "varDecl", localId: "i.0", init: { kind: "numLit", value: 0, type: F64, loc }, loc },
+              cond: { kind: "bin", op: "<", left: i, right: { kind: "arrIntrinsic", method: "length", receiver: a, args: [], type: F64, loc }, type: BOOL, loc },
+              update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i, right: { kind: "numLit", value: 1, type: F64, loc }, type: F64, loc }, loc },
+              body: [{
+                kind: "if",
+                cond: { kind: "arrayHas", arr: a, index: i, type: BOOL, loc },
+                then: [{ kind: "exprStmt", expr: { kind: "arrIntrinsic", method: "push", receiver: out, args: [{ kind: "toString", operand: i, type: STRING, loc }], type: F64, loc }, loc }],
+                else_: null,
+                loc,
+              }],
+              loc,
+            },
+            { kind: "return", value: out, loc },
+          ],
+          loc,
+        });
+      }
+      return { kind: "call", callee: helper, args: [L.lowerExpr(argNode)], type: resultT, loc };
+    }
     // JS: an unmappable CHECKER type over a value that lowered to a real
     // record (the narrowed export-table literal) — the lowered value's
     // shape is the honest dispatch key, exactly the identity-Set stance.

--- a/packages/compiler/src/frontend/lowering/lower-classes.ts
+++ b/packages/compiler/src/frontend/lowering/lower-classes.ts
@@ -6,7 +6,7 @@
 import * as ts from "../ts7/adapter.js";
 import type { Lowerer } from "./lowerer.js";
 import { BOOL, DYN, F64, bytesOf, IrClassDef, IrExpr, IrFunction, IrLocal, IrParam, IrStmt, IrType, JSVAL, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, SrcLoc, UNDEFINED_T, URL_T, VOID, arrayOf, isSupportedMapKey, isUnitType, typeEquals } from "../../ir/nodes.js";
-import { MAX_GENERIC_INSTANCES, genericCallInstance, implicitAnyParamSymbolsOf, implicitCallInstance, implicitMonoFile, omittedArgFor, type GenericFnInfo, type ParamShape } from "./lower-calls.js";
+import { MAX_GENERIC_INSTANCES, genericCallInstance, implicitAnyParamSymbolsOf, implicitCallInstance, implicitMonoFile, omittedArgFor, refineJsArrayFillType, type GenericFnInfo, type ParamShape } from "./lower-calls.js";
 import { isGenericCallableMemberType, typeKey } from "../types.js";
 import { cjsClassExprWholeExportOf, isCjsJsFile, isJsSourceFile, isModuleExportsAccess, isNodeTypesPath, locOf } from "../program.js";
 import { PoisonError, dynFallbackType, dynUndefinedExpr, newFnCtx, own } from "./lowerer.js";
@@ -5128,13 +5128,6 @@ export function lowerNew(L: Lowerer, expr: ts.NewExpression): IrExpr {
         if (args.some(ts.isSpreadElement)) {
           L.noLowering("new Array with spread arguments", expr, "write the array literal: [...xs]");
         }
-        if (args.length === 1 && L.mapTypeOf(L.typeOf(args[0]!))?.kind === "f64") {
-          L.noLowering(
-            "new Array(count)",
-            expr,
-            "the one-number form allocates HOLES (reads answer undefined, which the element type cannot carry) — build and push, or use the elements form: new Array(a, b)",
-          );
-        }
         let t = L.mapTypeOf(L.typeOf(expr));
         // JS's `new Array()` types any[]; the contextual type carries the
         // annotation when one exists (the new Map() stance).
@@ -5143,7 +5136,12 @@ export function lowerNew(L: Lowerer, expr: ts.NewExpression): IrExpr {
           const ctxMapped = ctx ? L.mapTypeOf(ctx) : null;
           if (ctxMapped?.kind === "array") t = ctxMapped;
         }
+        t = refineJsArrayFillType(L, expr, t);
         if (t?.kind !== "array") L.badType(expr, L.typeOf(expr));
+        if (args.length === 1 && L.mapTypeOf(L.typeOf(args[0]!))?.kind === "f64") {
+          const length = L.lowerExpr(args[0]!);
+          return { kind: "arrayNewLen", length, sparse: true, type: t, loc };
+        }
         const elems = args.map((a) => L.lowerExprExpecting(a, t.elem));
         return { kind: "arrayLit", elems, type: t, loc };
       }

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -12,6 +12,7 @@ import { isJsSourceFile, locOf } from "../program.js";
 import { DYN_DISPATCH_METHODS, islandPrimitiveExit } from "./lower-calls.js";
 import { typeKey } from "../types.js";
 import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
+import { requireArrayGetSafe } from "./array-density.js";
 
 /** Lower an expression whose checker type is statically `undefined`/`void`.
  * Optional builtin arguments use this before their ordinary expected-type
@@ -190,6 +191,7 @@ function lowerOptionalDefaultArg(
       if (call.arguments.length !== 0) {
         L.noLowering(`.toReversed with ${call.arguments.length} arguments`, call);
       }
+      requireArrayGetSafe(L, access.expression, elem, call, "Array.toReversed");
       return {
         kind: "arrIntrinsic",
         method: "toReversed",
@@ -203,6 +205,7 @@ function lowerOptionalDefaultArg(
       if (call.arguments.length !== 2 || call.arguments.some(ts.isSpreadElement)) {
         L.noLowering(`.with with ${call.arguments.length} arguments`, call);
       }
+      requireArrayGetSafe(L, access.expression, elem, call, "Array.with");
       const receiver = L.lowerExpr(access.expression);
       const index = L.lowerExprExpecting(call.arguments[0]!, F64);
       const value = L.coerceInto(
@@ -223,6 +226,7 @@ function lowerOptionalDefaultArg(
       if (call.arguments.some(ts.isSpreadElement)) {
         L.unsupported("SC1090", call, "spread arguments to Array.toSpliced");
       }
+      requireArrayGetSafe(L, access.expression, elem, call, "Array.toSpliced");
       const receiver = L.lowerExpr(access.expression);
       const start = call.arguments[0]
         ? L.lowerExprExpecting(call.arguments[0], F64)
@@ -319,6 +323,9 @@ function lowerOptionalDefaultArg(
             spreadArg,
             `pushing a spread of '${L.fmt(src.type)}' onto a '${L.fmt(receiverIr)}' array (only a same-element-type array spreads)`,
           );
+        }
+        if (L.mapTypeOf(L.typeOf(spreadArg.expression))?.kind === "array") {
+          requireArrayGetSafe(L, spreadArg.expression, elem, spreadArg, "array argument spread");
         }
         return { kind: "arrIntrinsic", method: "pushSpread", receiver, args: [src], type: F64, loc };
       }
@@ -1015,6 +1022,9 @@ function lowerOptionalDefaultArg(
     const loc = locOf(call);
     const receiver = L.lowerExpr(access.expression);
     const arrT = arrayOf(elem);
+    if (method !== "some" && method !== "every") {
+      requireArrayGetSafe(L, access.expression, elem, call, `Array.${method}`);
+    }
     const argNode = call.arguments[0];
     if (!argNode) L.unsupported("SC1090", call, "this call form"); // tsc-guarded
     const { fnArg, arity } = hofCallbackArg(L, argNode, [elem], arrT);
@@ -1583,6 +1593,7 @@ function lowerOptionalDefaultArg(
     const loc = locOf(call);
     const method = access.name.text === "toSorted" ? "toSorted" : "sort";
     const copyFirst = method === "toSorted";
+    if (copyFirst) requireArrayGetSafe(L, access.expression, elem, call, "Array.toSorted");
     if (call.arguments.length === 0 && elem.kind === "string") {
       const receiver = L.lowerExpr(access.expression);
       const cmp = defaultStringCmpHelper(L, loc);
@@ -1691,14 +1702,16 @@ function lowerOptionalDefaultArg(
     return name;
   }
 
-/** The insertion-sort loop, from existing IR nodes. Present elements compact
-   * to the front first; CompareArrayElements then sinks undefined past every
-   * value without calling the comparator, so the order is values, then
-   * undefineds. The tail beyond the present count is deleted for the
-   * in-place sort (holes land last, SortIndexedProperties' SKIP-HOLES) and
-   * assigned the interned undefined arm for toSorted (`undefExpr`, dense
-   * per READ-THROUGH-HOLES); a toSorted element type with no undefined arm
-   * cannot represent a read-through hole and keeps the holes.
+/** The insertion-sort loop, from existing IR nodes. Both methods first take a
+   * shallow working snapshot. Present elements compact within that private
+   * array; CompareArrayElements then sinks undefined past every value without
+   * calling the comparator, so the order is values, then undefineds. sort
+   * commits the sorted prefix and hole tail to the receiver only after every
+   * comparator call succeeds. This preserves the original receiver during
+   * comparator observation and leaves it untouched when a comparator throws.
+   * toSorted returns the working array directly; its hole tail becomes present
+   * undefined (the call site fences scalar receivers unless they are proven
+   * dense).
    *
    *   n = a.length;
     *   for (i = 1; i < n; i++) {
@@ -1728,7 +1741,9 @@ function lowerOptionalDefaultArg(
     const i = ref("i.0", F64);
     const j = ref("j.0", F64);
     const m = ref("m.0", F64);
-    const at = (index: IrExpr): IrExpr => ({ kind: "arrayGet", arr: ref("a.0", arrT), index, type: elem, loc });
+    const working = (): IrExpr => ref("w.0", arrT);
+    const at = (index: IrExpr): IrExpr => ({ kind: "arrayGet", arr: working(), index, type: elem, loc });
+    const hasWorking: IrExpr = { kind: "arrayHas", arr: working(), index: i, type: BOOL, loc };
     const jPlus1: IrExpr = { kind: "bin", op: "+", left: j, right: num(1), type: F64, loc };
     const isUndefined = (value: IrExpr): IrExpr | null => {
       if (elem.kind === "union" && undefinedTag !== null) {
@@ -1806,7 +1821,7 @@ function lowerOptionalDefaultArg(
           kind: "if",
           cond: shouldShift,
           then: [
-            { kind: "arraySet", arr: ref("a.0", arrT), index: jPlus1, value: at(j), loc },
+            { kind: "arraySet", arr: working(), index: jPlus1, value: at(j), loc },
             { kind: "assign", localId: "j.0", value: { kind: "bin", op: "-", left: j, right: num(1), type: F64, loc }, loc },
           ],
           else_: [{ kind: "break", loc }],
@@ -1816,28 +1831,26 @@ function lowerOptionalDefaultArg(
       loc,
     };
     const body: IrStmt[] = [
-      ...(copyFirst
-        ? [{
-            kind: "assign" as const,
-            localId: "a.0",
-            value: {
-              kind: "arrIntrinsic" as const,
-              method: "slice" as const,
-              receiver: ref("a.0", arrT),
-              args: [],
-              type: arrT,
-              loc,
-            },
-            loc,
-          }]
-        : []),
       readLenStmt(arrT, loc),
+      {
+        kind: "varDecl",
+        localId: "w.0",
+        init: {
+          kind: "arrIntrinsic",
+          method: "slice",
+          receiver: ref("a.0", arrT),
+          args: [],
+          type: arrT,
+          loc,
+        },
+        loc,
+      },
       { kind: "varDecl", localId: "m.0", init: num(0), loc },
       countedForLoop(loc, [{
         kind: "if",
-        cond: hasElemExpr(arrT, loc),
+        cond: hasWorking,
         then: [
-          { kind: "arraySet", arr: ref("a.0", arrT), index: m, value: at(i), loc },
+          { kind: "arraySet", arr: working(), index: m, value: at(i), loc },
           { kind: "assign", localId: "m.0", value: { kind: "bin", op: "+", left: m, right: num(1), type: F64, loc }, loc },
         ],
         else_: null,
@@ -1850,8 +1863,8 @@ function lowerOptionalDefaultArg(
         update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i, right: num(1), type: F64, loc }, loc },
         body: [
           copyFirst && undefExpr !== null
-            ? { kind: "arraySet", arr: ref("a.0", arrT), index: i, value: undefExpr, loc }
-            : { kind: "arrayDelete", arr: ref("a.0", arrT), index: i, loc },
+            ? { kind: "arraySet", arr: working(), index: i, value: undefExpr, loc }
+            : { kind: "arrayDelete", arr: working(), index: i, loc },
         ],
         loc,
       },
@@ -1866,14 +1879,44 @@ function lowerOptionalDefaultArg(
           loc,
         },
         body: [
-          { kind: "varDecl", localId: "v.0", init: getElemExpr(arrT, elem, loc), loc },
+          { kind: "varDecl", localId: "v.0", init: at(i), loc },
           { kind: "varDecl", localId: "j.0", init: { kind: "bin", op: "-", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
           shiftLoop,
-          { kind: "arraySet", arr: ref("a.0", arrT), index: jPlus1, value: ref("v.0", elem), loc },
+          { kind: "arraySet", arr: working(), index: jPlus1, value: ref("v.0", elem), loc },
         ],
         loc,
       },
-      { kind: "return", value: ref("a.0", arrT), loc },
+      ...(copyFirst
+        ? []
+        : [
+            {
+              kind: "for" as const,
+              init: { kind: "varDecl" as const, localId: "i.0", init: num(0), loc },
+              cond: { kind: "bin" as const, op: "<" as const, left: i, right: m, type: BOOL, loc },
+              update: {
+                kind: "assign" as const,
+                localId: "i.0",
+                value: { kind: "bin" as const, op: "+" as const, left: i, right: num(1), type: F64, loc },
+                loc,
+              },
+              body: [{ kind: "arraySet" as const, arr: ref("a.0", arrT), index: i, value: at(i), loc }],
+              loc,
+            },
+            {
+              kind: "for" as const,
+              init: { kind: "varDecl" as const, localId: "i.0", init: m, loc },
+              cond: { kind: "bin" as const, op: "<" as const, left: i, right: ref("n.0", F64), type: BOOL, loc },
+              update: {
+                kind: "assign" as const,
+                localId: "i.0",
+                value: { kind: "bin" as const, op: "+" as const, left: i, right: num(1), type: F64, loc },
+                loc,
+              },
+              body: [{ kind: "arrayDelete" as const, arr: ref("a.0", arrT), index: i, loc }],
+              loc,
+            },
+          ]),
+      { kind: "return", value: copyFirst ? working() : ref("a.0", arrT), loc },
     ];
     return {
       name,
@@ -1885,6 +1928,7 @@ function lowerOptionalDefaultArg(
       locals: [
         { id: "a.0", name: "a", type: arrT, mutable: true },
         { id: "f.0", name: "f", type: fnT, mutable: true },
+        { id: "w.0", name: "w", type: arrT, mutable: false },
         { id: "n.0", name: "n", type: F64, mutable: false },
         { id: "i.0", name: "i", type: F64, mutable: true },
         { id: "m.0", name: "m", type: F64, mutable: true },
@@ -2388,6 +2432,13 @@ function lowerOptionalDefaultArg(
         {
           kind: "if",
           cond: { kind: "bin", op: ">=", left: t, right: n, type: BOOL, loc },
+          then: [{ kind: "return", value: miss, loc }],
+          else_: null,
+          loc,
+        },
+        {
+          kind: "if",
+          cond: { kind: "unary", op: "!", operand: { kind: "arrayHas", arr: ref("a.0", arrT), index: t, type: BOOL, loc }, type: BOOL, loc },
           then: [{ kind: "return", value: miss, loc }],
           else_: null,
           loc,

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -816,8 +816,9 @@ function lowerOptionalDefaultArg(
   }
 
 /** Interned synthetic function for one (elem, argument-shape) concat —
-   * `%arr.concat.<n>(a, x0, x1, ...)`: a fresh array takes a's elements
-   * (pushSpread), then each argument pushes (element) or spreads (array)
+   * `%arr.concat.<n>(a, x0, x1, ...)`: a fresh array takes a's indexed
+   * properties (preserving holes), then each argument pushes an element or
+   * appends an array with the same presence-preserving operation
    * in order; the receiver and array arguments are only READ. Rides
    * liftedFns like the HOF helpers (a plain function — no captures). */
   export function arrayConcatHelper(L: Lowerer, elem: IrType, shape: ("e" | "a")[], loc: SrcLoc): string {
@@ -841,7 +842,7 @@ function lowerOptionalDefaultArg(
       kind: "exprStmt",
       expr: {
         kind: "arrIntrinsic",
-        method: s === "a" ? "pushSpread" : "push",
+        method: s === "a" ? "appendSparse" : "push",
         receiver: ref("out.0", arrT),
         args: [src],
         type: F64,
@@ -904,6 +905,13 @@ function lowerOptionalDefaultArg(
       type: elem,
       loc,
     };
+    const hasElem: IrExpr = {
+      kind: "arrayHas",
+      arr: ref("a.0", arrT),
+      index: ref("i.0", F64),
+      type: BOOL,
+      loc,
+    };
     const push = (outT: IrType, value: IrExpr): IrStmt => ({
       kind: "exprStmt",
       expr: {
@@ -943,9 +951,15 @@ function lowerOptionalDefaultArg(
       locals.push({ id: "out.0", name: "out", type: outT, mutable: false });
       returnType = outT;
       body = [
-        { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
         readLen,
-        forLoop([push(outT, callF(getElem))]),
+        { kind: "varDecl", localId: "out.0", init: { kind: "arrayNewLen", length: ref("n.0", F64), sparse: true, type: outT, loc }, loc },
+        forLoop([{
+          kind: "if",
+          cond: hasElem,
+          then: [{ kind: "arraySet", arr: ref("out.0", outT), index: ref("i.0", F64), value: callF(getElem), loc }],
+          else_: null,
+          loc,
+        }]),
         { kind: "return", value: ref("out.0", outT), loc },
       ];
     } else if (method === "filter") {
@@ -957,21 +971,27 @@ function lowerOptionalDefaultArg(
       body = [
         { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: arrT, loc }, loc },
         readLen,
-        forLoop([
-          { kind: "varDecl", localId: "v.0", init: getElem, loc },
-          {
-            kind: "if",
-            cond: callF(ref("v.0", elem)),
-            then: [push(arrT, ref("v.0", elem))],
-            else_: null,
-            loc,
-          },
-        ]),
+        forLoop([{
+          kind: "if",
+          cond: hasElem,
+          then: [
+            { kind: "varDecl", localId: "v.0", init: getElem, loc },
+            { kind: "if", cond: callF(ref("v.0", elem)), then: [push(arrT, ref("v.0", elem))], else_: null, loc },
+          ],
+          else_: null,
+          loc,
+        }]),
         { kind: "return", value: ref("out.0", arrT), loc },
       ];
     } else {
       returnType = VOID;
-      body = [readLen, forLoop([{ kind: "exprStmt", expr: callF(getElem), loc }])];
+      body = [readLen, forLoop([{
+        kind: "if",
+        cond: hasElem,
+        then: [{ kind: "exprStmt", expr: callF(getElem), loc }],
+        else_: null,
+        loc,
+      }])];
     }
     return { name, params, returnType, locals, body, loc };
   }
@@ -1213,15 +1233,19 @@ function lowerOptionalDefaultArg(
     });
     const body: IrStmt[] = [
       readLenStmt(arrT, loc),
-      countedForLoop(loc, [
-        {
+      countedForLoop(loc, [{
+        kind: "if",
+        cond: hasElemExpr(arrT, loc),
+        then: [{
           kind: "if",
           cond: method === "some" ? callF : { kind: "unary", op: "!", operand: callF, type: BOOL, loc },
           then: [{ kind: "return", value: bool(method === "some"), loc }],
           else_: null,
           loc,
-        },
-      ]),
+        }],
+        else_: null,
+        loc,
+      }]),
       { kind: "return", value: bool(method !== "some"), loc },
     ];
     L.liftedFns.push({
@@ -1313,8 +1337,10 @@ function lowerOptionalDefaultArg(
         value: { kind: "bin", op: "+", left: ref("j.0", F64), right: num(1), type: F64, loc },
         loc,
       },
-      body: [
-        {
+      body: [{
+        kind: "if",
+        cond: { kind: "arrayHas", arr: ref("r.0", fnRet), index: ref("j.0", F64), type: BOOL, loc },
+        then: [{
           kind: "exprStmt",
           expr: {
             kind: "arrIntrinsic",
@@ -1325,15 +1351,19 @@ function lowerOptionalDefaultArg(
             loc,
           },
           loc,
-        },
-      ],
+        }],
+        else_: null,
+        loc,
+      }],
       loc,
     };
     const body: IrStmt[] = [
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: fnRet, loc }, loc },
       readLenStmt(arrT, loc),
-      countedForLoop(loc, [
-        {
+      countedForLoop(loc, [{
+        kind: "if",
+        cond: hasElemExpr(arrT, loc),
+        then: [{
           kind: "varDecl",
           localId: "r.0",
           init: {
@@ -1344,15 +1374,15 @@ function lowerOptionalDefaultArg(
             loc,
           },
           loc,
-        },
-        {
+        }, {
           kind: "varDecl",
           localId: "m.0",
           init: { kind: "arrIntrinsic", method: "length", receiver: ref("r.0", fnRet), args: [], type: F64, loc },
           loc,
-        },
-        innerLoop,
-      ]),
+        }, innerLoop],
+        else_: null,
+        loc,
+      }]),
       { kind: "return", value: ref("out.0", fnRet), loc },
     ];
     L.liftedFns.push({
@@ -1445,61 +1475,63 @@ function lowerOptionalDefaultArg(
       { localId: "f.0", name: "f", type: fnT },
       ...(hasInit ? [{ localId: "z.0", name: "z", type: accT }] : []),
     ];
-    const seedStmts: IrStmt[] = hasInit
-      ? [{ kind: "varDecl", localId: "acc.0", init: ref("z.0", accT), loc }]
-      : [
-          {
-            kind: "if",
-            cond: { kind: "bin", op: "===", left: n, right: num(0), type: BOOL, loc },
-            then: [
-              {
+    const step = (): IrStmt => ({
+      kind: "assign",
+      localId: "i.0",
+      value: { kind: "bin", op: right ? "-" : "+", left: i, right: num(1), type: F64, loc },
+      loc,
+    });
+    const inBounds: IrExpr = right
+      ? { kind: "bin", op: ">=", left: i, right: num(0), type: BOOL, loc }
+      : { kind: "bin", op: "<", left: i, right: n, type: BOOL, loc };
+    const seedStmts: IrStmt[] = [
+      { kind: "varDecl", localId: "i.0", init: right ? { kind: "bin", op: "-", left: n, right: num(1), type: F64, loc } : num(0), loc },
+      ...(hasInit
+        ? [{ kind: "varDecl", localId: "acc.0", init: ref("z.0", accT), loc } as IrStmt]
+        : [
+            {
+              kind: "while",
+              cond: {
+                kind: "logical",
+                op: "&&",
+                left: inBounds,
+                right: { kind: "unary", op: "!", operand: hasElemExpr(arrT, loc), type: BOOL, loc },
+                type: BOOL,
+                loc,
+              },
+              body: [step()],
+              loc,
+            } as IrStmt,
+            {
+              kind: "if",
+              cond: { kind: "unary", op: "!", operand: inBounds, type: BOOL, loc },
+              then: [{
                 kind: "throw",
                 value: {
                   kind: "libCall",
                   fn: "error.new",
-                  args: [
-                    {
-                      kind: "strLit",
-                      value: "Reduce of empty array with no initial value",
-                      type: STRING,
-                      loc,
-                    },
-                  ],
+                  args: [{ kind: "strLit", value: "Reduce of empty array with no initial value", type: STRING, loc }],
                   type: { kind: "object", className: "%TypeError" },
                   loc,
                 },
                 loc,
-              },
-            ],
-            else_: null,
-            loc,
-          },
-          {
-            kind: "varDecl",
-            localId: "acc.0",
-            init: at(right ? { kind: "bin", op: "-", left: n, right: num(1), type: F64, loc } : num(0)),
-            loc,
-          },
-        ];
-    // Loop bounds: with init the walk covers every index; the seeded form
-    // starts one past the seed. reduce ascends, reduceRight descends.
-    const start: IrExpr = right
-      ? { kind: "bin", op: "-", left: n, right: num(hasInit ? 1 : 2), type: F64, loc }
-      : num(hasInit ? 0 : 1);
+              }],
+              else_: null,
+              loc,
+            } as IrStmt,
+            { kind: "varDecl", localId: "acc.0", init: at(i), loc } as IrStmt,
+            step(),
+          ]),
+    ];
     const loop: IrStmt = {
       kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: start, loc },
-      cond: right
-        ? { kind: "bin", op: ">=", left: i, right: num(0), type: BOOL, loc }
-        : { kind: "bin", op: "<", left: i, right: n, type: BOOL, loc },
-      update: {
-        kind: "assign",
-        localId: "i.0",
-        value: { kind: "bin", op: right ? "-" : "+", left: i, right: num(1), type: F64, loc },
-        loc,
-      },
-      body: [
-        {
+      init: null,
+      cond: inBounds,
+      update: step(),
+      body: [{
+        kind: "if",
+        cond: hasElemExpr(arrT, loc),
+        then: [{
           kind: "assign",
           localId: "acc.0",
           value: {
@@ -1510,8 +1542,10 @@ function lowerOptionalDefaultArg(
             loc,
           },
           loc,
-        },
-      ],
+        }],
+        else_: null,
+        loc,
+      }],
       loc,
     };
     const body: IrStmt[] = [
@@ -1558,7 +1592,7 @@ function lowerOptionalDefaultArg(
       if (!helper) {
         helper = `%arr.${method}.${L.arrHofHelpers.size}`;
         L.arrHofHelpers.set(key, helper);
-        L.liftedFns.push(buildArraySortFn(helper, STRING, 2, copyFirst, null, loc));
+        L.liftedFns.push(buildArraySortFn(helper, STRING, 2, copyFirst, null, null, loc));
       }
       const fnArg: IrExpr = { kind: "closure", fnName: cmp, captures: [], type: fnT, loc };
       return { kind: "call", callee: helper, args: [receiver, fnArg], type: arrT, loc };
@@ -1600,6 +1634,7 @@ function lowerOptionalDefaultArg(
           arity,
           copyFirst,
           undefinedTag >= 0 ? undefinedTag : null,
+          copyFirst ? L.wrappedUndefined(elem, loc) : null,
           loc,
         ),
       );
@@ -1656,7 +1691,14 @@ function lowerOptionalDefaultArg(
     return name;
   }
 
-/** The insertion-sort loop, from existing IR nodes:
+/** The insertion-sort loop, from existing IR nodes. Present elements compact
+   * to the front first; CompareArrayElements then sinks undefined past every
+   * value without calling the comparator, so the order is values, then
+   * undefineds. The tail beyond the present count is deleted for the
+   * in-place sort (holes land last, SortIndexedProperties' SKIP-HOLES) and
+   * assigned the interned undefined arm for toSorted (`undefExpr`, dense
+   * per READ-THROUGH-HOLES); a toSorted element type with no undefined arm
+   * cannot represent a read-through hole and keeps the holes.
    *
    *   n = a.length;
     *   for (i = 1; i < n; i++) {
@@ -1676,13 +1718,16 @@ function lowerOptionalDefaultArg(
     arity: number,
     copyFirst: boolean,
     undefinedTag: number | null,
+    undefExpr: IrExpr | null,
     loc: SrcLoc,
   ): IrFunction {
     const arrT = arrayOf(elem);
     const fnT = funcOf([elem, elem].slice(0, arity), F64);
     const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
     const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+    const i = ref("i.0", F64);
     const j = ref("j.0", F64);
+    const m = ref("m.0", F64);
     const at = (index: IrExpr): IrExpr => ({ kind: "arrayGet", arr: ref("a.0", arrT), index, type: elem, loc });
     const jPlus1: IrExpr = { kind: "bin", op: "+", left: j, right: num(1), type: F64, loc };
     const isUndefined = (value: IrExpr): IrExpr | null => {
@@ -1787,10 +1832,33 @@ function lowerOptionalDefaultArg(
           }]
         : []),
       readLenStmt(arrT, loc),
+      { kind: "varDecl", localId: "m.0", init: num(0), loc },
+      countedForLoop(loc, [{
+        kind: "if",
+        cond: hasElemExpr(arrT, loc),
+        then: [
+          { kind: "arraySet", arr: ref("a.0", arrT), index: m, value: at(i), loc },
+          { kind: "assign", localId: "m.0", value: { kind: "bin", op: "+", left: m, right: num(1), type: F64, loc }, loc },
+        ],
+        else_: null,
+        loc,
+      }]),
+      {
+        kind: "for",
+        init: { kind: "varDecl", localId: "i.0", init: m, loc },
+        cond: { kind: "bin", op: "<", left: i, right: ref("n.0", F64), type: BOOL, loc },
+        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i, right: num(1), type: F64, loc }, loc },
+        body: [
+          copyFirst && undefExpr !== null
+            ? { kind: "arraySet", arr: ref("a.0", arrT), index: i, value: undefExpr, loc }
+            : { kind: "arrayDelete", arr: ref("a.0", arrT), index: i, loc },
+        ],
+        loc,
+      },
       {
         kind: "for",
         init: { kind: "varDecl", localId: "i.0", init: num(1), loc },
-        cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: ref("n.0", F64), type: BOOL, loc },
+        cond: { kind: "bin", op: "<", left: i, right: m, type: BOOL, loc },
         update: {
           kind: "assign",
           localId: "i.0",
@@ -1819,6 +1887,7 @@ function lowerOptionalDefaultArg(
         { id: "f.0", name: "f", type: fnT, mutable: true },
         { id: "n.0", name: "n", type: F64, mutable: false },
         { id: "i.0", name: "i", type: F64, mutable: true },
+        { id: "m.0", name: "m", type: F64, mutable: true },
         { id: "v.0", name: "v", type: elem, mutable: false },
         { id: "j.0", name: "j", type: F64, mutable: true },
       ],
@@ -2158,6 +2227,16 @@ function lowerOptionalDefaultArg(
     };
   }
 
+  function hasElemExpr(arrT: IrType, loc: SrcLoc): IrExpr {
+    return {
+      kind: "arrayHas",
+      arr: { kind: "varRef", localId: "a.0", type: arrT, loc },
+      index: { kind: "varRef", localId: "i.0", type: F64, loc },
+      type: BOOL,
+      loc,
+    };
+  }
+
 /** `for (i = 0; i < n; i++) { ...body }` over the conventional locals. */
   function countedForLoop(loc: SrcLoc, body: IrStmt[]): IrStmt {
     const i: IrExpr = { kind: "varRef", localId: "i.0", type: F64, loc };
@@ -2385,7 +2464,7 @@ function lowerOptionalDefaultArg(
               "pass a mapper (Array.from({ length: n }, () => init)) instead",
           );
         }
-        return { kind: "arrayNewLen", length: n, type: arrT, loc };
+        return { kind: "arrayNewLen", length: n, sparse: false, type: arrT, loc };
       }
     }
     // `Array.from(s)` on a STRING: the string iterator's code-point walk

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -6508,7 +6508,7 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
         `Object.fromEntries over '${L.fmt(argIr)}' (the tuple's '${L.fmt(valT)}' value cannot flow into the '${L.fmt(iv)}' signature slot)`,
       );
     }
-    const receiver = L.lowerExpr(argNode);
+    const receiver = L.coerceToExpected(L.lowerExpr(argNode), argIr);
     const key = `obj.fromEntries:${argIr.elem.shapeId}:${resultT.shapeId}`;
     let helper = L.arrHofHelpers.get(key);
     if (!helper) {
@@ -6586,7 +6586,7 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
       kind: "record",
       shapeId: L.shapes.intern([], false, valT, []),
     };
-    const receiver = L.lowerExpr(argNode);
+    const receiver = L.coerceToExpected(L.lowerExpr(argNode), argIr);
     const key = `obj.fromEntries:strrows:${resultT.shapeId}`;
     let helper = L.arrHofHelpers.get(key);
     if (!helper) {

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -7839,48 +7839,70 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
         update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
         body: [
           {
-            kind: "varDecl",
-            localId: "v.0",
-            init: { kind: "dynKeyGet", key: { kind: "toString", operand: ref("i.0", F64), type: STRING, loc }, value: d, type: DYN, loc },
-            loc,
-          },
-          {
-            kind: "varDecl",
-            localId: "r.0",
-            init: {
-              kind: "callValue",
-              callee: ref("f.0", fnT),
-              args: [ref("v.0", DYN), ref("i.0", F64), d].slice(0, arity),
-              type: retT,
+            kind: "if",
+            cond: {
+              kind: "libCall",
+              fn: "dyn.hasKey",
+              args: [d, { kind: "toString", operand: ref("i.0", F64), type: STRING, loc }],
+              type: BOOL,
               loc,
             },
-            loc,
-          },
-          {
-            kind: "varDecl",
-            localId: "rn.0",
-            init: { kind: "arrIntrinsic", method: "length", receiver: ref("r.0", retT), args: [], type: F64, loc },
-            loc,
-          },
-          {
-            kind: "for",
-            init: { kind: "varDecl", localId: "j.0", init: num(0), loc },
-            cond: { kind: "bin", op: "<", left: ref("j.0", F64), right: ref("rn.0", F64), type: BOOL, loc },
-            update: { kind: "assign", localId: "j.0", value: { kind: "bin", op: "+", left: ref("j.0", F64), right: num(1), type: F64, loc }, loc },
-            body: [
+            then: [
               {
-                kind: "exprStmt",
-                expr: {
-                  kind: "arrIntrinsic",
-                  method: "push",
-                  receiver: ref("out.0", outT),
-                  args: [{ kind: "arrayGet", arr: ref("r.0", retT), index: ref("j.0", F64), type: elemT, loc }],
-                  type: F64,
+                kind: "varDecl",
+                localId: "v.0",
+                init: { kind: "dynKeyGet", key: { kind: "toString", operand: ref("i.0", F64), type: STRING, loc }, value: d, type: DYN, loc },
+                loc,
+              },
+              {
+                kind: "varDecl",
+                localId: "r.0",
+                init: {
+                  kind: "callValue",
+                  callee: ref("f.0", fnT),
+                  args: [ref("v.0", DYN), ref("i.0", F64), d].slice(0, arity),
+                  type: retT,
                   loc,
                 },
                 loc,
               },
+              {
+                kind: "varDecl",
+                localId: "rn.0",
+                init: { kind: "arrIntrinsic", method: "length", receiver: ref("r.0", retT), args: [], type: F64, loc },
+                loc,
+              },
+              {
+                kind: "for",
+                init: { kind: "varDecl", localId: "j.0", init: num(0), loc },
+                cond: { kind: "bin", op: "<", left: ref("j.0", F64), right: ref("rn.0", F64), type: BOOL, loc },
+                update: { kind: "assign", localId: "j.0", value: { kind: "bin", op: "+", left: ref("j.0", F64), right: num(1), type: F64, loc }, loc },
+                body: [
+                  {
+                    kind: "if",
+                    cond: { kind: "arrayHas", arr: ref("r.0", retT), index: ref("j.0", F64), type: BOOL, loc },
+                    then: [
+                      {
+                        kind: "exprStmt",
+                        expr: {
+                          kind: "arrIntrinsic",
+                          method: "push",
+                          receiver: ref("out.0", outT),
+                          args: [{ kind: "arrayGet", arr: ref("r.0", retT), index: ref("j.0", F64), type: elemT, loc }],
+                          type: F64,
+                          loc,
+                        },
+                        loc,
+                      },
+                    ],
+                    else_: null,
+                    loc,
+                  },
+                ],
+                loc,
+              },
             ],
+            else_: null,
             loc,
           },
         ],
@@ -7929,9 +7951,10 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
 /** out = []; n = d.length; for (i..n) { v = d[i]; if (f(v, i, d)) out.push(
  * check<T>(v)); } return out; — with the receiver-kind gate up front. The
  * length reads ONCE (the checked-dynamic tree is immutable under the static surface), the
- * element reads through the canonical-index keyed read, the callback gets
- * whatever prefix of (element, index, receiver) it declares — the element
- * and receiver as dyn values, exactly what `unknown` code sees. */
+ * own-property guard skips holes before the canonical-index keyed read;
+ * the callback gets whatever prefix of (element, index, receiver) it
+ * declares — the element and receiver as dyn values, exactly what
+ * `unknown` code sees. */
   function buildDynFilterFn(name: string, elemT: IrType, arity: number, loc: SrcLoc): IrFunction {
     const outT = arrayOf(elemT);
     const fnT = funcOf([DYN, F64, DYN].slice(0, arity), BOOL);
@@ -7965,31 +7988,45 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
         update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
         body: [
           {
-            kind: "varDecl",
-            localId: "v.0",
-            init: { kind: "dynKeyGet", key: { kind: "toString", operand: ref("i.0", F64), type: STRING, loc }, value: d, type: DYN, loc },
-            loc,
-          },
-          {
             kind: "if",
             cond: {
-              kind: "callValue",
-              callee: ref("f.0", fnT),
-              args: [ref("v.0", DYN), ref("i.0", F64), d].slice(0, arity),
+              kind: "libCall",
+              fn: "dyn.hasKey",
+              args: [d, { kind: "toString", operand: ref("i.0", F64), type: STRING, loc }],
               type: BOOL,
               loc,
             },
             then: [
               {
-                kind: "exprStmt",
-                expr: {
-                  kind: "arrIntrinsic",
-                  method: "push",
-                  receiver: ref("out.0", outT),
-                  args: [{ kind: "dynCheck", value: ref("v.0", DYN), type: elemT, loc }],
-                  type: F64,
+                kind: "varDecl",
+                localId: "v.0",
+                init: { kind: "dynKeyGet", key: { kind: "toString", operand: ref("i.0", F64), type: STRING, loc }, value: d, type: DYN, loc },
+                loc,
+              },
+              {
+                kind: "if",
+                cond: {
+                  kind: "callValue",
+                  callee: ref("f.0", fnT),
+                  args: [ref("v.0", DYN), ref("i.0", F64), d].slice(0, arity),
+                  type: BOOL,
                   loc,
                 },
+                then: [
+                  {
+                    kind: "exprStmt",
+                    expr: {
+                      kind: "arrIntrinsic",
+                      method: "push",
+                      receiver: ref("out.0", outT),
+                      args: [{ kind: "dynCheck", value: ref("v.0", DYN), type: elemT, loc }],
+                      type: F64,
+                      loc,
+                    },
+                    loc,
+                  },
+                ],
+                else_: null,
                 loc,
               },
             ],

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -3606,6 +3606,7 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
     }
     const type = mapped as IrType & { kind: "array" };
     const spreads: number[] = [];
+    const holes: number[] = [];
     const elems = expr.elements.map((el, i) => {
       if (ts.isSpreadElement(el)) {
         // `[...xs, b]`: xs must be an array of the literal's own element
@@ -3682,14 +3683,16 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
         spreads.push(i);
         return src;
       }
-      // A HOLE (`[,]` — an elision): the slot materializes the undefined
-      // arm — reads, length, and JSON answer exactly Node (JSON.stringify
-      // prints null for holes AND for undefined elements). Iteration
-      // methods do not skip the position the way JS skips holes — the
-      // documented sparse-literal divergence.
+      // A HOLE (`[,]` — an elision): the backing slot carries the undefined
+      // arm for hole-yielding reads/iteration while arrayLit's hole metadata
+      // keeps property presence distinct. HOFs consult that presence and
+      // skip the position like JavaScript.
       if (ts.isOmittedExpression(el)) {
         const hole = type.elem.kind === "union" ? L.wrappedUndefined(type.elem, locOf(el)) : null;
-        if (hole) return hole;
+        if (hole) {
+          holes.push(i);
+          return hole;
+        }
         L.unsupported("SC1090", el, "holes in array literals of this element type");
       }
       // An ARRAY-LITERAL element under a UNION element slot whose own type
@@ -3726,7 +3729,14 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
       if (!typeEquals(lowered.type, type.elem)) L.badType(el, L.typeOf(el));
       return lowered;
     });
-    return { kind: "arrayLit", elems, ...(spreads.length > 0 ? { spreads } : {}), type, loc };
+    return {
+      kind: "arrayLit",
+      elems,
+      ...(spreads.length > 0 ? { spreads } : {}),
+      ...(holes.length > 0 ? { holes } : {}),
+      type,
+      loc,
+    };
   }
 
 /** `{ a: 1, b: "x" }` → recordLit. The record type comes from the
@@ -8718,22 +8728,16 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
     // Compile-time-known STRING keys fold — literals, and the same
     // const/enum-literal and template folding computed property keys get
     // (foldedStringKeyOf); runtime-valued keys keep the fence.
-    // NUMERIC literal keys answer on ARRAY receivers: dense arrays hold
-    // exactly the indices [0, length), so `3 in xs` is a length test (and
-    // a negative/fractional literal is a constant miss — the receiver
-    // still evaluates once through its own length read).
+    // Numeric literal keys over arrays test own indexed-property presence,
+    // distinguishing holes from both values and out-of-bounds indices.
     {
       let kNode = expr.left;
       while (ts.isParenthesizedExpression(kNode)) kNode = kNode.expression;
       if (ts.isNumericLiteral(kNode) && L.mapTypeOf(L.typeOf(expr.right))?.kind === "array") {
         const recvArr = L.lowerExpr(expr.right);
         if (recvArr.type.kind === "array") {
-          const len: IrExpr = { kind: "arrIntrinsic", method: "length", receiver: recvArr, args: [], type: F64, loc };
           const n = Number(kNode.text);
-          if (Number.isInteger(n) && n >= 0) {
-            return { kind: "bin", op: "<", left: { kind: "numLit", value: n, type: F64, loc }, right: len, type: BOOL, loc };
-          }
-          return { kind: "bin", op: "<", left: len, right: { kind: "numLit", value: 0, type: F64, loc }, type: BOOL, loc };
+          return { kind: "arrayHas", arr: recvArr, index: { kind: "numLit", value: n, type: F64, loc }, type: BOOL, loc };
         }
       }
     }

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -7,7 +7,7 @@
 import * as ts from "../ts7/adapter.js";
 import { dirname } from "node:path";
 import type { Lowerer } from "./lowerer.js";
-import { BOOL, CAUGHT, DYN, DYN_HANDLE_KINDS, F64, IrExpr, IrFunction, IrJsOp, IrLocal, IrRecordShape, IrStmt, IrType, JSVAL, NULL_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_ERROR_CLASSES, SEARCH_PARAMS_T, STRING, SrcLoc, UNDEFINED_T, VOID, arrayOf, canAdaptDynFuncTo, canBoxFuncIntoDyn, canDynCheckTo, funcOf, isJsonSafeType, isUnitType, jsOpResultKind, shapeHasAccessorSlots, typeEquals, typeKey, unionFuncSetArmsOk } from "../../ir/nodes.js";
+import { BOOL, CAUGHT, DYN, F64, IrExpr, IrFunction, IrJsOp, IrLocal, IrRecordShape, IrStmt, IrType, JSVAL, NULL_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_ERROR_CLASSES, RUNTIME_HANDLE_IDENTITY_KINDS, SEARCH_PARAMS_T, STRING, SrcLoc, UNDEFINED_T, VOID, arrayOf, canBoxFuncIntoDyn, canDynCheckTo, funcOf, isJsonSafeType, isUnitType, jsOpResultKind, shapeHasAccessorSlots, typeEquals, typeKey, unionFuncSetArmsOk } from "../../ir/nodes.js";
 import { cjsClassExprWholeExportOf, cjsExportAssignmentOf, cjsExportDiscardReason, isCjsExportTableLiteral, isCjsJsFile, isJsSourceFile, isModuleExportsAccess, isNodeEsmFile, locOf } from "../program.js";
 import { ARRAY_METHODS, builtinConstLit, builtinFenceHintOf, builtinModuleConstOf, builtinModulesArrayLit, builtinModuleFnOf, CompoundOp, ISLAND_SURFACE, isChildSurfaceMember, MAP_METHODS, NARROW_FIRST, SET_METHODS, STR_METHODS, UNSUPPORTED_EXPR, sideEffectFreeOptionValue, stdlibGlobalNameOf } from "./surfaces.js";
 import { UNSUPPORTED, blockedBindingUseDiag, recordShapeMismatchDiag, requiresDynamicPackageDiag, unsupportedDiag } from "../../diagnostics/diagnostic.js";
@@ -6789,54 +6789,22 @@ export function lowerTemplate(L: Lowerer, expr: ts.TemplateExpression): IrExpr {
     const target = L.mapTypeOf(targetTs);
     if (!target) L.badType(expr.type, targetTs);
     if (target.kind === "dyn") return inner; // `as unknown`: erasure
-    if (target.kind === "void" || !L.jsonSafe(target)) {
-      // Bare undefined-armed targets pass when every OTHER arm is
-      // JSON-safe: the checked-dynamic tree holds a first-class undefined value now
-      // (index-signature overflow reads produce it for missing keys), and
-      // the undefined arm matches exactly it — `p[key] as string |
-      // undefined` is the missing-key idiom. Parsed JSON still never
-      // contains undefined, so casts over parse results keep failing on
-      // non-string values with the usual path-annotated TypeError.
-      if (target.kind === "union" && L.dynConvertible(target)) {
-        return { kind: "dynCheck", value: inner, type: target, loc: locOf(expr) };
-      }
-      // Uint8Array targets: the checked-dynamic tree carries a bytes kind now (converted
-      // stdin chunks) — the extraction validates the kind and copies out.
-      if (target.kind === "bytes" && target.elem === "u8") {
-        return { kind: "dynCheck", value: inner, type: target, loc: locOf(expr) };
-      }
-      // ADAPTABLE function targets (`u as (x: number) => number` — the
-      // checked-dynamic function boundary): kind check, then exact unwrap
-      // or the per-target adapter shim. Non-adaptable signatures keep the
-      // fence below.
+    // An all-`unknown`-fields record target (`err as { code?: unknown }`)
+    // is pure typing: reads can stay on the original dyn value.
+    if (target.kind === "record") {
+      const shape = L.shapes.get(target.shapeId);
       if (
-        target.kind === "func" &&
-        canAdaptDynFuncTo(target, (id) => L.shapes.get(id), (id) => L.unions.get(id))
+        shape && !shape.tuple &&
+        shape.fields.every((f) => f.type.kind === "dyn") &&
+        (!shape.indexValue || shape.indexValue.kind === "dyn")
       ) {
-        return { kind: "dynCheck", value: inner, type: target, loc: locOf(expr) };
+        return inner;
       }
-      // Runtime HANDLE targets (`u as IncomingMessage` — a boxed handle
-      // coming back out of an untyped wrapper): a tag-checked reference
-      // unwrap, identity preserved (DYN_HANDLE_KINDS).
-      if (DYN_HANDLE_KINDS.has(target.kind)) {
-        return { kind: "dynCheck", value: inner, type: target, loc: locOf(expr) };
-      }
-      // An all-`unknown`-fields record target (`err as { code?: unknown }`
-      // — the errno-probing idiom): there is nothing to validate (every
-      // field is unknown, exactly what the dyn value already answers) and
-      // nothing to build — the cast is pure typing, so it ERASES and the
-      // reads ride the dyn keyed read.
-      if (target.kind === "record") {
-        const shape = L.shapes.get(target.shapeId);
-        if (
-          shape &&
-          !shape.tuple &&
-          shape.fields.every((f) => f.type.kind === "dyn") &&
-          (!shape.indexValue || shape.indexValue.kind === "dyn")
-        ) {
-          return inner;
-        }
-      }
+    }
+    if (
+      target.kind === "void" ||
+      !canDynCheckTo(target, (id) => L.shapes.get(id), (id) => L.unions.get(id))
+    ) {
       L.unsupported(
         "SC1090",
         expr,
@@ -7643,7 +7611,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
         // Runtime HANDLES are objects to === too: one handle per socket/
         // request/response, so pointer identity IS JS's object equality
         // (`c.pause() === c` — Node's chaining assertions). */
-        if (DYN_HANDLE_KINDS.has(idLeft.type.kind) && typeEquals(idLeft.type, idRight.type)) {
+        if (RUNTIME_HANDLE_IDENTITY_KINDS.has(idLeft.type.kind) && typeEquals(idLeft.type, idRight.type)) {
           return { kind: "bin", op: negated ? "!==" : "===", left: idLeft, right: idRight, type: BOOL, loc };
         }
         L.unsupported("SC1043", expr);

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -25,6 +25,7 @@ import { mixinFnOfCallee } from "./lower-mixins.js";
 import { isConstAssertionTypeNode, isGenericCallableMemberType, underConstAssertion, unitOnlyUnion } from "../types.js";
 import { lowerYield } from "./lower-generators.js";
 import { lowerStreamProperty, lowerStreamStateProperty, streamSidesOf } from "./lower-stream.js";
+import { requireArrayGetSafe } from "./array-density.js";
 
 /** An assignable `obj.field` target — a class field, a record field, or a
  * class ACCESSOR property (reads become getter calls, writes setter calls;
@@ -3679,6 +3680,10 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
             el,
             `spreading '${L.fmt(src.type)}' into a '${L.fmt(type)}' literal (only a same-element-type array spreads)`,
           );
+        }
+        const sourceType = L.mapTypeOf(L.typeOf(el.expression));
+        if (sourceType?.kind === "array") {
+          requireArrayGetSafe(L, el.expression, sourceType.elem, el, "array spread");
         }
         spreads.push(i);
         return src;

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -10,6 +10,7 @@ import { requiresDynamicApiDiag, requiresDynamicPackageDiag } from "../../diagno
 import { isCjsJsFile, isJsSourceFile, locOf, npmPackageNameOf } from "../program.js";
 import { foldedStringKeyOf, lowerDynObjectLiteral, pureReemittable } from "./lower-exprs.js";
 import { PoisonError, dynUndefinedExpr, newFnCtx, nodeThrowExpr, own } from "./lowerer.js";
+import { requireArrayGetSafe } from "./array-density.js";
 import {
   NODE24_FETCH_COMPAT_PROFILE,
   STATIC_HEADERS_CALLS,
@@ -2947,6 +2948,7 @@ export function lowerStaticReadableStreamReaderCall(
           `spreading '${L.fmt(src.type)}' into Math.${name} (only a number[] spreads)`,
         );
       }
+      requireArrayGetSafe(L, spread.expression, F64, spread, `array spread into Math.${name}`);
       return {
         kind: "libCall",
         fn: name === "max" ? "math.maxArr" : "math.minArr",

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -12,7 +12,7 @@ import * as ts from "../ts7/adapter.js";
 import type { Lowerer } from "./lowerer.js";
 import { ladderFenceExpr, nodeThrowExpr } from "./lowerer.js";
 import { isJsSourceFile, locOf } from "../program.js";
-import { arrayOf, BOOL, BYTES_U8, canBoxFuncIntoDyn, canConvertToDyn, DYN, DYN_HANDLE_KINDS, F64, funcOf, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, IrExpr, IrLibFn, IrStmt, IrType, NETSERVER_T, NETSOCKET_T, NULL_T, SECURECTX_T, STRING, UNDEFINED_T, SrcLoc, typeKey, VOID } from "../../ir/nodes.js";
+import { arrayOf, BOOL, BYTES_U8, canBoxFuncIntoDyn, canConvertToDyn, DYN, DYN_CONVERTIBLE_HANDLE_KINDS, F64, funcOf, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, IrExpr, IrLibFn, IrStmt, IrType, NETSERVER_T, NETSOCKET_T, NULL_T, SECURECTX_T, STRING, UNDEFINED_T, SrcLoc, typeKey, VOID } from "../../ir/nodes.js";
 import {
   AGENT_DOCUMENTED_OPTIONS,
   builtinFenceHintOf,
@@ -227,7 +227,7 @@ const boolLit = (value: boolean, loc: SrcLoc): IrExpr => ({ kind: "boolLit", val
  * createServer(...)` — the keep-alive shape) so the STATIC lowering
  * claims the call while the binding's IR type is dyn: the receiver then
  * rides a dynCheck unwrap (a tag-checked reference extraction, identity
- * preserved — DYN_HANDLE_KINDS) onto the same entry points. */
+ * preserved — DYN_CONVERTIBLE_HANDLE_KINDS) onto the same entry points. */
 /** True iff `t` is the {address: string, family: string, port: number}
  * record — server.address()'s materialized shape (lower-dgram's
  * AddressInfo check, another receiver). */
@@ -241,7 +241,7 @@ function isAddressInfoRecord(L: Lowerer, t: IrType): boolean {
 
 function handleReceiver(L: Lowerer, node: ts.Expression, want: IrType): IrExpr {
   const recv = L.lowerExpr(node);
-  if (recv.type.kind === "dyn" && DYN_HANDLE_KINDS.has(want.kind)) {
+  if (recv.type.kind === "dyn" && DYN_CONVERTIBLE_HANDLE_KINDS.has(want.kind)) {
     return { kind: "dynCheck", value: recv, type: want, loc: locOf(node) };
   }
   return recv;

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -3676,6 +3676,13 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
       };
     }
     const obj = L.lowerExpr(target.expression);
+    if (obj.type.kind === "array" && ts.isElementAccessExpression(target)) {
+      const index = L.lowerExpr(target.argumentExpression);
+      if (index.type.kind !== "f64") {
+        L.unsupported("SC1090", target.argumentExpression, "array delete with non-number indices");
+      }
+      return { kind: "arrayDelete", arr: obj, index, loc };
+    }
     if (obj.type.kind === "record") {
       const shape = L.shapes.get(obj.type.shapeId);
       if (shape?.indexValue && shape.fields.length === 0 && !shape.tuple) {
@@ -4198,6 +4205,21 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
               expr: { kind: "libCall", fn: "process.envSet", args: [key, value], type: VOID, loc },
               loc,
             };
+          }
+          // `xs.length = n` on an array receiver. Gate on the CHECKER type
+          // so a non-array receiver with a `length` field never lowers the
+          // LHS speculatively (a discarded lowering can still register
+          // helpers or diagnostics).
+          if (
+            !expr.left.questionDotToken && expr.left.name.text === "length" &&
+            L.mapTypeOf(L.typeOf(expr.left.expression))?.kind === "array"
+          ) {
+            const arr = L.lowerExpr(expr.left.expression);
+            if (arr.type.kind === "array") {
+              const length = L.lowerExpr(expr.right);
+              if (length.type.kind !== "f64") L.badType(expr.right, L.typeOf(expr.right));
+              return { kind: "arraySetLength", arr, length, loc: locOf(expr) };
+            }
           }
           if (expr.left.expression.kind === ts.SyntaxKind.SuperKeyword) {
             // `super.x = v`: the base chain's SETTER, called directly over
@@ -7201,13 +7223,12 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
    *
    *   { const %inarr = <expr>; const %inlen = %inarr.length;
    *     for (let %ini = 0; %ini < %inlen; %ini += 1) {
-   *       if (%ini < %inarr.length) { const k = String(%ini); <body> } } }
+   *       if (%ini in %inarr) { const k = String(%ini); <body> } } }
    *
    * The length SNAPSHOT bounds the walk (keys added during the body are
    * not visited — V8's own-keys snapshot, verified against Node) and the
-   * live-length guard is the per-visit presence check (keys removed by
-   * pops are skipped, exactly Node's HasProperty re-check; indices are
-   * dense, so `i < length` IS presence). */
+   * arrayHas guard is the per-visit HasProperty re-check, so holes and keys
+   * removed by the body are skipped exactly like Node. */
   function lowerForInArray(L: Lowerer, stmt: ts.ForInStatement, labels: string[] | undefined): IrStmt {
     const loc = locOf(stmt);
     const arrExpr = L.lowerExpr(stmt.expression);
@@ -7304,7 +7325,7 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
             body: [
               {
                 kind: "if",
-                cond: { kind: "bin", op: "<", left: iRef(), right: liveLen(), type: BOOL, loc },
+                cond: { kind: "arrayHas", arr: arrRef(), index: iRef(), type: BOOL, loc },
                 then: [keyDecl, ...writes, ...body],
                 else_: null,
                 loc,

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -7221,14 +7221,17 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
 
 /** for-in over an ARRAY: Node's canonical ascending index strings.
    *
-   *   { const %inarr = <expr>; const %inlen = %inarr.length;
-   *     for (let %ini = 0; %ini < %inlen; %ini += 1) {
-   *       if (%ini in %inarr) { const k = String(%ini); <body> } } }
+   *   { const %inarr = <expr>; const %inkeys = [];
+   *     for (let %ini = 0, %inlen = %inarr.length; %ini < %inlen; %ini += 1)
+   *       if (%ini in %inarr) %inkeys.push(%ini);
+   *     for (%ini = 0; %ini < %inkeys.length; %ini += 1) {
+   *       const %inidx = %inkeys[%ini];
+   *       if (%inidx in %inarr) { const k = String(%inidx); <body> } } }
    *
-   * The length SNAPSHOT bounds the walk (keys added during the body are
-   * not visited — V8's own-keys snapshot, verified against Node) and the
-   * arrayHas guard is the per-visit HasProperty re-check, so holes and keys
-   * removed by the body are skipped exactly like Node. */
+   * The first loop snapshots the PRESENT indices, not merely length: filling
+   * an initial hole during the body must not add a candidate. The second
+   * arrayHas is the live HasProperty re-check, so candidates deleted before
+   * their turn are skipped. */
   function lowerForInArray(L: Lowerer, stmt: ts.ForInStatement, labels: string[] | undefined): IrStmt {
     const loc = locOf(stmt);
     const arrExpr = L.lowerExpr(stmt.expression);
@@ -7237,10 +7240,15 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
     try {
       const arr = L.declareHiddenLocal("%inarr", arrExpr.type);
       const len = L.declareHiddenLocal("%inlen", F64);
+      const keysT = arrayOf(F64);
+      const keys = L.declareHiddenLocal("%inkeys", keysT);
       const i = L.declareHiddenLocal("%ini", F64);
+      const index = L.declareHiddenLocal("%inidx", F64);
       i.mutable = true;
       const arrRef = (): IrExpr => ({ kind: "varRef", localId: arr.id, type: arrExpr.type, loc });
+      const keysRef = (): IrExpr => ({ kind: "varRef", localId: keys.id, type: keysT, loc });
       const iRef = (): IrExpr => ({ kind: "varRef", localId: i.id, type: F64, loc });
+      const indexRef = (): IrExpr => ({ kind: "varRef", localId: index.id, type: F64, loc });
       const liveLen = (): IrExpr => ({
         kind: "arrIntrinsic",
         method: "length",
@@ -7249,7 +7257,7 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         type: F64,
         loc,
       });
-      const keyInit: IrExpr = { kind: "toString", operand: iRef(), type: STRING, loc };
+      const keyInit: IrExpr = { kind: "toString", operand: indexRef(), type: STRING, loc };
 
       // The three binding forms, sharing the per-visit key declaration.
       let keyDecl: IrStmt;
@@ -7305,6 +7313,7 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         body: [
           { kind: "varDecl", localId: arr.id, init: arrExpr, loc },
           { kind: "varDecl", localId: len.id, init: liveLen(), loc },
+          { kind: "varDecl", localId: keys.id, init: { kind: "arrayLit", elems: [], type: keysT, loc }, loc },
           {
             kind: "for",
             init: { kind: "varDecl", localId: i.id, init: { kind: "numLit", value: 0, type: F64, loc }, loc },
@@ -7322,10 +7331,41 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
               value: { kind: "bin", op: "+", left: iRef(), right: { kind: "numLit", value: 1, type: F64, loc }, type: F64, loc },
               loc,
             },
+            body: [{
+              kind: "if",
+              cond: { kind: "arrayHas", arr: arrRef(), index: iRef(), type: BOOL, loc },
+              then: [{
+                kind: "exprStmt",
+                expr: { kind: "arrIntrinsic", method: "push", receiver: keysRef(), args: [iRef()], type: F64, loc },
+                loc,
+              }],
+              else_: null,
+              loc,
+            }],
+            loc,
+          },
+          {
+            kind: "for",
+            init: { kind: "varDecl", localId: i.id, init: { kind: "numLit", value: 0, type: F64, loc }, loc },
+            cond: {
+              kind: "bin",
+              op: "<",
+              left: iRef(),
+              right: { kind: "arrIntrinsic", method: "length", receiver: keysRef(), args: [], type: F64, loc },
+              type: BOOL,
+              loc,
+            },
+            update: {
+              kind: "assign",
+              localId: i.id,
+              value: { kind: "bin", op: "+", left: iRef(), right: { kind: "numLit", value: 1, type: F64, loc }, type: F64, loc },
+              loc,
+            },
             body: [
+              { kind: "varDecl", localId: index.id, init: { kind: "arrayGet", arr: keysRef(), index: iRef(), type: F64, loc }, loc },
               {
                 kind: "if",
-                cond: { kind: "arrayHas", arr: arrRef(), index: iRef(), type: BOOL, loc },
+                cond: { kind: "arrayHas", arr: arrRef(), index: indexRef(), type: BOOL, loc },
                 then: [keyDecl, ...writes, ...body],
                 else_: null,
                 loc,

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -27,6 +27,7 @@ import { UNSUPPORTED, checkerPanicDiag, isCheckerPanic, requiresDynamicDiag } fr
 import { isUnitOnlyTsType, unitOnlyUnion } from "../types.js";
 import { canonicalBuiltinModule, isRelativeSpecifier } from "../shared.js";
 import { probeNodeRequireRefusal } from "../npm.js";
+import { requireArrayGetSafe } from "./array-density.js";
 
 /** `const X = /* @__PURE__ *\/ makeX()` at a module's top level: every
  * declarator initialized by a call (or `new`) carrying the bundler PURE
@@ -996,6 +997,9 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
       )
     ) {
       L.badType(sourceNode, L.typeOf(sourceNode));
+    }
+    if (source.type.kind === "array") {
+      requireArrayGetSafe(L, sourceNode, source.type.elem, decl.initializer!, "stored array value iteration");
     }
     const loc = locOf(decl);
     const indexedSource = L.declareHiddenLocal("%numiterSource", source.type);
@@ -5898,6 +5902,15 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         if (recv?.kind === "array" && (proj === "keys" || proj === "entries")) {
           const container = L.lowerExpr(src.expression.expression);
           if (container.type.kind === "array") {
+            if (proj === "entries") {
+              requireArrayGetSafe(
+                L,
+                src.expression.expression,
+                container.type.elem,
+                stmt.expression,
+                "Array.entries iteration",
+              );
+            }
             return lowerForOfArrayIter(L, stmt, container as IrExpr & { type: IrType & { kind: "array" } }, proj);
           }
         }
@@ -6102,6 +6115,7 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         L.badType(stmt.expression, L.typeOf(stmt.expression));
       }
     }
+    requireArrayGetSafe(L, iterSrc, iterable.type.elem, stmt.expression, "array for-of iteration");
     if (!ts.isVariableDeclarationList(stmt.initializer)) {
       // `for (x of xs)` over a PRE-DECLARED writable binding: JS assigns
       // the existing binding once per pass — one shared binding across

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -51,7 +51,7 @@ import type {
   IrUnionDef,
   SrcLoc,
 } from "../../ir/nodes.js";
-import { arrayOf, BOOL, canAdaptDynFuncTo, canConvertToDyn, canCrossIslandBoundary, canExitIslandToType, canMarshalTypedFuncIntoIsland, DYN, F64, isJsonSafeType, isUndefinedArmedUnion, isUnitType, JSVAL, RUNTIME_ERROR_CLASSES, STRING, typeEquals, UNDEFINED_T, VOID } from "../../ir/nodes.js";
+import { arrayOf, BOOL, canAdaptDynFuncTo, canConvertToDyn, canCrossIslandBoundary, canDynCheckTo, canExitIslandToType, canMarshalTypedFuncIntoIsland, DYN, F64, isJsonSafeType, isUndefinedArmedUnion, isUnitType, JSVAL, RUNTIME_ERROR_CLASSES, STRING, typeEquals, UNDEFINED_T, VOID } from "../../ir/nodes.js";
 import { type DynamicImportResolution, type NpmBuiltinUse, type NpmLazyTrap } from "../npm.js";
 import { provenanceActive } from "../provenance-registry.js";
 import {
@@ -2997,6 +2997,13 @@ export class Lowerer {
     );
   }
 
+  dynCheckable(t: IrType): boolean {
+    const getRecord = (id: string) => this.shapes.get(id);
+    const getUnion = (id: string) => this.unions.get(id);
+    return canDynCheckTo(t, getRecord, getUnion) ||
+      (t.kind === "func" && canAdaptDynFuncTo(t, getRecord, getUnion));
+  }
+
   /** True when a type is a BARE undefined-armed union — the one JSON-unsafe
    * shape whose rejections deserve their own wording: Node's stringify of
    * bare undefined is not a string at all and JSON text never matches the
@@ -3368,23 +3375,7 @@ export class Lowerer {
     // undefined-armed unions of those, bytes<u8>, the %Error root)
     // converts; everything else keeps requireExactShape's SC1100 fence.
     if (expr.type.kind === "dyn" && expected.kind !== "dyn") {
-      const undefArmedOk =
-        expected.kind === "union" &&
-        (this.unions
-          .get(expected.unionId)
-          ?.arms.every((a) => a.kind === "undefinedT" || this.jsonSafe(a)) ??
-          false);
-      const bytesOk = expected.kind === "bytes" && expected.elem === "u8";
-      const errorOk = expected.kind === "object" && expected.className === "%Error";
-      // ADAPTABLE function targets (the checked-dynamic function
-      // boundary's OUT direction — `const wrapped: F = mustCall(fn)`):
-      // check callable-kind, then unwrap an identical boxed signature
-      // directly or adapt through a per-target shim that dynChecks
-      // arguments/results per F.
-      const funcOk =
-        expected.kind === "func" &&
-        canAdaptDynFuncTo(expected, (id) => this.shapes.get(id), (id) => this.unions.get(id));
-      if (this.jsonSafe(expected) || undefArmedOk || bytesOk || errorOk || funcOk) {
+      if (this.dynCheckable(expected)) {
         return { kind: "dynCheck", value: expr, type: expected, loc: expr.loc };
       }
       return expr;
@@ -4698,10 +4689,7 @@ export class Lowerer {
       // mechanical set: a dyn result landing in an adaptable func slot
       // takes dynCheck's per-target shim (coerceToExpected's funcOk rule
       // — the production/development function-choice ternary shape).
-      return (
-        this.jsonSafe(dst) ||
-        (dst.kind === "func" && canAdaptDynFuncTo(dst, (id) => this.shapes.get(id), (id) => this.unions.get(id)))
-      );
+      return this.dynCheckable(dst);
     }
     if (dst.kind === "union") {
       if (src.kind === "union") return this.unionRetagMappable(src.unionId, dst.unionId);

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -23,6 +23,7 @@ import { entryFunctionExports, type EntryExportInfo } from "./frontend/lib-expor
 import { entryContractFacts, type ContractFacts } from "./frontend/lib-contract.js";
 import { moduleLibAsyncSurface, moduleLibNondeterministicSurface, moduleEmbedsBuiltin, moduleEmbedsCompressedNpm, moduleUsesAssert, moduleUsesCopying, moduleUsesDc, moduleUsesDgram, moduleUsesDynAsync, moduleUsesDynInvoke, moduleUsesEmitter, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesInspect, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesQs, moduleUsesRegex, moduleUsesSearchParams, moduleUsesStream, moduleUsesSymbol, moduleUsesTls, moduleUsesTlsCa, moduleUsesZlib, type IrLibSection, type IrModule, type IrRecordShape, type IrType, type SrcLoc } from "./ir/nodes.js";
 import { serializeModule } from "./ir/serialize.js";
+import { markDenseArrayReads } from "./ir/dense-arrays.js";
 import { validateModule } from "./ir/validate.js";
 import { canonicalBuiltinModule, checkPreflight, isNodeTypesPath, loadProgram, locOf, requiresOf, resolveNpmImport, type LoadResult } from "./frontend/program.js";
 import { npmStaticIneligibleReason, npmStaticOffenders, npmStaticPackageOfPath } from "./frontend/npm-static.js";
@@ -740,6 +741,8 @@ export async function compile(entryPath: string, opts: CompileOptions): Promise<
     }
     if (lowered.module === null) return fail(lowered.diagnostics);
 
+    markDenseArrayReads(lowered.module);
+
     const validation = validateModule(lowered.module);
     if (validation.length > 0) {
       return fail(validation.map((v) => iceDiag(v.message, v.loc)));
@@ -1398,6 +1401,7 @@ export async function compileLibrary(opts: CompileLibraryOptions): Promise<Compi
     fe.dispose();
   }
   const mod = lowered.module!;
+  markDenseArrayReads(mod);
 
   const fail = (diagnostics: ScrDiagnostic[]): CompileLibraryResult => ({
     ok: false,

--- a/packages/compiler/src/ir/dense-arrays.ts
+++ b/packages/compiler/src/ir/dense-arrays.ts
@@ -88,7 +88,10 @@ function markFunction(fn: IrFunction): void {
         case "exprStmt": expr(s.expr); break;
         case "arraySet": {
           const id = directCandidate(s.arr);
-          if (id === null) expr(s.arr);
+          // A dynamic index can now grow past length and introduce holes.
+          // Without a range proof, later reads must inspect presence.
+          if (id !== null) invalidate(id);
+          else expr(s.arr);
           expr(s.index);
           expr(s.value);
           break;

--- a/packages/compiler/src/ir/dense-arrays.ts
+++ b/packages/compiler/src/ir/dense-arrays.ts
@@ -1,0 +1,136 @@
+import type { IrExpr, IrFunction, IrModule, IrStmt } from "./nodes.js";
+
+/** Mark reads of local arrays that cannot acquire a hole. This deliberately
+ * rejects aliases and unfamiliar operations: a missed optimization is safe,
+ * while a false positive would turn a required hole trap into a value read. */
+export function markDenseArrayReads(mod: IrModule): void {
+  for (const fn of mod.functions) markFunction(fn);
+}
+
+function markFunction(fn: IrFunction): void {
+  const candidates = new Set(fn.locals.filter((l) => l.type.kind === "array" && !l.boxed).map((l) => l.id));
+  const initialized = new Set<string>();
+  const reads = new Map<string, Extract<IrExpr, { kind: "arrayGet" }>[]>();
+
+  const invalidate = (id: string): void => { candidates.delete(id); };
+  const directCandidate = (e: IrExpr): string | null =>
+    e.kind === "varRef" && candidates.has(e.localId) ? e.localId : null;
+
+  const opaque = (value: unknown): void => {
+    if (Array.isArray(value)) {
+      value.forEach(opaque);
+    } else if (value !== null && typeof value === "object") {
+      const node = value as Record<string, unknown>;
+      if (typeof node.kind === "string" && "type" in node && "loc" in node) {
+        expr(node as IrExpr);
+        return;
+      }
+      if (node.kind === "varRef" && typeof node.localId === "string") {
+        invalidate(node.localId);
+        return;
+      }
+      for (const [key, child] of Object.entries(node)) {
+        if (key !== "kind" && key !== "type" && key !== "loc") opaque(child);
+      }
+    }
+  };
+
+  const expr = (e: IrExpr): void => {
+    if (e.kind === "varRef") {
+      invalidate(e.localId);
+      return;
+    }
+    if (e.kind === "arrayGet") {
+      const id = directCandidate(e.arr);
+      if (id !== null) {
+        const list = reads.get(id) ?? [];
+        list.push(e);
+        reads.set(id, list);
+        opaque(e.index);
+        return;
+      }
+    }
+    if (e.kind === "arrayHas") {
+      const id = directCandidate(e.arr);
+      if (id !== null) {
+        opaque(e.index);
+        return;
+      }
+    }
+    if (e.kind === "arrIntrinsic") {
+      const id = directCandidate(e.receiver);
+      // All intrinsic methods except these two preserve density when their
+      // receiver starts dense. Sparse sources can introduce holes.
+      if (id !== null) {
+        if (e.method === "pushSpread" || e.method === "appendSparse") invalidate(id);
+        e.args.forEach(opaque);
+        return;
+      }
+    }
+    for (const [key, child] of Object.entries(e)) {
+      if (key !== "kind" && key !== "type" && key !== "loc") opaque(child);
+    }
+  };
+
+  const stmts = (body: IrStmt[]): void => {
+    for (const s of body) {
+      switch (s.kind) {
+        case "varDecl":
+          if (candidates.has(s.localId) && s.init?.kind === "arrayLit" && !s.init.holes?.length && !s.init.spreads?.length) {
+            initialized.add(s.localId);
+            s.init.elems.forEach(opaque);
+          } else if (s.init) expr(s.init);
+          break;
+        case "assign":
+          invalidate(s.localId);
+          expr(s.value);
+          break;
+        case "exprStmt": expr(s.expr); break;
+        case "arraySet": {
+          const id = directCandidate(s.arr);
+          if (id === null) expr(s.arr);
+          expr(s.index);
+          expr(s.value);
+          break;
+        }
+        case "arrayDelete": {
+          const id = directCandidate(s.arr);
+          if (id !== null) invalidate(id);
+          else expr(s.arr);
+          expr(s.index);
+          break;
+        }
+        case "arraySetLength": {
+          const id = directCandidate(s.arr);
+          if (id !== null) invalidate(id);
+          else expr(s.arr);
+          expr(s.length);
+          break;
+        }
+        case "if": expr(s.cond); stmts(s.then); if (s.else_) stmts(s.else_); break;
+        case "while": expr(s.cond); stmts(s.body); break;
+        case "doWhile": stmts(s.body); expr(s.cond); break;
+        case "for": if (s.init) stmts([s.init]); if (s.cond) expr(s.cond); if (s.update) stmts([s.update]); stmts(s.body); break;
+        case "switch": expr(s.disc); s.cases.forEach((c) => { if (c.test) expr(c.test); stmts(c.body); }); break;
+        case "forOf": {
+          const id = directCandidate(s.iterable);
+          if (id === null) expr(s.iterable);
+          stmts(s.body);
+          break;
+        }
+        case "block": stmts(s.body); break;
+        case "tryCatch": stmts(s.tryBody); if (s.catchBody) stmts(s.catchBody); if (s.finallyBody) stmts(s.finallyBody); break;
+        case "return": if (s.value) expr(s.value); break;
+        case "throw": expr(s.value); break;
+        default: opaque(s);
+      }
+    }
+  };
+
+  stmts(fn.body);
+  for (const id of candidates) {
+    if (initialized.has(id)) {
+      for (const read of reads.get(id) ?? []) read.dense = true;
+    }
+  }
+}

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -5314,6 +5314,9 @@ export const DYN_CONVERTIBLE_HANDLE_KINDS: ReadonlyMap<string, { tag: string; ta
   ["httpRes", { tag: "SCR_DYNH_HTTP_RES", tagNum: 1, cls: "ServerResponse" }],
   ["netSocket", { tag: "SCR_DYNH_NET_SOCKET", tagNum: 2, cls: "Socket" }],
   ["netServer", { tag: "SCR_DYNH_NET_SERVER", tagNum: 3, cls: "Server" }],
+  ["http2Session", { tag: "SCR_DYNH_H2_SESSION", tagNum: 4, cls: "Http2Session" }],
+  ["http2Stream", { tag: "SCR_DYNH_H2_STREAM", tagNum: 5, cls: "Http2Stream" }],
+  ["httpClientReq", { tag: "SCR_DYNH_HTTP_CLIENT", tagNum: 6, cls: "ClientRequest" }],
 ]);
 
 /** Every runtime handle represented by one stable native pointer. Static

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -1160,6 +1160,10 @@ export type IrStmt =
    * scriptc traps instead, see SEMANTICS.md). Ownership of a refcounted
    * value MOVES into the array; the replaced element is released. */
   | { kind: "arraySet"; arr: IrExpr; index: IrExpr; value: IrExpr; loc: SrcLoc }
+  /** `delete a[i]`: clears presence without changing length. */
+  | { kind: "arrayDelete"; arr: IrExpr; index: IrExpr; loc: SrcLoc }
+  /** `a.length = n`: truncates or grows with holes. */
+  | { kind: "arraySetLength"; arr: IrExpr; length: IrExpr; loc: SrcLoc }
   /** Typed-array element write `b[i] = v` — arraySet's sibling for bytes
    * receivers: statement-only, receiver and index like bytesIntrinsic
    * `get` (any invalid index TRAPS — JS would ignore the write, a
@@ -1285,6 +1289,7 @@ export type IrArrIntrinsicMethod =
   | "length"
   | "push"
   | "pushSpread"
+  | "appendSparse"
   | "pop"
   | "indexOf"
   | "includes"
@@ -1303,6 +1308,7 @@ export type IrArrIntrinsicMethod =
 /** Array intrinsics whose runtime implementation can raise a catchable
  * exception (rather than the static tier's deliberate index traps). */
 export const MAY_THROW_ARR_METHODS: ReadonlySet<IrArrIntrinsicMethod> = new Set([
+  "appendSparse",
   "with",
 ]);
 
@@ -4122,21 +4128,16 @@ export type IrExpr =
    * untouched). Allocates; the result is owned (+1); ownership of
    * refcounted plain elements MOVES into the array, spread sources are
    * BORROWED (their elements copy in retained). */
-  | { kind: "arrayLit"; elems: IrExpr[]; spreads?: number[]; type: IrType; loc: SrcLoc }
-  /** Mapper-less `Array.from({ length: n })` — a length-n array of ABSENT
-   * slots: unions carrying an undefined arm hold the interned undefined
-   * instance (reads are JS-exact), every other refcounted element kind
-   * holds NULL — a slot that MUST be assigned before it is read (the
-   * pMap/allSettled fill-by-index pattern; reads of unassigned slots trap
-   * where Node yields undefined — SEMANTICS.md 46). Scalar elements have
-   * no absent value and are fenced by the frontend. The bound is ToLength
-   * via the `i <= n - 1` loop form (fractions truncate; negative/NaN give
-   * an empty array). Allocates; the result is owned (+1). */
-  | { kind: "arrayNewLen"; length: IrExpr; type: IrType; loc: SrcLoc }
+  | { kind: "arrayLit"; elems: IrExpr[]; spreads?: number[]; holes?: number[]; type: IrType; loc: SrcLoc }
+  /** A length-n sparse array. Every index begins as a hole; packed arrays
+   * remain the default for literals and push-built values. */
+  | { kind: "arrayNewLen"; length: IrExpr; sparse: boolean; type: IrType; loc: SrcLoc }
+  /** Own indexed-property presence (`i in a`), false for holes and OOB. */
+  | { kind: "arrayHas"; arr: IrExpr; index: IrExpr; type: IrType; loc: SrcLoc }
   /** Element read `a[i]`. Index is f64; a non-integer or out-of-bounds index
    * traps at runtime (JS returns undefined — documented divergence). For
    * refcounted elements the result is a fresh owned (+1) reference. */
-  | { kind: "arrayGet"; arr: IrExpr; index: IrExpr; type: IrType; loc: SrcLoc }
+  | { kind: "arrayGet"; arr: IrExpr; index: IrExpr; /** Proven packed local receiver: bypasses the hole check. */ dense?: true; type: IrType; loc: SrcLoc }
   /** Array method/property on an array receiver: `length` (f64), `push`
    * (VARIADIC like JS — zero or more elem-typed args; every argument
    * evaluates before any appends, then each appends in order; returns the

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -5350,7 +5350,7 @@ function canConvertToDynAt(
   // in records/arrays/unions. isJsonSafeType rejects them, but dynFrom
   // needs only that the walker can build the dyn value, so this composite
   // fold extends the JSON-safe core.
-  if (canBoxDynComposite(t, getRecord, getUnion)) return true;
+  if (canBoxDynComposite(t, getRecord, getUnion, next)) return true;
   if (t.kind === "bytes" && t.elem === "u8") return true;
   // %Error converts as the checked-dynamic tree's error encoding ({%error, name, message,
   // code?} — the caughtToDyn shape, scr_dyn_from_error): the dyn 'error'
@@ -5408,7 +5408,7 @@ function canBoxDynComposite(
     case "bytes":
       return t.elem === "u8";
     case "func":
-      return canBoxFuncIntoDyn(t, getRecord, getUnion);
+      return canBoxFuncIntoDynAt(t, getRecord, getUnion, visiting);
     case "array":
       return canBoxDynComposite(t.elem, getRecord, getUnion, visiting);
     case "record": {

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -1155,10 +1155,10 @@ export type IrStmt =
       labels?: string[];
       loc: SrcLoc;
     }
-  /** Element write `a[i] = v` — statement-only, like `assign`. Valid indices
-   * are [0, length]; i == length appends (JS would create a hole past that —
-   * scriptc traps instead, see SEMANTICS.md). Ownership of a refcounted
-   * value MOVES into the array; the replaced element is released. */
+  /** Element write `a[i] = v` — statement-only, like `assign`. Valid array
+   * indices are [0, 2^32-2]; writes at or beyond length grow through i + 1
+   * and leave intermediate holes. Ownership of a refcounted value MOVES
+   * into the array; the replaced element is released. */
   | { kind: "arraySet"; arr: IrExpr; index: IrExpr; value: IrExpr; loc: SrcLoc }
   /** `delete a[i]`: clears presence without changing length. */
   | { kind: "arrayDelete"; arr: IrExpr; index: IrExpr; loc: SrcLoc }

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -5308,25 +5308,42 @@ export function canMarshalTypedFuncIntoIsland(
  * crossing); other handle kinds keep the honest cannot-box fence. Each
  * entry carries the runtime tag spelling and the class display name
  * (dynCheck's "expected IncomingMessage ..." texts). */
-export const DYN_HANDLE_KINDS: ReadonlyMap<string, { tag: string; cls: string }> = new Map([
-  ["httpReq", { tag: "SCR_DYNH_HTTP_REQ", cls: "IncomingMessage" }],
-  ["httpRes", { tag: "SCR_DYNH_HTTP_RES", cls: "ServerResponse" }],
-  ["netSocket", { tag: "SCR_DYNH_NET_SOCKET", cls: "Socket" }],
-  ["netServer", { tag: "SCR_DYNH_NET_SERVER", cls: "Server" }],
-  ["http2Session", { tag: "SCR_DYNH_H2_SESSION", cls: "Http2Session" }],
-  ["http2Stream", { tag: "SCR_DYNH_H2_STREAM", cls: "Http2Stream" }],
-  ["httpClientReq", { tag: "SCR_DYNH_HTTP_CLIENT", cls: "ClientRequest" }],
+/** Runtime handles whose dyn box/unbox ABI is complete in both C and LLVM. */
+export const DYN_CONVERTIBLE_HANDLE_KINDS: ReadonlyMap<string, { tag: string; tagNum: number; cls: string }> = new Map([
+  ["httpReq", { tag: "SCR_DYNH_HTTP_REQ", tagNum: 0, cls: "IncomingMessage" }],
+  ["httpRes", { tag: "SCR_DYNH_HTTP_RES", tagNum: 1, cls: "ServerResponse" }],
+  ["netSocket", { tag: "SCR_DYNH_NET_SOCKET", tagNum: 2, cls: "Socket" }],
+  ["netServer", { tag: "SCR_DYNH_NET_SERVER", tagNum: 3, cls: "Server" }],
+]);
+
+/** Every runtime handle represented by one stable native pointer. Static
+ * same-type ===/!== is valid independently of dyn conversion support. */
+export const RUNTIME_HANDLE_IDENTITY_KINDS: ReadonlySet<string> = new Set([
+  "child", "childStream", "dgramSocket", "fsWatcher", "secureCtx", "testCtx",
+  "netServer", "netSocket", "httpReq", "httpRes", "httpClientReq", "http2Session", "http2Stream",
 ]);
 
 /** A static type that CONVERTS into a dyn value — the dynFrom domain:
  * JSON-safe data, bytes<u8> (payload copied), undefined-armed unions of
  * JSON-safe arms, boxable function types, and the runtime HANDLE kinds
- * (boxed by reference — DYN_HANDLE_KINDS). */
+ * (boxed by reference — DYN_CONVERTIBLE_HANDLE_KINDS). */
 export function canConvertToDyn(
   t: IrType,
   getRecord: (shapeId: string) => IrRecordShape | undefined,
   getUnion: (unionId: string) => IrUnionDef | undefined,
 ): boolean {
+  return canConvertToDynAt(t, getRecord, getUnion, new Set());
+}
+
+function canConvertToDynAt(
+  t: IrType,
+  getRecord: (shapeId: string) => IrRecordShape | undefined,
+  getUnion: (unionId: string) => IrUnionDef | undefined,
+  visiting: Set<string>,
+): boolean {
+  const visitKey = `convert:${typeKey(t)}`;
+  if (visiting.has(visitKey)) return true;
+  const next = new Set(visiting).add(visitKey);
   if (isJsonSafeType(t, getRecord, getUnion)) return true;
   // bytes<u8> and boxable functions are dyn kinds the walker boxes
   // ANYWHERE (bytes copied, functions held by identity), including nested
@@ -5339,8 +5356,8 @@ export function canConvertToDyn(
   // code?} — the caughtToDyn shape, scr_dyn_from_error): the dyn 'error'
   // listener boundary (a mustCall-wrapped handler receiving the payload).
   if (t.kind === "object" && t.className === "%Error") return true;
-  if (t.kind === "func") return canBoxFuncIntoDyn(t, getRecord, getUnion);
-  if (DYN_HANDLE_KINDS.has(t.kind)) return true;
+  if (t.kind === "func") return canBoxFuncIntoDynAt(t, getRecord, getUnion, next);
+  if (DYN_CONVERTIBLE_HANDLE_KINDS.has(t.kind)) return true;
   // Promises box by REFERENCE (SCR_DYN_PROMISE): promise<dyn> carries its
   // ScrPromise directly (the payload is already a dyn value), any other
   // convertible-or-void inner boxes an ADAPTER promise whose emitted
@@ -5351,7 +5368,7 @@ export function canConvertToDyn(
     return (
       t.inner.kind === "dyn" ||
       t.inner.kind === "void" ||
-      canConvertToDyn(t.inner, getRecord, getUnion)
+      canConvertToDynAt(t.inner, getRecord, getUnion, next)
     );
   }
   if (t.kind === "union") {
@@ -5362,7 +5379,7 @@ export function canConvertToDyn(
     // boundary exactly like a bare func dynFrom).
     return !!def && def.arms.every((a) =>
       a.kind === "undefinedT" || isJsonSafeType(a, getRecord, getUnion) ||
-      (a.kind === "func" && canBoxFuncIntoDyn(a, getRecord, getUnion)),
+      (a.kind === "func" && canBoxFuncIntoDynAt(a, getRecord, getUnion, next)),
     );
   }
   return false;
@@ -5419,22 +5436,95 @@ function canBoxDynComposite(
  * JSON-safe data, bytes<u8> (a fresh copy out), the %Error extraction,
  * undefined-armed unions of JSON-safe arms, adaptable function types,
  * and the runtime HANDLE kinds (a tag-checked reference unwrap —
- * DYN_HANDLE_KINDS). */
+ * DYN_CONVERTIBLE_HANDLE_KINDS). */
 export function canDynCheckTo(
   t: IrType,
   getRecord: (shapeId: string) => IrRecordShape | undefined,
   getUnion: (unionId: string) => IrUnionDef | undefined,
 ): boolean {
-  if (isJsonSafeType(t, getRecord, getUnion)) return true;
-  if (t.kind === "bytes" && t.elem === "u8") return true;
-  if (t.kind === "object" && t.className === "%Error") return true;
-  if (t.kind === "func") return canAdaptDynFuncTo(t, getRecord, getUnion);
-  if (DYN_HANDLE_KINDS.has(t.kind)) return true;
-  if (t.kind === "union") {
-    const def = getUnion(t.unionId);
-    return !!def && def.arms.every((a) => a.kind === "undefinedT" || isJsonSafeType(a, getRecord, getUnion));
+  return canDynCheckAt(t, getRecord, getUnion, new Set(), false);
+}
+
+function canDynCheckAt(
+  t: IrType,
+  getRecord: (shapeId: string) => IrRecordShape | undefined,
+  getUnion: (unionId: string) => IrUnionDef | undefined,
+  visiting: Set<string>,
+  requireMatch: boolean,
+): boolean {
+  switch (t.kind) {
+    case "f64":
+    case "string":
+    case "bool":
+    case "dyn":
+      return true;
+    // Unit builders exist only in the union builder. Bare unit targets
+    // would reach dynCheckHelper's unsupported default.
+    case "undefinedT":
+    case "nullT":
+      return false;
+    case "bytes":
+      return t.elem === "u8";
+    case "object":
+      return !requireMatch && t.className === "%Error";
+    case "func": {
+      const key = `func:${typeKey(t)}`;
+      if (visiting.has(key)) return true;
+      return canAdaptDynFuncAt(t, getRecord, getUnion, new Set(visiting).add(key));
+    }
+    case "array": {
+      if (!canAllocateDynCheckArrayElem(t.elem)) return false;
+      const key = `array:${typeKey(t)}:${requireMatch}`;
+      if (visiting.has(key)) return true;
+      const next = new Set(visiting).add(key);
+      return canDynCheckAt(t.elem, getRecord, getUnion, next, requireMatch);
+    }
+    case "record": {
+      const shape = getRecord(t.shapeId);
+      if (!shape) return false;
+      const key = `record:${t.shapeId}:${requireMatch}`;
+      if (visiting.has(key)) return true;
+      const next = new Set(visiting).add(key);
+      return shape.fields.every((f) => canDynCheckAt(f.type, getRecord, getUnion, next, requireMatch)) &&
+        (!shape.indexValue || canDynCheckAt(shape.indexValue, getRecord, getUnion, next, requireMatch));
+    }
+    case "union": {
+      const def = getUnion(t.unionId);
+      if (!def) return false;
+      const key = `union:${t.unionId}`;
+      if (visiting.has(key)) return true;
+      const next = new Set(visiting).add(key);
+      return def.arms.every((a) =>
+        a.kind === "undefinedT" || a.kind === "nullT" ||
+        canDynCheckAt(a, getRecord, getUnion, next, true)
+      );
+    }
+    default:
+      return !requireMatch && DYN_CONVERTIBLE_HANDLE_KINDS.has(t.kind);
   }
-  return false;
+}
+
+/** Element representations accepted by BOTH arrNewC and arrNewCall for a
+ * dynCheck-built static array. The recursive predicate separately verifies
+ * that the element itself has a builder (and, when needed, a matcher). */
+function canAllocateDynCheckArrayElem(t: IrType): boolean {
+  switch (t.kind) {
+    case "f64":
+    case "bool":
+    case "string":
+    case "array":
+    case "bytes":
+    case "record":
+    case "object":
+    case "union":
+    case "func":
+    // The one runtime-handle kind represented by both backends' REF-array
+    // allocation tables. Other handles remain directly extractable only.
+    case "netServer":
+      return true;
+    default:
+      return false;
+  }
 }
 
 /** A closure type that can BOX into the checked-dynamic tree's function kind (dynFrom):
@@ -5446,17 +5536,28 @@ export function canBoxFuncIntoDyn(
   getRecord: (shapeId: string) => IrRecordShape | undefined,
   getUnion: (unionId: string) => IrUnionDef | undefined,
 ): boolean {
+  return canBoxFuncIntoDynAt(t, getRecord, getUnion, new Set());
+}
+
+function canBoxFuncIntoDynAt(
+  t: IrType,
+  getRecord: (shapeId: string) => IrRecordShape | undefined,
+  getUnion: (unionId: string) => IrUnionDef | undefined,
+  visiting: Set<string>,
+): boolean {
   return (
     t.kind === "func" &&
     // A jsval (island) param converts through scr_jsval_from_dyn in the
     // thunk (wrapped cells unwrap by reference, dyn data deep-copies) —
     // the checker-'any' callback params of the routed-dispatch lane
     // (`bag.list.map((x) => ...)` with x typed any).
-    t.params.every((p) => p.kind === "dyn" || p.kind === "jsval" || canDynCheckTo(p, getRecord, getUnion)) &&
+    t.params.every((p) => p.kind === "dyn" || p.kind === "jsval" ||
+      canDynCheckAt(p, getRecord, getUnion, visiting, false)) &&
     // A jsval return converts through the by-reference wrap
     // (dynFromJsval — the thunk's result conversion), so engine-returning
     // callbacks box too: the routed-dispatch lane's flatMap shape.
-    (t.ret.kind === "void" || t.ret.kind === "dyn" || t.ret.kind === "jsval" || canConvertToDyn(t.ret, getRecord, getUnion))
+    (t.ret.kind === "void" || t.ret.kind === "dyn" || t.ret.kind === "jsval" ||
+      canConvertToDynAt(t.ret, getRecord, getUnion, visiting))
   );
 }
 
@@ -5469,14 +5570,24 @@ export function canAdaptDynFuncTo(
   getRecord: (shapeId: string) => IrRecordShape | undefined,
   getUnion: (unionId: string) => IrUnionDef | undefined,
 ): boolean {
+  return canAdaptDynFuncAt(t, getRecord, getUnion, new Set());
+}
+
+function canAdaptDynFuncAt(
+  t: IrType,
+  getRecord: (shapeId: string) => IrRecordShape | undefined,
+  getUnion: (unionId: string) => IrUnionDef | undefined,
+  visiting: Set<string>,
+): boolean {
   return (
     t.kind === "func" &&
     // A variadic (rest-marked) target would need the trailing rest-array
     // param synthesized by the adapter — no adapter models that; variadic
     // values live boxed and are called through their own thunks.
     t.rest !== true &&
-    t.params.every((p) => p.kind === "dyn" || canConvertToDyn(p, getRecord, getUnion)) &&
-    (t.ret.kind === "void" || t.ret.kind === "dyn" || canDynCheckTo(t.ret, getRecord, getUnion))
+    t.params.every((p) => p.kind === "dyn" || canConvertToDynAt(p, getRecord, getUnion, visiting)) &&
+    (t.ret.kind === "void" || t.ret.kind === "dyn" ||
+      canDynCheckAt(t.ret, getRecord, getUnion, visiting, false))
   );
 }
 
@@ -6768,6 +6879,8 @@ export const MAY_THROW_LIB_FNS: ReadonlySet<IrLibFn> = new Set([
   "dyn.cloneTransferFail",
   // the dyn Object walks throw on null/undefined receivers
   "dyn.objKeys",
+  // HasProperty on an engine-held Proxy can throw through its `has` trap.
+  "dyn.hasKey",
   "dyn.hasOwn",
   "dyn.assign",
   // variadic Object.assign: spread flattening throws V8's spread-call

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -18,7 +18,7 @@ import type {
   IrUnionDef,
   SrcLoc,
 } from "./nodes.js";
-import { arrayOf, BOOL, BYTES_U8, bytesOf, canAdaptDynFuncTo, canConvertToDyn, canExitIslandToType, canMarshalIntoIsland, canMarshalTypedFuncIntoIsland, CHILD_T, CHILDSTREAM_T, DGRAMSOCK_T, DYN, DYN_HANDLE_KINDS, F64, FSWATCHER_T, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, islandPromisePayloadTag, isJsonSafeType, isRefCounted, isSupportedIndexValue, isSupportedMapKey, isSupportedMapValue, isSupportedSetElem, isUnitType, jsOpResultKind, JSVAL, NETSERVER_T, NETSOCKET_T, PROCSTREAM_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, SEARCH_PARAMS_T, SECURECTX_T, SPAWNRES_T, STATS_T, STRING, SYMBOL_T, TESTCTX_T, typeEquals, typeKey, unionFuncSetArmsOk, URL_T, VOID } from "./nodes.js";
+import { arrayOf, BOOL, BYTES_U8, bytesOf, canAdaptDynFuncTo, canConvertToDyn, canExitIslandToType, canMarshalIntoIsland, canMarshalTypedFuncIntoIsland, CHILD_T, CHILDSTREAM_T, DGRAMSOCK_T, DYN, DYN_HANDLE_KINDS, F64, FSWATCHER_T, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, islandPromisePayloadTag, isJsonSafeType, isSupportedIndexValue, isSupportedMapKey, isSupportedMapValue, isSupportedSetElem, isUnitType, jsOpResultKind, JSVAL, NETSERVER_T, NETSOCKET_T, PROCSTREAM_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, SEARCH_PARAMS_T, SECURECTX_T, SPAWNRES_T, STATS_T, STRING, SYMBOL_T, TESTCTX_T, typeEquals, typeKey, unionFuncSetArmsOk, URL_T, VOID } from "./nodes.js";
 
 /** Per-method signature for strIntrinsic: `argTypes` lists every argument
  * position (optional ones included); `minArgs` is how many may be omitted
@@ -2147,9 +2147,15 @@ function validateFunction(
         }
         const elem = e.type.elem;
         const spreadSet = new Set(e.spreads ?? []);
+        const holeSet = new Set(e.holes ?? []);
         for (const i of spreadSet) {
           if (!Number.isInteger(i) || i < 0 || i >= e.elems.length) {
             err(`arrayLit spread index ${i} out of range`, e.loc);
+          }
+        }
+        for (const i of holeSet) {
+          if (!Number.isInteger(i) || i < 0 || i >= e.elems.length || spreadSet.has(i)) {
+            err(`arrayLit hole index ${i} invalid`, e.loc);
           }
         }
         e.elems.forEach((el, i) => {
@@ -2161,17 +2167,20 @@ function validateFunction(
         break;
       }
       case "arrayNewLen": {
-        // Mapper-less Array.from({length: n}): absent-slot fill exists
-        // only for refcounted element kinds (frontend fences scalars).
         if (e.type.kind !== "array") {
           err(`arrayNewLen must be array-typed, got ${e.type.kind}`, e.loc);
           break;
         }
-        if (!isRefCounted(e.type.elem)) {
-          err(`arrayNewLen with non-refcounted ${e.type.elem.kind} elements (no absent value)`, e.loc);
-        }
         checkExpr(e.length);
         expectType(e.length, F64, "arrayNewLen length");
+        break;
+      }
+      case "arrayHas": {
+        checkExpr(e.arr);
+        checkExpr(e.index);
+        if (e.arr.type.kind !== "array") err(`arrayHas on non-array ${e.arr.type.kind}`, e.loc);
+        expectType(e.index, F64, "arrayHas index");
+        expectType(e, BOOL, "arrayHas result");
         break;
       }
       case "arrayGet": {
@@ -2335,7 +2344,7 @@ function validateFunction(
         const sig =
           e.method === "push"
             ? { argTypes: e.args.map(() => elem), result: F64 }
-            : e.method === "pushSpread"
+            : e.method === "pushSpread" || e.method === "appendSparse"
               ? { argTypes: [e.receiver.type], result: F64 }
               : e.method === "pop"
               ? { argTypes: [], result: elem }
@@ -4979,6 +4988,20 @@ function validateFunction(
         } else {
           expectType(s.value, s.arr.type.elem, "arraySet value");
         }
+        break;
+      }
+      case "arrayDelete": {
+        checkExpr(s.arr);
+        checkExpr(s.index);
+        if (s.arr.type.kind !== "array") err(`arrayDelete on non-array ${s.arr.type.kind}`, s.loc);
+        expectType(s.index, F64, "arrayDelete index");
+        break;
+      }
+      case "arraySetLength": {
+        checkExpr(s.arr);
+        checkExpr(s.length);
+        if (s.arr.type.kind !== "array") err(`arraySetLength on non-array ${s.arr.type.kind}`, s.loc);
+        expectType(s.length, F64, "arraySetLength value");
         break;
       }
       case "bytesSet": {

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -18,7 +18,7 @@ import type {
   IrUnionDef,
   SrcLoc,
 } from "./nodes.js";
-import { arrayOf, BOOL, BYTES_U8, bytesOf, canAdaptDynFuncTo, canConvertToDyn, canExitIslandToType, canMarshalIntoIsland, canMarshalTypedFuncIntoIsland, CHILD_T, CHILDSTREAM_T, DGRAMSOCK_T, DYN, DYN_HANDLE_KINDS, F64, FSWATCHER_T, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, islandPromisePayloadTag, isJsonSafeType, isSupportedIndexValue, isSupportedMapKey, isSupportedMapValue, isSupportedSetElem, isUnitType, jsOpResultKind, JSVAL, NETSERVER_T, NETSOCKET_T, PROCSTREAM_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, SEARCH_PARAMS_T, SECURECTX_T, SPAWNRES_T, STATS_T, STRING, SYMBOL_T, TESTCTX_T, typeEquals, typeKey, unionFuncSetArmsOk, URL_T, VOID } from "./nodes.js";
+import { arrayOf, BOOL, BYTES_U8, bytesOf, canConvertToDyn, canDynCheckTo, canExitIslandToType, canMarshalIntoIsland, canMarshalTypedFuncIntoIsland, CHILD_T, CHILDSTREAM_T, DGRAMSOCK_T, DYN, F64, FSWATCHER_T, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, islandPromisePayloadTag, isJsonSafeType, isSupportedIndexValue, isSupportedMapKey, isSupportedMapValue, isSupportedSetElem, isUnitType, jsOpResultKind, JSVAL, NETSERVER_T, NETSOCKET_T, PROCSTREAM_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_HANDLE_IDENTITY_KINDS, RUNTIME_STREAM_CLASSES, SEARCH_PARAMS_T, SECURECTX_T, SPAWNRES_T, STATS_T, STRING, SYMBOL_T, TESTCTX_T, typeEquals, typeKey, unionFuncSetArmsOk, URL_T, VOID } from "./nodes.js";
 
 /** Per-method signature for strIntrinsic: `argTypes` lists every argument
  * position (optional ones included); `minArgs` is how many may be omitted
@@ -1709,7 +1709,7 @@ function validateFunction(
             e.left.type.kind === "promise" ||
             // Runtime handles are objects to === (one handle per socket/
             // request — pointer identity is JS's object equality).
-            DYN_HANDLE_KINDS.has(e.left.type.kind))
+            RUNTIME_HANDLE_IDENTITY_KINDS.has(e.left.type.kind))
         ) {
           // Reference identity: both operands must be the same ref type.
           if (!typeEquals(e.left.type, e.right.type)) {
@@ -4524,32 +4524,8 @@ function validateFunction(
       case "dynCheck": {
         checkExpr(e.value);
         expectType(e.value, DYN, "dynCheck operand");
-        // The target drives the emitted validator/builder: non-dyn,
-        // non-void, JSON-representable (closures/class instances can never
-        // be found inside a JSON dyn — the frontend rejects those casts).
-        // Bare undefined-armed unions of JSON-safe arms are additionally
-        // valid: the checked-dynamic tree holds a first-class undefined value (overflow
-        // reads), which matches exactly the undefined arm.
-        const jsonOk = (t: IrType): boolean =>
-          isJsonSafeType(t, (id) => records.get(id), (id) => unions.get(id));
-        const undefArmedOk =
-          e.type.kind === "union" &&
-          (unions.get(e.type.unionId)?.arms.every((a) => a.kind === "undefinedT" || jsonOk(a)) ??
-            false);
-        // bytes<u8> targets extract the checked-dynamic tree's bytes kind (a copy).
-        const bytesOk = e.type.kind === "bytes" && e.type.elem === "u8";
-        // The %Error root extracts the checked-dynamic tree's error encoding (the "%error"
-        // marker object caughtToDyn builds) as a fresh runtime error.
-        const errorOk = e.type.kind === "object" && e.type.className === "%Error";
-        // ADAPTABLE function targets unwrap or wrap the checked-dynamic tree's function
-        // kind (the checked-dynamic function boundary, nodes.ts).
-        const funcOk =
-          e.type.kind === "func" &&
-          canAdaptDynFuncTo(e.type, (id) => records.get(id), (id) => unions.get(id));
-        // Runtime HANDLE targets unwrap the checked-dynamic tree's handle kind by tag (a
-        // retained reference, no copy — DYN_HANDLE_KINDS).
-        const handleOk = DYN_HANDLE_KINDS.has(e.type.kind);
-        if (!jsonOk(e.type) && !undefArmedOk && !bytesOk && !errorOk && !funcOk && !handleOk) {
+        const dynCheckOk = canDynCheckTo(e.type, (id) => records.get(id), (id) => unions.get(id));
+        if (!dynCheckOk) {
           err(`dynCheck against non-JSON-representable type ${e.type.kind}`, e.loc);
         }
         break;

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -698,7 +698,7 @@ function globalEffectsOf(mod: IrModule): GlobalEffects {
 
 const STMT_KINDS = new Set([
   "varDecl", "assign", "exprStmt", "if", "while", "doWhile", "switch", "for",
-  "arraySet", "bytesSet", "forOf", "return", "fieldSet", "recordSet",
+  "arraySet", "arrayDelete", "arraySetLength", "bytesSet", "forOf", "return", "fieldSet", "recordSet",
   "recordKeySet", "recordKeyDelete", "break", "continue", "block", "throw",
   "runtimeFence", "rethrow", "tryCatch",
 ]);
@@ -892,6 +892,16 @@ class FnAnalyzer {
         this.evalExpr(s.arr, env);
         this.evalExpr(s.index, env);
         this.evalExpr(s.value, env);
+        clearPathFacts(env);
+        return env;
+      case "arrayDelete":
+        this.evalExpr(s.arr, env);
+        this.evalExpr(s.index, env);
+        clearPathFacts(env);
+        return env;
+      case "arraySetLength":
+        this.evalExpr(s.arr, env);
+        this.evalExpr(s.length, env);
         clearPathFacts(env);
         return env;
       case "fieldSet":

--- a/packages/compiler/test/dyncheck-eligibility.test.ts
+++ b/packages/compiler/test/dyncheck-eligibility.test.ts
@@ -4,7 +4,7 @@ import { join } from "node:path";
 import { expect, test } from "vitest";
 import { analyze } from "../src/index.js";
 
-test("frontend preserves static handle identity while rejecting unsupported dyn handles", () => {
+test("frontend preserves static handle identity while rejecting unsupported dyn handle arrays", () => {
   const dir = mkdtempSync(join(tmpdir(), "scriptc-dyncheck-"));
   const file = join(dir, "main.ts");
   writeFileSync(file, `
@@ -34,9 +34,6 @@ console.log(cloned, staticClient === staticClient, staticSession === staticSessi
     "SC1090: a checked cast of 'unknown' to 'number | IncomingMessage' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
     "SC2009: values of type 'IncomingMessage[]' cannot be compiled: the array shape is supported, but 'IncomingMessage' elements have no array representation yet",
     "SC1090: a checked cast of 'unknown' to 'Http2Session[]' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
-    "SC1090: a checked cast of 'unknown' to 'Http2Session' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
-    "SC1090: a checked cast of 'unknown' to 'Http2Stream' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
-    "SC1090: a checked cast of 'unknown' to 'ClientRequest' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
   ]);
 
   const identityFile = join(dir, "identity.ts");

--- a/packages/compiler/test/dyncheck-eligibility.test.ts
+++ b/packages/compiler/test/dyncheck-eligibility.test.ts
@@ -1,0 +1,71 @@
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { analyze } from "../src/index.js";
+
+test("frontend preserves static handle identity while rejecting unsupported dyn handles", () => {
+  const dir = mkdtempSync(join(tmpdir(), "scriptc-dyncheck-"));
+  const file = join(dir, "main.ts");
+  writeFileSync(file, `
+import { request as httpRequest } from "node:http";
+import type { ClientRequest, IncomingMessage } from "node:http";
+import { connect as http2Connect } from "node:http2";
+import type { ClientHttp2Session, ClientHttp2Stream } from "node:http2";
+const value: unknown = JSON.parse("1");
+const errorOrNumber = value as Error | number;
+const requestOrNumber = value as IncomingMessage | number;
+const requests = value as IncomingMessage[];
+const sessions = value as ClientHttp2Session[];
+const session = value as ClientHttp2Session;
+const stream = value as ClientHttp2Stream;
+const client = value as ClientRequest;
+const cloned: undefined = structuredClone(undefined);
+const staticClient = httpRequest("http://127.0.0.1/");
+const staticSession = http2Connect("http://127.0.0.1/");
+const staticStream = staticSession.request();
+console.log(cloned, staticClient === staticClient, staticSession === staticSession, staticStream !== staticStream);
+`);
+
+  const diagnostics = analyze(file).coverage.diagnostics;
+  expect(diagnostics.map((d) => `${d.code}: ${d.message}`)).toEqual([
+    "SC2009: values of type 'IncomingMessage[]' cannot be compiled: the array shape is supported, but 'IncomingMessage' elements have no array representation yet",
+    "SC1090: a checked cast of 'unknown' to 'number | Error' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
+    "SC1090: a checked cast of 'unknown' to 'number | IncomingMessage' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
+    "SC2009: values of type 'IncomingMessage[]' cannot be compiled: the array shape is supported, but 'IncomingMessage' elements have no array representation yet",
+    "SC1090: a checked cast of 'unknown' to 'Http2Session[]' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
+    "SC1090: a checked cast of 'unknown' to 'Http2Session' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
+    "SC1090: a checked cast of 'unknown' to 'Http2Stream' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
+    "SC1090: a checked cast of 'unknown' to 'ClientRequest' (a dynamic value can only be validated against JSON-representable types: number, string, boolean, records, arrays, and unions of those) is not supported yet",
+  ]);
+
+  const identityFile = join(dir, "identity.ts");
+  writeFileSync(identityFile, `
+import { spawn } from "node:child_process";
+import { createSocket } from "node:dgram";
+import { watch } from "node:fs";
+import test from "node:test";
+const child = spawn("true", [], { stdio: ["ignore", "pipe", "pipe"] });
+const socket = createSocket("udp4");
+const watcher = watch(".");
+console.log(child === child, socket === socket, watcher !== watcher);
+if (child.stdout) console.log(child.stdout === child.stdout);
+test("identity", (t) => console.log(t === t));
+`);
+  const identityDiagnostics = analyze(identityFile).coverage.diagnostics;
+  expect(identityDiagnostics.map((d) => `${d.code}: ${d.message}`)).toEqual([]);
+
+  const excludedSources = [
+    `console.log(process.stdout === process.stdout);`,
+    `import { statSync } from "node:fs"; const value = statSync("."); console.log(value === value);`,
+    `import { spawnSync } from "node:child_process"; const value = spawnSync("true"); console.log(value === value);`,
+  ];
+  for (const [i, source] of excludedSources.entries()) {
+    const excludedFile = join(dir, `excluded-${i}.ts`);
+    writeFileSync(excludedFile, source);
+    const excludedDiagnostics = analyze(excludedFile).coverage.diagnostics;
+    expect(excludedDiagnostics.map((d) => `${d.code}: ${d.message}`)).toEqual([
+      "SC1043: comparing non-number, non-string values are not supported yet",
+    ]);
+  }
+});

--- a/packages/compiler/test/ir.test.ts
+++ b/packages/compiler/test/ir.test.ts
@@ -2,7 +2,8 @@ import { expect, test } from "vitest";
 import { validateModule } from "../src/ir/validate.js";
 import { deserializeModule, serializeModule } from "../src/ir/serialize.js";
 import { fibModule } from "./fixtures/fib-ir.js";
-import { BOOL, F64, type IrModule } from "../src/ir/nodes.js";
+import { arrayOf, BOOL, F64, type IrModule } from "../src/ir/nodes.js";
+import { markDenseArrayReads } from "../src/ir/dense-arrays.js";
 
 test("hand-built fib module validates", () => {
   expect(validateModule(fibModule)).toEqual([]);
@@ -79,4 +80,30 @@ test("serializer round-trips ±Infinity and refuses NaN", () => {
 test("deserializer enforces IR version", () => {
   const json = serializeModule(fibModule).replace('"irVersion": 3', '"irVersion": 99');
   expect(() => deserializeModule(json)).toThrow(/version mismatch/);
+});
+
+test("dense-array pass bypasses hole checks only for untouched packed locals", () => {
+  const loc = { file: "t.ts", start: 0, end: 0 };
+  const arr = arrayOf(F64);
+  const get = (id: string) => ({ kind: "arrayGet" as const, arr: { kind: "varRef" as const, localId: id, type: arr, loc }, index: { kind: "numLit" as const, value: 0, type: F64, loc }, type: F64, loc });
+  const mod: IrModule = {
+    irVersion: 3,
+    sourceFile: "t.ts",
+    entry: "dense",
+    functions: [
+      {
+        name: "dense", params: [], returnType: F64, locals: [{ id: "a.0", name: "a", type: arr, mutable: false }], loc,
+        body: [{ kind: "varDecl", localId: "a.0", init: { kind: "arrayLit", elems: [{ kind: "numLit", value: 1, type: F64, loc }], type: arr, loc }, loc }, { kind: "return", value: get("a.0"), loc }],
+      },
+      {
+        name: "holey", params: [], returnType: F64, locals: [{ id: "a.0", name: "a", type: arr, mutable: false }], loc,
+        body: [{ kind: "varDecl", localId: "a.0", init: { kind: "arrayLit", elems: [{ kind: "numLit", value: 1, type: F64, loc }], type: arr, loc }, loc }, { kind: "arrayDelete", arr: { kind: "varRef", localId: "a.0", type: arr, loc }, index: { kind: "numLit", value: 0, type: F64, loc }, loc }, { kind: "return", value: get("a.0"), loc }],
+      },
+    ],
+  };
+  markDenseArrayReads(mod);
+  const dense = mod.functions[0]!.body[1]!;
+  const holey = mod.functions[1]!.body[2]!;
+  expect(dense.kind === "return" && dense.value?.kind === "arrayGet" && dense.value.dense).toBe(true);
+  expect(holey.kind === "return" && holey.value?.kind === "arrayGet" && holey.value.dense).toBeFalsy();
 });

--- a/packages/compiler/test/ir.test.ts
+++ b/packages/compiler/test/ir.test.ts
@@ -101,9 +101,9 @@ test("dynCheck eligibility matches recursive builders and union matchers", () =>
   expect(can(HTTPRES_T)).toBe(true);
   expect(can(NETSOCKET_T)).toBe(true);
   expect(can(NETSERVER_T)).toBe(true);
-  expect(can(HTTP2SESSION_T)).toBe(false);
-  expect(can(HTTP2STREAM_T)).toBe(false);
-  expect(can(HTTPCLIENTREQ_T)).toBe(false);
+  expect(can(HTTP2SESSION_T)).toBe(true);
+  expect(can(HTTP2STREAM_T)).toBe(true);
+  expect(can(HTTPCLIENTREQ_T)).toBe(true);
   expect(can(arrayOf(errorT))).toBe(true);
   expect(can(arrayOf(functionUnion))).toBe(true);
   expect(can(arrayOf({ kind: "bytes", elem: "u8" }))).toBe(true);

--- a/packages/compiler/test/ir.test.ts
+++ b/packages/compiler/test/ir.test.ts
@@ -2,7 +2,7 @@ import { expect, test } from "vitest";
 import { validateModule } from "../src/ir/validate.js";
 import { deserializeModule, serializeModule } from "../src/ir/serialize.js";
 import { fibModule } from "./fixtures/fib-ir.js";
-import { arrayOf, BOOL, F64, type IrModule } from "../src/ir/nodes.js";
+import { arrayOf, BOOL, canDynCheckTo, F64, funcOf, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, NETSERVER_T, NETSOCKET_T, NULL_T, RUNTIME_HANDLE_IDENTITY_KINDS, UNDEFINED_T, type IrModule, type IrRecordShape, type IrType, type IrUnionDef } from "../src/ir/nodes.js";
 import { markDenseArrayReads } from "../src/ir/dense-arrays.js";
 
 test("hand-built fib module validates", () => {
@@ -12,6 +12,115 @@ test("hand-built fib module validates", () => {
 test("fib module JSON round-trips", () => {
   const json = serializeModule(fibModule);
   expect(deserializeModule(json)).toEqual(fibModule);
+});
+
+test("runtime handle identity set covers every stable pointer handle", () => {
+  expect([...RUNTIME_HANDLE_IDENTITY_KINDS].sort()).toEqual([
+    "child", "childStream", "dgramSocket", "fsWatcher", "http2Session", "http2Stream",
+    "httpClientReq", "httpReq", "httpRes", "netServer", "netSocket", "secureCtx", "testCtx",
+  ]);
+  expect(RUNTIME_HANDLE_IDENTITY_KINDS.has("procStream")).toBe(false);
+  expect(RUNTIME_HANDLE_IDENTITY_KINDS.has("stats")).toBe(false);
+  expect(RUNTIME_HANDLE_IDENTITY_KINDS.has("spawnRes")).toBe(false);
+});
+
+test("validator rejects runtime-handle identity for scalar and snapshot kinds", () => {
+  const loc = { file: "identity.ts", start: 0, end: 0 };
+  const kinds: IrType[] = [{ kind: "procStream" }, { kind: "stats" }, { kind: "spawnRes" }];
+  const mod: IrModule = {
+    irVersion: 3,
+    sourceFile: "identity.ts",
+    entry: "eq0",
+    functions: kinds.map((type, i) => ({
+      name: `eq${i}`,
+      params: [
+        { localId: "a.0", name: "a", type },
+        { localId: "b.0", name: "b", type },
+      ],
+      returnType: BOOL,
+      locals: [
+        { id: "a.0", name: "a", type, mutable: false },
+        { id: "b.0", name: "b", type, mutable: false },
+      ],
+      body: [{
+        kind: "return" as const,
+        value: {
+          kind: "bin" as const,
+          op: "===" as const,
+          left: { kind: "varRef" as const, localId: "a.0", type, loc },
+          right: { kind: "varRef" as const, localId: "b.0", type, loc },
+          type: BOOL,
+          loc,
+        },
+        loc,
+      }],
+      loc,
+    })),
+  };
+  expect(validateModule(mod).map((e) => e.message)).toEqual([
+    "in eq0: bin === left: expected f64, got procStream",
+    "in eq0: bin === right: expected f64, got procStream",
+    "in eq1: bin === left: expected f64, got stats",
+    "in eq1: bin === right: expected f64, got stats",
+    "in eq2: bin === left: expected f64, got spawnRes",
+    "in eq2: bin === right: expected f64, got spawnRes",
+  ]);
+});
+
+test("dynCheck eligibility matches recursive builders and union matchers", () => {
+  const recursive: IrType = { kind: "union", unionId: "recursive" };
+  const callable = funcOf([], recursive);
+  const functionUnion: IrType = { kind: "union", unionId: "functionUnion" };
+  const errorT: IrType = { kind: "object", className: "%Error" };
+  const errorUnion: IrType = { kind: "union", unionId: "errorUnion" };
+  const handleUnion: IrType = { kind: "union", unionId: "handleUnion" };
+  const recordT: IrType = { kind: "record", shapeId: "functionRecord" };
+  const wrappedErrorT: IrType = { kind: "record", shapeId: "errorRecord" };
+  const wrappedHandleT: IrType = { kind: "record", shapeId: "handleRecord" };
+  const wrappedErrorUnion: IrType = { kind: "union", unionId: "wrappedErrorUnion" };
+  const wrappedHandleUnion: IrType = { kind: "union", unionId: "wrappedHandleUnion" };
+  const records = new Map<string, IrRecordShape>([
+    ["functionRecord", { id: "functionRecord", fields: [{ name: "item", type: functionUnion }] }],
+    ["errorRecord", { id: "errorRecord", fields: [{ name: "error", type: errorT }] }],
+    ["handleRecord", { id: "handleRecord", fields: [{ name: "request", type: HTTPREQ_T }] }],
+  ]);
+  const unions = new Map<string, IrUnionDef>([
+    ["recursive", { id: "recursive", arms: [F64, callable] }],
+    ["functionUnion", { id: "functionUnion", arms: [F64, funcOf([], F64)] }],
+    ["errorUnion", { id: "errorUnion", arms: [F64, errorT] }],
+    ["handleUnion", { id: "handleUnion", arms: [F64, HTTPREQ_T] }],
+    ["wrappedErrorUnion", { id: "wrappedErrorUnion", arms: [F64, wrappedErrorT] }],
+    ["wrappedHandleUnion", { id: "wrappedHandleUnion", arms: [F64, wrappedHandleT] }],
+  ]);
+  const can = (t: IrType): boolean => canDynCheckTo(t, (id) => records.get(id), (id) => unions.get(id));
+
+  expect(can(recursive)).toBe(true);
+  expect(can(recordT)).toBe(true);
+  expect(can(errorT)).toBe(true);
+  expect(can(HTTPREQ_T)).toBe(true);
+  expect(can(HTTPRES_T)).toBe(true);
+  expect(can(NETSOCKET_T)).toBe(true);
+  expect(can(NETSERVER_T)).toBe(true);
+  expect(can(HTTP2SESSION_T)).toBe(false);
+  expect(can(HTTP2STREAM_T)).toBe(false);
+  expect(can(HTTPCLIENTREQ_T)).toBe(false);
+  expect(can(arrayOf(errorT))).toBe(true);
+  expect(can(arrayOf(functionUnion))).toBe(true);
+  expect(can(arrayOf({ kind: "bytes", elem: "u8" }))).toBe(true);
+  expect(can(arrayOf(arrayOf(F64)))).toBe(true);
+  expect(can(arrayOf(NETSERVER_T))).toBe(true);
+  expect(can(arrayOf(HTTPREQ_T))).toBe(false);
+  expect(can(arrayOf(HTTPRES_T))).toBe(false);
+  expect(can(arrayOf(NETSOCKET_T))).toBe(false);
+  expect(can(arrayOf(HTTP2SESSION_T))).toBe(false);
+  expect(can(wrappedErrorT)).toBe(true);
+  expect(can(wrappedHandleT)).toBe(true);
+  expect(can(NULL_T)).toBe(false);
+  expect(can(UNDEFINED_T)).toBe(false);
+  expect(can(errorUnion)).toBe(false);
+  expect(can(handleUnion)).toBe(false);
+  expect(can(wrappedErrorUnion)).toBe(false);
+  expect(can(wrappedHandleUnion)).toBe(false);
 });
 
 test("validator rejects type mismatches and bad references", () => {

--- a/packages/compiler/test/ir.test.ts
+++ b/packages/compiler/test/ir.test.ts
@@ -208,11 +208,17 @@ test("dense-array pass bypasses hole checks only for untouched packed locals", (
         name: "holey", params: [], returnType: F64, locals: [{ id: "a.0", name: "a", type: arr, mutable: false }], loc,
         body: [{ kind: "varDecl", localId: "a.0", init: { kind: "arrayLit", elems: [{ kind: "numLit", value: 1, type: F64, loc }], type: arr, loc }, loc }, { kind: "arrayDelete", arr: { kind: "varRef", localId: "a.0", type: arr, loc }, index: { kind: "numLit", value: 0, type: F64, loc }, loc }, { kind: "return", value: get("a.0"), loc }],
       },
+      {
+        name: "written", params: [], returnType: F64, locals: [{ id: "a.0", name: "a", type: arr, mutable: false }], loc,
+        body: [{ kind: "varDecl", localId: "a.0", init: { kind: "arrayLit", elems: [{ kind: "numLit", value: 1, type: F64, loc }], type: arr, loc }, loc }, { kind: "arraySet", arr: { kind: "varRef", localId: "a.0", type: arr, loc }, index: { kind: "numLit", value: 4, type: F64, loc }, value: { kind: "numLit", value: 5, type: F64, loc }, loc }, { kind: "return", value: get("a.0"), loc }],
+      },
     ],
   };
   markDenseArrayReads(mod);
   const dense = mod.functions[0]!.body[1]!;
   const holey = mod.functions[1]!.body[2]!;
+  const written = mod.functions[2]!.body[2]!;
   expect(dense.kind === "return" && dense.value?.kind === "arrayGet" && dense.value.dense).toBe(true);
   expect(holey.kind === "return" && holey.value?.kind === "arrayGet" && holey.value.dense).toBeFalsy();
+  expect(written.kind === "return" && written.value?.kind === "arrayGet" && written.value.dense).toBeFalsy();
 });

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -5060,6 +5060,12 @@
    ],
    "diags": []
   },
+  "<repo>/tests/corpus/2603-sparse-arrays.ts": {
+   "order": [
+    "<repo>/tests/corpus/2603-sparse-arrays.ts"
+   ],
+   "diags": []
+  },
   "<repo>/tests/corpus/2604-cycle-classes-mutual/main.ts": {
    "order": [
     "<repo>/tests/corpus/2604-cycle-classes-mutual/group.ts",
@@ -5473,6 +5479,12 @@
   "<repo>/tests/corpus/2671-array-copying-js.cjs": {
    "order": [
     "<repo>/tests/corpus/2671-array-copying-js.cjs"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2673-sparse-array-js.js": {
+   "order": [
+    "<repo>/tests/corpus/2673-sparse-array-js.js"
    ],
    "diags": []
   },

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -5482,9 +5482,33 @@
    ],
    "diags": []
   },
+  "<repo>/tests/corpus/2672-http-request-response-callback.ts": {
+   "order": [
+    "<repo>/tests/corpus/2672-http-request-response-callback.ts"
+   ],
+   "diags": []
+  },
   "<repo>/tests/corpus/2673-sparse-array-js.js": {
    "order": [
     "<repo>/tests/corpus/2673-sparse-array-js.js"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2684-sparse-live-array-payload.ts": {
+   "order": [
+    "<repo>/tests/corpus/2684-sparse-live-array-payload.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2693-sparse-far-index-copy.ts": {
+   "order": [
+    "<repo>/tests/corpus/2693-sparse-far-index-copy.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2695-sparse-frontend-review-fixes.ts": {
+   "order": [
+    "<repo>/tests/corpus/2695-sparse-frontend-review-fixes.ts"
    ],
    "diags": []
   },
@@ -7458,6 +7482,12 @@
   "<repo>/tests/diagnostics/sets.ts": {
    "order": [
     "<repo>/tests/diagnostics/sets.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/diagnostics/sparse-get-scalar-fences.ts": {
+   "order": [
+    "<repo>/tests/diagnostics/sparse-get-scalar-fences.ts"
    ],
    "diags": []
   },

--- a/packages/runtime/src/scr_array.c
+++ b/packages/runtime/src/scr_array.c
@@ -80,7 +80,42 @@ static void scr_arr_grow(ScrArr *a, size_t need) {
   uint64_t *data = realloc(a->data, cap * sizeof(uint64_t));
   if (!data) scr_arr_oom();
   a->data = data;
+  if (a->present) {
+    size_t old_bytes = (a->cap + 7) / 8;
+    size_t new_bytes = (cap + 7) / 8;
+    uint8_t *present = realloc(a->present, new_bytes);
+    if (!present) scr_arr_oom();
+    memset(present + old_bytes, 0, new_bytes - old_bytes);
+    a->present = present;
+  }
   a->cap = cap;
+}
+
+static bool scr_arr_present_at(const ScrArr *a, size_t i) {
+  return !a->present || (a->present[i >> 3] & (uint8_t)(1u << (i & 7))) != 0;
+}
+
+static void scr_arr_mark_present(ScrArr *a, size_t i, bool present) {
+  if (!a->present) {
+    if (present) return;
+    size_t bytes = (a->cap + 7) / 8;
+    a->present = malloc(bytes ? bytes : 1);
+    if (!a->present) scr_arr_oom();
+    memset(a->present, 0xff, bytes);
+    if (a->cap & 7) a->present[bytes - 1] &= (uint8_t)((1u << (a->cap & 7)) - 1u);
+  }
+  uint8_t mask = (uint8_t)(1u << (i & 7));
+  if (present) a->present[i >> 3] |= mask;
+  else a->present[i >> 3] &= (uint8_t)~mask;
+}
+
+static void scr_arr_pack_if_dense(ScrArr *a) {
+  if (!a->present) return;
+  for (size_t i = 0; i < a->len; i++) {
+    if (!scr_arr_present_at(a, i)) return;
+  }
+  free(a->present);
+  a->present = NULL;
 }
 
 ScrArr *scr_arr_new(ScrElemKind elem, size_t initial_cap) {
@@ -94,6 +129,7 @@ ScrArr *scr_arr_new(ScrElemKind elem, size_t initial_cap) {
   a->elem_release = NULL;
   a->elem_trace = NULL;
   a->data = NULL;
+  a->present = NULL;
   if (initial_cap > 0) scr_arr_grow(a, initial_cap);
 #ifdef SCR_RC_AUDIT
   scr_live_arrays++;
@@ -107,12 +143,15 @@ ScrArr *scr_arr_new(ScrElemKind elem, size_t initial_cap) {
  * below releases none — the complement contract in scr_runtime.h. */
 void scr_arr_trace_v(void *a0, ScrTraceVisit visit, void *ctx) {
   ScrArr *a = (ScrArr *)a0;
-  for (size_t i = 0; i < a->len; i++) visit(scr_slot_to_ptr(a->data[i]), ctx);
+  for (size_t i = 0; i < a->len; i++) {
+    if (scr_arr_present_at(a, i)) visit(scr_slot_to_ptr(a->data[i]), ctx);
+  }
 }
 
 static void scr_arr_gc_free(void *a0) {
   ScrArr *a = (ScrArr *)a0;
   free(a->data);
+  free(a->present);
 #ifdef SCR_RC_AUDIT
   scr_live_arrays--;
 #endif
@@ -137,6 +176,7 @@ ScrArr *scr_arr_new_ref(void *(*elem_retain)(void *),
   a->elem_release = elem_release;
   a->elem_trace = elem_trace;
   a->data = NULL;
+  a->present = NULL;
   if (initial_cap > 0) scr_arr_grow(a, initial_cap);
 #ifdef SCR_RC_AUDIT
   scr_live_arrays++;
@@ -149,12 +189,15 @@ void scr_arr_release(ScrArr *a) {
   if (--a->rc == 0) {
     if (a->elem_trace) scr_cyc_on_dead(a);
     if (scr_elem_is_ref(a->elem)) {
-      for (size_t i = 0; i < a->len; i++) scr_elem_release(a, a->data[i]);
+      for (size_t i = 0; i < a->len; i++) {
+        if (scr_arr_present_at(a, i)) scr_elem_release(a, a->data[i]);
+      }
     }
     if (a->elem_trace) {
       scr_arr_gc_free(a);
     } else {
       free(a->data);
+      free(a->present);
 #ifdef SCR_RC_AUDIT
       scr_live_arrays--;
 #endif
@@ -167,6 +210,82 @@ void scr_arr_release(ScrArr *a) {
 
 double scr_arr_len(ScrArr *a) { return (double)a->len; }
 
+void scr_arr_set_sparse_len(ScrArr *a, double n, void *fill) {
+  if (!(n >= 0) || n != trunc(n) || n > 4294967295.0) {
+    scr_throw_error_msg(SCR_ERR_RANGE, "Invalid array length", sizeof "Invalid array length" - 1);
+    return;
+  }
+  size_t len = (size_t)n;
+  if (len < a->len) {
+    /* Shrink len BEFORE releasing so a release-triggered cycle collection
+     * never traces the dropped tail; presence bits above len are dead (every
+     * grow path rewrites them), so packed arrays stay bitmap-free and a
+     * sparse array whose surviving prefix is dense drops its bitmap. */
+    size_t old_len = a->len;
+    a->len = len;
+    if (scr_elem_is_ref(a->elem)) {
+      for (size_t i = len; i < old_len; i++) {
+        if (scr_arr_present_at(a, i)) scr_elem_release(a, a->data[i]);
+      }
+    }
+    scr_arr_pack_if_dense(a);
+    return;
+  }
+  if (len == a->len) return;
+  scr_arr_grow(a, len);
+  if (!a->present) {
+    size_t bytes = (a->cap + 7) / 8;
+    a->present = calloc(bytes ? bytes : 1, 1);
+    if (!a->present) scr_arr_oom();
+    for (size_t i = 0; i < a->len; i++) scr_arr_mark_present(a, i, true);
+  }
+  uint64_t slot = scr_slot_from_ptr(fill);
+  for (size_t i = a->len; i < len; i++) {
+    a->data[i] = slot;
+    scr_arr_mark_present(a, i, false);
+  }
+  a->len = len;
+}
+
+bool scr_arr_has(ScrArr *a, double i) {
+  if (!(i >= 0) || i != trunc(i) || i >= (double)a->len) return false;
+  return scr_arr_present_at(a, (size_t)i);
+}
+
+bool scr_arr_delete(ScrArr *a, double i, void *fill) {
+  if (!(i >= 0) || i != trunc(i) || i >= (double)a->len) return true;
+  size_t idx = (size_t)i;
+  if (!scr_arr_present_at(a, idx)) return true;
+  uint64_t old = a->data[idx];
+  a->data[idx] = scr_slot_from_ptr(fill);
+  scr_arr_mark_present(a, idx, false);
+  if (scr_elem_is_ref(a->elem)) scr_elem_release(a, old);
+  return true;
+}
+
+double scr_arr_append_sparse(ScrArr *dst, ScrArr *src, void *fill) {
+  size_t src_len = src->len;
+  size_t start = dst->len;
+  scr_arr_set_sparse_len(dst, (double)(start + src_len), fill);
+  if (scr_exc_pending()) return (double)dst->len;
+  for (size_t i = 0; i < src_len; i++) {
+    if (!scr_arr_present_at(src, i)) continue;
+    uint64_t slot = src->data[i];
+    if (scr_elem_is_ref(dst->elem)) {
+      void *p = scr_slot_to_ptr(slot);
+      if (dst->elem == SCR_ELEM_STR) p = scr_str_retain((ScrStr *)p);
+      else if (dst->elem == SCR_ELEM_ARR) p = scr_arr_retain((ScrArr *)p);
+      else if (dst->elem == SCR_ELEM_BYTES) p = scr_bytes_retain((ScrBytes *)p);
+      else p = dst->elem_retain(p);
+      slot = scr_slot_from_ptr(p);
+    }
+    dst->data[start + i] = slot;
+    scr_arr_mark_present(dst, start + i, true);
+  }
+  scr_arr_pack_if_dense(dst);
+  return (double)dst->len;
+}
+
 /* ── Math.max/min over one spread number[] ─────────────────────────────
  * The JS fold exactly (ECMA Math.max/min applied to the elements): any
  * NaN poisons the result, +0 beats -0 for max (the reverse for min), and
@@ -174,6 +293,7 @@ double scr_arr_len(ScrArr *a) { return (double)a->len; }
 double scr_math_max_arr(ScrArr *a) {
   double best = -INFINITY;
   for (size_t i = 0; i < a->len; i++) {
+    if (!scr_arr_present_at(a, i)) return NAN;
     double v = scr_slot_to_f64(a->data[i]);
     if (isnan(v)) return v;
     if (v > best || (v == 0.0 && best == 0.0 && !signbit(v))) best = v;
@@ -184,6 +304,7 @@ double scr_math_max_arr(ScrArr *a) {
 double scr_math_min_arr(ScrArr *a) {
   double best = INFINITY;
   for (size_t i = 0; i < a->len; i++) {
+    if (!scr_arr_present_at(a, i)) return NAN;
     double v = scr_slot_to_f64(a->data[i]);
     if (isnan(v)) return v;
     if (v < best || (v == 0.0 && best == 0.0 && signbit(v))) best = v;
@@ -194,14 +315,43 @@ double scr_math_min_arr(ScrArr *a) {
 /* ── reads ─────────────────────────────────────────────────────────────── */
 
 double scr_arr_get_f64(ScrArr *a, double i) {
+  size_t idx = scr_arr_check_index(a, i, false);
+  if (!scr_arr_present_at(a, idx)) {
+    scr_trap("scriptc: TypeError: array hole cannot be represented by the element type\n");
+  }
+  return scr_slot_to_f64(a->data[idx]);
+}
+
+double scr_arr_get_dense_f64(ScrArr *a, double i) {
   return scr_slot_to_f64(a->data[scr_arr_check_index(a, i, false)]);
 }
 
 bool scr_arr_get_bool(ScrArr *a, double i) {
+  size_t idx = scr_arr_check_index(a, i, false);
+  if (!scr_arr_present_at(a, idx)) {
+    scr_trap("scriptc: TypeError: array hole cannot be represented by the element type\n");
+  }
+  return a->data[idx] != 0;
+}
+
+bool scr_arr_get_dense_bool(ScrArr *a, double i) {
   return a->data[scr_arr_check_index(a, i, false)] != 0;
 }
 
 void *scr_arr_get_ref(ScrArr *a, double i) {
+  size_t idx = scr_arr_check_index(a, i, false);
+  void *p = scr_slot_to_ptr(a->data[idx]);
+  if (!scr_arr_present_at(a, idx) && !p) {
+    scr_trap("scriptc: TypeError: array hole cannot be represented by the element type\n");
+  }
+  if (a->elem == SCR_ELEM_STR) scr_str_retain((ScrStr *)p);
+  else if (a->elem == SCR_ELEM_BYTES) scr_bytes_retain((ScrBytes *)p);
+  else if (a->elem == SCR_ELEM_REF) p = a->elem_retain(p);
+  else scr_arr_retain((ScrArr *)p);
+  return p;
+}
+
+void *scr_arr_get_dense_ref(ScrArr *a, double i) {
   void *p = scr_slot_to_ptr(a->data[scr_arr_check_index(a, i, false)]);
   if (a->elem == SCR_ELEM_STR) scr_str_retain((ScrStr *)p);
   else if (a->elem == SCR_ELEM_BYTES) scr_bytes_retain((ScrBytes *)p);
@@ -218,13 +368,17 @@ static void scr_arr_set_slot(ScrArr *a, double i, uint64_t slot) {
     scr_arr_grow(a, a->len + 1);
     a->len++;
     a->data[idx] = slot;
+    scr_arr_mark_present(a, idx, true);
     return;
   }
   /* Unlink-then-release: a release can trigger a cycle collection, which
    * must never see a heap edge whose count was already given up. */
+  bool had_old = scr_arr_present_at(a, idx);
   uint64_t old = a->data[idx];
   a->data[idx] = slot;
-  if (scr_elem_is_ref(a->elem)) scr_elem_release(a, old);
+  scr_arr_mark_present(a, idx, true);
+  if (!had_old && idx + 1 == a->len) scr_arr_pack_if_dense(a);
+  if (had_old && scr_elem_is_ref(a->elem)) scr_elem_release(a, old);
 }
 
 void scr_arr_set_f64(ScrArr *a, double i, double v) {
@@ -243,7 +397,9 @@ void scr_arr_set_ref(ScrArr *a, double i, void *v) {
 
 static double scr_arr_push_slot(ScrArr *a, uint64_t slot) {
   scr_arr_grow(a, a->len + 1);
-  a->data[a->len++] = slot;
+  a->data[a->len] = slot;
+  scr_arr_mark_present(a, a->len, true);
+  a->len++;
   return (double)a->len;
 }
 
@@ -263,7 +419,15 @@ static uint64_t scr_arr_pop_slot(ScrArr *a) {
   if (a->len == 0) {
     scr_trap("scriptc: RangeError: pop() on an empty array\n");
   }
-  return a->data[--a->len];
+  size_t idx = --a->len;
+  /* pop() on a hole is Get(len-1): undefined. A union element's backing
+   * slot carries the interned undefined arm (immortal — handing it out as
+   * owned is safe, its release is a no-op); a zero backing has no value
+   * the element type can represent. */
+  if (!scr_arr_present_at(a, idx) && a->data[idx] == 0) {
+    scr_trap("scriptc: TypeError: array hole cannot be represented by the element type\n");
+  }
+  return a->data[idx];
 }
 
 double scr_arr_pop_f64(ScrArr *a) { return scr_slot_to_f64(scr_arr_pop_slot(a)); }
@@ -281,9 +445,20 @@ static uint64_t scr_arr_shift_slot(ScrArr *a) {
   if (a->len == 0) {
     scr_trap("scriptc: internal error: shift() on an empty array\n");
   }
+  /* shift() on a hole is Get(0): undefined — representable only when the
+   * backing slot carries an interned undefined arm (pop's discipline). */
+  if (!scr_arr_present_at(a, 0) && a->data[0] == 0) {
+    scr_trap("scriptc: TypeError: array hole cannot be represented by the element type\n");
+  }
   uint64_t s = a->data[0];
   a->len--;
   memmove(a->data, a->data + 1, a->len * sizeof(uint64_t));
+  if (a->present) {
+    for (size_t i = 0; i < a->len; i++) {
+      scr_arr_mark_present(a, i, scr_arr_present_at(a, i + 1));
+    }
+    scr_arr_mark_present(a, a->len, false);
+  }
   return s;
 }
 
@@ -316,7 +491,17 @@ ScrArr *scr_arr_splice(ScrArr *a, double start, double deleteCount) {
   if (n > 0) {
     memcpy(out->data, a->data + from, n * sizeof(uint64_t));
     out->len = n;
+    if (a->present) {
+      for (size_t i = 0; i < n; i++) {
+        if (!scr_arr_present_at(a, from + i)) scr_arr_mark_present(out, i, false);
+      }
+    }
     memmove(a->data + from, a->data + from + n, (a->len - from - n) * sizeof(uint64_t));
+    if (a->present) {
+      for (size_t i = from; i + n < a->len; i++) {
+        scr_arr_mark_present(a, i, scr_arr_present_at(a, i + n));
+      }
+    }
     a->len -= n;
   }
   return out;
@@ -337,6 +522,7 @@ static bool scr_arr_ref_eq(const ScrArr *a, uint64_t slot, void *v) {
 
 double scr_arr_index_of_f64(ScrArr *a, double v) {
   for (size_t i = 0; i < a->len; i++) {
+    if (!scr_arr_present_at(a, i)) continue;
     if (scr_slot_to_f64(a->data[i]) == v) return (double)i; /* NaN: never */
   }
   return -1;
@@ -344,6 +530,7 @@ double scr_arr_index_of_f64(ScrArr *a, double v) {
 
 double scr_arr_index_of_bool(ScrArr *a, bool v) {
   for (size_t i = 0; i < a->len; i++) {
+    if (!scr_arr_present_at(a, i)) continue;
     if ((a->data[i] != 0) == v) return (double)i;
   }
   return -1;
@@ -351,6 +538,7 @@ double scr_arr_index_of_bool(ScrArr *a, bool v) {
 
 double scr_arr_index_of_ref(ScrArr *a, void *v) {
   for (size_t i = 0; i < a->len; i++) {
+    if (!scr_arr_present_at(a, i)) continue;
     if (scr_arr_ref_eq(a, a->data[i], v)) return (double)i;
   }
   return -1;
@@ -358,6 +546,7 @@ double scr_arr_index_of_ref(ScrArr *a, void *v) {
 
 bool scr_arr_includes_f64(ScrArr *a, double v) {
   for (size_t i = 0; i < a->len; i++) {
+    if (!scr_arr_present_at(a, i)) continue;
     double x = scr_slot_to_f64(a->data[i]);
     if (x == v || (x != x && v != v)) return true; /* SameValueZero: NaN hits */
   }
@@ -369,7 +558,14 @@ bool scr_arr_includes_bool(ScrArr *a, bool v) {
 }
 
 bool scr_arr_includes_ref(ScrArr *a, void *v) {
-  return scr_arr_index_of_ref(a, v) >= 0;
+  for (size_t i = 0; i < a->len; i++) {
+    /* Get treats a hole as undefined. Union-backed sparse arrays store the
+     * undefined singleton in the hole; NULL means this element type cannot
+     * represent undefined and therefore cannot match the needle. */
+    if (!scr_arr_present_at(a, i) && a->data[i] == 0) continue;
+    if (scr_arr_ref_eq(a, a->data[i], v)) return true;
+  }
+  return false;
 }
 
 /* ── join ──────────────────────────────────────────────────────────────── */
@@ -412,7 +608,8 @@ ScrArr *scr_arr_slice(ScrArr *a, double start, double end) {
           : scr_arr_new(a->elem, n ? n : 1);
   for (size_t i = 0; i < n; i++) {
     uint64_t slot = a->data[from + i];
-    if (scr_elem_is_ref(a->elem)) {
+    bool present = scr_arr_present_at(a, from + i);
+    if (present && scr_elem_is_ref(a->elem)) {
       void *pv = scr_slot_to_ptr(slot);
       if (a->elem == SCR_ELEM_STR) scr_str_retain((ScrStr *)pv);
       else if (a->elem == SCR_ELEM_ARR) scr_arr_retain((ScrArr *)pv);
@@ -421,6 +618,7 @@ ScrArr *scr_arr_slice(ScrArr *a, double start, double end) {
       slot = scr_slot_from_ptr(pv);
     }
     out->data[out->len++] = slot;
+    if (!present) scr_arr_mark_present(out, i, false);
   }
   return out;
 }
@@ -431,6 +629,7 @@ ScrStr *scr_arr_join(ScrArr *a, ScrStr *sep) {
   if (!buf) scr_arr_oom();
   for (size_t i = 0; i < a->len; i++) {
     if (i > 0) scr_join_append(&buf, &len, &cap, sep->data, sep->len);
+    if (!scr_arr_present_at(a, i)) continue;
     switch (a->elem) {
       case SCR_ELEM_F64: {
         char nb[32];

--- a/packages/runtime/src/scr_array.c
+++ b/packages/runtime/src/scr_array.c
@@ -16,9 +16,9 @@ static void scr_arr_oom(void) {
   scr_trap("scriptc: out of memory\n");
 }
 
-/* JS would return undefined for an OOB read and create holes for a far OOB
- * write; both are unrepresentable here (see SEMANTICS.md), so any invalid
- * index — negative, fractional, NaN, or past the allowed end — traps. */
+/* Reads outside length and values that are not array indices remain
+ * unrepresentable. Writes accept every JS array index (through 2^32-2),
+ * growing length and creating holes as needed. */
 static void scr_arr_trap_oob(double i, size_t len) {
   char buf[32];
   scr_f64_to_str(i, buf);
@@ -26,12 +26,10 @@ static void scr_arr_trap_oob(double i, size_t len) {
                buf, len);
 }
 
-/* Validate i as an element index. limit is a->len for reads, a->len + 1 for
- * writes (i == len appends). NaN fails the >= 0 test; fractional indices
- * fail the trunc test. */
-static size_t scr_arr_check_index(const ScrArr *a, double i, bool allow_append) {
-  size_t limit = a->len + (allow_append ? 1 : 0);
-  if (!(i >= 0) || i != trunc(i) || i >= (double)limit) {
+/* 2^32-1 is the maximum array length and therefore not an array index. */
+static size_t scr_arr_check_index(const ScrArr *a, double i, bool write) {
+  double limit = write ? 4294967295.0 : (double)a->len;
+  if (!(i >= 0) || i != trunc(i) || i >= limit) {
     scr_arr_trap_oob(i, a->len);
   }
   return (size_t)i;
@@ -93,6 +91,16 @@ static void scr_arr_grow(ScrArr *a, size_t need) {
 
 static bool scr_arr_present_at(const ScrArr *a, size_t i) {
   return !a->present || (a->present[i >> 3] & (uint8_t)(1u << (i & 7))) != 0;
+}
+
+static void scr_arr_make_sparse(ScrArr *a) {
+  if (a->present) return;
+  size_t bytes = (a->cap + 7) / 8;
+  a->present = calloc(bytes ? bytes : 1, 1);
+  if (!a->present) scr_arr_oom();
+  for (size_t i = 0; i < a->len; i++) {
+    a->present[i >> 3] |= (uint8_t)(1u << (i & 7));
+  }
 }
 
 static void scr_arr_mark_present(ScrArr *a, size_t i, bool present) {
@@ -233,12 +241,7 @@ void scr_arr_set_sparse_len(ScrArr *a, double n, void *fill) {
   }
   if (len == a->len) return;
   scr_arr_grow(a, len);
-  if (!a->present) {
-    size_t bytes = (a->cap + 7) / 8;
-    a->present = calloc(bytes ? bytes : 1, 1);
-    if (!a->present) scr_arr_oom();
-    for (size_t i = 0; i < a->len; i++) scr_arr_mark_present(a, i, true);
-  }
+  scr_arr_make_sparse(a);
   uint64_t slot = scr_slot_from_ptr(fill);
   for (size_t i = a->len; i < len; i++) {
     a->data[i] = slot;
@@ -360,15 +363,35 @@ void *scr_arr_get_dense_ref(ScrArr *a, double i) {
   return p;
 }
 
-/* ── writes: i == len appends ──────────────────────────────────────────── */
+/* ── writes: far indices grow length and create holes ──────────────────── */
 
-static void scr_arr_set_slot(ScrArr *a, double i, uint64_t slot) {
+static void scr_arr_set_slot(ScrArr *a, double i, uint64_t slot,
+                             uint64_t hole) {
   size_t idx = scr_arr_check_index(a, i, true);
-  if (idx == a->len) {
-    scr_arr_grow(a, a->len + 1);
-    a->len++;
+  if (idx >= a->len) {
+    size_t old_len = a->len;
+    /* An already-sparse REF array can carry the undefined union singleton
+     * in its holes. Extend with the same inert backing when the caller did
+     * not supply the static element type's undefined arm. */
+    if (idx > old_len && hole == 0 && a->present && a->elem == SCR_ELEM_REF) {
+      for (size_t j = 0; j < old_len; j++) {
+        if (!scr_arr_present_at(a, j)) {
+          hole = a->data[j];
+          break;
+        }
+      }
+    }
+    scr_arr_grow(a, idx + 1);
+    if (idx > old_len) {
+      scr_arr_make_sparse(a);
+      for (size_t j = old_len; j < idx; j++) {
+        a->data[j] = hole;
+        scr_arr_mark_present(a, j, false);
+      }
+    }
     a->data[idx] = slot;
     scr_arr_mark_present(a, idx, true);
+    a->len = idx + 1;
     return;
   }
   /* Unlink-then-release: a release can trigger a cycle collection, which
@@ -382,15 +405,19 @@ static void scr_arr_set_slot(ScrArr *a, double i, uint64_t slot) {
 }
 
 void scr_arr_set_f64(ScrArr *a, double i, double v) {
-  scr_arr_set_slot(a, i, scr_slot_from_f64(v));
+  scr_arr_set_slot(a, i, scr_slot_from_f64(v), 0);
 }
 
 void scr_arr_set_bool(ScrArr *a, double i, bool v) {
-  scr_arr_set_slot(a, i, (uint64_t)(v ? 1 : 0));
+  scr_arr_set_slot(a, i, (uint64_t)(v ? 1 : 0), 0);
 }
 
 void scr_arr_set_ref(ScrArr *a, double i, void *v) {
-  scr_arr_set_slot(a, i, scr_slot_from_ptr(v));
+  scr_arr_set_slot(a, i, scr_slot_from_ptr(v), 0);
+}
+
+void scr_arr_set_ref_fill(ScrArr *a, double i, void *v, void *fill) {
+  scr_arr_set_slot(a, i, scr_slot_from_ptr(v), scr_slot_from_ptr(fill));
 }
 
 /* ── push / pop ────────────────────────────────────────────────────────── */

--- a/packages/runtime/src/scr_assert.c
+++ b/packages/runtime/src/scr_assert.c
@@ -516,6 +516,10 @@ static bool scr_assert_dyn_deep_eq(const ScrDyn *a, const ScrDyn *b) {
     case SCR_DYN_ARR: {
       if (a->v.arr.len != b->v.arr.len) return false;
       for (size_t i = 0; i < a->v.arr.len; i++) {
+        bool ah = scr_dyn_arr_has_index(a, i);
+        bool bh = scr_dyn_arr_has_index(b, i);
+        if (ah != bh) return false;
+        if (!ah) continue;
         if (!scr_assert_dyn_deep_eq(a->v.arr.items[i], b->v.arr.items[i])) return false;
       }
       return true;
@@ -681,11 +685,22 @@ static void scr_assert_cf_value(ScrAssertBuf *b, const ScrDyn *d, size_t indent,
         return;
       }
       ab_char(b, '[');
-      for (size_t i = 0; i < d->v.arr.len; i++) {
+      for (size_t i = 0; i < d->v.arr.len;) {
         ab_char(b, '\n');
         scr_assert_cf_pad(b, indent + 2);
-        scr_assert_cf_value(b, d->v.arr.items[i], indent + 2, depth - 1);
-        if (i + 1 < d->v.arr.len) ab_char(b, ',');
+        if (!scr_dyn_arr_has_index(d, i)) {
+          size_t end = i + 1;
+          while (end < d->v.arr.len && !scr_dyn_arr_has_index(d, end)) end++;
+          size_t n = end - i;
+          char empty[48];
+          int len = snprintf(empty, sizeof empty, "<%zu empty item%s>", n, n == 1 ? "" : "s");
+          ab_bytes(b, empty, (size_t)len);
+          i = end;
+        } else {
+          scr_assert_cf_value(b, d->v.arr.items[i], indent + 2, depth - 1);
+          i++;
+        }
+        if (i < d->v.arr.len) ab_char(b, ',');
       }
       ab_char(b, '\n');
       scr_assert_cf_pad(b, indent);

--- a/packages/runtime/src/scr_async.c
+++ b/packages/runtime/src/scr_async.c
@@ -1520,7 +1520,7 @@ ScrPromise *scr_tp_set_immediate(void) {
 static void scr_imm_dyn_fire(ScrClosure *c) {
   ScrDyn *fn = (ScrDyn *)scr_box_get_ref(c->caps[0]);
   ScrDyn *args = (ScrDyn *)scr_box_get_ref(c->caps[1]);
-  ScrDyn *r = scr_dyn_call(fn, args->v.arr.items, args->v.arr.len, "immediate callback");
+  ScrDyn *r = scr_dyn_apply(fn, args, "immediate callback");
   if (r != NULL) scr_dyn_release(r);
   scr_dyn_release(fn);
   scr_dyn_release(args);

--- a/packages/runtime/src/scr_async_dyn.c
+++ b/packages/runtime/src/scr_async_dyn.c
@@ -131,9 +131,8 @@ void scr_als_disable(double id) {
  * dyn function with the forwarded arguments, restore — the finally, so a
  * throw still restores before propagating. Result +1 or NULL pending. */
 static ScrDyn *scr_als_call_in(ScrAlsCtx *prev, ScrDyn *fn, ScrDyn *args) {
-  size_t argc = args->kind == SCR_DYN_ARR ? args->v.arr.len : 0;
-  ScrDyn *const *items = args->kind == SCR_DYN_ARR ? args->v.arr.items : NULL;
-  ScrDyn *r = scr_dyn_call(fn, items, argc, "callback");
+  ScrDyn *r = args->kind == SCR_DYN_ARR ? scr_dyn_apply(fn, args, "callback")
+                                        : scr_dyn_call(fn, NULL, 0, "callback");
   scr_als_restore(prev);
   return r;
 }

--- a/packages/runtime/src/scr_copying.c
+++ b/packages/runtime/src/scr_copying.c
@@ -3,6 +3,8 @@
 #include <math.h>
 #include <stdio.h>
 #include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
 
 /* ES2023 Array/TypedArray copying methods and the typed-array-to-number[]
  * bridge live in their own archive member. Programs that do not use this
@@ -38,8 +40,35 @@ static uint64_t copying_arr_retain_slot(const ScrArr *a, uint64_t slot) {
   return copying_slot_from_ptr(p);
 }
 
+static bool copying_arr_present_at(const ScrArr *a, size_t i) {
+  return !a->present || (a->present[i >> 3] & (uint8_t)(1u << (i & 7))) != 0;
+}
+
+static void copying_arr_mark_hole(ScrArr *a, size_t i) {
+  if (!a->present) {
+    size_t bytes = (a->cap + 7) / 8;
+    a->present = malloc(bytes ? bytes : 1);
+    if (!a->present) scr_trap("scriptc: out of memory\n");
+    memset(a->present, 0xff, bytes);
+    if (a->cap & 7) a->present[bytes - 1] &= (uint8_t)((1u << (a->cap & 7)) - 1u);
+  }
+  a->present[i >> 3] &= (uint8_t)~(1u << (i & 7));
+}
+
+/* The ES2023 copying methods read every index (Get), so a source hole
+ * densifies to its backing where that carries the value Get answers — the
+ * interned undefined arm of a union element (nonzero). A zero backing
+ * (f64/bool/plain ref) has no undefined to give: the slot stays a hole so
+ * reads keep the deliberate trap instead of silently answering 0/NULL. */
 static void copying_arr_copy_slot(ScrArr *out, const ScrArr *src, size_t i) {
-  out->data[out->len++] = copying_arr_retain_slot(src, src->data[i]);
+  uint64_t slot = src->data[i];
+  if (!copying_arr_present_at(src, i) && slot == 0) {
+    out->data[out->len] = 0;
+    copying_arr_mark_hole(out, out->len);
+    out->len++;
+    return;
+  }
+  out->data[out->len++] = copying_arr_retain_slot(src, slot);
 }
 
 ScrArr *scr_arr_to_reversed(const ScrArr *a) {
@@ -76,6 +105,23 @@ ScrArr *scr_arr_to_spliced(const ScrArr *a, double start,
   return out;
 }
 
+/* `with` builds on slice (which preserves holes); densify the copy under
+ * the same representability rule as copying_arr_copy_slot. */
+static void copying_arr_densify(ScrArr *out) {
+  if (!out->present) return;
+  bool all_present = true;
+  for (size_t i = 0; i < out->len; i++) {
+    uint8_t mask = (uint8_t)(1u << (i & 7));
+    if (out->present[i >> 3] & mask) continue;
+    if (out->data[i] != 0) out->present[i >> 3] |= mask;
+    else all_present = false;
+  }
+  if (all_present) {
+    free(out->present);
+    out->present = NULL;
+  }
+}
+
 static bool copying_arr_with_index(const ScrArr *a, double index,
                                    size_t *out) {
   double rel = isnan(index) ? 0 : trunc(index);
@@ -97,6 +143,7 @@ ScrArr *scr_arr_with_f64(ScrArr *a, double index, double value) {
   size_t i;
   if (!copying_arr_with_index(a, index, &i)) return NULL;
   ScrArr *out = scr_arr_slice(a, 0, INFINITY);
+  copying_arr_densify(out);
   scr_arr_set_f64(out, (double)i, value);
   return out;
 }
@@ -105,6 +152,7 @@ ScrArr *scr_arr_with_bool(ScrArr *a, double index, bool value) {
   size_t i;
   if (!copying_arr_with_index(a, index, &i)) return NULL;
   ScrArr *out = scr_arr_slice(a, 0, INFINITY);
+  copying_arr_densify(out);
   scr_arr_set_bool(out, (double)i, value);
   return out;
 }
@@ -113,6 +161,7 @@ ScrArr *scr_arr_with_ref(ScrArr *a, double index, void *value) {
   size_t i;
   if (!copying_arr_with_index(a, index, &i)) return NULL;
   ScrArr *out = scr_arr_slice(a, 0, INFINITY);
+  copying_arr_densify(out);
   uint64_t retained =
       copying_arr_retain_slot(a, copying_slot_from_ptr(value));
   scr_arr_set_ref(out, (double)i, copying_slot_to_ptr(retained));

--- a/packages/runtime/src/scr_copying.c
+++ b/packages/runtime/src/scr_copying.c
@@ -44,29 +44,15 @@ static bool copying_arr_present_at(const ScrArr *a, size_t i) {
   return !a->present || (a->present[i >> 3] & (uint8_t)(1u << (i & 7))) != 0;
 }
 
-static void copying_arr_mark_hole(ScrArr *a, size_t i) {
-  if (!a->present) {
-    size_t bytes = (a->cap + 7) / 8;
-    a->present = malloc(bytes ? bytes : 1);
-    if (!a->present) scr_trap("scriptc: out of memory\n");
-    memset(a->present, 0xff, bytes);
-    if (a->cap & 7) a->present[bytes - 1] &= (uint8_t)((1u << (a->cap & 7)) - 1u);
-  }
-  a->present[i >> 3] &= (uint8_t)~(1u << (i & 7));
-}
-
 /* The ES2023 copying methods read every index (Get), so a source hole
- * densifies to its backing where that carries the value Get answers — the
- * interned undefined arm of a union element (nonzero). A zero backing
- * (f64/bool/plain ref) has no undefined to give: the slot stays a hole so
- * reads keep the deliberate trap instead of silently answering 0/NULL. */
+ * densifies to the undefined value carried in a REF hole's backing slot.
+ * Scalar and NULL-backed holes cannot encode undefined in their typed ABI;
+ * fail explicitly rather than fabricating 0/NULL or preserving the hole. */
 static void copying_arr_copy_slot(ScrArr *out, const ScrArr *src, size_t i) {
   uint64_t slot = src->data[i];
-  if (!copying_arr_present_at(src, i) && slot == 0) {
-    out->data[out->len] = 0;
-    copying_arr_mark_hole(out, out->len);
-    out->len++;
-    return;
+  if (!copying_arr_present_at(src, i) &&
+      (src->elem != SCR_ELEM_REF || slot == 0)) {
+    scr_trap("scriptc: TypeError: array hole cannot be represented as undefined by the element type\n");
   }
   out->data[out->len++] = copying_arr_retain_slot(src, slot);
 }
@@ -95,31 +81,25 @@ ScrArr *scr_arr_to_spliced(const ScrArr *a, double start,
   size_t out_len = a->len - ndelete + items->len;
   ScrArr *out = copying_arr_new_like(a, out_len);
   for (size_t i = 0; i < from; i++) copying_arr_copy_slot(out, a, i);
-  for (size_t i = 0; i < items->len; i++) {
-    out->data[out->len++] =
-        copying_arr_retain_slot(a, items->data[i]);
-  }
+  for (size_t i = 0; i < items->len; i++)
+    copying_arr_copy_slot(out, items, i);
   for (size_t i = from + ndelete; i < a->len; i++) {
     copying_arr_copy_slot(out, a, i);
   }
   return out;
 }
 
-/* `with` builds on slice (which preserves holes); densify the copy under
- * the same representability rule as copying_arr_copy_slot. */
-static void copying_arr_densify(ScrArr *out) {
-  if (!out->present) return;
-  bool all_present = true;
-  for (size_t i = 0; i < out->len; i++) {
-    uint8_t mask = (uint8_t)(1u << (i & 7));
-    if (out->present[i >> 3] & mask) continue;
-    if (out->data[i] != 0) out->present[i >> 3] |= mask;
-    else all_present = false;
+static ScrArr *copying_arr_with_slot(ScrArr *a, size_t index,
+                                     uint64_t replacement) {
+  ScrArr *out = copying_arr_new_like(a, a->len);
+  for (size_t i = 0; i < a->len; i++) {
+    if (i == index) {
+      out->data[out->len++] = copying_arr_retain_slot(a, replacement);
+    } else {
+      copying_arr_copy_slot(out, a, i);
+    }
   }
-  if (all_present) {
-    free(out->present);
-    out->present = NULL;
-  }
+  return out;
 }
 
 static bool copying_arr_with_index(const ScrArr *a, double index,
@@ -142,30 +122,21 @@ static bool copying_arr_with_index(const ScrArr *a, double index,
 ScrArr *scr_arr_with_f64(ScrArr *a, double index, double value) {
   size_t i;
   if (!copying_arr_with_index(a, index, &i)) return NULL;
-  ScrArr *out = scr_arr_slice(a, 0, INFINITY);
-  copying_arr_densify(out);
-  scr_arr_set_f64(out, (double)i, value);
-  return out;
+  uint64_t slot;
+  memcpy(&slot, &value, sizeof slot);
+  return copying_arr_with_slot(a, i, slot);
 }
 
 ScrArr *scr_arr_with_bool(ScrArr *a, double index, bool value) {
   size_t i;
   if (!copying_arr_with_index(a, index, &i)) return NULL;
-  ScrArr *out = scr_arr_slice(a, 0, INFINITY);
-  copying_arr_densify(out);
-  scr_arr_set_bool(out, (double)i, value);
-  return out;
+  return copying_arr_with_slot(a, i, value ? 1 : 0);
 }
 
 ScrArr *scr_arr_with_ref(ScrArr *a, double index, void *value) {
   size_t i;
   if (!copying_arr_with_index(a, index, &i)) return NULL;
-  ScrArr *out = scr_arr_slice(a, 0, INFINITY);
-  copying_arr_densify(out);
-  uint64_t retained =
-      copying_arr_retain_slot(a, copying_slot_from_ptr(value));
-  scr_arr_set_ref(out, (double)i, copying_slot_to_ptr(retained));
-  return out;
+  return copying_arr_with_slot(a, i, copying_slot_from_ptr(value));
 }
 
 ScrBytes *scr_bytes_to_reversed(const ScrBytes *b) {

--- a/packages/runtime/src/scr_dc.c
+++ b/packages/runtime/src/scr_dc.c
@@ -328,10 +328,9 @@ ScrDyn *scr_dc_chan_run_stores(double handle, ScrDyn *data, ScrDyn *fn, ScrDyn *
   scr_dc_publish(handle, data);
   ScrDyn *r = NULL;
   if (!scr_exc_pending()) {
-    size_t argc = args->kind == SCR_DYN_ARR ? args->v.arr.len : 0;
-    ScrDyn *const *items = args->kind == SCR_DYN_ARR ? args->v.arr.items : NULL;
     scr_dyn_this_push_dyn(this_arg);
-    r = scr_dyn_call(fn, items, argc, "runStores");
+    r = args->kind == SCR_DYN_ARR ? scr_dyn_apply(fn, args, "runStores")
+                                  : scr_dyn_call(fn, NULL, 0, "runStores");
     scr_dyn_this_pop();
   }
   dc_stores_restore(prevs, entered);
@@ -484,9 +483,18 @@ static void dc_tc_publish(ScrDcTracing *tc, int ev, ScrDyn *ctx) {
 /* The traced call: thisArg bound as the ambient receiver. Result +1 or
  * NULL with the exception pending. */
 static ScrDyn *dc_tc_apply(ScrDyn *fn, ScrDyn *this_arg, ScrDyn *const *items, size_t n,
-                            const char *what) {
+                             const char *what) {
   scr_dyn_this_push_dyn(this_arg);
   ScrDyn *r = scr_dyn_call(fn, items, n, what);
+  scr_dyn_this_pop();
+  return r;
+}
+
+static ScrDyn *dc_tc_apply_args(ScrDyn *fn, ScrDyn *this_arg, ScrDyn *args,
+                                const char *what) {
+  scr_dyn_this_push_dyn(this_arg);
+  ScrDyn *r = args->kind == SCR_DYN_ARR ? scr_dyn_apply(fn, args, what)
+                                        : scr_dyn_call(fn, NULL, 0, what);
   scr_dyn_this_pop();
   return r;
 }
@@ -495,10 +503,10 @@ static ScrDyn *dc_tc_apply(ScrDyn *fn, ScrDyn *this_arg, ScrDyn *const *items, s
  * (start.runStores — Node wraps the WHOLE body: the start publish, the
  * traced call, and the finally end publish). */
 static ScrDyn *dc_tc_trace_sync_body(ScrDcTracing *tc, ScrDyn *fn, ScrDyn *ctx,
-                                     ScrDyn *this_arg, ScrDyn *const *items, size_t argc) {
+                                      ScrDyn *this_arg, ScrDyn *args) {
   dc_tc_publish(tc, DC_TC_START, ctx);
   if (scr_exc_pending()) return NULL;
-  ScrDyn *r = dc_tc_apply(fn, this_arg, items, argc, "traceSync");
+  ScrDyn *r = dc_tc_apply_args(fn, this_arg, args, "traceSync");
   if (r == NULL) {
     /* context.error = err; error.publish; end.publish (finally); rethrow */
     ScrCaught *c = scr_exc_take();
@@ -521,16 +529,14 @@ static ScrDyn *dc_tc_trace_sync_body(ScrDcTracing *tc, ScrDyn *fn, ScrDyn *ctx,
 
 ScrDyn *scr_dc_tc_trace_sync(double h, ScrDyn *fn, ScrDyn *ctx, ScrDyn *this_arg, ScrDyn *args) {
   ScrDcTracing *tc = dc_tc_of(h);
-  size_t argc = args->kind == SCR_DYN_ARR ? args->v.arr.len : 0;
-  ScrDyn *const *items = args->kind == SCR_DYN_ARR ? args->v.arr.items : NULL;
   if (!scr_dc_tc_has_subscribers(h)) {
-    return dc_tc_apply(fn, this_arg, items, argc, "traceSync");
+    return dc_tc_apply_args(fn, this_arg, args, "traceSync");
   }
   /* start.runStores: the body runs inside the start channel's stores. */
   size_t entered = 0;
   ScrAlsCtx **prevs = dc_stores_enter(&dc_channels[tc->ch[DC_TC_START]], ctx, &entered);
   ScrDyn *r = scr_exc_pending() ? NULL
-                                : dc_tc_trace_sync_body(tc, fn, ctx, this_arg, items, argc);
+                                 : dc_tc_trace_sync_body(tc, fn, ctx, this_arg, args);
   dc_stores_restore(prevs, entered);
   return r;
 }
@@ -601,10 +607,8 @@ static ScrPromise *dc_tp_promise_of(ScrDyn *r) {
 ScrPromise *scr_dc_tc_trace_promise(double h, ScrDyn *fn, ScrDyn *ctx, ScrDyn *this_arg,
                                      ScrDyn *args) {
   ScrDcTracing *tc = dc_tc_of(h);
-  size_t argc = args->kind == SCR_DYN_ARR ? args->v.arr.len : 0;
-  ScrDyn *const *items = args->kind == SCR_DYN_ARR ? args->v.arr.items : NULL;
   if (!scr_dc_tc_has_subscribers(h)) {
-    ScrDyn *r = dc_tc_apply(fn, this_arg, items, argc, "tracePromise");
+    ScrDyn *r = dc_tc_apply_args(fn, this_arg, args, "tracePromise");
     if (r == NULL) return NULL;
     ScrPromise *p = dc_tp_promise_of(r);
     scr_dyn_release(r);
@@ -623,7 +627,7 @@ ScrPromise *scr_dc_tc_trace_promise(double h, ScrDyn *fn, ScrDyn *ctx, ScrDyn *t
   if (!scr_exc_pending()) {
     dc_tc_publish(tc, DC_TC_START, ctx);
     if (!scr_exc_pending()) {
-      ScrDyn *r = dc_tc_apply(fn, this_arg, items, argc, "tracePromise");
+      ScrDyn *r = dc_tc_apply_args(fn, this_arg, args, "tracePromise");
       if (r == NULL) {
         /* ctx.error = err; error.publish; end.publish (finally); rethrow */
         ScrCaught *c = scr_exc_take();
@@ -718,12 +722,14 @@ ScrDyn *scr_dc_tc_trace_callback(double h, ScrDyn *fn, double position, ScrDyn *
   size_t argc = args->kind == SCR_DYN_ARR ? args->v.arr.len : 0;
   ScrDyn *const *items = args->kind == SCR_DYN_ARR ? args->v.arr.items : NULL;
   if (!scr_dc_tc_has_subscribers(h)) {
-    return dc_tc_apply(fn, this_arg, items, argc, "traceCallback");
+    return dc_tc_apply_args(fn, this_arg, args, "traceCallback");
   }
   /* args.at(position), JS-style negative indexing */
   double pos = position < 0 ? (double)argc + position : position;
   size_t idx = (size_t)pos;
-  ScrDyn *cb = (pos >= 0 && idx < argc) ? items[idx] : NULL;
+  ScrDyn *cb = (pos >= 0 && idx < argc)
+    ? (scr_dyn_arr_has_index(args, idx) ? items[idx] : scr_dyn_undefined())
+    : NULL;
   if (cb == NULL || cb->kind != SCR_DYN_FUNC) {
     dc_throw_bad_fn_arg(cb, "callback");
     return NULL;
@@ -746,7 +752,10 @@ ScrDyn *scr_dc_tc_trace_callback(double h, ScrDyn *fn, double position, ScrDyn *
       fputs("scriptc: out of memory\n", stderr);
       abort();
     }
-    for (size_t i = 0; i < argc; i++) call_items[i] = i == idx ? wrapped : items[i];
+    for (size_t i = 0; i < argc; i++) {
+      ScrDyn *item = scr_dyn_arr_has_index(args, i) ? items[i] : scr_dyn_undefined();
+      call_items[i] = i == idx ? wrapped : item;
+    }
   }
   /* start.runStores: the start publish, the traced call, and the finally
    * end publish run inside the start channel's entered stores. */

--- a/packages/runtime/src/scr_dyn_invoke.c
+++ b/packages/runtime/src/scr_dyn_invoke.c
@@ -222,9 +222,10 @@ static ScrDyn *scr_dynh_dispatch(ScrDyn *recv, const char *method, ScrDyn *const
 }
 
 /* JS Array.prototype.sort over a dyn array: the spec's snapshot-sort —
- * elements copy (retained) into a work list, a stable merge sort orders
- * it (undefined elements sink to the end before any comparator runs),
- * and the ordered list writes back index by index, so a comparator that
+ * present elements copy (retained) into a work list, a stable merge sort
+ * orders them (undefined elements sink before the omitted holes, without
+ * invoking the comparator), and the ordered list writes back followed by
+ * holes, so a comparator that
  * mutates the receiver mid-sort never dangles the items being ordered.
  * The default comparator compares ToString images (scr_dyn_display_buf —
  * join's conversion) bytewise: code-POINT order, where JS orders UTF-16
@@ -277,27 +278,34 @@ static bool dyn_arr_sort_range(ScrDyn **work, ScrDyn **tmp, size_t lo, size_t hi
 }
 static bool dyn_arr_sort(ScrDyn *recv, ScrDyn *cmp) {
   size_t len = recv->v.arr.len;
-  ScrDyn **buf = (ScrDyn **)malloc(2 * len * sizeof(ScrDyn *));
+  size_t present = 0;
+  for (size_t i = 0; i < len; i++) {
+    if (scr_dyn_arr_has_index(recv, i)) present++;
+  }
+  if (present == 0) return true;
+  ScrDyn **buf = (ScrDyn **)malloc(2 * present * sizeof(ScrDyn *));
   if (!buf) return true; /* OOM: answer the array unsorted over crashing */
-  ScrDyn **work = buf, **tmp = buf + len;
-  for (size_t i = 0; i < len; i++) work[i] = scr_dyn_retain(recv->v.arr.items[i]);
-  bool ok = dyn_arr_sort_range(work, tmp, 0, len, cmp);
+  ScrDyn **work = buf, **tmp = buf + present;
+  for (size_t i = 0, j = 0; i < len; i++) {
+    if (scr_dyn_arr_has_index(recv, i)) work[j++] = scr_dyn_retain(recv->v.arr.items[i]);
+  }
+  bool ok = dyn_arr_sort_range(work, tmp, 0, present, cmp);
   if (ok) {
-    /* Write back into whatever the array holds NOW (a mutating comparator
-     * may have replaced entries): the work list's +1 moves in, the
-     * displaced entry releases. Elements beyond the current length (a
-     * shrinking comparator) just release. */
-    for (size_t i = 0; i < len; i++) {
-      if (i < recv->v.arr.len) {
-        ScrDyn *old = recv->v.arr.items[i];
-        recv->v.arr.items[i] = work[i];
-        scr_dyn_release(old);
-      } else {
-        scr_dyn_release(work[i]);
-      }
+    /* Write every sorted snapshot element even when the comparator shrank
+     * the receiver. Set operations regrow through the last present element;
+     * deleting trailing snapshot indices does not itself extend length.
+     * Comparator additions beyond the snapshot survive. */
+    while (recv->v.arr.len < present) scr_dyn_arr_push_hole(recv);
+    for (size_t i = 0; i < present; i++) {
+      ScrDyn *old = recv->v.arr.items[i];
+      recv->v.arr.items[i] = work[i];
+      scr_dyn_release(old);
+    }
+    for (size_t i = present; i < len && i < recv->v.arr.len; i++) {
+      scr_dyn_arr_set_hole(recv, i);
     }
   } else {
-    for (size_t i = 0; i < len; i++) scr_dyn_release(work[i]);
+    for (size_t i = 0; i < present; i++) scr_dyn_release(work[i]);
   }
   free(buf);
   return ok;
@@ -430,7 +438,7 @@ static ScrDyn *scr_dyn_invoke_impl(
         return NULL;
       }
       scr_dyn_this_push_dyn(thisv);
-      ScrDyn *r = scr_dyn_call(recv, list->v.arr.items, list->v.arr.len, what);
+      ScrDyn *r = scr_dyn_apply(recv, list, what);
       scr_dyn_this_pop();
       return r;
     }
@@ -502,14 +510,17 @@ static ScrDyn *scr_dyn_invoke_impl(
     }
     if (dyn_name_is(method, "pop")) {
       if (len == 0) return scr_dyn_retain(scr_dyn_undefined());
-      return recv->v.arr.items[--recv->v.arr.len]; /* ownership moves out */
+      bool present = scr_dyn_arr_has_index(recv, len - 1);
+      ScrDyn *last = recv->v.arr.items[--recv->v.arr.len];
+      return present ? last : scr_dyn_retain(scr_dyn_undefined()); /* ownership moves out when present */
     }
     if (dyn_name_is(method, "shift")) {
       if (len == 0) return scr_dyn_retain(scr_dyn_undefined());
+      bool present = scr_dyn_arr_has_index(recv, 0);
       ScrDyn *first = recv->v.arr.items[0];
       memmove(recv->v.arr.items, recv->v.arr.items + 1, (len - 1) * sizeof(ScrDyn *));
       recv->v.arr.len = len - 1;
-      return first; /* ownership moves out */
+      return present ? first : scr_dyn_retain(scr_dyn_undefined()); /* ownership moves out when present */
     }
     if (dyn_name_is(method, "unshift")) {
       /* Append first (the push path grows capacity and takes the +1s),
@@ -529,26 +540,30 @@ static ScrDyn *scr_dyn_invoke_impl(
       size_t start = dyn_rel_index(startD, len);
       size_t end = dyn_rel_index(endD, len);
       ScrDyn *out = scr_dyn_new_arr();
-      for (size_t i = start; i < end; i++) scr_dyn_arr_push(out, scr_dyn_retain(recv->v.arr.items[i]));
+      for (size_t i = start; i < end; i++) {
+        if (scr_dyn_arr_has_index(recv, i)) scr_dyn_arr_push(out, scr_dyn_retain(recv->v.arr.items[i]));
+        else scr_dyn_arr_push_hole(out);
+      }
       return out;
     }
     if (dyn_name_is(method, "at")) {
       double iD = dyn_index_arg(args, argc, 0, 0, what);
       if (scr_exc_pending()) return NULL;
       double idx = iD < 0 ? (double)len + iD : iD;
-      if (idx < 0 || idx >= (double)len) return scr_dyn_retain(scr_dyn_undefined());
-      return scr_dyn_retain(recv->v.arr.items[(size_t)idx]);
+      return scr_dyn_arr_at(recv, idx);
     }
     if (dyn_name_is(method, "indexOf") || dyn_name_is(method, "lastIndexOf") ||
         dyn_name_is(method, "includes")) {
       ScrDyn *needle = argc > 0 ? args[0] : scr_dyn_undefined();
       if (dyn_name_is(method, "lastIndexOf")) {
         for (size_t i = len; i > 0; i--) {
+          if (!scr_dyn_arr_has_index(recv, i - 1)) continue;
           if (scr_dyn_strict_eq(recv->v.arr.items[i - 1], needle)) return scr_dyn_new_num((double)(i - 1));
         }
         return scr_dyn_new_num(-1);
       }
       for (size_t i = 0; i < len; i++) {
+        if (!dyn_name_is(method, "includes") && !scr_dyn_arr_has_index(recv, i)) continue;
         if (scr_dyn_strict_eq(recv->v.arr.items[i], needle)) {
           return dyn_name_is(method, "includes") ? scr_dyn_new_bool(true) : scr_dyn_new_num((double)i);
         }
@@ -574,11 +589,15 @@ static ScrDyn *scr_dyn_invoke_impl(
     }
     if (dyn_name_is(method, "concat")) {
       ScrDyn *out = scr_dyn_new_arr();
-      for (size_t i = 0; i < len; i++) scr_dyn_arr_push(out, scr_dyn_retain(recv->v.arr.items[i]));
+      for (size_t i = 0; i < len; i++) {
+        if (scr_dyn_arr_has_index(recv, i)) scr_dyn_arr_push(out, scr_dyn_retain(recv->v.arr.items[i]));
+        else scr_dyn_arr_push_hole(out);
+      }
       for (size_t a = 0; a < argc; a++) {
         if (args[a]->kind == SCR_DYN_ARR) {
           for (size_t i = 0; i < args[a]->v.arr.len; i++) {
-            scr_dyn_arr_push(out, scr_dyn_retain(args[a]->v.arr.items[i]));
+            if (scr_dyn_arr_has_index(args[a], i)) scr_dyn_arr_push(out, scr_dyn_retain(args[a]->v.arr.items[i]));
+            else scr_dyn_arr_push_hole(out);
           }
         } else {
           scr_dyn_arr_push(out, scr_dyn_retain(args[a]));
@@ -601,16 +620,20 @@ static ScrDyn *scr_dyn_invoke_impl(
       if (!dyn_cb_check(args, argc)) return NULL;
       ScrDyn *cb = args[0];
       ScrDyn *out = (dyn_name_is(method, "map") || dyn_name_is(method, "filter")) ? scr_dyn_new_arr() : NULL;
-      /* Array iteration methods snapshot length before the first callback.
-       * A shrinking callback can remove a later dense entry; an expanding
-       * callback must not make the new tail observable to this pass. Live
-       * Web-boundary capsules are the externally visible receiver, so pass
-       * that capsule as callback arg 3: mutations through the callback's
-       * array argument then commit directly to the original static array. */
+      /* Every method snapshots length before the first callback. Presence
+       * remains live per index: deletions are skipped by the HasProperty
+       * methods and observed as undefined by find/findIndex. Live Web-
+       * boundary capsules remain the externally visible callback receiver. */
       size_t n = len;
       ScrDyn *visible_recv = callback_recv ? callback_recv : recv;
-      for (size_t i = 0; i < n && i < recv->v.arr.len; i++) {
-        ScrDyn *item = scr_dyn_retain(recv->v.arr.items[i]);
+      for (size_t i = 0; i < n; i++) {
+        bool present = scr_dyn_arr_has_index(recv, i);
+        bool visitsHoles = dyn_name_is(method, "find") || dyn_name_is(method, "findIndex");
+        if (!present && !visitsHoles) {
+          if (dyn_name_is(method, "map")) scr_dyn_arr_push_hole(out);
+          continue;
+        }
+        ScrDyn *item = present ? scr_dyn_retain(recv->v.arr.items[i]) : scr_dyn_retain(scr_dyn_undefined());
         ScrDyn *r = dyn_call_cb(cb, item, i, visible_recv);
         if (!r) { scr_dyn_release(item); scr_dyn_release(out); return NULL; }
         if (dyn_name_is(method, "map")) {
@@ -647,6 +670,7 @@ static ScrDyn *scr_dyn_invoke_impl(
       ScrDyn *out = scr_dyn_new_arr();
       size_t n = recv->v.arr.len;
       for (size_t i = 0; i < n && i < recv->v.arr.len; i++) {
+        if (!scr_dyn_arr_has_index(recv, i)) continue;
         ScrDyn *item = scr_dyn_retain(recv->v.arr.items[i]);
         ScrDyn *r = dyn_call_cb(
             cb, item, i, callback_recv ? callback_recv : recv);
@@ -654,7 +678,7 @@ static ScrDyn *scr_dyn_invoke_impl(
         if (!r) { scr_dyn_release(out); return NULL; }
         if (r->kind == SCR_DYN_ARR) {
           for (size_t j = 0; j < r->v.arr.len; j++) {
-            scr_dyn_arr_push(out, scr_dyn_retain(r->v.arr.items[j]));
+            if (scr_dyn_arr_has_index(r, j)) scr_dyn_arr_push(out, scr_dyn_retain(r->v.arr.items[j]));
           }
           scr_dyn_release(r);
         } else if (scr_dyn_isl_is_array(r)) {
@@ -670,6 +694,17 @@ static ScrDyn *scr_dyn_invoke_impl(
             char idx[24];
             int ilen = snprintf(idx, sizeof idx, "%zu", j);
             ScrStr *jk = scr_str_new(idx, (size_t)ilen);
+            bool present = scr_dyn_has_key(r, jk);
+            if (scr_exc_pending()) {
+              scr_str_release(jk);
+              scr_dyn_release(r);
+              scr_dyn_release(out);
+              return NULL;
+            }
+            if (!present) {
+              scr_str_release(jk);
+              continue;
+            }
             ScrDyn *el = scr_dyn_isl_key_get(r, jk);
             scr_str_release(jk);
             if (!el) { scr_dyn_release(r); scr_dyn_release(out); return NULL; }

--- a/packages/runtime/src/scr_inspect.c
+++ b/packages/runtime/src/scr_inspect.c
@@ -752,17 +752,33 @@ ScrStr *scr_insp_dyn(ScrDyn *d, double recurse, double depth) {
       if (d->v.arr.len == 0) return scr_str_new("[]", 2);
       if (recurse > depth) return scr_str_new("[Array]", 7);
       scr_insp_begin(recurse + 1);
-      size_t shown = d->v.arr.len < 100 ? d->v.arr.len : 100;
-      for (size_t i = 0; i < shown; i++) {
+      size_t i = 0;
+      size_t entries_shown = 0;
+      while (i < d->v.arr.len && entries_shown < 100) {
+        if (!scr_dyn_arr_has_index(d, i)) {
+          size_t end = i + 1;
+          while (end < d->v.arr.len && !scr_dyn_arr_has_index(d, end)) end++;
+          size_t n = end - i;
+          char empty[48];
+          int len = snprintf(empty, sizeof empty, "<%zu empty item%s>", n, n == 1 ? "" : "s");
+          ScrStr *s = scr_str_new(empty, (size_t)len);
+          scr_insp_entry(s, false);
+          scr_str_release(s);
+          i = end;
+          entries_shown++;
+          continue;
+        }
         ScrDyn *item = d->v.arr.items[i];
         ScrStr *s = scr_insp_dyn(item, recurse + 1, depth);
         scr_insp_entry(s, item->kind == SCR_DYN_NUM);
         scr_str_release(s);
+        i++;
+        entries_shown++;
       }
-      bool more = d->v.arr.len > 100;
+      bool more = i < d->v.arr.len;
       if (more) {
-        ScrStr *m = scr_insp_more_items((double)(d->v.arr.len - 100));
-        scr_insp_entry(m, d->v.arr.items[100]->kind == SCR_DYN_NUM);
+        ScrStr *m = scr_insp_more_items((double)(d->v.arr.len - i));
+        scr_insp_entry(m, scr_dyn_arr_has_index(d, i) && d->v.arr.items[i]->kind == SCR_DYN_NUM);
         scr_str_release(m);
       }
       ScrStr *base = scr_str_new("", 0);

--- a/packages/runtime/src/scr_island.c
+++ b/packages/runtime/src/scr_island.c
@@ -1000,6 +1000,7 @@ static const char *isl_dyn_unmarshalable(const ScrDyn *d) {
     return "a promise";
   case SCR_DYN_ARR:
     for (size_t i = 0; i < d->v.arr.len; i++) {
+      if (!scr_dyn_arr_has_index(d, i)) continue;
       const char *r = isl_dyn_unmarshalable(d->v.arr.items[i]);
       if (r != NULL) return r;
     }
@@ -1042,12 +1043,17 @@ static JSValue isl_from_dyn(const ScrDyn *d) {
     JSValue arr = JS_NewArray(isl_ctx);
     if (JS_IsException(arr)) return arr;
     for (size_t i = 0; i < d->v.arr.len; i++) {
+      if (!scr_dyn_arr_has_index(d, i)) continue;
       JSValue item = isl_from_dyn(d->v.arr.items[i]);
       if (JS_IsException(item) ||
           JS_SetPropertyUint32(isl_ctx, arr, (uint32_t)i, item) < 0) {
         JS_FreeValue(isl_ctx, arr);
         return JS_EXCEPTION;
       }
+    }
+    if (JS_SetPropertyStr(isl_ctx, arr, "length", JS_NewFloat64(isl_ctx, (double)d->v.arr.len)) < 0) {
+      JS_FreeValue(isl_ctx, arr);
+      return JS_EXCEPTION;
     }
     return arr;
   }
@@ -1311,6 +1317,18 @@ static int isl_dynjs_has_own(ScrJsval *cell, const ScrStr *k) {
   return b > 0 ? 1 : 0;
 }
 
+static int isl_dynjs_has_property(ScrJsval *cell, const ScrStr *k) {
+  isl_entry();
+  JSAtom key = JS_NewAtomLen(isl_ctx, k->data, k->len);
+  int has = JS_HasProperty(isl_ctx, cell->v, key);
+  JS_FreeAtom(isl_ctx, key);
+  if (has < 0) {
+    isl_bridge_exception();
+    return -1;
+  }
+  return has != 0 ? 1 : 0;
+}
+
 static bool isl_dynjs_assign(ScrJsval *cell, const ScrDyn *src) {
   ScrJsval *sj = scr_jsval_from_dyn(src);
   if (!sj) return false;
@@ -1373,6 +1391,7 @@ static const ScrDynJsvalOps isl_dynjs_ops = {
   isl_dynjs_is_nullish,
   isl_dynjs_obj_walk,
   isl_dynjs_has_own,
+  isl_dynjs_has_property,
   isl_dynjs_assign,
   isl_dynjs_to_json,
   isl_dynjs_iter_drain,

--- a/packages/runtime/src/scr_json.c
+++ b/packages/runtime/src/scr_json.c
@@ -2695,7 +2695,7 @@ void scr_sc_validate_options(const ScrDyn *options) {
   if (tr == NULL || tr->kind == SCR_DYN_UNDEF) return;
   if (tr->kind != SCR_DYN_ARR) {
     static const char msg[] =
-        "Failed to execute 'structuredClone': transfer in Options can not be converted to sequence.";
+        "Failed to execute 'structuredClone': transfer in Options cannot be converted to sequence.";
     scr_throw_error_msg_code(SCR_ERR_TYPE, msg, sizeof msg - 1, "ERR_INVALID_ARG_TYPE");
     return;
   }

--- a/packages/runtime/src/scr_json.c
+++ b/packages/runtime/src/scr_json.c
@@ -432,9 +432,15 @@ ScrDyn *scr_dyn_obj_get(const ScrDyn *d, const char *key, size_t key_len) {
   return NULL;
 }
 
-/* Public: the compiler-emitted static→dyn converters push through this
- * too. Ownership of the item moves in. */
-void scr_dyn_arr_push(ScrDyn *arr, ScrDyn *item) {
+/* A distinct immortal undefined-shaped sentinel preserves array-property
+ * absence internally. Reads expose ordinary undefined; presence-sensitive
+ * operations recognize the sentinel. */
+static ScrDyn *scr_dyn_hole(void) {
+  static ScrDyn hole = { SIZE_MAX, SCR_DYN_UNDEF, { false } };
+  return &hole;
+}
+
+static void scr_dyn_arr_push_raw(ScrDyn *arr, ScrDyn *item) {
   if (arr->v.arr.len == arr->v.arr.cap) {
     size_t cap = arr->v.arr.cap ? arr->v.arr.cap * 2 : 4;
     ScrDyn **items = realloc(arr->v.arr.items, cap * sizeof *items);
@@ -443,6 +449,27 @@ void scr_dyn_arr_push(ScrDyn *arr, ScrDyn *item) {
     arr->v.arr.cap = cap;
   }
   arr->v.arr.items[arr->v.arr.len++] = item; /* ownership moves in */
+}
+
+/* Public: the compiler-emitted static→dyn converters push through these
+ * too. Ownership of an ordinary item moves in. */
+void scr_dyn_arr_push(ScrDyn *arr, ScrDyn *item) {
+  if (item == scr_dyn_hole()) item = scr_dyn_retain(scr_dyn_undefined());
+  scr_dyn_arr_push_raw(arr, item);
+}
+
+void scr_dyn_arr_push_hole(ScrDyn *arr) {
+  scr_dyn_arr_push_raw(arr, scr_dyn_hole());
+}
+
+bool scr_dyn_arr_has_index(const ScrDyn *arr, size_t i) {
+  return arr->kind == SCR_DYN_ARR && i < arr->v.arr.len && arr->v.arr.items[i] != scr_dyn_hole();
+}
+
+void scr_dyn_arr_set_hole(ScrDyn *arr, size_t i) {
+  if (arr->kind != SCR_DYN_ARR || i >= arr->v.arr.len || !scr_dyn_arr_has_index(arr, i)) return;
+  scr_dyn_release(arr->v.arr.items[i]);
+  arr->v.arr.items[i] = scr_dyn_hole();
 }
 
 /* Spread completion for a runtime-arity argument list (`f(...xs)` in the
@@ -578,6 +605,7 @@ ScrDyn *scr_dyn_arr_at(const ScrDyn *d, double i) {
   if (d->kind != SCR_DYN_ARR || i < 0 || i >= (double)d->v.arr.len) {
     return scr_dyn_retain(scr_dyn_undefined());
   }
+  if (!scr_dyn_arr_has_index(d, (size_t)i)) return scr_dyn_retain(scr_dyn_undefined());
   return scr_dyn_retain(d->v.arr.items[(size_t)i]);
 }
 
@@ -871,7 +899,20 @@ ScrDyn *scr_dyn_call(const ScrDyn *d, ScrDyn *const *args, size_t argc, const ch
  * (`f(...args)` after the emitted argument array is built). Borrows both;
  * result owned (+1), or NULL with the exception pending. */
 ScrDyn *scr_dyn_apply(const ScrDyn *d, const ScrDyn *args, const char *what) {
-  return scr_dyn_call(d, args->v.arr.items, args->v.arr.len, what);
+  size_t argc = args->v.arr.len;
+  bool sparse = false;
+  for (size_t i = 0; i < argc; i++) {
+    if (!scr_dyn_arr_has_index(args, i)) { sparse = true; break; }
+  }
+  if (!sparse) return scr_dyn_call(d, args->v.arr.items, argc, what);
+  ScrDyn **items = malloc(argc * sizeof *items);
+  if (!items) scr_trap("scriptc: out of memory\n");
+  for (size_t i = 0; i < argc; i++) {
+    items[i] = scr_dyn_arr_has_index(args, i) ? args->v.arr.items[i] : scr_dyn_undefined();
+  }
+  ScrDyn *r = scr_dyn_call(d, items, argc, what);
+  free(items);
+  return r;
 }
 
 /* ── native handles in the checked-dynamic tree (SCR_DYN_HANDLE) ───────────────────────
@@ -1807,6 +1848,9 @@ bool scr_dyn_has_key(const ScrDyn *v, const ScrStr *key) {
     scr_dyn_release(materialized);
     return out;
   }
+  if (v->kind == SCR_DYN_JSVAL) {
+    return scr_dyn_jsval_ops()->has_property(v->v.jsval.cell, key) == 1;
+  }
   if (v->kind == SCR_DYN_OBJ) return scr_dyn_obj_get(v, key->data, key->len) != NULL;
   if (v->kind == SCR_DYN_ARR) {
     if (key->len == 6 && memcmp(key->data, "length", 6) == 0) return true;
@@ -1818,7 +1862,7 @@ bool scr_dyn_has_key(const ScrDyn *v, const ScrStr *key) {
       if (i > 0 && idx == 0) return false; /* a leading zero is no canonical index */
       idx = idx * 10 + (size_t)(c - '0');
     }
-    return idx < v->v.arr.len;
+    return scr_dyn_arr_has_index(v, idx);
   }
   return false;
 }
@@ -1847,9 +1891,7 @@ void scr_dyn_key_set(ScrDyn *recv, ScrStr *key, ScrDyn *value) {
       else idx = idx * 10 + (size_t)(key->data[i] - '0');
     }
     if (is_index) {
-      while (recv->v.arr.len <= idx) {
-        scr_dyn_arr_push(recv, scr_dyn_retain(scr_dyn_undefined()));
-      }
+      while (recv->v.arr.len <= idx) scr_dyn_arr_push_hole(recv);
       scr_dyn_release(recv->v.arr.items[idx]);
       recv->v.arr.items[idx] = scr_dyn_retain(value);
       return;
@@ -2700,6 +2742,10 @@ static ScrDyn *scr_sc_clone(const ScrDyn *v, const ScrScParent *up) {
     if (v->kind == SCR_DYN_ARR) {
       ScrDyn *out = scr_dyn_new_arr();
       for (size_t i = 0; i < v->v.arr.len; i++) {
+        if (!scr_dyn_arr_has_index(v, i)) {
+          scr_dyn_arr_push_hole(out);
+          continue;
+        }
         ScrDyn *c = scr_sc_clone(v->v.arr.items[i], &self);
         if (c == NULL) { /* threw */
           scr_dyn_release(out);
@@ -2905,6 +2951,7 @@ static ScrDyn *scr_dyn_objwalk(const ScrDyn *v, ScrObjWalk mode) {
   if (v->kind == SCR_DYN_ARR || v->kind == SCR_DYN_BYTES) {
     size_t n = v->kind == SCR_DYN_ARR ? v->v.arr.len : v->v.bytes->len;
     for (size_t i = 0; i < n; i++) {
+      if (v->kind == SCR_DYN_ARR && !scr_dyn_arr_has_index(v, i)) continue;
       char key[24];
       int klen = snprintf(key, sizeof key, "%zu", i);
       ScrDyn *val = NULL;
@@ -3160,7 +3207,7 @@ bool scr_dyn_has_own(const ScrDyn *v, const ScrStr *key) {
       if (key->data[i] < '0' || key->data[i] > '9') is_index = 0;
       else idx = idx * 10 + (size_t)(key->data[i] - '0');
     }
-    return is_index != 0 && idx < v->v.arr.len;
+    return is_index != 0 && scr_dyn_arr_has_index(v, idx);
   }
   return false;
 }

--- a/packages/runtime/src/scr_json.c
+++ b/packages/runtime/src/scr_json.c
@@ -2695,7 +2695,7 @@ void scr_sc_validate_options(const ScrDyn *options) {
   if (tr == NULL || tr->kind == SCR_DYN_UNDEF) return;
   if (tr->kind != SCR_DYN_ARR) {
     static const char msg[] =
-        "Failed to execute 'structuredClone': transfer in Options cannot be converted to sequence.";
+        "Failed to execute 'structuredClone': transfer in Options can not be converted to sequence.";
     scr_throw_error_msg_code(SCR_ERR_TYPE, msg, sizeof msg - 1, "ERR_INVALID_ARG_TYPE");
     return;
   }

--- a/packages/runtime/src/scr_json.c
+++ b/packages/runtime/src/scr_json.c
@@ -2653,7 +2653,7 @@ void scr_sc_validate_options(const ScrDyn *options) {
   if (tr == NULL || tr->kind == SCR_DYN_UNDEF) return;
   if (tr->kind != SCR_DYN_ARR) {
     static const char msg[] =
-        "Failed to execute 'structuredClone': transfer in Options can not be converted to sequence.";
+        "Failed to execute 'structuredClone': transfer in Options cannot be converted to sequence.";
     scr_throw_error_msg_code(SCR_ERR_TYPE, msg, sizeof msg - 1, "ERR_INVALID_ARG_TYPE");
     return;
   }

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -2894,9 +2894,10 @@ ScrDyn *scr_dyn_obj_entries(const ScrDyn *v);
 /* dyn construction — the compiler-emitted static→dyn converters (sc_td_*)
  * and index-signature overflow machinery build dyn values directly.
  * Constructors return +1; _new_str RETAINS the string into the node.
- * arr_push and obj_set take OWNERSHIP of the value (+1 moves in); obj_set
- * COPIES the key bytes and replaces a duplicate key's value (later wins,
- * like JS). scr_dyn_undefined returns THE immortal undefined value
+ * arr_push and obj_set take OWNERSHIP of the value (+1 moves in);
+ * arr_push_hole appends an absent indexed property while retaining length.
+ * obj_set COPIES the key bytes and replaces a duplicate key's value (later
+ * wins, like JS). scr_dyn_undefined returns THE immortal undefined value
  * (rc == SIZE_MAX — retains/releases are no-ops). */
 ScrDyn *scr_dyn_undefined(void);
 ScrDyn *scr_dyn_new_null(void);
@@ -2946,6 +2947,9 @@ void scr_dyn_typed_ref_cache_cast(
  * extraction (`u as Uint8Array`). */
 ScrBytes *scr_dyn_bytes_copy_out(const ScrDyn *d);
 void scr_dyn_arr_push(ScrDyn *arr, ScrDyn *item);
+void scr_dyn_arr_push_hole(ScrDyn *arr);
+bool scr_dyn_arr_has_index(const ScrDyn *arr, size_t i);
+void scr_dyn_arr_set_hole(ScrDyn *arr, size_t i);
 /* Spread completion for a runtime-arity argument list (`f(...xs)` in the
  * checked-dynamic tier): flattens `src` into `arr` per JS's spread over the
  * dyn's iterable kinds — arrays element-by-element (retained), strings by
@@ -3204,6 +3208,7 @@ typedef struct ScrDynJsvalOps {
    * dyn pairs. NULL with the engine's exception pending on refusal. */
   ScrDyn *(*obj_walk)(ScrJsval *cell, int mode);
   int (*has_own)(ScrJsval *cell, const ScrStr *k); /* 0/1; -1 = pending */
+  int (*has_property)(ScrJsval *cell, const ScrStr *k); /* JS HasProperty; 0/1; -1 = pending */
   /* Object.assign(target, src) with the ENGINE target: src converts per
    * member semantics (a wrapped src spreads by reference; dyn data
    * enters as the usual deep copy). false = pending. */

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -719,10 +719,10 @@ ScrStr *scr_b64_missing_arg(void);
  * layout is untouched (interned-literal statics depend on it), so the
  * element kind lives here instead of in a shared object header.
  *
- * Index arguments are doubles (JS numbers). A valid index is a non-negative
- * integer; reads must be < len, writes may also be == len (append — JS
- * would create a hole past the end; scriptc traps instead, see
- * SEMANTICS.md). Anything else prints
+ * Index arguments are doubles (JS numbers). A valid array index is an
+ * integer in [0, 2^32-2]. Reads must also be < len; writes grow length to
+ * index + 1 and create holes between the old end and the written slot.
+ * Anything else prints
  *   scriptc: RangeError: array index <i> out of bounds (length <n>)
  * to stderr and abort()s. pop() on an empty array likewise traps (JS
  * returns undefined — unrepresentable here).
@@ -825,20 +825,26 @@ double scr_arr_get_dense_f64(ScrArr *a, double i);
 bool scr_arr_get_dense_bool(ScrArr *a, double i);
 void *scr_arr_get_dense_ref(ScrArr *a, double i);
 
-/* i == len appends; the _ref variant releases the old element (when
- * replacing) and takes ownership of the new one. */
+/* A write at or beyond len grows through i + 1, leaving intermediate slots
+ * as holes. The _ref variants release the old element (when replacing) and
+ * take ownership of the new one. _ref_fill stores fill as inert backing for
+ * new holes, allowing a statically known undefined union arm to answer Get. */
 void scr_arr_set_f64(ScrArr *a, double i, double v);
 void scr_arr_set_bool(ScrArr *a, double i, bool v);
 void scr_arr_set_ref(ScrArr *a, double i, void *v);
+void scr_arr_set_ref_fill(ScrArr *a, double i, void *v, void *fill);
 
 /* slice(start?, end?): a fresh +1 shallow copy of the index range —
  * ToIntegerOrInfinity indices, negatives from the end, clamping; ref
  * elements retain into the copy. Borrows a. */
 ScrArr *scr_arr_slice(ScrArr *a, double start, double end);
 
-/* ES2023 copying methods. All borrow their inputs and return fresh +1
- * shallow copies. with() raises Node's catchable RangeError for an invalid
- * relative index; the ref variant retains the borrowed replacement. */
+/* ES2023 copying methods. All borrow their inputs and return fresh packed +1
+ * shallow copies; source holes densify to present undefined values via a
+ * REF array's non-NULL hole backing. A hole whose typed element ABI cannot
+ * encode undefined traps rather than becoming 0/NULL. with() raises Node's
+ * catchable RangeError for an invalid relative index; the ref variant
+ * retains the borrowed replacement. */
 ScrArr *scr_arr_to_reversed(const ScrArr *a);
 ScrArr *scr_arr_to_spliced(const ScrArr *a, double start,
                            double delete_count, const ScrArr *items);

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -762,6 +762,9 @@ typedef struct ScrArr {
   void (*elem_release)(void *);
   ScrTraceFn elem_trace;
   uint64_t *data;
+  /* NULL for packed arrays. Sparse arrays carry one bit per capacity slot;
+   * a clear bit is a hole, independently of the slot's stored bits. */
+  uint8_t *present;
 } ScrArr;
 
 ScrArr *scr_arr_new(ScrElemKind elem, size_t initial_cap); /* returns +1 */
@@ -773,6 +776,13 @@ ScrArr *scr_arr_new(ScrElemKind elem, size_t initial_cap); /* returns +1 */
 ScrArr *scr_arr_new_ref(void *(*elem_retain)(void *),
                          void (*elem_release)(void *),
                          ScrTraceFn elem_trace, size_t initial_cap);
+
+/* Grow an array to n with holes. fill is stored only as inert backing for
+ * representable hole reads (for example an undefined union singleton). */
+void scr_arr_set_sparse_len(ScrArr *a, double n, void *fill);
+bool scr_arr_has(ScrArr *a, double i);
+bool scr_arr_delete(ScrArr *a, double i, void *fill);
+double scr_arr_append_sparse(ScrArr *dst, ScrArr *src, void *fill);
 
 static inline ScrArr *scr_arr_retain(ScrArr *a) {
   if (a->rc != SIZE_MAX) {
@@ -810,6 +820,10 @@ double scr_math_random(void);
 double scr_arr_get_f64(ScrArr *a, double i); /* trap OOB */
 bool scr_arr_get_bool(ScrArr *a, double i);  /* trap OOB */
 void *scr_arr_get_ref(ScrArr *a, double i);  /* trap OOB; returns +1 */
+/* Compiler-proven packed receivers: still trap OOB, never inspect present. */
+double scr_arr_get_dense_f64(ScrArr *a, double i);
+bool scr_arr_get_dense_bool(ScrArr *a, double i);
+void *scr_arr_get_dense_ref(ScrArr *a, double i);
 
 /* i == len appends; the _ref variant releases the old element (when
  * replacing) and takes ownership of the new one. */

--- a/packages/runtime/src/scr_web.c
+++ b/packages/runtime/src/scr_web.c
@@ -1212,7 +1212,7 @@ static const char web_prelude[] =
     "          if (typeof tr === 'string') throw 0;\n"
     "          list = [...tr];\n"
     "        } catch (e) {\n"
-    "          throw scErr(\"Failed to execute 'structuredClone': transfer in Options can not be converted to sequence.\");\n"
+    "          throw scErr(\"Failed to execute 'structuredClone': transfer in Options cannot be converted to sequence.\");\n"
     "        }\n"
     "        if (list.length > 0) {\n"
     "          throw new DOMException('Found invalid value in transferList.', 'DataCloneError');\n"

--- a/packages/runtime/src/scr_web.c
+++ b/packages/runtime/src/scr_web.c
@@ -1212,7 +1212,7 @@ static const char web_prelude[] =
     "          if (typeof tr === 'string') throw 0;\n"
     "          list = [...tr];\n"
     "        } catch (e) {\n"
-    "          throw scErr(\"Failed to execute 'structuredClone': transfer in Options cannot be converted to sequence.\");\n"
+    "          throw scErr(\"Failed to execute 'structuredClone': transfer in Options can not be converted to sequence.\");\n"
     "        }\n"
     "        if (list.length > 0) {\n"
     "          throw new DOMException('Found invalid value in transferList.', 'DataCloneError');\n"

--- a/packages/runtime/test/array.test.ts
+++ b/packages/runtime/test/array.test.ts
@@ -19,6 +19,7 @@ beforeAll(async () => {
     "-o", bin,
     join(testDir, "test_array.c"),
     join(testDir, "../src/scr_array.c"),
+    join(testDir, "../src/scr_copying.c"),
     join(testDir, "../src/scr_string.c"),
     join(testDir, "../src/scr_number.c"),
     join(testDir, "../src/scr_bytes.c"),
@@ -35,13 +36,12 @@ test("array runtime: push/pop/set/get, RC recursion, growth", async () => {
   expect(stderr.trim()).toMatch(/^(\d+)\/\1 cases passed$/);
 });
 
-// JS returns undefined for OOB reads and creates holes for far writes; both
-// are unrepresentable, so the runtime must trap (documented divergence).
 test.each([
-  ["--crash-get-oob", "array index 1 out of bounds (length 1)"],
-  ["--crash-get-frac", "array index 0.5 out of bounds (length 1)"],
-  ["--crash-set-oob", "array index 2 out of bounds (length 1)"],
-  ["--crash-pop-empty", "pop() on an empty array"],
+  ["--crash-get-oob", "RangeError: array index 1 out of bounds (length 1)"],
+  ["--crash-get-frac", "RangeError: array index 0.5 out of bounds (length 1)"],
+  ["--crash-set-max", "RangeError: array index 4294967295 out of bounds (length 1)"],
+  ["--crash-pop-empty", "RangeError: pop() on an empty array"],
+  ["--crash-copy-hole", "TypeError: array hole cannot be represented as undefined by the element type"],
 ])("trap aborts (%s)", async (mode, message) => {
   const err = await execFileAsync(bin, [mode]).then(
     () => {
@@ -50,5 +50,5 @@ test.each([
     (e: Error & { signal?: string; stderr?: string }) => e,
   );
   expect(err.signal).toBe("SIGABRT");
-  expect(err.stderr).toContain(`scriptc: RangeError: ${message}`);
+  expect(err.stderr).toContain(`scriptc: ${message}`);
 });

--- a/packages/runtime/test/test_array.c
+++ b/packages/runtime/test/test_array.c
@@ -188,6 +188,17 @@ static void test_index_of_includes(void) {
   scr_arr_release(inner);
   scr_arr_release(other);
   scr_arr_release(outer);
+
+  /* includes performs Get and therefore sees a union-backed hole's stored
+   * undefined value; indexOf skips holes per HasProperty. An array pointer
+   * stands in for the runtime's immortal undefined singleton here. */
+  ScrArr *sparse = scr_arr_new(SCR_ELEM_ARR, 0);
+  ScrArr *undefined_fill = scr_arr_new(SCR_ELEM_F64, 0);
+  scr_arr_set_sparse_len(sparse, 1, undefined_fill);
+  check(scr_arr_includes_ref(sparse, undefined_fill), "includes reads a represented hole");
+  check_f64(scr_arr_index_of_ref(sparse, undefined_fill), -1, "indexOf skips a represented hole");
+  scr_arr_release(sparse);
+  scr_arr_release(undefined_fill);
 }
 
 /* ── SCR_ELEM_REF: a mock "record" the runtime cannot lay out ─────────
@@ -325,6 +336,22 @@ static void test_ref_cycle(void) {
   scr_arr_release(arr); /* external edge gone; the cycle keeps both alive */
   scr_collect_cycles();
   check(mock_live == 0, "cycle collected through the array element");
+
+  arr = scr_arr_new_ref(&mock_cyc_retain, &mock_cyc_release, &mock_trace, 0);
+  rec = mock_cyc_new(8);
+  rec->owner = (ScrArr *)scr_arr_retain(arr);
+  scr_arr_push_ref(arr, rec);
+  scr_arr_delete(arr, 0, NULL);
+  check(mock_live == 0, "cycle: delete unlinks before releasing element");
+  scr_arr_release(arr);
+
+  arr = scr_arr_new_ref(&mock_cyc_retain, &mock_cyc_release, &mock_trace, 0);
+  rec = mock_cyc_new(9);
+  rec->owner = (ScrArr *)scr_arr_retain(arr);
+  scr_arr_push_ref(arr, rec);
+  scr_arr_set_sparse_len(arr, 0, NULL);
+  check(mock_live == 0, "cycle: truncation unlinks before releasing element");
+  scr_arr_release(arr);
 #ifdef SCR_RC_AUDIT
   check(scr_arr_live_count() == arrays0, "cycle: no arrays leaked");
 #endif
@@ -378,6 +405,54 @@ static void test_join(void) {
 #endif
 }
 
+static void test_sparse(void) {
+#ifdef SCR_RC_AUDIT
+  long strings0 = scr_str_live_count();
+  long arrays0 = scr_arr_live_count();
+#endif
+  ScrArr *a = scr_arr_new(SCR_ELEM_STR, 0);
+  check(a->present == NULL, "packed arrays have no presence bitmap");
+  scr_arr_set_sparse_len(a, 4, NULL);
+  check_f64(scr_arr_len(a), 4, "sparse allocation sets length");
+  check(!scr_arr_has(a, 0) && !scr_arr_has(a, 3), "sparse allocation creates holes");
+  scr_arr_set_ref(a, 1, scr_str_new("x", 1));
+  scr_arr_set_ref(a, 3, scr_str_new("z", 1));
+  check(scr_arr_has(a, 1) && scr_arr_has(a, 3), "indexed writes mark slots present");
+  ScrStr *missing = scr_str_new("missing", 7);
+  check_f64(scr_arr_index_of_ref(a, missing), -1, "indexOf skips holes");
+  scr_str_release(missing);
+  ScrStr *sep = scr_str_new(",", 1);
+  ScrStr *joined = scr_arr_join(a, sep);
+  check(strcmp(joined->data, ",x,,z") == 0, "join renders holes as empty fields");
+  scr_str_release(joined);
+  scr_str_release(sep);
+
+  ScrArr *slice = scr_arr_slice(a, 1, 4);
+  check(scr_arr_has(slice, 0) && !scr_arr_has(slice, 1) && scr_arr_has(slice, 2),
+        "slice preserves holes");
+  scr_arr_delete(slice, 0, NULL);
+  check(!scr_arr_has(slice, 0) && scr_arr_len(slice) == 3,
+        "delete clears presence without changing length");
+  scr_arr_release(slice);
+  scr_arr_release(a);
+
+  ScrArr *dst = scr_arr_new(SCR_ELEM_F64, 0);
+  ScrArr *src = scr_arr_new(SCR_ELEM_F64, 1);
+  scr_arr_push_f64(src, 1);
+  dst->len = UINT32_MAX;
+  check_f64(scr_arr_append_sparse(dst, src, NULL), UINT32_MAX,
+            "sparse append leaves destination unchanged above max length");
+  check(scr_exc_pending(), "sparse append above max length throws");
+  scr_exc_clear();
+  dst->len = 0; /* The synthetic oversized length owns no slots. */
+  scr_arr_release(src);
+  scr_arr_release(dst);
+#ifdef SCR_RC_AUDIT
+  check(scr_str_live_count() == strings0, "sparse: no strings leaked");
+  check(scr_arr_live_count() == arrays0, "sparse: no arrays leaked");
+#endif
+}
+
 int main(int argc, char **argv) {
   if (argc > 1) {
     ScrArr *a = scr_arr_new(SCR_ELEM_F64, 0);
@@ -407,6 +482,7 @@ int main(int argc, char **argv) {
   test_ref_elements();
   test_ref_cycle();
   test_join();
+  test_sparse();
 
   fprintf(stderr, "%ld/%ld cases passed\n", total - failed, total);
   return failed == 0 ? 0 : 1;

--- a/packages/runtime/test/test_array.c
+++ b/packages/runtime/test/test_array.c
@@ -4,8 +4,9 @@
  *   (no args)          run all assertions; prints "N/N cases passed"
  *   --crash-get-oob    read past the end        → RangeError + abort()
  *   --crash-get-frac   read a fractional index  → RangeError + abort()
- *   --crash-set-oob    write past len (holes)   → RangeError + abort()
+ *   --crash-set-max    write at 2^32-1          → RangeError + abort()
  *   --crash-pop-empty  pop an empty array       → RangeError + abort()
+ *   --crash-copy-hole  densify a scalar hole    → TypeError + abort()
  *
  * The RC-recursion cases (array of strings, array of arrays of strings)
  * assert live counts directly: releasing the outer array must release
@@ -436,6 +437,30 @@ static void test_sparse(void) {
   scr_arr_release(slice);
   scr_arr_release(a);
 
+  ScrArr *far = scr_arr_new(SCR_ELEM_F64, 0);
+  scr_arr_push_f64(far, 1);
+  scr_arr_set_f64(far, 4, 5);
+  check_f64(scr_arr_len(far), 5, "far indexed write grows length");
+  check(scr_arr_has(far, 0) && !scr_arr_has(far, 1) &&
+            !scr_arr_has(far, 2) && !scr_arr_has(far, 3) &&
+            scr_arr_has(far, 4),
+        "far indexed write creates intermediate holes");
+  check_f64(scr_arr_get_f64(far, 0), 1, "far write preserves prefix");
+  check_f64(scr_arr_get_f64(far, 4), 5, "far write stores endpoint");
+  scr_arr_set_f64(far, 5, 6);
+  check_f64(scr_arr_len(far), 6, "write at sparse length appends");
+  check(!scr_arr_has(far, 3) && scr_arr_has(far, 5),
+        "sparse append preserves existing holes");
+  scr_arr_release(far);
+
+  ScrArr *far_refs = scr_arr_new(SCR_ELEM_STR, 0);
+  scr_arr_push_ref(far_refs, scr_str_new("a", 1));
+  scr_arr_set_ref(far_refs, 3, scr_str_new("d", 1));
+  check_f64(scr_arr_len(far_refs), 4, "far ref write grows length");
+  check(!scr_arr_has(far_refs, 1) && !scr_arr_has(far_refs, 2),
+        "far ref write leaves unowned holes");
+  scr_arr_release(far_refs);
+
   ScrArr *dst = scr_arr_new(SCR_ELEM_F64, 0);
   ScrArr *src = scr_arr_new(SCR_ELEM_F64, 1);
   scr_arr_push_f64(src, 1);
@@ -453,6 +478,76 @@ static void test_sparse(void) {
 #endif
 }
 
+static void test_copying_holes(void) {
+  long live0 = mock_live;
+  MockRec *undefined_fill = mock_new(-1);
+  ScrArr *src = scr_arr_new_ref(&mock_retain, &mock_release, NULL, 0);
+  scr_arr_push_ref(src, mock_new(1));
+  scr_arr_set_sparse_len(src, 4, undefined_fill);
+  scr_arr_set_ref(src, 2, mock_new(3));
+
+  ScrArr *reversed = scr_arr_to_reversed(src);
+  check(reversed->present == NULL, "toReversed densifies represented holes");
+  check(scr_arr_has(reversed, 0) && scr_arr_has(reversed, 1) &&
+            scr_arr_has(reversed, 2) && scr_arr_has(reversed, 3),
+        "toReversed result has every index");
+  MockRec *v = scr_arr_get_ref(reversed, 0);
+  check(v == undefined_fill, "toReversed reads a hole as undefined backing");
+  mock_release(v);
+  check(undefined_fill->rc == 3,
+        "toReversed retains each densified undefined backing");
+  scr_arr_release(reversed);
+  check(undefined_fill->rc == 1,
+        "toReversed releases densified undefined backings");
+
+  ScrArr *items = scr_arr_new_ref(&mock_retain, &mock_release, NULL, 0);
+  scr_arr_push_ref(items, mock_new(2));
+  ScrArr *spliced = scr_arr_to_spliced(src, 1, 1, items);
+  check(spliced->present == NULL, "toSpliced densifies kept holes");
+  check_f64(scr_arr_len(spliced), 4, "toSpliced keeps expected length");
+  v = scr_arr_get_ref(spliced, 3);
+  check(v == undefined_fill, "toSpliced reads a kept hole as undefined backing");
+  mock_release(v);
+  check(undefined_fill->rc == 2,
+        "toSpliced retains a kept undefined backing");
+  scr_arr_release(spliced);
+  check(undefined_fill->rc == 1,
+        "toSpliced releases a kept undefined backing");
+
+  MockRec *replacement = mock_new(9);
+  ScrArr *with = scr_arr_with_ref(src, 0, replacement);
+  check(with->present == NULL, "with densifies represented holes");
+  check(undefined_fill->rc == 3, "with retains densified undefined backings");
+  check(replacement->rc == 2, "with retains the borrowed replacement");
+  scr_arr_release(with);
+  check(undefined_fill->rc == 1, "with releases densified undefined backings");
+  check(replacement->rc == 1, "with releases its replacement reference");
+  mock_release(replacement);
+
+  ScrArr *plain = scr_arr_new(SCR_ELEM_F64, 0);
+  scr_arr_push_f64(plain, 1);
+  scr_arr_set_f64(plain, 2, 3);
+  ScrArr *no_items = scr_arr_new(SCR_ELEM_F64, 0);
+  ScrArr *deleted = scr_arr_to_spliced(plain, 1, 1, no_items);
+  check(deleted->present == NULL && scr_arr_len(deleted) == 2,
+        "toSpliced does not Get a deleted unrepresentable hole");
+  check_f64(scr_arr_get_f64(deleted, 0), 1, "toSpliced deleted-hole prefix");
+  check_f64(scr_arr_get_f64(deleted, 1), 3, "toSpliced deleted-hole suffix");
+  ScrArr *replaced = scr_arr_with_f64(plain, 1, 2);
+  check(replaced->present == NULL && scr_arr_has(replaced, 1),
+        "with does not Get its replaced hole");
+  check_f64(scr_arr_get_f64(replaced, 1), 2, "with stores over a scalar hole");
+  scr_arr_release(replaced);
+  scr_arr_release(deleted);
+  scr_arr_release(no_items);
+  scr_arr_release(plain);
+
+  scr_arr_release(items);
+  scr_arr_release(src);
+  mock_release(undefined_fill);
+  check(mock_live == live0, "copying methods balance ref elements");
+}
+
 int main(int argc, char **argv) {
   if (argc > 1) {
     ScrArr *a = scr_arr_new(SCR_ELEM_F64, 0);
@@ -461,11 +556,15 @@ int main(int argc, char **argv) {
       scr_arr_get_f64(a, 1); /* len is 1 */
     } else if (strcmp(argv[1], "--crash-get-frac") == 0) {
       scr_arr_get_f64(a, 0.5);
-    } else if (strcmp(argv[1], "--crash-set-oob") == 0) {
-      scr_arr_set_f64(a, 2, 9); /* would create a hole */
+    } else if (strcmp(argv[1], "--crash-set-max") == 0) {
+      scr_arr_set_f64(a, 4294967295.0, 9);
     } else if (strcmp(argv[1], "--crash-pop-empty") == 0) {
       scr_arr_pop_f64(a);
       scr_arr_pop_f64(a); /* now empty */
+    } else if (strcmp(argv[1], "--crash-copy-hole") == 0) {
+      scr_arr_set_sparse_len(a, 2, NULL);
+      ScrArr *copy = scr_arr_to_reversed(a);
+      scr_arr_release(copy);
     } else {
       fprintf(stderr, "unknown mode %s\n", argv[1]);
       return 2;
@@ -481,6 +580,7 @@ int main(int argc, char **argv) {
   test_index_of_includes();
   test_ref_elements();
   test_ref_cycle();
+  test_copying_holes();
   test_join();
   test_sparse();
 

--- a/packages/runtime/test/test_inspect.c
+++ b/packages/runtime/test/test_inspect.c
@@ -116,6 +116,75 @@ int main(int argc, char **argv) {
     check(op, argbuf, arg_len, result, expbuf, exp_len);
     scr_str_release(result);
   }
+  {
+    ScrDyn *holes = scr_dyn_new_arr();
+    for (size_t i = 0; i < 200; i++) scr_dyn_arr_push_hole(holes);
+    ScrStr *result = scr_insp_dyn(holes, 0, 2);
+    static const char expected[] = "[ <200 empty items> ]";
+    check("holes", "200", 3, result, expected, sizeof expected - 1);
+    scr_str_release(result);
+    scr_dyn_release(holes);
+  }
+  {
+    ScrDyn *mixed = scr_dyn_new_arr();
+    for (size_t i = 0; i < 200; i++) scr_dyn_arr_push_hole(mixed);
+    ScrDyn *one = scr_dyn_new_num(1);
+    ScrDyn *two = scr_dyn_new_num(2);
+    ScrStr *k99 = scr_str_new("99", 2);
+    ScrStr *k150 = scr_str_new("150", 3);
+    scr_dyn_key_set(mixed, k99, one);
+    scr_dyn_key_set(mixed, k150, two);
+    ScrStr *result = scr_insp_dyn(mixed, 0, 2);
+    static const char expected[] = "[ <99 empty items>, 1, <50 empty items>, 2, <49 empty items> ]";
+    check("holes-mixed", "200", 3, result, expected, sizeof expected - 1);
+    scr_str_release(result);
+    scr_str_release(k99);
+    scr_str_release(k150);
+    scr_dyn_release(one);
+    scr_dyn_release(two);
+    scr_dyn_release(mixed);
+  }
+  {
+    ScrDyn *boundary = scr_dyn_new_arr();
+    for (size_t i = 0; i < 101; i++) scr_dyn_arr_push_hole(boundary);
+    for (size_t i = 1; i < 101; i++) {
+      char key[24];
+      int key_len = snprintf(key, sizeof key, "%zu", i);
+      ScrStr *k = scr_str_new(key, (size_t)key_len);
+      ScrDyn *v = scr_dyn_new_num((double)i);
+      scr_dyn_key_set(boundary, k, v);
+      scr_str_release(k);
+      scr_dyn_release(v);
+    }
+    ScrStr *result = scr_insp_dyn(boundary, 0, 2);
+    static const char expected[] =
+      "[\n"
+      "  <1 empty item>, 1,  2,  3,  4,\n"
+      "  5,              6,  7,  8,  9,\n"
+      "  10,             11, 12, 13, 14,\n"
+      "  15,             16, 17, 18, 19,\n"
+      "  20,             21, 22, 23, 24,\n"
+      "  25,             26, 27, 28, 29,\n"
+      "  30,             31, 32, 33, 34,\n"
+      "  35,             36, 37, 38, 39,\n"
+      "  40,             41, 42, 43, 44,\n"
+      "  45,             46, 47, 48, 49,\n"
+      "  50,             51, 52, 53, 54,\n"
+      "  55,             56, 57, 58, 59,\n"
+      "  60,             61, 62, 63, 64,\n"
+      "  65,             66, 67, 68, 69,\n"
+      "  70,             71, 72, 73, 74,\n"
+      "  75,             76, 77, 78, 79,\n"
+      "  80,             81, 82, 83, 84,\n"
+      "  85,             86, 87, 88, 89,\n"
+      "  90,             91, 92, 93, 94,\n"
+      "  95,             96, 97, 98, 99,\n"
+      "  ... 1 more item\n"
+      "]";
+    check("holes-boundary", "101", 3, result, expected, sizeof expected - 1);
+    scr_str_release(result);
+    scr_dyn_release(boundary);
+  }
   fclose(f);
   fprintf(stderr, "%ld/%ld cases passed\n", total - failed, total);
   return failed ? 1 : 0;

--- a/tests/corpus/1871-empty-array-never.ts
+++ b/tests/corpus/1871-empty-array-never.ts
@@ -18,10 +18,8 @@ console.log(none.length);
 const s: string[] | undefined = [];
 console.log(JSON.stringify(s));
 
-// Sparse literals: holes materialize the undefined arm — length and index
-// reads answer exactly Node. (Node's iteration methods SKIP holes; scriptc
-// visits the positions — the documented sparse divergence — so this
-// fixture pins only length/index/JSON-free surfaces.)
+// Sparse literals retain a distinct hole while their backing undefined arm
+// makes length and indexed reads answer exactly Node.
 var v1 = [,];
 console.log(v1.length);
 console.log(v1[0] === undefined);

--- a/tests/corpus/2283-structured-clone.cjs
+++ b/tests/corpus/2283-structured-clone.cjs
@@ -8,7 +8,7 @@ const assert = require('assert');
 assert.throws(() => structuredClone(), { code: 'ERR_MISSING_ARGS' });
 assert.throws(() => structuredClone(undefined, ''), { code: 'ERR_INVALID_ARG_TYPE', message: "Failed to execute 'structuredClone': Options cannot be converted to a dictionary" });
 assert.throws(() => structuredClone(undefined, 1), { code: 'ERR_INVALID_ARG_TYPE' });
-assert.throws(() => structuredClone(undefined, { transfer: 1 }), { code: 'ERR_INVALID_ARG_TYPE', message: "Failed to execute 'structuredClone': transfer in Options can not be converted to sequence." });
+assert.throws(() => structuredClone(undefined, { transfer: 1 }), { code: 'ERR_INVALID_ARG_TYPE', message: "Failed to execute 'structuredClone': transfer in Options cannot be converted to sequence." });
 assert.throws(() => structuredClone(undefined, { transfer: null }), { code: 'ERR_INVALID_ARG_TYPE' });
 assert.strictEqual(structuredClone(undefined), undefined);
 assert.strictEqual(structuredClone(undefined, null), undefined);

--- a/tests/corpus/2283-structured-clone.cjs
+++ b/tests/corpus/2283-structured-clone.cjs
@@ -8,7 +8,7 @@ const assert = require('assert');
 assert.throws(() => structuredClone(), { code: 'ERR_MISSING_ARGS' });
 assert.throws(() => structuredClone(undefined, ''), { code: 'ERR_INVALID_ARG_TYPE', message: "Failed to execute 'structuredClone': Options cannot be converted to a dictionary" });
 assert.throws(() => structuredClone(undefined, 1), { code: 'ERR_INVALID_ARG_TYPE' });
-assert.throws(() => structuredClone(undefined, { transfer: 1 }), { code: 'ERR_INVALID_ARG_TYPE', message: "Failed to execute 'structuredClone': transfer in Options can not be converted to sequence." });
+assert.throws(() => structuredClone(undefined, { transfer: 1 }), { code: 'ERR_INVALID_ARG_TYPE', message: /Failed to execute 'structuredClone': transfer in Options can ?not be converted to sequence\./ });
 assert.throws(() => structuredClone(undefined, { transfer: null }), { code: 'ERR_INVALID_ARG_TYPE' });
 assert.strictEqual(structuredClone(undefined), undefined);
 assert.strictEqual(structuredClone(undefined, null), undefined);

--- a/tests/corpus/2283-structured-clone.cjs
+++ b/tests/corpus/2283-structured-clone.cjs
@@ -8,7 +8,7 @@ const assert = require('assert');
 assert.throws(() => structuredClone(), { code: 'ERR_MISSING_ARGS' });
 assert.throws(() => structuredClone(undefined, ''), { code: 'ERR_INVALID_ARG_TYPE', message: "Failed to execute 'structuredClone': Options cannot be converted to a dictionary" });
 assert.throws(() => structuredClone(undefined, 1), { code: 'ERR_INVALID_ARG_TYPE' });
-assert.throws(() => structuredClone(undefined, { transfer: 1 }), { code: 'ERR_INVALID_ARG_TYPE', message: "Failed to execute 'structuredClone': transfer in Options cannot be converted to sequence." });
+assert.throws(() => structuredClone(undefined, { transfer: 1 }), { code: 'ERR_INVALID_ARG_TYPE', message: "Failed to execute 'structuredClone': transfer in Options can not be converted to sequence." });
 assert.throws(() => structuredClone(undefined, { transfer: null }), { code: 'ERR_INVALID_ARG_TYPE' });
 assert.strictEqual(structuredClone(undefined), undefined);
 assert.strictEqual(structuredClone(undefined, null), undefined);

--- a/tests/corpus/2283-structured-clone.cjs
+++ b/tests/corpus/2283-structured-clone.cjs
@@ -1,4 +1,4 @@
-// structuredClone: the JSON-safe + bytes subset clones deep (option
+// structuredClone: JSON-safe values and the bytes subset clone deep (option
 // validation with Node's exact errors, DataCloneError on non-empty
 // transfer lists, DOMException per WebIDL serialization), and builtin
 // error classes answer instanceof on checked-dynamic values through the

--- a/tests/corpus/2365-dyn-into-island.ts
+++ b/tests/corpus/2365-dyn-into-island.ts
@@ -45,6 +45,41 @@ const u: unknown = rec;
 const island: any = u;
 console.log(`${island.a * 2} ${island.b}`);
 
+// Sparse checked-dynamic arrays rebuild as sparse engine arrays: holes are
+// absent own properties, explicit undefined remains present, and a trailing
+// hole still contributes to length.
+const sparseStatic: (number | undefined)[] = Array<number | undefined>(4);
+sparseStatic[1] = undefined;
+sparseStatic[2] = 7;
+const sparseUnknown: unknown = sparseStatic;
+const sparseIsland: any = sparseUnknown;
+let sparseIslandVisits = "";
+sparseIsland.forEach((_value: any, index: number) => { sparseIslandVisits += index; });
+console.log(`${sparseIsland.length} ${sparseIslandVisits} ${JSON.stringify(sparseIsland)}`);
+
+// Typed helpers use HasProperty, not hasOwn: inherited array indices are
+// visited and read through the engine prototype chain.
+const inheritedArray: any = [2];
+inheritedArray.length = 2;
+const inheritedProto: any = {};
+inheritedProto[1] = 7;
+inheritedProto.__proto__ = inheritedArray.__proto__;
+inheritedArray.__proto__ = inheritedProto;
+const inheritedUnknown: unknown = inheritedArray;
+if (Array.isArray(inheritedUnknown)) {
+  let inheritedFilterVisits = "";
+  const inheritedFiltered: number[] = inheritedUnknown.filter((value: unknown, index: number): value is number => {
+    inheritedFilterVisits += index;
+    return typeof value === "number";
+  });
+  let inheritedFlatVisits = "";
+  const inheritedFlat: number[] = inheritedUnknown.flatMap((value: unknown, index: number): number[] => {
+    inheritedFlatVisits += index;
+    return typeof value === "number" ? [value] : [];
+  });
+  console.log(`${inheritedFilterVisits} ${inheritedFiltered.join(",")} ${inheritedFlatVisits} ${inheritedFlat.join(",")}`);
+}
+
 async function main(): Promise<void> {
   for (const k of ["gh", "sl"]) {
     const e = REGISTRY[k]!;

--- a/tests/corpus/2603-sparse-arrays.ts
+++ b/tests/corpus/2603-sparse-arrays.ts
@@ -1,0 +1,116 @@
+// Sparse arrays retain length independently from indexed-property presence.
+const a: (number | undefined)[] = new Array(5);
+a[1] = 10;
+a[3] = undefined;
+console.log("new", a.length, 0 in a, 1 in a, 3 in a, 4 in a, a.join("|"));
+console.log("keys", Object.keys(a).join(","), Object.hasOwn(a, 0), Object.hasOwn(a, 1));
+const jsonNumbers: number[] = new Array(3);
+jsonNumbers[1] = 2;
+console.log("json", JSON.stringify(jsonNumbers));
+
+let maps = 0;
+const mapped = a.map((v, i) => {
+  maps++;
+  return v === undefined ? i : v + i;
+});
+console.log("map", maps, mapped.length, 0 in mapped, 1 in mapped, 3 in mapped);
+
+let visits = 0;
+a.forEach(() => visits++);
+const filtered = a.filter((v): boolean => v === undefined);
+console.log("hof", visits, filtered.length, filtered[0] === undefined);
+
+const sliced = a.slice(1, 5);
+console.log("slice", sliced.length, 0 in sliced, 1 in sliced, 2 in sliced, 3 in sliced);
+delete sliced[0];
+console.log("delete", sliced.length, 0 in sliced, sliced.join(","));
+
+let iter = "";
+for (const value of a) iter += value === undefined ? "u" : String(value);
+console.log("iter", iter);
+
+const called: (string | undefined)[] = Array<string | undefined>(3);
+called[2] = "x";
+console.log("call", called.length, 0 in called, 2 in called, called.join("-"));
+
+const literal: (number | undefined)[] = [1, , undefined];
+console.log("literal", 0 in literal, 1 in literal, 2 in literal, literal.join(","));
+
+literal.length = 1;
+literal.length = 4;
+console.log("length", literal.length, 0 in literal, 1 in literal, literal.join("|"));
+
+const holes: number[] = new Array(3);
+let skipped = 0;
+console.log("pred", holes.some(() => { skipped++; return true; }), holes.every(() => { skipped++; return false; }), skipped);
+console.log("reduce-init", holes.reduce((sum, value) => sum + value, 7));
+try {
+  holes.reduce((sum, value) => sum + value);
+} catch (error) {
+  console.log("reduce-empty", (error as Error).message);
+}
+
+const enumerable: (number | undefined)[] = new Array(4);
+enumerable[1] = 2;
+enumerable[3] = undefined;
+let sparseKeys = "";
+for (const key in enumerable) sparseKeys += key;
+console.log("for-in-holes", sparseKeys);
+
+try {
+  const invalid: number[] = new Array<number>(-1);
+  console.log(invalid.length);
+} catch (error) {
+  console.log("new-length-error", error instanceof RangeError, (error as Error).message);
+}
+try {
+  enumerable.length = NaN;
+} catch (error) {
+  console.log("set-length-error", error instanceof RangeError, (error as Error).message, enumerable.length);
+}
+
+const sparseNumbers: number[] = new Array(5);
+sparseNumbers[1] = 3;
+sparseNumbers[3] = 1;
+let reductions = 0;
+console.log("reduce", sparseNumbers.reduce((sum, value) => { reductions++; return sum + value; }), reductions);
+console.log("reduce-right", sparseNumbers.reduceRight((sum, value) => sum * 10 + value, 0));
+
+let flatVisits = 0;
+const flattened = sparseNumbers.flatMap((value) => {
+  flatVisits++;
+  return [value, , value + 10];
+});
+console.log("flatMap", flatVisits, flattened.join(","), flattened.length);
+
+const concatTail: (number | undefined)[] = new Array(3);
+concatTail[1] = 20;
+const concatenated = a.concat(concatTail, undefined);
+console.log("concat", concatenated.length, 0 in concatenated, 5 in concatenated, 6 in concatenated, 7 in concatenated, 8 in concatenated);
+
+sparseNumbers.sort((x, y) => x - y);
+console.log("sort-presence", sparseNumbers.length, 0 in sparseNumbers, 1 in sparseNumbers, 2 in sparseNumbers, 4 in sparseNumbers);
+console.log("sort", sparseNumbers[0], sparseNumbers[1]);
+
+// ES2023 copying methods read through holes (Get): union-backed holes
+// densify to present undefined; sort/toSorted sink undefineds past values
+// without calling the comparator, holes last (deleted in place, undefined
+// in the dense copy).
+const src: (number | undefined)[] = [1, , undefined, 4];
+const rev = src.toReversed();
+console.log("toReversed", rev.length, 0 in rev, 1 in rev, 2 in rev, 3 in rev, rev.join(","));
+const spl = src.toSpliced(1, 1, 9);
+console.log("toSpliced", spl.length, 1 in spl, 2 in spl, spl.join(","));
+const wth = src.with(0, 9);
+console.log("with", wth.length, 1 in wth, 2 in wth, wth[1], wth.join(","));
+let cmpCalls = 0;
+const mixed: (number | undefined)[] = [undefined, 3, , 1, undefined, , 2];
+const dense = mixed.toSorted((x, y) => { cmpCalls++; return (x as number) - (y as number); });
+console.log("toSorted", dense.length, dense.join(","), 3 in dense, 6 in dense, dense[4] === undefined);
+mixed.sort((x, y) => (x as number) - (y as number));
+console.log("sort", mixed.join(","), 2 in mixed, 4 in mixed, 6 in mixed, mixed[3] === undefined);
+console.log("cmp-suppressed", cmpCalls <= 6);
+
+// pop() reads through the hole: undefined, length shrinks.
+const tail: (string | undefined)[] = ["x", ,];
+console.log("pop", tail.pop(), tail.length, tail.pop(), tail.length);

--- a/tests/corpus/2603-sparse-arrays.ts
+++ b/tests/corpus/2603-sparse-arrays.ts
@@ -1,3 +1,5 @@
+import assert from "node:assert";
+
 // Sparse arrays retain length independently from indexed-property presence.
 const a: (number | undefined)[] = new Array(5);
 a[1] = 10;
@@ -56,6 +58,273 @@ enumerable[3] = undefined;
 let sparseKeys = "";
 for (const key in enumerable) sparseKeys += key;
 console.log("for-in-holes", sparseKeys);
+
+const filledDuringForIn = [1, , 3];
+let filledKeys = "";
+for (const key in filledDuringForIn) {
+  filledKeys += key;
+  if (key === "0") filledDuringForIn[1] = 2;
+}
+console.log("for-in-fill-snapshot", filledKeys);
+
+const deletedDuringForIn = [1, 2, 3];
+let deletedKeys = "";
+for (const key in deletedDuringForIn) {
+  deletedKeys += key;
+  if (key === "0") delete deletedDuringForIn[1];
+}
+console.log("for-in-delete-live", deletedKeys);
+
+function inspectSparseUnknown(value: unknown): void {
+  if (!Array.isArray(value)) return;
+  console.log("unknown-sparse", typeof value, value.length, Object.keys(value).join(","), 0 in value, 1 in value, JSON.stringify(value));
+  const first = "0";
+  console.log("unknown-presence", first in value, Object.hasOwn(value, first), Object.hasOwn(value, "1"));
+}
+const sparseIntoUnknown: number[] = new Array(2);
+sparseIntoUnknown[1] = 42;
+inspectSparseUnknown(sparseIntoUnknown);
+
+function inspectSparseMethods(value: unknown): void {
+  if (!Array.isArray(value)) return;
+
+  const sliced = value.slice();
+  const concatenated = value.concat([9]);
+  console.log("dyn-copy", Object.keys(sliced).join(","), JSON.stringify(sliced), Object.keys(concatenated).join(","), JSON.stringify(concatenated));
+
+  let forEachVisits = "";
+  value.forEach((_entry: unknown, index: number) => { forEachVisits += index; });
+  let mapVisits = "";
+  const mappedUnknown: unknown = value.map((_entry: unknown, index: number) => { mapVisits += index; return index; });
+  if (!Array.isArray(mappedUnknown)) return;
+  const mapped = mappedUnknown;
+  let filterVisits = "";
+  const filteredUnknown: unknown = value.filter((_entry: unknown, index: number) => { filterVisits += index; return index === 2; });
+  if (!Array.isArray(filteredUnknown)) return;
+  const filtered = filteredUnknown;
+  let someVisits = "";
+  const some = value.some((_entry: unknown, index: number) => { someVisits += index; return false; });
+  let everyVisits = "";
+  const every = value.every((_entry: unknown, index: number) => { everyVisits += index; return true; });
+  console.log("dyn-hof", forEachVisits, mapVisits, Object.keys(mapped).join(","), JSON.stringify(mapped), filterVisits, JSON.stringify(filtered), someVisits, some, everyVisits, every);
+
+  let findVisits = "";
+  const found = value.find((entry: unknown, index: number) => { findVisits += `${index}${entry === undefined ? "u" : "v"}`; return index === 0; });
+  let findIndexVisits = "";
+  const foundIndex = value.findIndex((entry: unknown, index: number) => { findIndexVisits += `${index}${entry === undefined ? "u" : "v"}`; return index === 0; });
+  console.log("dyn-search", value.includes(undefined), value.indexOf(undefined), value.lastIndexOf(undefined), found === undefined, findVisits, foundIndex, findIndexVisits);
+
+  let flatVisits = "";
+  const flatMappedUnknown: unknown = value.flatMap((_entry: unknown, index: number): unknown => {
+    flatVisits += index;
+    return [index, , index + 10];
+  });
+  if (!Array.isArray(flatMappedUnknown)) return;
+  const flatMapped = flatMappedUnknown;
+  console.log("dyn-flatMap", flatVisits, Object.keys(flatMapped).join(","), flatMapped.length, flatMapped.join(","));
+  let typedFlatVisits = "";
+  const typedFlatMapped: number[] = value.flatMap((_entry: unknown, index: number): number[] => {
+    typedFlatVisits += index;
+    const returned: number[] = new Array(3);
+    returned[0] = index;
+    returned[2] = index + 10;
+    return returned;
+  });
+  console.log("dyn-flatMap-typed", typedFlatVisits, typedFlatMapped.length, typedFlatMapped.join(","));
+
+  const sorted = value.slice();
+  sorted.sort();
+  console.log("dyn-sort", Object.keys(sorted).join(","), 2 in sorted, 3 in sorted, JSON.stringify(sorted));
+  const shrinkSorted = value.slice();
+  let shrinkComparisons = 0;
+  shrinkSorted.sort((left: unknown, right: unknown) => {
+    shrinkComparisons++;
+    while (shrinkSorted.length > 0) shrinkSorted.pop();
+    return (left as number) - (right as number);
+  });
+  console.log("dyn-sort-shrink", shrinkComparisons, shrinkSorted.length, Object.keys(shrinkSorted).join(","), JSON.stringify(shrinkSorted));
+  const cloned = structuredClone(value);
+  console.log("dyn-clone", Object.keys(cloned).join(","), JSON.stringify(cloned));
+  assert.deepStrictEqual(cloned, value);
+  const denseUndefined: unknown = [undefined, undefined, 3, undefined, 1, undefined];
+  assert.notDeepStrictEqual(value, denseUndefined);
+  console.log("dyn-deep hole-distinct");
+
+  const popped = value.slice();
+  const popResult = popped.pop();
+  const shifted = value.slice();
+  const shiftResult = shifted.shift();
+  console.log("dyn-ends", popResult === undefined, popped.length, Object.keys(popped).join(","), shiftResult === undefined, shifted.length, Object.keys(shifted).join(","), value.at(0) === undefined);
+
+  let iterated = "";
+  for (const entry of value) iterated += entry === undefined ? "u" : "v";
+  console.log("dyn-iterate", iterated);
+  console.log("dyn-inspect", value);
+}
+
+const sparseMethods: (number | undefined)[] = new Array(6);
+sparseMethods[1] = undefined;
+sparseMethods[2] = 3;
+sparseMethods[4] = 1;
+inspectSparseMethods(sparseMethods);
+
+function appendedCallbackVisits(kind: number): string {
+  const initial: number[] = [1];
+  const value: unknown = initial;
+  if (!Array.isArray(value)) return "not-array";
+  let visits = "";
+  const append = (index: number): void => { visits += index; value.push(2); };
+  if (kind === 0) value.forEach((_entry: unknown, index: number) => append(index));
+  else if (kind === 1) value.map((_entry: unknown, index: number) => { append(index); return index; });
+  else if (kind === 2) value.filter((_entry: unknown, index: number): boolean => { append(index); return true; });
+  else if (kind === 3) value.some((_entry: unknown, index: number) => { append(index); return false; });
+  else if (kind === 4) value.every((_entry: unknown, index: number) => { append(index); return true; });
+  else if (kind === 5) value.find((_entry: unknown, index: number) => { append(index); return false; });
+  else value.findIndex((_entry: unknown, index: number) => { append(index); return false; });
+  return `${visits}:${value.length}`;
+}
+const appendVisits: string[] = [];
+for (let method = 0; method < 7; method++) appendVisits.push(appendedCallbackVisits(method));
+console.log("dyn-append-snapshot", appendVisits.join(","));
+
+function deletionVisits(find: boolean): string {
+  const initial = [1, 2];
+  const value: unknown = initial;
+  if (!Array.isArray(value)) return "not-array";
+  let visits = "";
+  const callback = (entry: unknown, index: number): boolean => {
+    visits += `${index}${entry === undefined ? "u" : "v"}`;
+    if (index === 0) value.pop();
+    return false;
+  };
+  if (find) value.find(callback);
+  else value.forEach(callback);
+  return visits;
+}
+console.log("dyn-delete-live", deletionVisits(false), deletionVisits(true));
+
+const twoHoles: number[] = new Array(3);
+twoHoles[2] = 1;
+const twoHolesUnknown: unknown = twoHoles;
+const denseForMessage: unknown = [undefined, undefined, 1];
+try {
+  assert.deepStrictEqual(twoHolesUnknown, denseForMessage);
+} catch (error) {
+  const message = error instanceof Error ? error.message : "";
+  console.log("dyn-assert-holes", message.includes("<2 empty items>"), message.includes("undefined"));
+}
+
+function inspectExtractedSparse(numbersValue: unknown, unionValue: unknown, stringsValue: unknown): void {
+  const numbers = numbersValue as number[];
+  const union = unionValue as (number | string)[];
+  const strings = stringsValue as string[];
+  console.log("dyn-extract", numbers.length, Object.keys(numbers).join(","), JSON.stringify(numbers), Object.keys(union).join(","), JSON.stringify(union), Object.keys(strings).join(","), JSON.stringify(strings));
+  numbers[0] = 9;
+  strings[0] = "set";
+  console.log("dyn-extract-set", 0 in numbers, numbers[0], 0 in strings, strings[0]);
+}
+const extractNumbers: number[] = new Array(3);
+extractNumbers[1] = 5;
+const extractUnion: (number | string)[] = new Array(3);
+extractUnion[1] = "u";
+extractUnion[2] = 7;
+const extractStrings: string[] = new Array(2);
+extractStrings[1] = "x";
+inspectExtractedSparse(extractNumbers, extractUnion, extractStrings);
+
+function applyHoleProbe(first: unknown): string {
+  const targetValue: unknown = [];
+  if (!Array.isArray(targetValue)) return "not-array";
+  targetValue[0] = first;
+  return `${first === undefined} ${Object.hasOwn(targetValue, 0)} ${0 in targetValue}`;
+}
+const applyProbeValue: unknown = applyHoleProbe;
+const sparseApplyArgs: number[] = new Array(1);
+if (typeof applyProbeValue === "function") {
+  console.log("dyn-apply-hole", applyProbeValue.apply(null, sparseApplyArgs));
+}
+
+function inspectTupleHole(value: unknown): void {
+  const tuple = value as [unknown];
+  const targetValue: unknown = [];
+  if (!Array.isArray(targetValue)) return;
+  targetValue[0] = tuple[0];
+  console.log("dyn-tuple-hole", tuple[0] === undefined, Object.hasOwn(targetValue, 0), 0 in targetValue);
+  try {
+    const required = value as [number];
+    console.log(required[0].toFixed(0));
+  } catch (error) {
+    console.log("dyn-tuple-required", error instanceof TypeError);
+  }
+}
+const sparseTupleSource: number[] = new Array(1);
+inspectTupleHole(sparseTupleSource);
+
+function inspectFunctionTuple(value: unknown): void {
+  const tuple = value as [number | (() => number)];
+  const item = tuple[0];
+  console.log("dyn-tuple-function", typeof item, typeof item === "function" ? item() : item);
+}
+const functionTupleSource: unknown = [];
+const boxedTupleFunction: unknown = (): number => 42;
+if (Array.isArray(functionTupleSource)) functionTupleSource[0] = boxedTupleFunction;
+inspectFunctionTuple(functionTupleSource);
+
+type RecursiveCallable = number | (() => RecursiveCallable);
+function recursiveCallable(): RecursiveCallable {
+  return recursiveCallable;
+}
+function inspectRecursiveCallable(value: unknown): void {
+  const tuple = value as [RecursiveCallable];
+  const first = tuple[0];
+  const second = typeof first === "function" ? first() : first;
+  console.log("dyn-recursive-callable", typeof first, typeof second);
+}
+const recursiveTupleSource: unknown = [];
+const recursiveCallableValue: unknown = recursiveCallable;
+if (Array.isArray(recursiveTupleSource)) recursiveTupleSource[0] = recursiveCallableValue;
+inspectRecursiveCallable(recursiveTupleSource);
+
+type FunctionValue = number | (() => number);
+function inspectFunctionComposites(arrayValue: unknown, recordValue: unknown): void {
+  const array = arrayValue as FunctionValue[];
+  const record = recordValue as { item: FunctionValue };
+  const av = array[0];
+  const rv = record.item;
+  console.log("dyn-function-composites", typeof av === "function" ? av() : av, typeof rv === "function" ? rv() : rv);
+}
+const functionArraySource: unknown = [];
+if (Array.isArray(functionArraySource)) functionArraySource[0] = boxedTupleFunction;
+const functionRecordSource: Record<string, unknown> = { item: boxedTupleFunction };
+inspectFunctionComposites(functionArraySource, functionRecordSource);
+
+function inspectNestedTuple(value: unknown): void {
+  const tuple = value as [[unknown]];
+  const targetValue: unknown = [];
+  if (!Array.isArray(targetValue)) return;
+  targetValue[0] = tuple[0][0];
+  console.log("dyn-tuple-nested", tuple[0][0] === undefined, Object.hasOwn(targetValue, 0), 0 in targetValue);
+}
+const nestedInnerStatic: number[] = new Array(1);
+const nestedInner: unknown = nestedInnerStatic;
+const nestedOuter: unknown = [];
+if (Array.isArray(nestedOuter)) nestedOuter[0] = nestedInner;
+inspectNestedTuple(nestedOuter);
+
+function inspectLargeSparse(value: unknown, label: string): void {
+  console.log(label, value);
+}
+const inspectHoles200: number[] = new Array(200);
+inspectLargeSparse(inspectHoles200, "dyn-inspect-200");
+const inspectMixed200: number[] = new Array(200);
+inspectMixed200[99] = 1;
+inspectMixed200[150] = 2;
+inspectLargeSparse(inspectMixed200, "dyn-inspect-mixed");
+const inspectBoundary101: number[] = new Array(101);
+for (let i = 1; i < inspectBoundary101.length; i++) inspectBoundary101[i] = i;
+inspectLargeSparse(inspectBoundary101, "dyn-inspect-boundary");
+const clonedBareUndefined: undefined = structuredClone(undefined);
+console.log("clone-bare-undefined", clonedBareUndefined === undefined);
 
 try {
   const invalid: number[] = new Array<number>(-1);

--- a/tests/corpus/2673-sparse-array-js.js
+++ b/tests/corpus/2673-sparse-array-js.js
@@ -1,0 +1,8 @@
+function build(length) {
+  var result = Array(length);
+  for (var i = 0; i < length; i++) result[i] = i * 2;
+  return result;
+}
+
+const packed = build(4);
+console.log(packed.length, packed.join(","), Object.keys(packed).join(","));

--- a/tests/corpus/2684-sparse-live-array-payload.ts
+++ b/tests/corpus/2684-sparse-live-array-payload.ts
@@ -1,0 +1,42 @@
+// Live Web references must carry an array's hole bitmap through dynamic
+// materialization, mutation commits, and cached structural-cast refreshes.
+
+const materializedSource: number[] = new Array(4);
+materializedSource[1] = 11;
+materializedSource[3] = 33;
+const materialized: unknown = AbortSignal.abort(materializedSource).reason;
+if (Array.isArray(materialized)) {
+  console.log(
+    "materialized",
+    materialized.length,
+    Object.keys(materialized).join(","),
+    JSON.stringify(materialized),
+  );
+}
+
+const committedSource: number[] = new Array(3);
+committedSource[0] = 1;
+committedSource[2] = 3;
+const committed: unknown = AbortSignal.abort(committedSource).reason;
+if (Array.isArray(committed)) committed[1] = 2;
+console.log(
+  "committed",
+  committedSource.length,
+  Object.keys(committedSource).join(","),
+  JSON.stringify(committedSource),
+);
+
+const refreshedSource: number[] = new Array(4);
+refreshedSource[1] = 10;
+const refreshValue: unknown = AbortSignal.abort(refreshedSource).reason;
+const first = refreshValue as (number | string)[];
+delete refreshedSource[1];
+refreshedSource[2] = 20;
+const second = refreshValue as (number | string)[];
+console.log(
+  "refreshed",
+  first === second,
+  second.length,
+  Object.keys(second).join(","),
+  JSON.stringify(second),
+);

--- a/tests/corpus/2693-sparse-far-index-copy.ts
+++ b/tests/corpus/2693-sparse-far-index-copy.ts
@@ -1,0 +1,47 @@
+// Far indexed writes grow ordinary arrays and leave intermediate holes.
+const numbers = [1];
+numbers[4] = 5;
+console.log(
+  "numbers",
+  numbers.length,
+  0 in numbers,
+  1 in numbers,
+  3 in numbers,
+  4 in numbers,
+  numbers.join(","),
+);
+
+const words = ["a"];
+words[3] = "d";
+console.log("words", words.length, 1 in words, 2 in words, words.join("|"));
+
+// A far write on an initially empty optional REF array gives each new hole
+// the undefined arm as backing. Join skips the holes, while copying methods
+// Get and densify them as present undefined values.
+const optional: (number | undefined)[] = [];
+optional[2] = 7;
+console.log(
+  "optional",
+  optional.length,
+  0 in optional,
+  1 in optional,
+  2 in optional,
+  optional.join(","),
+);
+const reversed = optional.toReversed();
+console.log(
+  "copy",
+  reversed.length,
+  0 in reversed,
+  1 in reversed,
+  2 in reversed,
+  reversed[0],
+  reversed[1] === undefined,
+  reversed[2] === undefined,
+);
+
+// Join must not read a hole even when its REF representation has no
+// undefined arm and therefore leaves zero backing.
+const mixed: (number | string)[] = [];
+mixed[2] = "x";
+console.log("mixed", mixed.join("|"));

--- a/tests/corpus/2695-sparse-frontend-review-fixes.ts
+++ b/tests/corpus/2695-sparse-frontend-review-fixes.ts
@@ -1,0 +1,79 @@
+import assert from "node:assert";
+
+// Static deep equality compares indexed-property presence before values. Two
+// scalar holes never reach an unrepresentable arrayGet, while a hole remains
+// distinct from a present undefined in an undefined-capable array.
+const scalarHolesA: number[] = new Array(3);
+const scalarHolesB: number[] = new Array(3);
+assert.deepStrictEqual(scalarHolesA, scalarHolesB);
+scalarHolesB[1] = 0;
+assert.notDeepStrictEqual(scalarHolesA, scalarHolesB);
+
+const unionHole: (number | undefined)[] = new Array(1);
+const unionUndefined: (number | undefined)[] = new Array(1);
+unionUndefined[0] = undefined;
+assert.notDeepStrictEqual(unionHole, unionUndefined);
+console.log("deep-presence", Object.keys(scalarHolesA).length, 0 in unionHole, 0 in unionUndefined);
+
+// In-place sort works privately until all comparisons succeed. Comparator
+// observation sees the original receiver, and a throw commits no writes.
+const observed = [3, 1, 2];
+let receiverStayedOriginal = true;
+observed.sort((a, b) => {
+  receiverStayedOriginal = receiverStayedOriginal && observed.join(",") === "3,1,2";
+  return a - b;
+});
+console.log("sort-observe", receiverStayedOriginal, observed.join(","));
+
+const throwing = [4, 2, 3];
+let caught = false;
+try {
+  throwing.sort((_a, _b): number => {
+    throw new Error("stop sort");
+  });
+} catch (error) {
+  caught = error instanceof Error && error.message === "stop sort";
+}
+console.log("sort-throw", caught, throwing.join(","));
+
+const sparseSort: number[] = new Array(5);
+sparseSort[1] = 3;
+sparseSort[3] = 1;
+const sparseKeys = Object.keys(sparseSort).join(",");
+try {
+  sparseSort.sort((_a, _b): number => {
+    throw new Error("sparse stop");
+  });
+} catch {}
+console.log("sparse-throw", Object.keys(sparseSort).join(",") === sparseKeys, sparseSort.length);
+sparseSort.sort((a, b) => a - b);
+console.log("sparse-commit", sparseSort.join(","), Object.keys(sparseSort).join(","), sparseSort.length);
+
+// at has an undefined-capable result even when the element slot is scalar,
+// so a presence miss returns that result arm without touching the slot.
+const scalarAt: number[] = new Array(2);
+scalarAt[1] = 7;
+console.log("at-hole", scalarAt.at(0) === undefined, scalarAt.at(1), scalarAt.at(-2) === undefined);
+
+// Undefined-capable element storage supports Get-based callback visits to
+// holes directly.
+const searchable: (number | undefined)[] = new Array(3);
+searchable[2] = 5;
+let visits = "";
+const holeIndex = searchable.findIndex((value, index) => {
+  visits += `${index}${value === undefined ? "u" : "v"}`;
+  return value === undefined;
+});
+const lastHole = searchable.findLastIndex((value) => value === undefined);
+console.log("find-holes", holeIndex, lastHole, visits);
+
+// Packed provenance discharges scalar Get fences through a direct parameter,
+// for-of, spread, and toSorted.
+function firstEven(values: number[]): number {
+  return values.findIndex((value) => value % 2 === 0);
+}
+const packed = [3, 2, 1];
+let packedSum = 0;
+for (const value of packed) packedSum += value;
+const packedCopy = [...packed];
+console.log("packed", firstEven(packed), packedSum, packedCopy.join(","), packed.toSorted((a, b) => a - b).join(","));

--- a/tests/diagnostics/sparse-get-scalar-fences.ts
+++ b/tests/diagnostics/sparse-get-scalar-fences.ts
@@ -1,0 +1,44 @@
+const scalarHoles: number[] = new Array(3);
+// Direct Get-based methods cannot materialize undefined in number slots.
+scalarHoles.find((value) => value > 0);
+scalarHoles.findIndex((value) => value > 0);
+scalarHoles.findLast((value) => value > 0);
+scalarHoles.findLastIndex((value) => value > 0);
+// Iteration and spread have the same read-through-holes behavior.
+for (const value of scalarHoles) console.log(value);
+const copied = [...scalarHoles];
+console.log(copied.length);
+
+function takeAll(...values: number[]): number {
+  return values.length;
+}
+takeAll(...scalarHoles);
+Math.max(...scalarHoles);
+String.fromCharCode(...scalarHoles);
+// Copying sort reads through holes and produces present undefined entries.
+scalarHoles.toSorted((a, b) => a - b);
+// A later write cannot make this earlier Get safe.
+const writtenLater = new Array<number>(2);
+writtenLater.find((value) => value > 0);
+writtenLater[0] = 1;
+
+// Dense construction is safe even with scalar element storage.
+const denseLiteral = [3, 1, 2];
+denseLiteral.find((value) => value > 0);
+for (const value of denseLiteral) console.log(value);
+console.log([...denseLiteral].length, denseLiteral.toSorted((a, b) => a - b).length);
+
+const filled = new Array<number>(3);
+filled[0] = 0;
+filled[1] = 0;
+filled[2] = 0;
+filled.find((value) => value > 0);
+for (const value of filled) console.log(value);
+console.log([...filled].length, filled.toSorted((a, b) => a - b).length);
+
+// Parameters and other unknown provenance retain historical lowering.
+function readUnknown(values: number[]): void {
+  values.find((value) => value > 0);
+  for (const value of values) console.log(value);
+  console.log([...values].length, values.toSorted((a, b) => a - b).length);
+}

--- a/tests/harness/__snapshots__/sparse-get-scalar-fences.ts.txt
+++ b/tests/harness/__snapshots__/sparse-get-scalar-fences.ts.txt
@@ -1,0 +1,76 @@
+sparse-get-scalar-fences.ts:3:1 - error SC1090: Array.find on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  2 | // Direct Get-based methods cannot materialize undefined in number slots.
+  3 | scalarHoles.find((value) => value > 0);
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  4 | scalarHoles.findIndex((value) => value > 0);
+
+sparse-get-scalar-fences.ts:4:1 - error SC1090: Array.findIndex on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  3 | scalarHoles.find((value) => value > 0);
+  4 | scalarHoles.findIndex((value) => value > 0);
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  5 | scalarHoles.findLast((value) => value > 0);
+
+sparse-get-scalar-fences.ts:5:1 - error SC1090: Array.findLast on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  4 | scalarHoles.findIndex((value) => value > 0);
+  5 | scalarHoles.findLast((value) => value > 0);
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  6 | scalarHoles.findLastIndex((value) => value > 0);
+
+sparse-get-scalar-fences.ts:6:1 - error SC1090: Array.findLastIndex on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  5 | scalarHoles.findLast((value) => value > 0);
+  6 | scalarHoles.findLastIndex((value) => value > 0);
+    | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  7 | // Iteration and spread have the same read-through-holes behavior.
+
+sparse-get-scalar-fences.ts:8:21 - error SC1090: array for-of iteration on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  7 | // Iteration and spread have the same read-through-holes behavior.
+  8 | for (const value of scalarHoles) console.log(value);
+    |                     ^~~~~~~~~~~
+  9 | const copied = [...scalarHoles];
+
+sparse-get-scalar-fences.ts:9:17 - error SC1090: array spread on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+   8 | for (const value of scalarHoles) console.log(value);
+   9 | const copied = [...scalarHoles];
+     |                 ^~~~~~~~~~~~~~
+  10 | console.log(copied.length);
+
+sparse-get-scalar-fences.ts:15:9 - error SC1090: array argument spread on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  14 | }
+  15 | takeAll(...scalarHoles);
+     |         ^~~~~~~~~~~~~~
+  16 | Math.max(...scalarHoles);
+
+sparse-get-scalar-fences.ts:16:10 - error SC1090: array spread into Math.max on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  15 | takeAll(...scalarHoles);
+  16 | Math.max(...scalarHoles);
+     |          ^~~~~~~~~~~~~~
+  17 | String.fromCharCode(...scalarHoles);
+
+sparse-get-scalar-fences.ts:17:21 - error SC1090: array argument spread on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  16 | Math.max(...scalarHoles);
+  17 | String.fromCharCode(...scalarHoles);
+     |                     ^~~~~~~~~~~~~~
+  18 | // Copying sort reads through holes and produces present undefined entries.
+
+sparse-get-scalar-fences.ts:19:1 - error SC1090: Array.toSorted on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  18 | // Copying sort reads through holes and produces present undefined entries.
+  19 | scalarHoles.toSorted((a, b) => a - b);
+     | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  20 | // A later write cannot make this earlier Get safe.
+
+sparse-get-scalar-fences.ts:22:1 - error SC1090: Array.find on a sparse 'number[]' value (a hole must be observed as undefined, which 'number' element slots cannot represent - use an undefined-capable element type or a dense array) is not supported yet
+
+  21 | const writtenLater = new Array<number>(2);
+  22 | writtenLater.find((value) => value > 0);
+     | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+  23 | writtenLater[0] = 1;

--- a/tests/harness/errors.test.ts
+++ b/tests/harness/errors.test.ts
@@ -414,6 +414,107 @@ process.on('__proto__', () => {});
       /^Uncaught Error: 'process\.on\("__proto__", \.\.\.\)' is part of the standard library types but has no scriptc lowering yet \[SC2020 at .*process-on-proto\.cjs:2\]\n$/,
     );
   });
+
+  test("partial JavaScript Array fills retain the compile fence", async () => {
+    const r = await compileAndRun(
+      "partial-js-array-fill",
+      `function printPartial(length) {
+  var partial = Array(length);
+  partial[0] = 1;
+  console.log(partial[1]);
+}
+printPartial(2);
+`,
+      "js",
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toMatch(
+      /^Uncaught Error: 'Array whose indexed writes do not provably initialize every element' is part of the standard library types but has no scriptc lowering yet \[SC2020 at .*partial-js-array-fill\.js:2\]\n$/,
+    );
+  });
+
+  test("partial JavaScript new Array fills retain the compile fence", async () => {
+    const r = await compileAndRun(
+      "partial-js-new-array-fill",
+      `function printPartial(length) {
+  var partial = new Array(length);
+  partial[0] = 1;
+  console.log(partial[1]);
+}
+printPartial(2);
+`,
+      "js",
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toMatch(
+      /^Uncaught Error: 'Array whose indexed writes do not provably initialize every element' is part of the standard library types but has no scriptc lowering yet \[SC2020 at .*partial-js-new-array-fill\.js:2\]\n$/,
+    );
+  });
+
+  test("JavaScript Array fills with effectful values retain the compile fence", async () => {
+    const r = await compileAndRun(
+      "effectful-js-array-fill",
+      `let bound = 0;
+function shorten() { bound = 1; return 7; }
+function build(length) {
+  bound = length;
+  var result = Array(bound);
+  for (var i = 0; i < bound; i++) result[i] = shorten();
+  return result;
+}
+build(3);
+`,
+      "js",
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toMatch(
+      /^Uncaught Error: 'Array whose indexed writes do not provably initialize every element' is part of the standard library types but has no scriptc lowering yet \[SC2020 at .*effectful-js-array-fill\.js:5\]\n$/,
+    );
+  });
+
+  test("JavaScript Array fills with constructor effects retain the compile fence", async () => {
+    const r = await compileAndRun(
+      "constructor-effect-js-array-fill",
+      `let bound = 0;
+class Shortener { constructor() { bound = 1; } }
+function build(length) {
+  bound = length;
+  var result = Array(bound);
+  for (var i = 0; i < bound; i++) result[i] = (new Shortener(), i);
+  return result;
+}
+build(3);
+`,
+      "js",
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toMatch(
+      /^Uncaught Error: 'Array whose indexed writes do not provably initialize every element' is part of the standard library types but has no scriptc lowering yet \[SC2020 at .*constructor-effect-js-array-fill\.js:5\]\n$/,
+    );
+  });
+
+  test("JavaScript Array fills with later declarators retain the compile fence", async () => {
+    const r = await compileAndRun(
+      "multi-declarator-js-array-fill",
+      `function build(length) {
+  var result = Array(length), shortened = (length = 1);
+  for (var i = 0; i < length; i++) result[i] = i;
+  return result;
+}
+build(3);
+`,
+      "js",
+    );
+    expect(r.exitCode).toBe(1);
+    expect(r.stdout).toBe("");
+    expect(r.stderr).toMatch(
+      /^Uncaught Error: 'Array whose indexed writes do not provably initialize every element' is part of the standard library types but has no scriptc lowering yet \[SC2020 at .*multi-declarator-js-array-fill\.js:2\]\n$/,
+    );
+  });
 });
 
 // Node's CJS named-import LINK error: a named import of an export the CJS

--- a/tests/harness/regex.test.ts
+++ b/tests/harness/regex.test.ts
@@ -170,7 +170,7 @@ console.log(/${"(a)".repeat(300)}/.test("a"));
       process.platform === "linux" ? 392_000 : 378_000,
     );
     expect(statSync(regexBuild.binaryPath).size).toBeLessThan(
-      process.platform === "linux" ? 545_000 : 512_000,
+      process.platform === "linux" ? 545_000 : 528_000,
     );
   });
 });

--- a/tests/harness/regex.test.ts
+++ b/tests/harness/regex.test.ts
@@ -160,7 +160,8 @@ console.log(/${"(a)".repeat(300)}/.test("a"));
     // re-based the static class by one more; the ambient-receiver stack,
     // the %j dyn stringify walk, and the runtime-encoding readFileSync
     // form (all in always-linked TUs) tipped the regex class one more
-    // page.
+    // page. Sparse-array presence tracking tipped the Mach-O static class
+    // by one 16KB page without changing regex linkage.
     // The canonical Ubuntu 24.04/clang Sandbox measures 387,600 bytes for
     // the plain binary and 540,232 with regex linked. The Linux bounds leave
     // roughly one ELF page of growth. Mach-O keeps its independently

--- a/tests/harness/web-globals.test.ts
+++ b/tests/harness/web-globals.test.ts
@@ -129,7 +129,7 @@ describe(`island web globals (scriptc-only${sanitize ? ", sanitized" : ""})`, ()
         "DataCloneError:t:true",
         'TypeError/ERR_MISSING_ARGS: The "The value argument must be specified" argument must be specified',
         "TypeError/ERR_INVALID_ARG_TYPE: Failed to execute 'structuredClone': Options cannot be converted to a dictionary",
-        "TypeError/ERR_INVALID_ARG_TYPE: Failed to execute 'structuredClone': transfer in Options can not be converted to sequence.",
+        "TypeError/ERR_INVALID_ARG_TYPE: Failed to execute 'structuredClone': transfer in Options cannot be converted to sequence.",
         "true",
         "DataCloneError/25: () => {} could not be cloned.",
       ].join(" | "),

--- a/tests/harness/web-globals.test.ts
+++ b/tests/harness/web-globals.test.ts
@@ -129,7 +129,7 @@ describe(`island web globals (scriptc-only${sanitize ? ", sanitized" : ""})`, ()
         "DataCloneError:t:true",
         'TypeError/ERR_MISSING_ARGS: The "The value argument must be specified" argument must be specified',
         "TypeError/ERR_INVALID_ARG_TYPE: Failed to execute 'structuredClone': Options cannot be converted to a dictionary",
-        "TypeError/ERR_INVALID_ARG_TYPE: Failed to execute 'structuredClone': transfer in Options cannot be converted to sequence.",
+        "TypeError/ERR_INVALID_ARG_TYPE: Failed to execute 'structuredClone': transfer in Options can not be converted to sequence.",
         "true",
         "DataCloneError/25: () => {} could not be cloned.",
       ].join(" | "),


### PR DESCRIPTION
Represent array holes independently from element storage with an optional runtime presence bitmap. Preserve hole state through length changes, deletion, slicing, concatenation, sorting, copying methods, iteration, serialization, and reference-counted cleanup while retaining packed-array fast paths.

Extend frontend lowering and IR validation for sparse literals, Array length construction, property-presence checks, delete, length assignment, and sparse appends. Add dense-array analysis so proven packed reads can use dedicated unchecked-presence runtime entry points in both native backends.

Add differential corpus coverage, runtime lifecycle tests, IR analysis tests, and compile fences for JavaScript fill loops that cannot prove complete initialization. Update affected binary-size expectations and align structuredClone transfer diagnostics with Node wording.