### PR TITLE
feat(compiler): lower stored text codec calls

### DIFF
--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -473,10 +473,11 @@ interface BufferConstructor {
 }
 declare var Buffer: BufferConstructor;
 
-/* The WHATWG encoders (Node globals). Only the COMPOSED forms lower —
- * `new TextEncoder().encode(s)` and `new TextDecoder().decode(bytes)`;
- * the label is typed as the utf-8 spellings (the one supported decoder;
- * other labels and the fatal/ignoreBOM options fence at the use site). */
+/* The WHATWG encoders (Node globals). The COMPOSED forms lower —
+ * `new TextEncoder().encode(s)` and `new TextDecoder().decode(bytes)` —
+ * as do same-scope const store-then-call forms. The label is typed as the
+ * utf-8 spellings (the one supported decoder; other labels and the
+ * fatal/ignoreBOM options fence at the use site). */
 interface TextEncoder {
   encode(input?: string): Uint8Array;
 }

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -6218,9 +6218,21 @@ type TextCodecCtor = {
     // imported binding can be observed during a module cycle; both need
     // real runtime storage rather than this deliberately trivial rewrite.
     const executionScope = (node: ts.Node): ts.Node => {
-      let cur = node;
-      while (!ts.isFunctionLike(cur) && !ts.isSourceFile(cur)) cur = cur.parent;
-      return cur;
+      let child = node;
+      for (let cur = node.parent; ; child = cur, cur = cur.parent) {
+        if (ts.isFunctionLike(cur) || ts.isSourceFile(cur)) return cur;
+        // An instance field initializer runs when an object is constructed,
+        // not when its enclosing class expression evaluates. Treat it like
+        // a closure boundary: a later source position does not prove the
+        // codec declaration ran (a switch can enter a following case and
+        // instantiate the class while the binding is still in its TDZ).
+        if (
+          ts.isPropertyDeclaration(cur) && cur.initializer === child &&
+          (ts.getCombinedModifierFlags(cur) & ts.ModifierFlags.Static) === 0
+        ) {
+          return cur;
+        }
+      }
     };
     if (executionScope(receiver) !== executionScope(decl) || receiver.getStart() < decl.end) return null;
     return directTextCodecCtorOf(L, decl.initializer);

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -6235,6 +6235,31 @@ type TextCodecCtor = {
       }
     };
     if (executionScope(receiver) !== executionScope(decl) || receiver.getStart() < decl.end) return null;
+    // All switch clauses share one lexical environment, but dispatch can
+    // enter a later clause without executing a const in an earlier one.
+    // TypeScript normally diagnoses the direct read; an @ts-expect-error
+    // can deliberately retain the runtime TDZ shape, so source order alone
+    // is not a sufficient proof. A codec declared in a clause is erasable
+    // only for uses inside that exact clause's subtree (nested switches are
+    // fine; closures and instance initializers already fail executionScope).
+    const switchClauseOf = (node: ts.Node): ts.CaseOrDefaultClause | null => {
+      for (let cur: ts.Node | undefined = node.parent; cur !== undefined; cur = cur.parent) {
+        if (ts.isCaseClause(cur) || ts.isDefaultClause(cur)) return cur;
+        if (ts.isFunctionLike(cur) || ts.isSourceFile(cur)) return null;
+      }
+      return null;
+    };
+    const declClause = switchClauseOf(decl);
+    if (declClause !== null) {
+      let insideDeclClause = false;
+      for (let cur: ts.Node | undefined = receiver; cur !== undefined; cur = cur.parent) {
+        if (cur === declClause) {
+          insideDeclClause = true;
+          break;
+        }
+      }
+      if (!insideDeclClause) return null;
+    }
     return directTextCodecCtorOf(L, decl.initializer);
   }
 

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -6130,25 +6130,120 @@ const NUMBER_CONSTANTS: Record<string, number | undefined> = {
     return { kind: "libCall", fn: "date.toISOString", args: [ms], type: STRING, loc };
   }
 
