### PR TITLE
Prove integer writes to synthesized record slots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to scriptc will be documented in this file.
 
 ### Fixes
 
-- **Contract integer attestations cover synthesized tagged-record payloads.** Integer slots declared on lowered payload paths such as `TextInputEvent_set_composition.cursor` and `Msg_audio_event.at` now carry compile-time write obligations, so fractional writes refuse instead of surviving until runtime encoding.
+- **Contract integer attestations cover synthesized tagged-record payloads.** Integer slots declared on lowered payload paths such as `TextInputEvent_set_composition.cursor` and `Msg_audio_event.at` now carry compile-time write obligations, so fractional writes refuse instead of surviving until runtime encoding. Distinct inline records whose underscore-joined synthesized names collide now refuse instead of reusing the wrong table entry and dropping an obligation.
 
 <!-- release:start -->
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to scriptc will be documented in this file.
 
 ## Unreleased
 
+### Fixes
+
+- **Contract integer attestations cover synthesized tagged-record payloads.** Integer slots declared on lowered payload paths such as `TextInputEvent_set_composition.cursor` and `Msg_audio_event.at` now carry compile-time write obligations, so fractional writes refuse instead of surviving until runtime encoding.
+
 <!-- release:start -->
 
 ## 0.0.20

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -413,15 +413,24 @@ class Projector {
   }
 
   /** intify for a struct field (declared or synthesized), recording the
-   * record-resolution fact the inference maps onto interned IR shapes. */
-  intifyStructField(ref: TypeRef, container: string, field: string, allFields: ContractField[], loc: SrcLoc): TypeRef {
+   * record-resolution fact the inference maps onto interned IR shapes.
+   * Synthesized records that are tagged-union payloads retain the source
+   * arm's `kind` field in IR even though the wire struct omits it. */
+  intifyStructField(
+    ref: TypeRef,
+    container: string,
+    field: string,
+    allFields: ContractField[],
+    tagged: boolean,
+    loc: SrcLoc,
+  ): TypeRef {
     const slotPath = `${container}.${field}`;
     const before = this.intConsumed.has(slotPath);
     const out = this.intify(ref, slotPath, loc);
     if (!before && this.intConsumed.has(slotPath)) {
       this.pendingIntRecordFacts.push({
         fields: allFields,
-        tagged: false,
+        tagged,
         targetField: field,
         cls: this.intConsumed.get(slotPath)!,
         path: slotPath,
@@ -854,7 +863,7 @@ class Projector {
         return { kind: "union", name: r.name };
       }
       case "object":
-        return { kind: "value", name: this.tableSynthesized(container, member, shape.fields, loc) };
+        return { kind: "value", name: this.tableSynthesized(container, member, shape.fields, false, loc) };
       case "stringLit":
         throw new SidecarError(
           `'${container}.${member}' is a bare string-literal type — declare a named string-literal union and reference it as an enum`,
@@ -915,7 +924,7 @@ class Projector {
           seen.add(f.name);
           entry.fields.push({
             name: f.name,
-            type: this.intifyStructField(this.fieldRef(f, name), name, f.name, c.fields, f.loc),
+            type: this.intifyStructField(this.fieldRef(f, name), name, f.name, c.fields, false, f.loc),
           });
         }
         this.table.set(name, { kind: "struct", entry, anchor: c.index, sub: -1 });
@@ -954,13 +963,15 @@ class Projector {
   armPayloadRef(unionName: string, arm: { name: string; fields: ContractField[]; loc: SrcLoc }): TypeRef {
     if (arm.fields.length === 0) return { kind: "void" };
     if (arm.fields.length === 1) return this.fieldRef(arm.fields[0]!, unionName);
-    return { kind: "value", name: this.tableSynthesized(unionName, arm.name, arm.fields, arm.loc) };
+    return { kind: "value", name: this.tableSynthesized(unionName, arm.name, arm.fields, true, arm.loc) };
   }
 
   /** Table an anonymous inline record under the schema's synthesized-name
    * contract: `<Container>_<member>`, deterministic and stable across
-   * identical re-compiles, unique in the one namespace. */
-  tableSynthesized(container: string, member: string, fields: ContractField[], loc: SrcLoc): string {
+   * identical re-compiles, unique in the one namespace. `tagged` records
+   * whether this wire payload comes from a union arm whose lowered IR shape
+   * also carries the discriminant. */
+  tableSynthesized(container: string, member: string, fields: ContractField[], tagged: boolean, loc: SrcLoc): string {
     const name = `${container}_${member}`;
     const existing = this.table.get(name);
     if (existing !== undefined) return name; // the same inline decl, revisited
@@ -980,7 +991,7 @@ class Projector {
       seen.add(f.name);
       entry.fields.push({
         name: f.name,
-        type: this.intifyStructField(this.fieldRef(f, name), name, f.name, fields, f.loc),
+        type: this.intifyStructField(this.fieldRef(f, name), name, f.name, fields, tagged, f.loc),
       });
     }
     return name;
@@ -1060,7 +1071,7 @@ class Projector {
     }
     // Everything else — bytes-first pairs, three-plus fields, optional
     // payload fields — tables a synthesized record (family 5).
-    return { kind: "record", name: this.tableSynthesized(msgName, arm.name, fields, arm.loc) };
+    return { kind: "record", name: this.tableSynthesized(msgName, arm.name, fields, true, arm.loc) };
   }
 
   /** Materialize structural join patterns only after normal sidecar

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -281,6 +281,17 @@ interface PendingIntegerRecordFact {
   loc: SrcLoc;
 }
 
+type SynthesizedRecordVariant =
+  | { fields: ContractField[]; loc: SrcLoc }
+  | { fields: null; loc: SrcLoc; why: string };
+
+/** The composed-arm provenance of a synthesized record, kept separately
+ * from whether this particular record's IR shape carries the discriminant. */
+interface SynthesizedRecordContext {
+  armName: string;
+  variants: () => SynthesizedRecordVariant[];
+}
+
 function classify(decl: ContractTypeDecl, index: number): Classified {
   const s = decl.shape;
   if (s.k === "unsupported") {
@@ -432,22 +443,22 @@ class Projector {
     allFields: ContractField[],
     tagged: boolean,
     loc: SrcLoc,
-    taggedArm?: { unionName: string; armName: string },
+    synthesizedContext?: SynthesizedRecordContext,
   ): TypeRef {
     const slotPath = `${container}.${field}`;
     const before = this.intConsumed.has(slotPath);
     const out = this.intify(ref, slotPath, loc);
     if (!before && this.intConsumed.has(slotPath)) {
       const cls = this.intConsumed.get(slotPath)!;
-      if (taggedArm !== undefined) {
+      if (synthesizedContext !== undefined) {
         this.recordIntegerSynthesizedRecordFacts(
-          taggedArm.unionName,
-          taggedArm.armName,
+          synthesizedContext,
+          container,
           field,
           out,
+          tagged,
           cls,
           slotPath,
-          loc,
         );
       } else {
         this.pendingIntRecordFacts.push({
@@ -725,6 +736,71 @@ class Projector {
     }
   }
 
+  /** Lazily retain every source occurrence of a wire-selected arm. Most
+   * synthesized records have no integer declaration, so the full composed
+   * walk stays deferred until a nested slot actually needs proof facts. */
+  private synthesizedArmContext(
+    unionName: string,
+    armName: string,
+    loc: SrcLoc,
+  ): SynthesizedRecordContext {
+    return {
+      armName,
+      variants: () =>
+        this.allUnionArms(unionName, loc)
+          .filter((arm) => arm.name === armName)
+          .map((arm) => ({ fields: arm.fields, loc: arm.loc })),
+    };
+  }
+
+  /** Follow one inline-object field through every composed occurrence of
+   * the selected arm. Missing or differently shaped occurrences remain in
+   * the context as refusals, but only matter if an integer slot is declared
+   * inside this nested synthesized record. */
+  private nestedSynthesizedRecordContext(
+    parent: SynthesizedRecordContext,
+    member: string,
+  ): SynthesizedRecordContext {
+    return {
+      armName: parent.armName,
+      variants: () =>
+        parent.variants().map((variant): SynthesizedRecordVariant => {
+          if (variant.fields === null) return variant;
+          const field = variant.fields.find((candidate) => candidate.name === member);
+          if (field === undefined) {
+            return {
+              fields: null,
+              loc: variant.loc,
+              why: `has no field '${member}' leading to that nested record`,
+            };
+          }
+          const fields = this.inlineRecordFields(field.shape);
+          return fields === null
+            ? {
+                fields: null,
+                loc: field.loc,
+                why: `projects field '${member}' as a non-inline-record shape`,
+              }
+            : { fields, loc: field.loc };
+        }),
+    };
+  }
+
+  /** The object whose fields tableSynthesized will project through the
+   * sidecar's optional/array wrappers, or null when the shape names or
+   * projects something other than an inline record. */
+  private inlineRecordFields(shape: ContractTypeShape): ContractField[] | null {
+    if (shape.k === "object") return shape.fields;
+    if (shape.k === "array") return this.inlineRecordFields(shape.elem);
+    if (shape.k === "union") {
+      const present = shape.parts.filter((part) => part.k !== "absent");
+      return present.length === 1 && present.length !== shape.parts.length
+        ? this.inlineRecordFields(present[0]!)
+        : null;
+    }
+    return null;
+  }
+
   /** Record a synthesized-record field obligation for every composed
    * occurrence of the wire-selected discriminant. The first arm supplies
    * the wire struct, but later same-named arms may lower to distinct record
@@ -732,49 +808,54 @@ class Projector {
    * An absent, non-number, or newly optional field cannot satisfy the
    * selected wire slot and refuses at projection. */
   private recordIntegerSynthesizedRecordFacts(
-    unionName: string,
-    armName: string,
+    context: SynthesizedRecordContext,
+    container: string,
     targetField: string,
     intifiedRef: TypeRef,
+    tagged: boolean,
     cls: "i64" | "u64",
     path: string,
-    loc: SrcLoc,
   ): void {
     const selectedOptional =
       intifiedRef.kind === "optional" && intifiedRef.inner.kind === "i64";
     if (intifiedRef.kind !== "i64" && !selectedOptional) {
       throw new Error(`sidecar pattern bug: synthesized integer field '${path}' has ref '${intifiedRef.kind}'`);
     }
-    for (const arm of this.allUnionArms(unionName, loc)) {
-      if (arm.name !== armName) continue;
-      const field = arm.fields.find((candidate) => candidate.name === targetField);
-      if (field === undefined) {
+    for (const variant of context.variants()) {
+      if (variant.fields === null) {
         throw new SidecarError(
-          `integer slot '${path}' (${cls}) selects synthesized record field '${targetField}', but another composed '${armName}' arm has no such field`,
-          arm.loc,
+          `integer slot '${path}' (${cls}) selects synthesized record field '${targetField}', but another composed '${context.armName}' arm ${variant.why}`,
+          variant.loc,
         );
       }
-      const ref = this.fieldRef(field, unionName);
+      const field = variant.fields.find((candidate) => candidate.name === targetField);
+      if (field === undefined) {
+        throw new SidecarError(
+          `integer slot '${path}' (${cls}) selects synthesized record field '${targetField}', but another composed '${context.armName}' arm has no such field`,
+          variant.loc,
+        );
+      }
+      const ref = this.fieldRef(field, container);
       const candidateOptional = ref.kind === "optional" && ref.inner.kind === "f64";
       if (ref.kind !== "f64" && !candidateOptional) {
         throw new SidecarError(
-          `integer slot '${path}' (${cls}) selects synthesized record field '${targetField}', but another composed '${armName}' arm projects that field as '${ref.kind}'`,
+          `integer slot '${path}' (${cls}) selects synthesized record field '${targetField}', but another composed '${context.armName}' arm projects that field as '${ref.kind}'`,
           field.loc,
         );
       }
       if (!selectedOptional && candidateOptional) {
         throw new SidecarError(
-          `integer slot '${path}' (${cls}) selects required synthesized record field '${targetField}', but another composed '${armName}' arm makes that field optional`,
+          `integer slot '${path}' (${cls}) selects required synthesized record field '${targetField}', but another composed '${context.armName}' arm makes that field optional`,
           field.loc,
         );
       }
       this.pendingIntRecordFacts.push({
-        fields: arm.fields,
-        tagged: true,
+        fields: variant.fields,
+        tagged,
         targetField,
         cls,
         path,
-        loc: arm.loc,
+        loc: variant.loc,
       });
     }
   }
@@ -881,8 +962,12 @@ class Projector {
 
   /** Project a syntactic field to a TypeRef, tabling every named type it
    * references. `container`/`member` seed synthesized names. */
-  fieldRef(field: ContractField, container: string): TypeRef {
-    const inner = this.shapeRef(field.shape, container, field.name, field.loc);
+  fieldRef(
+    field: ContractField,
+    container: string,
+    synthesizedContext?: SynthesizedRecordContext,
+  ): TypeRef {
+    const inner = this.shapeRef(field.shape, container, field.name, field.loc, synthesizedContext);
     if (field.optional) {
       if (inner.kind === "optional") return inner;
       return { kind: "optional", inner };
@@ -890,7 +975,13 @@ class Projector {
     return inner;
   }
 
-  shapeRef(shape: ContractTypeShape, container: string, member: string, loc: SrcLoc): TypeRef {
+  shapeRef(
+    shape: ContractTypeShape,
+    container: string,
+    member: string,
+    loc: SrcLoc,
+    synthesizedContext?: SynthesizedRecordContext,
+  ): TypeRef {
     switch (shape.k) {
       case "bool":
         return { kind: "bool" };
@@ -902,12 +993,12 @@ class Projector {
       case "bytes":
         return { kind: "bytes" };
       case "array":
-        return { kind: "slice", elem: this.shapeRef(shape.elem, container, member, loc) };
+        return { kind: "slice", elem: this.shapeRef(shape.elem, container, member, loc, synthesizedContext) };
       case "union": {
         const present = shape.parts.filter((p) => p.k !== "absent");
         const absents = shape.parts.length - present.length;
         if (absents > 0 && present.length === 1) {
-          const inner = this.shapeRef(present[0]!, container, member, loc);
+          const inner = this.shapeRef(present[0]!, container, member, loc, synthesizedContext);
           return inner.kind === "optional" ? inner : { kind: "optional", inner };
         }
         throw new SidecarError(
@@ -920,7 +1011,7 @@ class Projector {
         // aliases remain transparent to the aliased table declaration.
         const r = this.resolve(shape.name, loc);
         if (r.c.c === "scalar") {
-          return this.shapeRef(r.c.shape, container, member, loc);
+          return this.shapeRef(r.c.shape, container, member, loc, synthesizedContext);
         }
         if (r.c.c === "struct") {
           this.tableNamed(r.name, loc);
@@ -940,7 +1031,19 @@ class Projector {
         return { kind: "union", name: r.name };
       }
       case "object":
-        return { kind: "value", name: this.tableSynthesized(container, member, shape.fields, false, loc) };
+        return {
+          kind: "value",
+          name: this.tableSynthesized(
+            container,
+            member,
+            shape.fields,
+            false,
+            loc,
+            synthesizedContext === undefined
+              ? undefined
+              : this.nestedSynthesizedRecordContext(synthesizedContext, member),
+          ),
+        };
       case "stringLit":
         throw new SidecarError(
           `'${container}.${member}' is a bare string-literal type — declare a named string-literal union and reference it as an enum`,
@@ -1039,8 +1142,12 @@ class Projector {
    * multi-field inline payloads. */
   armPayloadRef(unionName: string, arm: { name: string; fields: ContractField[]; loc: SrcLoc }): TypeRef {
     if (arm.fields.length === 0) return { kind: "void" };
-    if (arm.fields.length === 1) return this.fieldRef(arm.fields[0]!, unionName);
-    return { kind: "value", name: this.tableSynthesized(unionName, arm.name, arm.fields, true, arm.loc) };
+    const synthesizedContext = this.synthesizedArmContext(unionName, arm.name, arm.loc);
+    if (arm.fields.length === 1) return this.fieldRef(arm.fields[0]!, unionName, synthesizedContext);
+    return {
+      kind: "value",
+      name: this.tableSynthesized(unionName, arm.name, arm.fields, true, arm.loc, synthesizedContext),
+    };
   }
 
   /** Table an anonymous inline record under the schema's synthesized-name
@@ -1048,7 +1155,14 @@ class Projector {
    * identical re-compiles, unique in the one namespace. `tagged` records
    * whether this wire payload comes from a union arm whose lowered IR shape
    * also carries the discriminant. */
-  tableSynthesized(container: string, member: string, fields: ContractField[], tagged: boolean, loc: SrcLoc): string {
+  tableSynthesized(
+    container: string,
+    member: string,
+    fields: ContractField[],
+    tagged: boolean,
+    loc: SrcLoc,
+    synthesizedContext?: SynthesizedRecordContext,
+  ): string {
     const name = `${container}_${member}`;
     if (this.byName.has(name)) {
       throw new SidecarError(
@@ -1094,13 +1208,13 @@ class Projector {
       entry.fields.push({
         name: f.name,
         type: this.intifyStructField(
-          this.fieldRef(f, name),
+          this.fieldRef(f, name, synthesizedContext),
           name,
           f.name,
           fields,
           tagged,
           f.loc,
-          tagged ? { unionName: container, armName: member } : undefined,
+          synthesizedContext,
         ),
       });
     }
@@ -1111,6 +1225,7 @@ class Projector {
   msgDescriptor(msgName: string, arm: { name: string; fields: ContractField[]; loc: SrcLoc }): PayloadDescriptor {
     const fields = arm.fields;
     if (fields.length === 0) return { kind: "void" };
+    const synthesizedContext = this.synthesizedArmContext(msgName, arm.name, arm.loc);
     if (fields.length === 2) {
       const [first, second] = [fields[0]!, fields[1]!];
       const firstShape = this.scalarShape(first.shape, first.loc);
@@ -1143,7 +1258,7 @@ class Projector {
       }
     }
     if (fields.length === 1 && !fields[0]!.optional) {
-      let ref = this.fieldRef(fields[0]!, msgName);
+      let ref = this.fieldRef(fields[0]!, msgName, synthesizedContext);
       // A bare or optional number payload is an ask-4 declarable slot:
       // `<msg>.<arm>`. Calling intify for every one-field family also makes
       // a declaration targeting a non-number refuse at the precise arm.
@@ -1181,7 +1296,10 @@ class Projector {
     }
     // Everything else — bytes-first pairs, three-plus fields, optional
     // payload fields — tables a synthesized record (family 5).
-    return { kind: "record", name: this.tableSynthesized(msgName, arm.name, fields, true, arm.loc) };
+    return {
+      kind: "record",
+      name: this.tableSynthesized(msgName, arm.name, fields, true, arm.loc, synthesizedContext),
+    };
   }
 
   /** Materialize structural join patterns only after normal sidecar

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -423,19 +423,33 @@ class Projector {
     allFields: ContractField[],
     tagged: boolean,
     loc: SrcLoc,
+    taggedArm?: { unionName: string; armName: string },
   ): TypeRef {
     const slotPath = `${container}.${field}`;
     const before = this.intConsumed.has(slotPath);
     const out = this.intify(ref, slotPath, loc);
     if (!before && this.intConsumed.has(slotPath)) {
-      this.pendingIntRecordFacts.push({
-        fields: allFields,
-        tagged,
-        targetField: field,
-        cls: this.intConsumed.get(slotPath)!,
-        path: slotPath,
-        loc,
-      });
+      const cls = this.intConsumed.get(slotPath)!;
+      if (taggedArm !== undefined) {
+        this.recordIntegerSynthesizedRecordFacts(
+          taggedArm.unionName,
+          taggedArm.armName,
+          field,
+          out,
+          cls,
+          slotPath,
+          loc,
+        );
+      } else {
+        this.pendingIntRecordFacts.push({
+          fields: allFields,
+          tagged,
+          targetField: field,
+          cls,
+          path: slotPath,
+          loc,
+        });
+      }
     }
     return out;
   }
@@ -699,6 +713,60 @@ class Projector {
       return out;
     } finally {
       this.allFlattening.delete(unionName);
+    }
+  }
+
+  /** Record a synthesized-record field obligation for every composed
+   * occurrence of the wire-selected discriminant. The first arm supplies
+   * the wire struct, but later same-named arms may lower to distinct record
+   * shapes; every compatible numeric field therefore needs the same proof.
+   * An absent, non-number, or newly optional field cannot satisfy the
+   * selected wire slot and refuses at projection. */
+  private recordIntegerSynthesizedRecordFacts(
+    unionName: string,
+    armName: string,
+    targetField: string,
+    intifiedRef: TypeRef,
+    cls: "i64" | "u64",
+    path: string,
+    loc: SrcLoc,
+  ): void {
+    const selectedOptional =
+      intifiedRef.kind === "optional" && intifiedRef.inner.kind === "i64";
+    if (intifiedRef.kind !== "i64" && !selectedOptional) {
+      throw new Error(`sidecar pattern bug: synthesized integer field '${path}' has ref '${intifiedRef.kind}'`);
+    }
+    for (const arm of this.allUnionArms(unionName, loc)) {
+      if (arm.name !== armName) continue;
+      const field = arm.fields.find((candidate) => candidate.name === targetField);
+      if (field === undefined) {
+        throw new SidecarError(
+          `integer slot '${path}' (${cls}) selects synthesized record field '${targetField}', but another composed '${armName}' arm has no such field`,
+          arm.loc,
+        );
+      }
+      const ref = this.fieldRef(field, unionName);
+      const candidateOptional = ref.kind === "optional" && ref.inner.kind === "f64";
+      if (ref.kind !== "f64" && !candidateOptional) {
+        throw new SidecarError(
+          `integer slot '${path}' (${cls}) selects synthesized record field '${targetField}', but another composed '${armName}' arm projects that field as '${ref.kind}'`,
+          field.loc,
+        );
+      }
+      if (!selectedOptional && candidateOptional) {
+        throw new SidecarError(
+          `integer slot '${path}' (${cls}) selects required synthesized record field '${targetField}', but another composed '${armName}' arm makes that field optional`,
+          field.loc,
+        );
+      }
+      this.pendingIntRecordFacts.push({
+        fields: arm.fields,
+        tagged: true,
+        targetField,
+        cls,
+        path,
+        loc: arm.loc,
+      });
     }
   }
 
@@ -991,7 +1059,15 @@ class Projector {
       seen.add(f.name);
       entry.fields.push({
         name: f.name,
-        type: this.intifyStructField(this.fieldRef(f, name), name, f.name, fields, tagged, f.loc),
+        type: this.intifyStructField(
+          this.fieldRef(f, name),
+          name,
+          f.name,
+          fields,
+          tagged,
+          f.loc,
+          tagged ? { unionName: container, armName: member } : undefined,
+        ),
       });
     }
     return name;

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -330,6 +330,15 @@ interface TableEntry {
   kind: "struct" | "enum" | "union";
   anchor: number;
   sub: number;
+  /** Present only for anonymous inline records. The generated name is not
+   * injective (`A.B_C` and `A_B.C` both become `A_B_C`), so a table hit is
+   * reusable only when it came from this exact source declaration. */
+  synthesizedOrigin?: {
+    container: string;
+    member: string;
+    fields: ContractField[];
+    tagged: boolean;
+  };
 }
 
 class SidecarError extends Error {
@@ -1041,18 +1050,43 @@ class Projector {
    * also carries the discriminant. */
   tableSynthesized(container: string, member: string, fields: ContractField[], tagged: boolean, loc: SrcLoc): string {
     const name = `${container}_${member}`;
-    const existing = this.table.get(name);
-    if (existing !== undefined) return name; // the same inline decl, revisited
     if (this.byName.has(name)) {
       throw new SidecarError(
         `the inline record at '${container}.${member}' needs the synthesized name '${name}', which a declared type already uses — rename one`,
         loc,
       );
     }
+    const existing = this.table.get(name);
+    if (existing !== undefined) {
+      const origin = existing.synthesizedOrigin;
+      if (
+        origin !== undefined &&
+        origin.container === container &&
+        origin.member === member &&
+        origin.fields === fields &&
+        origin.tagged === tagged
+      ) {
+        return name; // the same inline declaration, revisited
+      }
+      const owner =
+        origin === undefined
+          ? `a declared type`
+          : `another inline record at '${origin.container}.${origin.member}'`;
+      throw new SidecarError(
+        `the inline record at '${container}.${member}' needs the synthesized name '${name}', which ${owner} already uses — rename one`,
+        loc,
+      );
+    }
     const entry: SidecarStruct = { name, synthesized: true, fields: [] };
     const anchor = this.byName.get(container)?.index ?? this.facts.types.length;
     const sub = this.synthCounter++;
-    this.table.set(name, { kind: "struct", entry, anchor, sub });
+    this.table.set(name, {
+      kind: "struct",
+      entry,
+      anchor,
+      sub,
+      synthesizedOrigin: { container, member, fields, tagged },
+    });
     const seen = new Set<string>();
     for (const f of fields) {
       if (seen.has(f.name)) throw new SidecarError(`the inline record at '${container}.${member}' repeats field '${f.name}'`, f.loc);

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -1141,6 +1141,55 @@ export function update(m: Model, msg: Msg): Model {
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 
+  test("an unproven write into a synthesized named-union payload field refuses", async () => {
+    const source = `export type TextInputEvent =
+  | { kind: "set_composition"; text: string; cursor: number }
+  | { kind: "clear_composition" };
+export interface Model { input: TextInputEvent; }
+export type Msg = { kind: "noop" } | { kind: "other" };
+export function init(): Model {
+  return { input: { kind: "set_composition", text: "", cursor: 0.5 } };
+}
+export function update(m: Model, msg: Msg): Model { return m; }
+`;
+    const r = await buildCase(
+      "sidecar-refuse-synthesized-union-record-slot",
+      source,
+      sidecarProfile([{ slot: "TextInputEvent_set_composition.cursor", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'TextInputEvent_set_composition.cursor'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
+  test("an unproven write into a synthesized msg payload field refuses", async () => {
+    const source = `export interface Model { value: number; }
+export type Msg =
+  | { kind: "audio_event"; name: string; at: number }
+  | { kind: "noop" };
+let last: Msg = { kind: "noop" };
+export function init(): Model { return { value: 0 }; }
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "noop") {
+    last = { kind: "audio_event", name: "", at: 0.5 };
+  }
+  return m;
+}
+`;
+    const r = await buildCase(
+      "sidecar-refuse-synthesized-msg-record-slot",
+      source,
+      sidecarProfile([{ slot: "Msg_audio_event.at", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Msg_audio_event.at'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
   test("an unproven declared helper return refuses by slot path", async () => {
     const broken = SIDECAR_ENTRY.replace("return i | 0;", "return i * 0.5;");
     const r = await buildCase("sidecar-refuse-helper", broken, sidecarProfile(DECLARED));

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -1196,6 +1196,36 @@ export function update(m: Model, msg: Msg): Model {
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 
+  test("colliding synthesized names refuse before a tagged integer obligation can escape", async () => {
+    const source = `export interface A {
+  B_C: { value: number; plain: string };
+}
+export type A_B =
+  | { kind: "C"; value: number; tagged: boolean }
+  | { kind: "noop" };
+export interface Model { a: A; tagged: A_B; }
+export type Msg = { kind: "noop" } | { kind: "other" };
+export function init(): Model {
+  return {
+    a: { B_C: { value: 1, plain: "" } },
+    tagged: { kind: "C", value: 0.5, tagged: false },
+  };
+}
+export function update(m: Model, msg: Msg): Model { return m; }
+`;
+    const r = await buildCase(
+      "sidecar-refuse-colliding-synthesized-integer-records",
+      source,
+      sidecarProfile([{ slot: "A_B_C.value", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4009"]);
+    expect(r.diagnostics[0]!.message).toContain("'A_B.C'");
+    expect(r.diagnostics[0]!.message).toContain("'A.B_C'");
+    expect(r.diagnostics[0]!.message).toContain("'A_B_C'");
+  });
+
   test("an unproven write into a synthesized msg payload field refuses", async () => {
     const source = `export interface Model { value: number; }
 export type Msg =

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -1196,6 +1196,58 @@ export function update(m: Model, msg: Msg): Model {
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 
+  test("nested synthesized union records keep every composed-arm integer obligation live", async () => {
+    const source = `export type First =
+  | { kind: "dup"; payload: { nested: { value: number; first: string }; marker: string } }
+  | { kind: "firstOnly" };
+export type Second =
+  | { kind: "dup"; payload: { nested: { value: number; second: boolean }; marker: string } }
+  | { kind: "secondOnly" };
+export type Nested = First | Second;
+export interface Model { nested: Nested; }
+export type Msg = { kind: "fractional" } | { kind: "noop" };
+export function init(): Model {
+  return {
+    nested: {
+      kind: "dup",
+      payload: { nested: { value: 1, first: "" }, marker: "" },
+    },
+  };
+}
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "fractional") {
+    return {
+      nested: {
+        kind: "dup",
+        payload: { nested: { value: 0.5, second: false }, marker: "" },
+      },
+    };
+  }
+  return m;
+}
+`;
+    const r = await buildCase(
+      "sidecar-refuse-composed-nested-synthesized-union-record-slot",
+      source,
+      sidecarProfile([{ slot: "Nested_payload_nested.value", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Nested_payload_nested.value'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+
+    const proved = await buildCase(
+      "sidecar-prove-composed-nested-synthesized-union-record-slot",
+      source.replace("value: 0.5", "value: 2"),
+      sidecarProfile([{ slot: "Nested_payload_nested.value", class: "u64" }], { exports: [] }),
+    );
+    expect(
+      proved.ok,
+      proved.ok ? "" : proved.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n"),
+    ).toBe(true);
+  });
+
   test("colliding synthesized names refuse before a tagged integer obligation can escape", async () => {
     const source = `export interface A {
   B_C: { value: number; plain: string };
@@ -1249,6 +1301,36 @@ export function update(m: Model, msg: Msg): Model {
     if (r.ok) return;
     expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
     expect(r.diagnostics[0]!.message).toContain("'Msg_audio_event.at'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
+  test("nested synthesized msg records keep every composed-arm integer obligation live", async () => {
+    const source = `export type First =
+  | { kind: "dup"; payload: { value: number; first: string } }
+  | { kind: "firstOnly" };
+export type Second =
+  | { kind: "dup"; payload: { value: number; second: boolean } }
+  | { kind: "secondOnly" };
+export type Msg = First | Second;
+export interface Model { value: number; }
+let last: Msg = { kind: "dup", payload: { value: 1, first: "" } };
+export function init(): Model { return { value: 0 }; }
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "secondOnly") {
+    last = { kind: "dup", payload: { value: 0.5, second: false } };
+  }
+  return m;
+}
+`;
+    const r = await buildCase(
+      "sidecar-refuse-composed-nested-synthesized-msg-record-slot",
+      source,
+      sidecarProfile([{ slot: "Msg_payload.value", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Msg_payload.value'");
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -1164,6 +1164,38 @@ export function update(m: Model, msg: Msg): Model { return m; }
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 
+  test("same-named composed synthesized union records each keep the integer obligation live", async () => {
+    const source = `export type First =
+  | { kind: "dup"; value: number; first: string }
+  | { kind: "firstOnly" };
+export type Second =
+  | { kind: "dup"; value: number; second: boolean }
+  | { kind: "secondOnly" };
+export type Nested = First | Second;
+export interface Model { nested: Nested; }
+export type Msg = { kind: "fractional" } | { kind: "noop" };
+export function init(): Model {
+  return { nested: { kind: "dup", value: 1, first: "" } };
+}
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "fractional") {
+    return { nested: { kind: "dup", value: 0.5, second: false } };
+  }
+  return m;
+}
+`;
+    const r = await buildCase(
+      "sidecar-refuse-composed-synthesized-union-record-slot",
+      source,
+      sidecarProfile([{ slot: "Nested_dup.value", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Nested_dup.value'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
   test("an unproven write into a synthesized msg payload field refuses", async () => {
     const source = `export interface Model { value: number; }
 export type Msg =
@@ -1187,6 +1219,36 @@ export function update(m: Model, msg: Msg): Model {
     if (r.ok) return;
     expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
     expect(r.diagnostics[0]!.message).toContain("'Msg_audio_event.at'");
+    expect(r.diagnostics[0]!.message).toContain("wholeness failed");
+  });
+
+  test("same-named composed synthesized msg records each keep the integer obligation live", async () => {
+    const source = `export type First =
+  | { kind: "dup"; first: string; value: number }
+  | { kind: "firstOnly" };
+export type Second =
+  | { kind: "dup"; second: boolean; value: number }
+  | { kind: "secondOnly" };
+export type Msg = First | Second;
+export interface Model { value: number; }
+let last: Msg = { kind: "dup", first: "", value: 1 };
+export function init(): Model { return { value: 0 }; }
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "secondOnly") {
+    last = { kind: "dup", second: false, value: 0.5 };
+  }
+  return m;
+}
+`;
+    const r = await buildCase(
+      "sidecar-refuse-composed-synthesized-msg-record-slot",
+      source,
+      sidecarProfile([{ slot: "Msg_dup.value", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok).toBe(false);
+    if (r.ok) return;
+    expect(r.diagnostics.map((d) => d.code)).toEqual(["SC4022"]);
+    expect(r.diagnostics[0]!.message).toContain("'Msg_dup.value'");
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 


### PR DESCRIPTION
- Preserve tagged-union shape identity when mapping synthesized payload fields into integer inference.
- Refuse fractional writes on named-union and message payload slots, with regressions for both paths.