### PR TITLE
Restore sandbox test performance

### DIFF
--- a/scripts/sandbox-config.mjs
+++ b/scripts/sandbox-config.mjs
@@ -29,6 +29,23 @@ export function sandboxRunnerConfig(env) {
   };
 }
 
+/** Reserve one Vitest worker for each concurrently scheduled side process
+ * without ever starving the case-sharded corpus or exceeding the configured
+ * per-Sandbox worker budget. Extra side processes share the reserved slots. */
+export function sandboxTestWorkerAllocation(workerCount, sideTaskCount) {
+  if (!Number.isInteger(workerCount) || workerCount < 1) {
+    throw new Error("workerCount must be a positive integer");
+  }
+  if (!Number.isInteger(sideTaskCount) || sideTaskCount < 0) {
+    throw new Error("sideTaskCount must be a non-negative integer");
+  }
+  const sideConcurrency = Math.min(sideTaskCount, Math.max(0, workerCount - 1));
+  return {
+    caseWorkers: workerCount - sideConcurrency,
+    sideConcurrency,
+  };
+}
+
 export function sandboxImageConfig() {
   loadLocalEnv();
   // Keep tenancy explicit: a public clone must use a Vercel project its

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -32,9 +32,14 @@ const laneCaseShardedFiles = [
 // checked, but running the same sweep in the second lane adds no coverage.
 const invariantCaseShardedFiles = ["tests/harness/coverage.test.ts"];
 // Native-cache invalidation cases mutate process-wide compiler inputs and
-// therefore stay serial inside a worker. They are sanitizer-invariant, but
-// use their own shard variable so the independent cases can spread across the
-// once lane's Sandboxes without colliding with corpus case selection.
+// deliberately disable the immutable-toolchain memo used by the differential
+// corpus. Keep them in their own Vitest process, matching CI: co-scheduling
+// this file with the corpus can consume one of the corpus workers with the
+// strict (and intentionally expensive) production probe path.
+//
+// They are sanitizer-invariant and use their own shard variable so the
+// independent cases can spread across the once lane's Sandboxes without
+// colliding with corpus case selection.
 const cacheCaseShardedFiles = ["packages/compiler/src/backend/cc-cache.test.ts"];
 const caseShardedFiles = [
   ...laneCaseShardedFiles,
@@ -619,9 +624,7 @@ try {
       };
       const workerCaseFiles = [
         ...laneCaseShardedFiles,
-        ...(worker.lane === onceLane
-          ? [...invariantCaseShardedFiles, ...cacheCaseShardedFiles]
-          : []),
+        ...(worker.lane === onceLane ? invariantCaseShardedFiles : []),
       ];
       const cases = () =>
         execIn(
@@ -631,7 +634,6 @@ try {
           {
             ...sharedTestEnv,
             SCRIPTC_TEST_SHARD: `${worker.shard}/${shardCount}`,
-            SCRIPTC_CACHE_TEST_SHARD: `${worker.shard}/${shardCount}`,
             SCRIPTC_TEST_WORKERS: caseWorkers,
           },
           "cases",
@@ -662,11 +664,32 @@ try {
           },
           "files",
         );
+      const cacheCases = () =>
+        execIn(
+          worker,
+          "pnpm",
+          ["test", "--reporter=dot", ...cacheCaseShardedFiles],
+          {
+            ...sharedTestEnv,
+            SCRIPTC_CACHE_TEST_SHARD: `${worker.shard}/${shardCount}`,
+            // This is the strict production-path contract. Keep it out of
+            // the memoized corpus process and pin the opt-out explicitly,
+            // just as the GitHub Actions matrix does.
+            SCRIPTC_TEST_STABLE_TOOLCHAIN: "0",
+            SCRIPTC_TEST_WORKERS: "1",
+          },
+          "cache",
+        );
       if (remoteWorkerCount === 1) {
         await cases();
         await files();
+        if (worker.lane === onceLane) await cacheCases();
       } else {
-        await Promise.all([cases(), files()]);
+        await Promise.all([
+          cases(),
+          files(),
+          ...(worker.lane === onceLane ? [cacheCases()] : []),
+        ]);
       }
     });
 

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -10,6 +10,7 @@ import { fileURLToPath } from "node:url";
 import {
   sandboxImageConfig,
   sandboxRunnerConfig,
+  sandboxTestWorkerAllocation,
 } from "./sandbox-config.mjs";
 import {
   sandboxHostSchedule,
@@ -197,7 +198,6 @@ const remoteWorkerCount = Number(testWorkers);
 if (!Number.isInteger(remoteWorkerCount) || remoteWorkerCount < 1) {
   throw new Error(`SCRIPTC_TEST_WORKERS must be a positive integer (got ${testWorkers})`);
 }
-const caseWorkers = String(Math.max(1, remoteWorkerCount - 1));
 const fileWorkers = "1";
 const localCaseShardCount = Number(localCaseShards);
 if (!Number.isInteger(localCaseShardCount) || localCaseShardCount < 1) {
@@ -517,6 +517,12 @@ async function allWorkers(phase, task, concurrency = workers.length) {
   console.log(`${phase} completed in ${((Date.now() - started) / 1000).toFixed(1)}s`);
 }
 
+async function runTaskQueue(tasks, concurrency) {
+  for (let offset = 0; offset < tasks.length; offset += concurrency) {
+    await Promise.all(tasks.slice(offset, offset + concurrency).map((task) => task()));
+  }
+}
+
 async function cleanup() {
   if (values.keep || created.size === 0) return;
   if (!cleanupPromise) {
@@ -626,6 +632,11 @@ try {
         ...laneCaseShardedFiles,
         ...(worker.lane === onceLane ? invariantCaseShardedFiles : []),
       ];
+      const runCacheCases = worker.lane === onceLane;
+      const { caseWorkers, sideConcurrency } = sandboxTestWorkerAllocation(
+        remoteWorkerCount,
+        runCacheCases ? 2 : 1,
+      );
       const cases = () =>
         execIn(
           worker,
@@ -634,7 +645,7 @@ try {
           {
             ...sharedTestEnv,
             SCRIPTC_TEST_SHARD: `${worker.shard}/${shardCount}`,
-            SCRIPTC_TEST_WORKERS: caseWorkers,
+            SCRIPTC_TEST_WORKERS: String(caseWorkers),
           },
           "cases",
         );
@@ -680,15 +691,16 @@ try {
           },
           "cache",
         );
-      if (remoteWorkerCount === 1) {
+      // The corpus owns the remaining pool while file/cache processes share
+      // the reserved side slots (serially when only one slot is available).
+      const sideTasks = [files, ...(runCacheCases ? [cacheCases] : [])];
+      if (sideConcurrency === 0) {
         await cases();
-        await files();
-        if (worker.lane === onceLane) await cacheCases();
+        await runTaskQueue(sideTasks, 1);
       } else {
         await Promise.all([
           cases(),
-          files(),
-          ...(worker.lane === onceLane ? [cacheCases()] : []),
+          runTaskQueue(sideTasks, sideConcurrency),
         ]);
       }
     });

--- a/tests/harness/sandbox-config.test.ts
+++ b/tests/harness/sandbox-config.test.ts
@@ -1,5 +1,8 @@
 import { expect, test } from "vitest";
-import { sandboxRunnerConfig } from "../../scripts/sandbox-config.mjs";
+import {
+  sandboxRunnerConfig,
+  sandboxTestWorkerAllocation,
+} from "../../scripts/sandbox-config.mjs";
 
 test("runner settings are read after loading the sandbox environment", () => {
   expect(
@@ -26,5 +29,24 @@ test("runner settings retain their documented defaults", () => {
     localTestWorkers: "2",
     localCaseShards: "2",
     sandboxTimeout: "45m",
+  });
+});
+
+test("test processes stay within the per-Sandbox worker budget", () => {
+  expect(sandboxTestWorkerAllocation(4, 1)).toEqual({
+    caseWorkers: 3,
+    sideConcurrency: 1,
+  });
+  expect(sandboxTestWorkerAllocation(4, 2)).toEqual({
+    caseWorkers: 2,
+    sideConcurrency: 2,
+  });
+  expect(sandboxTestWorkerAllocation(2, 2)).toEqual({
+    caseWorkers: 1,
+    sideConcurrency: 1,
+  });
+  expect(sandboxTestWorkerAllocation(1, 2)).toEqual({
+    caseWorkers: 1,
+    sideConcurrency: 0,
   });
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -17,7 +17,7 @@ const cacheDir =
 // create (or repair) it before any oracle subdirectory can implicitly create
 // the root with the process umask (normally 0755). Otherwise native caching is
 // silently disabled and every corpus case recompiles the complete C runtime.
-if (configuredCacheDir === undefined) {
+if (configuredCacheDir === undefined && process.env["SCRIPTC_NO_CACHE"] !== "1") {
   mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
   if (process.platform !== "win32") chmodSync(cacheDir, 0o700);
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,3 +1,4 @@
+import { chmodSync, mkdirSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { defineConfig } from "vitest/config";
 
@@ -6,9 +7,20 @@ import { defineConfig } from "vitest/config";
 // SCRIPTC_NO_CACHE=1 in the caller's environment bypasses every cache in both
 // directions (no reads, no writes). Production builds use the platform cache;
 // this explicit override keeps test artifacts repo-local and disposable.
+const configuredCacheDir = process.env["SCRIPTC_CACHE_DIR"];
 const cacheDir =
-  process.env["SCRIPTC_CACHE_DIR"] ??
+  configuredCacheDir ??
   fileURLToPath(new URL("./node_modules/.cache/scriptc-tests/cas", import.meta.url));
+
+// The production cache refuses an existing explicit override that is visible
+// to other users. This repository owns the default test-only override, so
+// create (or repair) it before any oracle subdirectory can implicitly create
+// the root with the process umask (normally 0755). Otherwise native caching is
+// silently disabled and every corpus case recompiles the complete C runtime.
+if (configuredCacheDir === undefined) {
+  mkdirSync(cacheDir, { recursive: true, mode: 0o700 });
+  if (process.platform !== "win32") chmodSync(cacheDir, 0o700);
+}
 
 // Contention control for concurrent agents: SCRIPTC_TEST_WORKERS caps the vitest
 // worker pool (the default — all cores — is unchanged when unset). Full-suite


### PR DESCRIPTION
- Re-enable secure native compiler caching for repo-local test artifacts.
- Isolate strict cache coverage while keeping it off the sandbox critical path.