-/** The WHATWG encoder pair, COMPOSED: `new TextDecoder().decode(bytes)`
-   * and `new TextEncoder().encode(s)` — the encoder object between the two
-   * calls never exists (the crypto/Date precedent; bare construction is
-   * fenced in lowerNew with the composed hint). decode is the runtime's
-   * WHATWG utf-8 decode with the leading BOM stripped; a zero-argument
-   * decode() is "" like the spec's. encode IS Buffer.from(s, "utf8") —
-   * ScrStr storage is well-formed UTF-8, so the bytes are identical (lone
+type TextCodecCtor = {
+  cls: "TextDecoder" | "TextEncoder";
+  ctor: ts.NewExpression;
+};
+
+/** A direct construction of THE stdlib TextEncoder/TextDecoder, through
+   * type-only wrappers. Name alone is never enough: a user class with the
+   * same spelling keeps the ordinary class lowering. */
+  function directTextCodecCtorOf(L: Lowerer, expr: ts.Expression): TextCodecCtor | null {
+    const ctor = stripTypeCasts(expr);
+    if (!ts.isNewExpression(ctor)) return null;
+    const callee = stripTypeCasts(ctor.expression);
+    if (!ts.isIdentifier(callee)) return null;
+    if (callee.text !== "TextDecoder" && callee.text !== "TextEncoder") return null;
+    const sym = L.resolveValueSymbol(callee);
+    if (!sym || !L.isStdlibSymbol(sym)) return null;
+    if (sym.name !== "TextDecoder" && sym.name !== "TextEncoder") return null;
+    return { cls: sym.name, ctor };
+  }
+
+/** True when construction itself is effect-free and inside the already
+   * lowered codec slice, so a const binding can be erased and calls can
+   * resolve back to the initializer. TextDecoder's explicit label must be
+   * an actual literal here: accepting an arbitrary expression merely typed
+   * as "utf-8" would move or repeat its effects when the binding is erased. */
+  function erasableTextCodecCtor(info: TextCodecCtor): boolean {
+    const args = info.ctor.arguments ?? [];
+    if (info.cls === "TextEncoder") return args.length === 0;
+    if (args.length === 0) return true;
+    if (args.length !== 1) return false;
+    const label = stripTypeCasts(args[0]!);
+    return ts.isStringLiteralLike(label) && (label.text === "utf-8" || label.text === "utf8");
+  }
+
+/** `const encoder = new TextEncoder()` / the default TextDecoder twin:
+   * compile-time alias plumbing with no runtime object. Calls through the
+   * stable binding are recognized by textCodecReceiverOf below; any other
+   * reached value use keeps the ordinary SC2020 representation fence. Both
+   * declaration walks call this and independently gate on constness. */
+  export function textCodecBindingClassOf(
+    L: Lowerer,
+    nameNode: ts.Node,
+    init: ts.Expression | undefined,
+  ): TextCodecCtor["cls"] | null {
+    if (!ts.isIdentifier(nameNode) || init === undefined) return null;
+    const decl = nameNode.parent;
+    if (
+      !ts.isVariableDeclaration(decl) || !ts.isVariableDeclarationList(decl.parent) ||
+      !ts.isVariableStatement(decl.parent.parent)
+    ) {
+      return null;
+    }
+    const info = directTextCodecCtorOf(L, init);
+    return info !== null && erasableTextCodecCtor(info) ? info.cls : null;
+  }
+
+  export function textCodecBindingDecl(
+    L: Lowerer,
+    nameNode: ts.Node,
+    init: ts.Expression | undefined,
+  ): boolean {
+    return textCodecBindingClassOf(L, nameNode, init) !== null;
+  }
+
+/** The inline composed receiver, or a const identifier whose initializer
+   * is an erasable codec construction in the same execution scope and
+   * after that declaration. Following the declaration instead of
+   * materializing the value is honest for the supported slice: receiver
+   * reads are pure, construction has no effects, and every non-call use
+   * fences because there is deliberately no general value lowering. */
+  function textCodecReceiverOf(L: Lowerer, expr: ts.Expression): TextCodecCtor | null {
+    const direct = directTextCodecCtorOf(L, expr);
+    if (direct !== null) return direct;
+    const receiver = stripTypeCasts(expr);
+    if (!ts.isIdentifier(receiver)) return null;
+    const sym = L.resolveValueSymbol(receiver);
+    const decl = sym ? L.checker.valueDeclarationOf(sym) : undefined;
+    if (
+      !decl || !ts.isVariableDeclaration(decl) || decl.initializer === undefined ||
+      !ts.isVariableDeclarationList(decl.parent) || (decl.parent.flags & ts.NodeFlags.Const) === 0 ||
+      !textCodecBindingDecl(L, decl.name, decl.initializer)
+    ) {
+      return null;
+    }
+    // A closure can run before the const initializes (TDZ), and an
+    // imported binding can be observed during a module cycle; both need
+    // real runtime storage rather than this deliberately trivial rewrite.
+    const executionScope = (node: ts.Node): ts.Node => {
+      let cur = node;
+      while (!ts.isFunctionLike(cur) && !ts.isSourceFile(cur)) cur = cur.parent;
+      return cur;
+    };
+    if (executionScope(receiver) !== executionScope(decl) || receiver.getStart() < decl.end) return null;
+    return directTextCodecCtorOf(L, decl.initializer);
+  }
+
+/** The WHATWG encoder pair, COMPOSED or through an erasable const binding:
+   * `new TextDecoder().decode(bytes)`, `new TextEncoder().encode(s)`, and
+   * the idiomatic store-then-call equivalents. The codec object never
+   * exists (the crypto/Date precedent); bare construction and value uses
+   * are fenced with the composed hint. decode is the runtime's WHATWG
+   * utf-8 decode with the leading BOM stripped; a zero-argument decode()
+   * is "" like the spec's. encode IS Buffer.from(s, "utf8") — ScrStr
+   * storage is well-formed UTF-8, so the bytes are identical (lone
    * surrogates became U+FFFD at string construction, exactly what the
-   * spec's encoder emits). Null when this is neither composed form. */
+   * spec's encoder emits). Null when this is neither supported form. */
   export function lowerTextCodecCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,): IrExpr | null {
     if (call.questionDotToken || access.questionDotToken) return null;
     const member = access.name.text;
     if (member !== "decode" && member !== "encode") return null;
-    const recv = access.expression;
-    if (!ts.isNewExpression(recv) || !ts.isIdentifier(recv.expression)) return null;
-    const sym = L.resolveValueSymbol(recv.expression);
-    const cls = sym?.name;
-    if (!sym || !L.isStdlibSymbol(sym)) return null;
+    const info = textCodecReceiverOf(L, access.expression);
+    if (info === null || !L.isStdlibMember(access)) return null;
+    const { cls, ctor: recv } = info;
     if (!(cls === "TextDecoder" && member === "decode") && !(cls === "TextEncoder" && member === "encode")) {
       return null;
     }

--- a/packages/compiler/src/frontend/lowering/lower-classes.ts
+++ b/packages/compiler/src/frontend/lowering/lower-classes.ts
@@ -5055,13 +5055,14 @@ export function lowerNew(L: Lowerer, expr: ts.NewExpression): IrExpr {
           loc,
         };
       }
