### PR TITLE
fix: coalesce same-class integer slot obligations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to scriptc will be documented in this file.
 ### Fixes
 
 - **Contract integer attestations cover synthesized tagged-record payloads.** Integer slots declared on lowered payload paths such as `TextInputEvent_set_composition.cursor` and `Msg_audio_event.at` now carry compile-time write obligations, so fractional writes refuse instead of surviving until runtime encoding. Distinct inline records whose underscore-joined synthesized names collide now refuse instead of reusing the wrong table entry and dropping an obligation.
+- Same-shaped contract integer slots with the same declared class now share one lowered proof obligation while retaining every source slot path in refusals. Differing-class collisions remain SC4009 until arm provenance can keep their assumptions distinct.
 
 <!-- release:start -->
 

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1135,9 +1135,10 @@ function sidecarRecordMatcher(
  * projection already shifted past the model receiver); record-field
  * slots map onto every interned IR shape whose complete structural field
  * signature matches the projected record's. Shapes intern structurally,
- * so a same-shaped second type shares the obligation; two DECLARED paths
- * resolving to the same shape-field key refuse because overwriting either
- * attestation would be unsound. A
+ * so a same-shaped second type shares the obligation. DECLARED paths with
+ * the same class coalesce while retaining every source path for verdicts;
+ * differing classes refuse because one lowered field cannot seed or check
+ * two distinct class contracts without arm provenance. A
  * record fact that matches no shape binds nothing: no compiled code
  * constructs the type (the contract surface — init/update/subscriptions
  * and every helper — is force-lowered whenever integer slots are
@@ -1188,17 +1189,25 @@ function mergeSidecarIntSlots(
         cfg.records.set(shape.id, m);
       }
       const existing = m.get(r.targetField);
-      if (existing !== undefined && existing.path !== r.path) {
+      if (existing !== undefined && existing.cls !== r.cls) {
+        const paths = [
+          ...existing.paths.map((path) => `'${path}' (${existing.cls})`),
+          `'${r.path}' (${r.cls})`,
+        ];
         return {
           ok: false,
           diagnostic: libSidecarDiag(
-            `integer slots '${existing.path}' (${existing.cls}) and '${r.path}' (${r.cls}) collapse to the same lowered record field '${r.targetField}' — their proof obligations cannot be kept distinct`,
+            `integer slots ${paths.join(" and ")} collapse to the same lowered record field '${r.targetField}' — their proof obligations cannot be kept distinct`,
             r.loc,
-            "kind-tagged union arms and structurally identical records may share one lowered shape — give the colliding payloads distinct structural shapes, or integer-class at most one of these slots",
+            "kind-tagged union arms and structurally identical records may share one lowered shape — same-class declarations coalesce, but differing classes require distinct structural shapes or at most one classified slot",
           ),
         };
       }
-      m.set(r.targetField, { cls: r.cls, path: r.path });
+      if (existing === undefined) {
+        m.set(r.targetField, { cls: r.cls, paths: [r.path] });
+      } else if (!existing.paths.includes(r.path)) {
+        existing.paths.push(r.path);
+      }
     }
   }
   return { ok: true, config: cfg };

