### PR TITLE
fix: guard Buffer.from island arguments before bytesNew

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -6038,10 +6038,16 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
             return { kind: "libCall", fn: "buffer.fromStr", args: [s, enc], type: BYTES_U8, loc };
           }
           if (args.length === 1 && srcIr?.kind === "bytes" && srcIr.elem === "u8") {
-            return { kind: "bytesNew", source: L.lowerExpr(argNode), type: BYTES_U8, loc };
+            const source = L.lowerExpr(argNode);
+            if (source.type.kind === "bytes" && source.type.elem === "u8") {
+              return { kind: "bytesNew", source, type: BYTES_U8, loc };
+            }
           }
           if (args.length === 1 && srcIr?.kind === "array" && srcIr.elem.kind === "f64") {
-            return { kind: "bytesNew", source: L.lowerExpr(argNode), type: BYTES_U8, loc };
+            const source = L.lowerExpr(argNode);
+            if (source.type.kind === "array" && source.type.elem.kind === "f64") {
+              return { kind: "bytesNew", source, type: BYTES_U8, loc };
+            }
           }
         }
       }

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -6653,6 +6653,12 @@
    ],
    "diags": []
   },
+  "<repo>/tests/diagnostics/buffer-from-island/main.ts": {
+   "order": [
+    "<repo>/tests/diagnostics/buffer-from-island/main.ts"
+   ],
+   "diags": []
+  },
   "<repo>/tests/diagnostics/catch-bindings.ts": {
    "order": [
     "<repo>/tests/diagnostics/catch-bindings.ts"

--- a/tests/diagnostics/buffer-from-island/main.ts
+++ b/tests/diagnostics/buffer-from-island/main.ts
@@ -1,0 +1,7 @@
+// @dynamic
+// A package call keeps its value in the island even when its declaration
+// promises a supported container. Buffer.from must fence that boundary.
+import { bytes, numbers } from "bytekit";
+Buffer.from(bytes());
+Buffer.from(numbers());
+void 0;

--- a/tests/diagnostics/buffer-from-island/node_modules/bytekit/index.d.ts
+++ b/tests/diagnostics/buffer-from-island/node_modules/bytekit/index.d.ts
@@ -1,0 +1,2 @@
+export declare function bytes(): Uint8Array;
+export declare function numbers(): number[];

--- a/tests/diagnostics/buffer-from-island/node_modules/bytekit/index.js
+++ b/tests/diagnostics/buffer-from-island/node_modules/bytekit/index.js
@@ -1,0 +1,9 @@
+"use strict";
+
+exports.bytes = function bytes() {
+  return new Uint8Array([1, 2, 3]);
+};
+
+exports.numbers = function numbers() {
+  return [1, 2, 3];
+};

--- a/tests/diagnostics/buffer-from-island/node_modules/bytekit/package.json
+++ b/tests/diagnostics/buffer-from-island/node_modules/bytekit/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "bytekit",
+  "version": "1.0.0",
+  "main": "index.js",
+  "types": "index.d.ts"
+}

--- a/tests/harness/__snapshots__/buffer-from-island/main.ts.txt
+++ b/tests/harness/__snapshots__/buffer-from-island/main.ts.txt
@@ -1,0 +1,17 @@
+buffer-from-island/main.ts:5:1 - error SC2020: 'Buffer.from with this argument shape' is part of the standard library types but has no scriptc lowering yet
+
+  4 | import { bytes, numbers } from "bytekit";
+  5 | Buffer.from(bytes());
+    | ^~~~~~~~~~~~~~~~~~~~
+  6 | Buffer.from(numbers());
+
+  hint: supported: Buffer.from(string, encoding?) with a literal encoding, Buffer.from(u8Array) — a copy — Buffer.from(number[]), or Buffer.from(x.buffer, byteOffset?, length?) — a view sharing x's storage (no free-standing ArrayBuffer value exists; narrow unions first)
+
+buffer-from-island/main.ts:6:1 - error SC2020: 'Buffer.from with this argument shape' is part of the standard library types but has no scriptc lowering yet
+
+  5 | Buffer.from(bytes());
+  6 | Buffer.from(numbers());
+    | ^~~~~~~~~~~~~~~~~~~~~~
+  7 | void 0;
+
+  hint: supported: Buffer.from(string, encoding?) with a literal encoding, Buffer.from(u8Array) — a copy — Buffer.from(number[]), or Buffer.from(x.buffer, byteOffset?, length?) — a view sharing x's storage (no free-standing ArrayBuffer value exists; narrow unions first)


### PR DESCRIPTION
Fixes #35.

## Summary

- validate the actual lowered source IR before constructing `bytesNew` for `Buffer.from`
- fall back to the existing SC2020 unsupported-shape diagnostic for island-backed `Uint8Array` and `number[]` values
- add a dynamic regression fixture for both container branches and record its order-parity baseline

This preserves the currently supported `Buffer.from` surface; it only prevents an invalid `jsval` source from reaching `bytesNew`.

## Testing

- `pnpm -r build`
- `pnpm lint`
- `pnpm exec vitest run tests/harness/diagnostics.test.ts` (101 passed)
- `pnpm exec vitest run packages/compiler/test/ts7/order-parity.test.ts` (23 passed)
- `SCRIPTC_TEST_WORKERS=4 pnpm test` (3348 passed, 54 skipped)
- `SCRIPTC_TEST_WORKERS=4 SCRIPTC_SAN=1 pnpm test` (3345 passed, 54 skipped, 3 parallel timeouts; all three passed in a single-worker targeted rerun)