### PR TITLE
Document synthesized sidecar structs

### DIFF
--- a/packages/compiler/src/library/sidecar-validate.ts
+++ b/packages/compiler/src/library/sidecar-validate.ts
@@ -184,6 +184,11 @@ export function validateSidecar(doc: unknown): string[] {
 
   /* ── V3 (inner uniqueness) + table entry shapes ───────────────────── */
   for (const [name, s] of structs) {
+    // Format 1 marks compiler-created anonymous inline records with the
+    // optional literal `synthesized: true`; source-declared records omit it.
+    if ("synthesized" in s && s["synthesized"] !== true) {
+      bad("V1", `struct '${name}' has a synthesized marker other than literal true`);
+    }
     const fields = s["fields"];
     if (!Array.isArray(fields)) {
       bad("V1", `struct '${name}' has no fields array`);

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -86,6 +86,9 @@ export type PayloadDescriptor =
 
 export interface SidecarStruct {
   name: string;
+  /** Present, with the literal value `true`, only when the compiler
+   * synthesized this table entry for an anonymous inline record. Omitted
+   * for records declared by name in the entry module. */
   synthesized?: true;
   fields: { name: string; type: TypeRef }[];
 }

--- a/tests/harness/library-contract.test.ts
+++ b/tests/harness/library-contract.test.ts
@@ -590,6 +590,12 @@ describe("the V1-V14 validator", () => {
     });
   });
 
+  test("V1: a synthesized struct marker is absent or literal true", () => {
+    expectViolation("V1", (d) => {
+      d["types"].structs[0].synthesized = false;
+    });
+  });
+
   test("V2: hashes are exactly 16 lowercase hex digits", () => {
     expectViolation("V2", (d) => {
       d["build_id"] = "B01DFACE00C0FFEE";


### PR DESCRIPTION
- Define the optional marker as literal true for compiler-created inline records.
- Reject malformed markers and pin the format-1 validator behavior.