--- a/packages/compiler/src/library/int-infer.test.ts
+++ b/packages/compiler/src/library/int-infer.test.ts
@@ -127,7 +127,7 @@ const countWrite = (value: IrExpr, name = "m"): IrStmt => ({
 const RECORD_CFG: IntSlotConfig = {
   fns: new Map(),
   records: new Map([
-    [MODEL.shapeId, new Map([["count", { cls: "i64", path: "Model.count" }]])],
+    [MODEL.shapeId, new Map([["count", { cls: "i64", paths: ["Model.count"] }]])],
   ]),
 };
 

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -419,23 +419,21 @@ export interface FnIntSlots {
   paramSeeds: (AbsVal | null)[];
 }
 
-/** One record-field slot, resolved to an interned IR record shape: every
- * program-side construction (recordLit) or write (recordSet) of `field`
- * on shape `shapeId` must discharge the obligations. Shapes are interned
- * STRUCTURALLY, so a second type with the identical field list shares the
- * shape — and inherits the obligation, a sound over-approximation. */
+/** One lowered record-field obligation. Every program-side construction
+ * (recordLit) or write (recordSet) of the field must discharge `cls` for
+ * EVERY source contract path in `paths`. Shapes are interned STRUCTURALLY,
+ * so same-shaped source slots with the same declared class coalesce here:
+ * one proof fact, all attestation/diagnostic identities retained. */
 export interface RecordIntSlot {
-  shapeId: string;
-  field: string;
   cls: IntClass;
-  path: string;
+  paths: string[];
 }
 
 export interface IntSlotConfig {
   /** Keyed by IR function name. */
   fns: Map<string, FnIntSlots>;
   /** shapeId → field → slot. */
-  records: Map<string, Map<string, { cls: IntClass; path: string }>>;
+  records: Map<string, Map<string, RecordIntSlot>>;
 }
 
 /** The IR representations whose PRESENT values can carry one number slot.
@@ -798,6 +796,14 @@ class FnAnalyzer {
     this.verdicts.push(checkBoundary(v, path, cls, loc));
   }
 
+  /** One lowered write can conservatively cover several same-class source
+   * contract slots. Check once per path so every attestation identity
+   * survives into a refusal instead of inheriting the first declarer's
+   * label. */
+  private emitRecordSlot(v: AbsVal, slot: RecordIntSlot, loc: SrcLoc): void {
+    for (const path of slot.paths) this.emit(v, path, slot.cls, loc);
+  }
+
   /* ── statements ─────────────────────────────────────────────────────── */
 
   private execStmts(stmts: IrStmt[], env: Env | null): Env | null {
@@ -897,7 +903,7 @@ class FnAnalyzer {
         this.evalExpr(s.obj, env);
         const v = this.evalExpr(s.value, env);
         const slot = this.cfg.records.get(s.shapeId)?.get(s.field);
-        if (slot !== undefined) this.emit(v, slot.path, slot.cls, s.loc);
+        if (slot !== undefined) this.emitRecordSlot(v, slot, s.loc);
         // The RHS and its boundary obligation observe the pre-write value;
         // only the completed heap write invalidates paths (JS evaluation
         // order, and what lets `m.count = m.count + 1` prove).
@@ -915,7 +921,7 @@ class FnAnalyzer {
         // independent obligations (their classes and paths may differ).
         if (s.overflowOnly !== true) {
           for (const slot of this.cfg.records.get(s.shapeId)?.values() ?? []) {
-            this.emit(v, slot.path, slot.cls, s.loc);
+            this.emitRecordSlot(v, slot, s.loc);
           }
         }
         clearPathFacts(env);
@@ -1604,7 +1610,7 @@ class FnAnalyzer {
           const v = this.evalExpr(f.value, env);
           const slot = slotMap?.get(f.name);
           if (slot !== undefined && numberCarrierKind(f.value.type, this.mod) !== null) {
-            this.emit(v, slot.path, slot.cls, f.value.loc);
+            this.emitRecordSlot(v, slot, f.value.loc);
           }
         }
         return { ...TOP };

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -950,7 +950,53 @@ export function update(m: Model, msg: Msg): Model { return m }
     expect(r.diagnostics[0]!.message).toContain(evidence);
   });
 
-  test("same-shaped tagged-union integer slots refuse instead of overwriting an obligation", async () => {
+  test("same-shaped tagged-union slots with the same class coalesce and retain every path", async () => {
+    const source = `export interface Model { value: number; }
+export type Msg = { kind: "first"; id: number } | { kind: "second"; id: number };
+let last: Msg = { kind: "first", id: 1 };
+export function init(): Model { return { value: 0 }; }
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "first") last = { kind: "second", id: 2 };
+  return m;
+}
+`;
+    const slots = [
+      { slot: "Msg.first", class: "i64" },
+      { slot: "Msg.second", class: "i64" },
+    ];
+    const proved = await buildCase(
+      "sidecar-int-same-class-shape-collision",
+      source,
+      sidecarProfile(slots, { exports: [] }),
+    );
+    expect(
+      proved.ok,
+      proved.ok ? "" : proved.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n"),
+    ).toBe(true);
+    if (!proved.ok) return;
+    const doc = JSON.parse(readFileSync(proved.sidecarPath!, "utf8")) as {
+      integer_slots: { slot: string; class: string }[];
+    };
+    expect(doc.integer_slots).toEqual(slots);
+    expect(validateSidecar(doc)).toEqual([]);
+
+    const refused = await buildCase(
+      "sidecar-int-same-class-shape-collision-refuse",
+      source.replace('last = { kind: "second", id: 2 }', 'last = { kind: "second", id: 0.5 }'),
+      sidecarProfile(slots, { exports: [] }),
+    );
+    expect(refused.ok).toBe(false);
+    if (refused.ok) return;
+    expect(refused.diagnostics.map((d) => d.code)).toEqual(["SC4022", "SC4022"]);
+    expect(refused.diagnostics.map((d) => d.message)).toEqual(
+      expect.arrayContaining([
+        expect.stringContaining("'Msg.first' (i64)"),
+        expect.stringContaining("'Msg.second' (i64)"),
+      ]),
+    );
+  });
+
+  test("same-shaped tagged-union integer slots with differing classes refuse instead of overwriting an obligation", async () => {
     const source = `export interface Model { value: number; }
 export type Msg = { kind: "first"; id: number } | { kind: "second"; id: number };
 export function init(): Model { return { value: 0 }; }


### PR DESCRIPTION
- Retain every declared path when structurally identical arms share a lowered record field.
- Keep differing-class collisions on SC4009 and cover both outcomes with regressions.