-      // Encoder objects likewise exist only inside the composed forms
-      // (lowerTextCodecCall claims those before the receiver lowers).
+      // Encoder objects likewise never exist: lowerTextCodecCall claims
+      // composed calls before the receiver lowers, while the same-scope
+      // const store-then-call declaration is erased before reaching here.
       if (symbol && (symbol.name === "TextDecoder" || symbol.name === "TextEncoder") && L.isStdlibSymbol(symbol)) {
         L.noLowering(
           `new ${symbol.name}`,
           expr,
-          `${symbol.name} values have no representation — the composed form compiles: ` +
+          `${symbol.name} values have no representation — a same-scope const store-then-call or the composed form compiles: ` +
             (symbol.name === "TextDecoder"
               ? "new TextDecoder().decode(bytes)"
               : "new TextEncoder().encode(s)"),

--- a/packages/compiler/src/frontend/lowering/lower-modules.ts
+++ b/packages/compiler/src/frontend/lowering/lower-modules.ts
@@ -13,7 +13,7 @@ import type { CycleEdge } from "../program.js";
 import { invalidJsonModuleDiag, npmEmbedFailedDiag, requiresDynamicImportDiag } from "../../diagnostics/diagnostic.js";
 import { BOOL, DYN, IrClassDef, IrExpr, IrFunction, IrGlobal, IrRecordShape, IrStmt, IrType, IrUnionDef, JSVAL, RUNTIME_ERROR_CLASSES, STRING, SrcLoc, VOID, arrayOf, canConvertToDyn, isUnitType } from "../../ir/nodes.js";
 import { ENTRY_NAME, PoisonError, boundIdentifiersOf, dynFallbackType, dynUndefinedExpr, importCallHandleType, newFnCtx, uncheckedOverloadHandleCall } from "./lowerer.js";
-import { builtinMemberRequireDecl, builtinNamespaceDestructureModuleOf, createRequireBindingDecl, createRequireNamespaceDecl, createRequireSpecOf, isPromisifyCall } from "./lower-builtins.js";
+import { builtinMemberRequireDecl, builtinNamespaceDestructureModuleOf, createRequireBindingDecl, createRequireNamespaceDecl, createRequireSpecOf, isPromisifyCall, textCodecBindingDecl } from "./lower-builtins.js";
 import { bindingContextualGenericFnNodeOf, bindingGenericFnAliasInfoOf, bindingGenericFnInfoOf, bindingGenericFnNodeOf, deadUnmappableBinding, implicitLocalFnInfoOf, implicitLocalFnNodeOf, nullishGenericBindingUnitOf } from "./lower-calls.js";
 import { isVarDeclared, numericIteratorSourceOf, provenanceElidedConstDecl } from "./lower-stmts.js";
 import { streamClassAliasDecl } from "./lower-stream.js";
@@ -1260,6 +1260,10 @@ export function collectGlobals(L: Lowerer, sf: ts.SourceFile, topStmts: ts.State
         // stdlibGlobalAliasDecl; the statement lowering skips it by the
         // same test).
         if (isConst && stdlibGlobalAliasDecl(L, decl.name, decl.initializer)) continue;
+        // Stored default TextEncoder/TextDecoder instances are the same
+        // compile-time alias plumbing as their statement lowering: calls
+        // trace this const initializer, so no module global exists.
+        if (isConst && textCodecBindingDecl(L, decl.name, decl.initializer)) continue;
         // Destructuring declarations register EVERY bound identifier (the
         // desugar in the init function assigns the pre-registered globals,
         // exactly like plain declarations).

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -20,7 +20,7 @@ import type { ClassInfo, ClassIteratorInfo } from "./lower-classes.js";
 import { genericIfaceBindingKeepsClass } from "./lower-classes.js";
 import { lowerStreamUnderscoreAssign, streamClassAliasDecl, streamSidesOf } from "./lower-stream.js";
 import { lowerHttpResPropertyAssignment, lowerServerCloseOverrideAssignment } from "./lower-server.js";
-import { builtinMemberRequireDecl, builtinNamespaceDestructureModuleOf, createRequireBindingDecl, createRequireCalleeFileOf, createRequireNamespaceDecl } from "./lower-builtins.js";
+import { builtinMemberRequireDecl, builtinNamespaceDestructureModuleOf, createRequireBindingDecl, createRequireCalleeFileOf, createRequireNamespaceDecl, textCodecBindingDecl } from "./lower-builtins.js";
 import { lowerEnumDeclaration } from "./lower-enums.js";
 import { abstractPropertyDeclOf, aliasTypeofNarrows, isMatchSliceType, lowerGroupsProjection, matchResultNamedGroupsOf, probeLower, pureReemittable, symbolFieldInfo } from "./lower-exprs.js";
 import { UNSUPPORTED, checkerPanicDiag, isCheckerPanic, requiresDynamicDiag } from "../../diagnostics/diagnostic.js";
@@ -2990,6 +2990,13 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
     // `const process = globalThis.process` — a stdlib-global snapshot:
     // alias plumbing (see stdlibGlobalAliasDecl), no storage, no code.
     if (!isLet && stdlibGlobalAliasDecl(L, decl.name, decl.initializer)) return null;
+
+    // `const encoder = new TextEncoder()` and the default TextDecoder
+    // twin: the codec has no general value representation, but calls
+    // through this stable binding resolve back to the initializer. The
+    // supported constructors are effect-free, so the declaration itself
+    // is compile-time alias plumbing with no storage or code.
+    if (!isLet && textCodecBindingDecl(L, decl.name, decl.initializer)) return null;
 
     // `const f = <T>(x: T) => x` — a generic function value binding: the
     // initializer monomorphizes per call-site-resolved signature exactly

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -95,7 +95,7 @@ import { ParamShape, FnSig, GenericFnInfo, GenericInstance, bindingNeverReassign
 import { lowerArrayMethodCall, lowerBufferStaticCall, lowerBytesMethodCall, lowerBytesNew, lowerMapMethodCall, lowerMapForEachCall, buildMapForEachFn, lowerRecordOvfCaptureHelper, lowerEnvToPairsHelper, lowerSetMethodCall, lowerSetForEachCall, buildSetForEachFn, lowerRegexMethodCall, lowerStringMethodCall } from "./lower-containers.js";
 import { lowerStreamModuleCall } from "./lower-stream.js";
 import { lowerEmitOverrideSpec, type EmitSpecCtx, type EmitSpecRequest } from "./lower-emitter.js";
-import { builtinImportOf, createRequireBindingDecl, createRequireNamespaceDecl, createRequireSpecOf, stripTypeCasts, lowerBuiltinModuleCall, lowerFsToUnixTimestampCall, lowerFsLadderCall, lowerChildArgsArg, lowerSpawnSyncCall, lowerSpawnCall, lowerExecSyncCall, recordToEnvPairs, lowerJsonMethodCall, fencedBuiltinImportOf, lowerCryptoComposedCall, lowerUrlMethodCall, lowerSearchParamsMethodCall, lowerStatsMethodCall, lowerChildMethodCall, lowerAtomicsCall, lowerBuiltinExtraProperty, promisifiedExecFileDecl, lowerExecFileAsyncCall, execFileAsyncHelper, lowerStringDecoderMethodCall, strdecHelper, lowerReadlineMethodCall, lowerDcChannelMethodCall, lowerDcChannelProperty, lowerAlsMethodCall, lowerDcTracingChannelMethodCall, lowerDcTracingChannelProperty, lowerJsonProperty, lowerErrorCodeProperty, lowerProcessProperty, isProcessEnv, envValueType, lowerProcessEnvGet, lowerProcessMethodCall, lowerProcessOptionalMethodCall, lowerTimeoutMethodCall, envSnapshotHelper, isConsoleLog, consoleCallMember, lowerNumberStaticCall, lowerNumberStaticProperty, lowerDateCall, lowerTextCodecCall, lowerCryptoModuleCall, lowerFsConstantsProperty, lowerBuiltinConstantsProperty, builtinConstantBindingOf, builtinConstantsDestructureDecl, lowerProcessStreamProperty, lowerStringStaticCall, lowerStringLastIndexOfCall, lowerPromiseStaticCall } from "./lower-builtins.js";
+import { builtinImportOf, createRequireBindingDecl, createRequireNamespaceDecl, createRequireSpecOf, stripTypeCasts, lowerBuiltinModuleCall, lowerFsToUnixTimestampCall, lowerFsLadderCall, lowerChildArgsArg, lowerSpawnSyncCall, lowerSpawnCall, lowerExecSyncCall, recordToEnvPairs, lowerJsonMethodCall, fencedBuiltinImportOf, lowerCryptoComposedCall, lowerUrlMethodCall, lowerSearchParamsMethodCall, lowerStatsMethodCall, lowerChildMethodCall, lowerAtomicsCall, lowerBuiltinExtraProperty, promisifiedExecFileDecl, lowerExecFileAsyncCall, execFileAsyncHelper, lowerStringDecoderMethodCall, strdecHelper, lowerReadlineMethodCall, lowerDcChannelMethodCall, lowerDcChannelProperty, lowerAlsMethodCall, lowerDcTracingChannelMethodCall, lowerDcTracingChannelProperty, lowerJsonProperty, lowerErrorCodeProperty, lowerProcessProperty, isProcessEnv, envValueType, lowerProcessEnvGet, lowerProcessMethodCall, lowerProcessOptionalMethodCall, lowerTimeoutMethodCall, envSnapshotHelper, isConsoleLog, consoleCallMember, lowerNumberStaticCall, lowerNumberStaticProperty, lowerDateCall, lowerTextCodecCall, lowerCryptoModuleCall, lowerFsConstantsProperty, lowerBuiltinConstantsProperty, builtinConstantBindingOf, builtinConstantsDestructureDecl, lowerProcessStreamProperty, lowerStringStaticCall, lowerStringLastIndexOfCall, lowerPromiseStaticCall, textCodecBindingClassOf } from "./lower-builtins.js";
 import { fenceFetchObjectAssignment, fenceFetchObjectBinding, fenceStaticHeadersIteration, fenceStaticHeadersMember, fenceStaticReadableStreamMember, fenceStaticResponseMember, fenceUnsupportedFetchConstructorMember, isIslandExpr, islandFuncValueFence, islandRegexpOf, jsvalIn, requireDynamicApi, islandGlobalFnOf, lowerDynamicHeadersIteratorCall, lowerDynamicHeadersSpread, lowerDynamicImportCall, lowerFetchCall, lowerFetchElementMethodCall, lowerStaticFetchCompanionCall, lowerStaticAbortSignalListenerCall, lowerStaticReadableStreamCancelCall, lowerStaticReadableStreamControllerCall, lowerStaticReadableStreamNew, lowerStaticReadableStreamReaderCall, lowerStaticResponseCall, lowerIslandMethodCall, lowerMathProperty, npmPackageOf, npmMemberFence, npmPackageOfSymbol } from "./lower-island.js";
 import { lowerHttpHeadersElement, lowerNetModuleCall, lowerServerMethodCall, lowerServerProperty, lowerTlsRootCertificates } from "./lower-server.js";
 import { lowerDgramDnsModuleCall, lowerDgramMethodCall } from "./lower-dgram.js";
@@ -2559,6 +2559,10 @@ export class Lowerer {
         RelativeTimeFormat: intlHint,
         Segmenter: intlHint,
         DisplayNames: intlHint,
+        TextEncoder:
+          "TextEncoder values have no representation — call through a const initialized with new TextEncoder(), or use the composed new TextEncoder().encode(s) form",
+        TextDecoder:
+          "TextDecoder values have no representation — call through a const initialized with the default new TextDecoder(), or use the composed new TextDecoder().decode(bytes) form",
       };
       this.pushDiag(
         noLoweringDiag(this.checker.typeToString(type), locOf(node), typeHints[stdlibOwnSym?.name ?? ""]),
@@ -6799,6 +6803,24 @@ export class Lowerer {
     // binding-form text.
     if (symbol) {
       const d = this.checker.valueDeclarationOf(symbol);
+      if (
+        d && ts.isVariableDeclaration(d) && ts.isVariableDeclarationList(d.parent) &&
+        (d.parent.flags & ts.NodeFlags.Const) !== 0
+      ) {
+        const codec = textCodecBindingClassOf(this, d.name, d.initializer);
+        if (codec !== null) {
+          const call = codec === "TextEncoder" ? `${name}.encode(s)` : `${name}.decode(bytes)`;
+          const composed =
+            codec === "TextEncoder"
+              ? "new TextEncoder().encode(s)"
+              : "new TextDecoder().decode(bytes)";
+          this.noLowering(
+            `${codec} instance stored in ${name}`,
+            node,
+            `${call} compiles through this const; the codec object itself has no representation (the composed ${composed} form also compiles)`,
+          );
+        }
+      }
       if (d && ts.isVariableDeclaration(d) && d.initializer === undefined) {
         const t = this.checker.getTypeOfSymbol(symbol);
         const parts = t.isUnionType() ? t.getTypes() : [t];

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -1387,6 +1387,16 @@ export const BUILTIN_MODULE_FENCE_HINTS: Record<string, Record<string, string | 
         "console.log/info/debug (stdout) and console.error/warn (stderr) are the supported " +
         "console surface (arguments render with Node's console semantics: strings verbatim, " +
         "everything else through the static util.inspect)";
+    } else if (container === "TextEncoder") {
+      hint =
+        "the inline new TextEncoder().encode(s) form and same-scope const store-then-call " +
+        "(const encoder = new TextEncoder(); encoder.encode(s)) compile; captured/imported " +
+        "instances and other members need a runtime object representation";
+    } else if (container === "TextDecoder") {
+      hint =
+        "the inline new TextDecoder().decode(bytes) form and same-scope const store-then-call " +
+        "(const decoder = new TextDecoder(); decoder.decode(bytes)) compile; captured/imported " +
+        "instances, streaming state, and other members need a runtime object representation";
     } else if (member === "prototype") {
       hint =
         "prototype objects are not values here (method lookup is static) — call the method on an instance instead";

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -3817,12 +3817,12 @@ export type IrLibFn =
   /** WHATWG TextDecoder.decode over u8 bytes (scr_bytes.c): utf-8 with
    * default options — the same maximal-subpart replacement decode as
    * Buffer.toString("utf8"), with the leading BOM stripped (the one
-   * behavioral difference; ignoreBOM defaults to false). Only the
-   * COMPOSED `new TextDecoder().decode(bytes)` form lowers — decoder
-   * values have no representation. TextEncoder.encode needs no libFn:
-   * `new TextEncoder().encode(s)` lowers to buffer.fromStr(s, "utf8")
-   * (identical bytes — ScrStr storage is well-formed UTF-8). Borrowed
-   * arg; owned (+1) string; never throws. */
+   * behavioral difference; ignoreBOM defaults to false). The composed
+   * `new TextDecoder().decode(bytes)` form and its same-scope const
+   * store-then-call twin lower — decoder values still have no general
+   * representation. TextEncoder.encode needs no libFn: its matching forms
+   * lower to buffer.fromStr(s, "utf8") (identical bytes — ScrStr storage
+   * is well-formed UTF-8). Borrowed arg; owned (+1) string; never throws. */
   | "text.decode"
   /** The wider sync fs slice (scr_lib.c), all throwing catchably with
    * Node's errno message shapes and `.code` stamped like the rest of

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -7485,6 +7485,12 @@
    ],
    "diags": []
   },
+  "<repo>/tests/diagnostics/text-codec-value.ts": {
+   "order": [
+    "<repo>/tests/diagnostics/text-codec-value.ts"
+   ],
+   "diags": []
+  },
   "<repo>/tests/diagnostics/tuples.ts": {
    "order": [
     "<repo>/tests/diagnostics/tuples.ts"

--- a/tests/corpus/1423-text-codec.ts
+++ b/tests/corpus/1423-text-codec.ts
@@ -1,6 +1,6 @@
-// The WHATWG encoder pair, composed: new TextEncoder().encode(s) and
-// new TextDecoder().decode(bytes) — utf-8 round trips, BOM stripping, and
-// maximal-subpart replacement, byte-compared against Node.
+// The WHATWG encoder pair, composed and same-scope const store-then-call:
+// utf-8 round trips, BOM stripping, and maximal-subpart replacement,
+// byte-compared against Node.
 const enc = new TextEncoder().encode("héllo😀");
 console.log(enc.length, enc[0], enc[1], enc[2], enc[6]);
 console.log(new TextDecoder().decode(enc));
@@ -23,3 +23,21 @@ console.log(new TextDecoder("utf-8").decode(Buffer.from("hi", "utf8")));
 const rt = new TextDecoder().decode(new TextEncoder().encode("round ✓ trip"));
 console.log(rt === "round ✓ trip", rt);
 console.log(new TextEncoder().encode("").length);
+
+// The ordinary stored-instance idiom is compile-time alias plumbing: the
+// default constructors have no effects, and supported calls resolve back
+// through a stable const without materializing the codec object.
+const encoder = new TextEncoder();
+const decoder = new TextDecoder();
+const stored = encoder.encode("stored héllo 😀");
+console.log(stored.length, decoder.decode(stored));
+console.log(encoder.encode("again").length, decoder.decode(Buffer.from("twice", "utf8")));
+
+// An explicit literal utf-8 label is equally effect-free. Function-local
+// bindings take the same rewrite within their own execution scope.
+function localRoundTrip(s: string): string {
+  const labelledDecoder = new TextDecoder("utf-8");
+  const localEncoder = new TextEncoder();
+  return labelledDecoder.decode(localEncoder.encode(s));
+}
+console.log(localRoundTrip("local ✓"));

--- a/tests/corpus/1423-text-codec.ts
+++ b/tests/corpus/1423-text-codec.ts
@@ -41,3 +41,13 @@ function localRoundTrip(s: string): string {
   return labelledDecoder.decode(localEncoder.encode(s));
 }
 console.log(localRoundTrip("local ✓"));
+
+// A switch clause is still one straight-line execution region: the
+// declaration dominates the call when both live in that clause.
+const codecCase = 1;
+switch (codecCase) {
+  case 1:
+    const caseEncoder = new TextEncoder();
+    console.log(caseEncoder.encode("same clause").length);
+    break;
+}

--- a/tests/diagnostics/text-codec-value.ts
+++ b/tests/diagnostics/text-codec-value.ts
@@ -1,0 +1,8 @@
+const encoder = new TextEncoder();
+console.log(encoder);
+
+function encodeCaptured(s: string): Uint8Array {
+  return sharedEncoder.encode(s);
+}
+const sharedEncoder = new TextEncoder();
+console.log(encodeCaptured("x").length);

--- a/tests/diagnostics/text-codec-value.ts
+++ b/tests/diagnostics/text-codec-value.ts
@@ -6,3 +6,16 @@ function encodeCaptured(s: string): Uint8Array {
 }
 const sharedEncoder = new TextEncoder();
 console.log(encodeCaptured("x").length);
+
+let codecCase = 1;
+switch (codecCase) {
+  case 0:
+    const caseEncoder = new TextEncoder();
+    break;
+  case 1:
+    const Encoded = class {
+      bytes = caseEncoder.encode("should fence");
+    };
+    console.log(new Encoded().bytes.length);
+    break;
+}

--- a/tests/diagnostics/text-codec-value.ts
+++ b/tests/diagnostics/text-codec-value.ts
@@ -18,4 +18,8 @@ switch (codecCase) {
     };
     console.log(new Encoded().bytes.length);
     break;
+  case 2:
+    // @ts-expect-error -- dispatch can enter here while caseEncoder is in its TDZ
+    console.log(caseEncoder.encode("should fence directly").length);
+    break;
 }

--- a/tests/harness/__snapshots__/text-codec-value.ts.txt
+++ b/tests/harness/__snapshots__/text-codec-value.ts.txt
@@ -1,0 +1,17 @@
+text-codec-value.ts:2:13 - error SC2020: 'TextEncoder instance stored in encoder' is part of the standard library types but has no scriptc lowering yet
+
+  1 | const encoder = new TextEncoder();
+  2 | console.log(encoder);
+    |             ^~~~~~~
+  3 | 
+
+  hint: encoder.encode(s) compiles through this const; the codec object itself has no representation (the composed new TextEncoder().encode(s) form also compiles)
+
+text-codec-value.ts:5:10 - error SC2020: 'TextEncoder.encode' is part of the standard library types but has no scriptc lowering yet
+
+  4 | function encodeCaptured(s: string): Uint8Array {
+  5 |   return sharedEncoder.encode(s);
+    |          ^~~~~~~~~~~~~~~~~~~~
+  6 | }
+
+  hint: the inline new TextEncoder().encode(s) form and same-scope const store-then-call (const encoder = new TextEncoder(); encoder.encode(s)) compile; captured/imported instances and other members need a runtime object representation

--- a/tests/harness/__snapshots__/text-codec-value.ts.txt
+++ b/tests/harness/__snapshots__/text-codec-value.ts.txt
@@ -15,3 +15,12 @@ text-codec-value.ts:5:10 - error SC2020: 'TextEncoder.encode' is part of the sta
   6 | }
 
   hint: the inline new TextEncoder().encode(s) form and same-scope const store-then-call (const encoder = new TextEncoder(); encoder.encode(s)) compile; captured/imported instances and other members need a runtime object representation
+
+text-codec-value.ts:17:15 - error SC2020: 'TextEncoder.encode' is part of the standard library types but has no scriptc lowering yet
+
+  16 |     const Encoded = class {
+  17 |       bytes = caseEncoder.encode("should fence");
+     |               ^~~~~~~~~~~~~~~~~~
+  18 |     };
+
+  hint: the inline new TextEncoder().encode(s) form and same-scope const store-then-call (const encoder = new TextEncoder(); encoder.encode(s)) compile; captured/imported instances and other members need a runtime object representation

--- a/tests/harness/__snapshots__/text-codec-value.ts.txt
+++ b/tests/harness/__snapshots__/text-codec-value.ts.txt
@@ -24,3 +24,12 @@ text-codec-value.ts:17:15 - error SC2020: 'TextEncoder.encode' is part of the st
   18 |     };
 
   hint: the inline new TextEncoder().encode(s) form and same-scope const store-then-call (const encoder = new TextEncoder(); encoder.encode(s)) compile; captured/imported instances and other members need a runtime object representation
+
+text-codec-value.ts:23:17 - error SC2020: 'TextEncoder.encode' is part of the standard library types but has no scriptc lowering yet
+
+  22 |     // @ts-expect-error -- dispatch can enter here while caseEncoder is in its TDZ
+  23 |     console.log(caseEncoder.encode("should fence directly").length);
+     |                 ^~~~~~~~~~~~~~~~~~
+  24 |     break;
+
+  hint: the inline new TextEncoder().encode(s) form and same-scope const store-then-call (const encoder = new TextEncoder(); encoder.encode(s)) compile; captured/imported instances and other members need a runtime object representation


### PR DESCRIPTION
- Lower same-scope const TextEncoder and TextDecoder call receivers without runtime instances.
- Preserve fences for escaping, captured, and imported codec values with actionable diagnostics.
- Add differential, diagnostic, and preflight baseline coverage for the supported idiom.