### PR TITLE
fix(compiler): refine narrowed union payload fields

### DIFF
--- a/packages/compiler/src/library/int-infer.test.ts
+++ b/packages/compiler/src/library/int-infer.test.ts
@@ -586,6 +586,40 @@ describe("straight-line ordinary-field refinement", () => {
     expect(v.provenHi).toBe(65535);
   });
 
+  test("a union discriminant read preserves an existing field fact", () => {
+    const msgRef = (): IrExpr => ({ kind: "varRef", localId: "msg.0", type: RESIZE_MSG, loc });
+    const isResized: IrExpr = {
+      kind: "strEq",
+      negated: false,
+      left: {
+        kind: "unionDisc",
+        unionId: RESIZE_MSG.unionId,
+        field: "kind",
+        value: msgRef(),
+        type: STRING,
+        loc,
+      },
+      right: { kind: "strLit", value: "resized", type: STRING, loc },
+      type: BOOL,
+      loc,
+    };
+    const mod = recordCase([
+      iff(bin(">=", countRead(), num(0)), [
+        iff(and(isResized, bin("<=", countRead(), num(100))), [
+          send(math("trunc", countRead()), "sendU64"),
+        ]),
+      ]),
+    ], ["m", "msg"], [sink("sendU64")]);
+    mod.functions[1]!.params[1]!.type = RESIZE_MSG;
+    mod.functions[1]!.locals[1]!.type = RESIZE_MSG;
+    mod.unions = [{ id: RESIZE_MSG.unionId, arms: [NOOP, RESIZED] }];
+
+    const v = only(mod);
+    expect(v.outcome).toBe("prove");
+    expect(v.provenLo).toBe(0);
+    expect(v.provenHi).toBe(100);
+  });
+
   test("ordered comparisons refine a repeated class field into Math.trunc", () => {
     const v = onlyOrdinaryClass([
       iff(and(bin(">=", classCountRead(), num(0)), bin("<=", classCountRead(), num(100))), [

--- a/packages/compiler/src/library/int-infer.test.ts
+++ b/packages/compiler/src/library/int-infer.test.ts
@@ -27,6 +27,9 @@ const VOID = { kind: "void" } as const;
 const MODEL = { kind: "record", shapeId: "model-shape" } as const;
 const MODEL_CLASS = { kind: "object", className: "Model" } as const;
 const OPTIONAL_NUMBER = { kind: "union", unionId: "optional-number" } as const;
+const RESIZE_MSG = { kind: "union", unionId: "resize-msg" } as const;
+const RESIZED = { kind: "record", shapeId: "resized-shape" } as const;
+const NOOP = { kind: "record", shapeId: "noop-shape" } as const;
 
 const num = (value: number, spelling?: string): IrExpr =>
   spelling === undefined
@@ -534,6 +537,53 @@ describe("straight-line ordinary-field refinement", () => {
     expect(v.outcome).toBe("prove");
     expect(v.provenLo).toBe(0);
     expect(v.provenHi).toBe(100);
+  });
+
+  test("a union discriminant conjunct preserves narrowed payload-field facts", () => {
+    const msgRef = (): IrExpr => ({ kind: "varRef", localId: "msg.0", type: RESIZE_MSG, loc });
+    const widthRead = (): IrExpr => ({
+      kind: "recordGet",
+      obj: {
+        kind: "unionNarrow",
+        unionId: RESIZE_MSG.unionId,
+        tag: 1,
+        value: msgRef(),
+        type: RESIZED,
+        loc,
+      },
+      shapeId: RESIZED.shapeId,
+      field: "w",
+      type: F64,
+      loc,
+    });
+    const isResized: IrExpr = {
+      kind: "strEq",
+      negated: false,
+      left: {
+        kind: "unionDisc",
+        unionId: RESIZE_MSG.unionId,
+        field: "kind",
+        value: msgRef(),
+        type: STRING,
+        loc,
+      },
+      right: { kind: "strLit", value: "resized", type: STRING, loc },
+      type: BOOL,
+      loc,
+    };
+    const mod = recordCase([
+      iff(and(isResized, and(bin(">=", widthRead(), num(0)), bin("<=", widthRead(), num(65535)))), [
+        send(math("trunc", widthRead())),
+      ]),
+    ], ["msg"], [sink("send")]);
+    mod.functions[1]!.params[0]!.type = RESIZE_MSG;
+    mod.functions[1]!.locals[0]!.type = RESIZE_MSG;
+    mod.unions = [{ id: RESIZE_MSG.unionId, arms: [NOOP, RESIZED] }];
+
+    const v = only(mod);
+    expect(v.outcome).toBe("prove");
+    expect(v.provenLo).toBe(0);
+    expect(v.provenHi).toBe(65535);
   });
 
   test("ordered comparisons refine a repeated class field into Math.trunc", () => {

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -1400,6 +1400,7 @@ class FnAnalyzer {
       case "fieldGet":
         return this.staticAccessPath(e) !== null;
       case "unionIsTag":
+      case "unionDisc":
         return this.stablePathGuard(e.value);
       case "unionNarrow":
         return this.stablePathGuard(e.value);

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -1488,6 +1488,7 @@ class FnAnalyzer {
         this.evalExpr(e.right, env);
         return { ...TOP };
       case "unionIsTag":
+      case "unionDisc":
         this.evalExpr(e.value, env);
         return { ...TOP };
       case "unary": {
@@ -1524,7 +1525,10 @@ class FnAnalyzer {
         const left = this.evalExpr(e.left, env);
         const rightEnv = cloneEnv(env);
         const right = this.evalExpr(e.right, rightEnv);
-        mergeInto(env, joinEnv(env, rightEnv));
+        // A stable logical tree cannot change the environment, so its
+        // short-circuit join must not discard an access-path fact merely
+        // because the RHS may not execute.
+        if (!this.stablePathGuard(e)) mergeInto(env, joinEnv(env, rightEnv));
         return numberCarrierKind(e.type, this.mod) !== null ? join(left, right) : { ...TOP };
       }
       case "optChain": {

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -1222,6 +1222,30 @@ export function update(m: Model, msg: Msg): Model {
     expect(r.ok, r.ok ? "" : r.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n")).toBe(true);
   });
 
+  test("a discriminant read preserves a prior model-field refinement", async () => {
+    const source = `export interface Model { width: number; }
+export type Msg =
+  | { kind: "resized"; w: number }
+  | { kind: "noop" };
+export function init(): Model { return { width: 0 }; }
+export function update(m: Model, msg: Msg): Model {
+  if (m.width >= 0) {
+    if (msg.kind === "resized" && m.width <= 100) {
+      return acceptWidth(m, Math.trunc(m.width));
+    }
+  }
+  return m;
+}
+export function acceptWidth(m: Model, width: number): Model { return m; }
+`;
+    const r = await buildCase(
+      "sidecar-prove-discriminant-preserves-field-fact",
+      source,
+      sidecarProfile([{ slot: "helpers.acceptWidth.params[0]", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok, r.ok ? "" : r.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n")).toBe(true);
+  });
+
   test("an unproven write into a synthesized named-union payload field refuses", async () => {
     const source = `export type TextInputEvent =
   | { kind: "set_composition"; text: string; cursor: number }

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -1201,6 +1201,27 @@ export function update(m: Model, msg: Msg): Model {
     expect(r.diagnostics[0]!.message).toContain("wholeness failed");
   });
 
+  test("a compound discriminant guard refines a narrowed msg payload field", async () => {
+    const source = `export interface Model { width: number; }
+export type Msg =
+  | { kind: "resized"; w: number }
+  | { kind: "noop" };
+export function init(): Model { return { width: 0 }; }
+export function update(m: Model, msg: Msg): Model {
+  if (msg.kind === "resized" && msg.w >= 0 && msg.w <= 65535) {
+    return { width: Math.trunc(msg.w) };
+  }
+  return m;
+}
+`;
+    const r = await buildCase(
+      "sidecar-prove-compound-msg-payload-guard",
+      source,
+      sidecarProfile([{ slot: "Model.width", class: "u64" }], { exports: [] }),
+    );
+    expect(r.ok, r.ok ? "" : r.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n")).toBe(true);
+  });
+
   test("an unproven write into a synthesized named-union payload field refuses", async () => {
     const source = `export type TextInputEvent =
   | { kind: "set_composition"; text: string; cursor: number }


### PR DESCRIPTION
- Treat pure union discriminant reads as stable within compound guards.
- Cover payload-field range refinement in analysis and library builds.