### PR TITLE
feat: support compiling and running Portless

### DIFF
--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -2444,18 +2444,10 @@ declare module "node:https" {
   export * from "https";
 }
 
-/* node:http2 — the COMPATIBILITY slice (SEMANTICS.md divergence 57):
- * createSecureServer({ allowHTTP1: true, cert, key }) is the https
- * server without an eager handler — ALPN advertises http/1.1 ONLY, so
- * h2-capable clients negotiate down and every connection serves
- * HTTP/1.1 (h2-only clients fail the handshake; no multiplexing, no
- * server push). The handler arrives via server.on("request", ...);
- * Http2ServerRequest/Response ARE the http req/res surface (exactly
- * what Node hands an allowHTTP1 server's HTTP/1.1 connections), with
- * the h2-only members (stream, session) answering undefined behind a
- * '?.' guard and fencing unguarded. 'sessionError' registers and never
- * fires (no h2 session ever exists). h2 sessions themselves — connect,
- * the h2c createServer — have no lowering. */
+/* node:http2 — the compatibility surface: allowHTTP1 servers negotiate
+ * h2 or HTTP/1.1 and expose the shared request/response API. HTTP/2
+ * requests retain their backing stream; server session failures surface
+ * through sessionError. */
 declare module "http2" {
   import { Socket } from "net";
   export interface Http2Stream {
@@ -2529,7 +2521,7 @@ declare module "http2" {
     on(event: "request", listener: (req: Http2ServerRequest, res: Http2ServerResponse) => void): void;
     on(event: "error", listener: (err: Error) => void): void;
     on(event: "close", listener: () => void): void;
-    on(event: "sessionError", listener: () => void): void;
+    on(event: "sessionError", listener: (err: Error, session: ServerHttp2Session) => void): void;
     /* The ALPN=h2 server's surface (createSecureServer WITHOUT
      * allowHTTP1 — the real h2-over-TLS stack): per-stream and
      * per-session listeners, exactly the h2c server's. */

--- a/packages/compiler/src/backend/emission/emit-async.ts
+++ b/packages/compiler/src/backend/emission/emit-async.ts
@@ -2,7 +2,7 @@
  * scaffolding, plus the interned resolve/child-exit thunks that adapt typed
  * payloads onto the runtime's promise and child-process machinery. */
 import type { CEmitter } from "./emitter.js";
-import { mangleArgPack, mangleAsyncSpawn, mangleChildDataThunk, mangleChildExitThunk, mangleCloseBindThunk, mangleCloseOverrideWrap, mangleConnectSockThunk, mangleDgramMsgThunk, mangleDnsLookupThunk, mangleField, mangleFsRenameThunk, mangleFunction, mangleGenDrop, mangleGenResThunk, mangleGenSpawn, mangleGlobal, mangleLocal, mangleRaceThunk, mangleRawParam, mangleNetLookupAnswerThunk, mangleEmitterInvokeThunk, mangleStreamCbThunk, mangleStreamDoneFn, mangleRecordNew, mangleRecordRelease, mangleRecordStruct, mangleResolveThunk, mangleSniAnswerThunk, mangleTrampoline } from "../mangle.js";
+import { mangleArgPack, mangleAsyncSpawn, mangleChildDataThunk, mangleChildExitThunk, mangleCloseBindThunk, mangleCloseOverrideWrap, mangleConnectResThunk, mangleConnectSockThunk, mangleDgramMsgThunk, mangleDnsLookupThunk, mangleField, mangleFsRenameThunk, mangleFunction, mangleGenDrop, mangleGenResThunk, mangleGenSpawn, mangleGlobal, mangleLocal, mangleRaceThunk, mangleRawParam, mangleNetLookupAnswerThunk, mangleEmitterInvokeThunk, mangleStreamCbThunk, mangleStreamDoneFn, mangleRecordNew, mangleRecordRelease, mangleRecordStruct, mangleResolveThunk, mangleSniAnswerThunk, mangleTrampoline } from "../mangle.js";
 import { cDecl, cType, releaseCallC, retainCallC, vAdapters } from "./emit-types.js";
 import { IrType, isRefCounted, isUnitType, typeEquals, typeKey } from "../../ir/nodes.js";
 
@@ -563,6 +563,35 @@ import { IrType, isRefCounted, isUnitType, typeEquals, typeKey } from "../../ir/
       three
         ? `  ((void (*)(ScrClosure *, ScrHttpReq *, ScrUnion *, ScrBytes *))sc_cb->fn)(sc_cb, sc_req, sc_u, sc_head);`
         : `  ((void (*)(ScrClosure *, ScrHttpReq *, ScrUnion *))sc_cb->fn)(sc_cb, sc_req, sc_u);`,
+      `}`,
+    );
+    return sym;
+  }
+
+  export function connectResThunkFor(E: CEmitter, cbT: IrType): string {
+    if (cbT.kind !== "func") throw new Error("emitter bug: connect listener shape");
+    const key = `res:${typeKey(cbT)}`;
+    let sym = E.connectSockThunks.get(key);
+    if (sym) return sym;
+    sym = mangleConnectResThunk(E.connectSockThunks.size);
+    E.connectSockThunks.set(key, sym);
+    const p1 = cbT.params[1];
+    const def = p1?.kind === "union" ? E.unionsById.get(p1.unionId) : undefined;
+    const tag = def ? def.arms.findIndex((a) => a.kind === "httpRes") : -1;
+    if (p1?.kind === "union" && tag < 0) throw new Error("emitter bug: connect listener union lacks its response arm");
+    E.walkerProtos.push(`static void ${sym}(ScrClosure *sc_cb, ScrHttpReq *sc_req, ScrHttpRes *sc_res);`);
+    const second = p1?.kind === "union"
+      ? `ScrUnion *sc_u = scr_union_new_ref(${tag}, sc_res, &scr_http_res_retain_v, &scr_http_res_release_v, NULL);`
+      : "";
+    const arg = p1?.kind === "union" ? "sc_u" : "sc_res";
+    E.walkerDefs.push(
+      `static void ${sym}(ScrClosure *sc_cb, ScrHttpReq *sc_req, ScrHttpRes *sc_res) {`,
+      ...(second ? [`  ${second}`] : []),
+      ...(cbT.params.length === 0
+        ? ["  scr_http_req_release(sc_req);", "  scr_http_res_release(sc_res);", "  ((void (*)(ScrClosure *))sc_cb->fn)(sc_cb);"]
+        : cbT.params.length === 1
+          ? ["  scr_http_res_release(sc_res);", "  ((void (*)(ScrClosure *, ScrHttpReq *))sc_cb->fn)(sc_cb, sc_req);"]
+          : [`  ((void (*)(ScrClosure *, ScrHttpReq *, ${p1?.kind === "union" ? "ScrUnion" : "ScrHttpRes"} *))sc_cb->fn)(sc_cb, sc_req, ${arg});`]),
       `}`,
     );
     return sym;

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -2778,6 +2778,12 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
         const call = `${E.unionEqHelper(e.unionId, e.sameValue)}(${l.name}, ${r.name})`;
         return E.newTemp(e.type, e.negated ? `!${call}` : call);
       }
+      case "unionFuncEq": {
+        const u = E.emitExpr(e.union);
+        const f = E.emitExpr(e.func);
+        const test = `(${u.name}->tag == ${e.tag} && scr_union_peek(${u.name}) == ${f.name})`;
+        return E.newTemp(e.type, e.negated ? `!${test}` : test);
+      }
       case "caughtTest": {
         // Kind-tag tests read the snapshot directly; instanceof compares an
         // OBJ payload's vtable preorder against the class's compile-time
@@ -4404,6 +4410,19 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           }
           case "http.reqSocket":
             return finish(`scr_http_req_socket(${arg(0)})`);
+          case "http.reqH2Stream": {
+            if (e.type.kind !== "union") throw new Error("emitter bug: http.reqH2Stream result is not a union");
+            const def = E.unionsById.get(e.type.unionId);
+            const streamTag = def ? def.arms.findIndex((a) => a.kind === "http2Stream") : -1;
+            const undefTag = E.undefinedArmTag(e.type);
+            if (streamTag < 0 || undefTag < 0) throw new Error("emitter bug: http.reqH2Stream union lacks its arms");
+            const st = E.newTemp({ kind: "http2Stream" }, `scr_http_req_h2_stream(${arg(0)})`);
+            E.moveTemp(st);
+            const present = `scr_union_new_ref(${streamTag}, ${st.name}, &scr_http2_stream_retain_v, &scr_http2_stream_release_v, NULL)`;
+            return E.newTemp(e.type, `${st.name} ? ${present} : ${E.unitInstanceRef(e.type.unionId, undefTag)}`);
+          }
+          case "http.reqH2StreamOrThrow":
+            return finish(`scr_http_req_h2_stream_or_throw(${arg(0)}, ${arg(1)})`);
           case "http.reqRawHeaders":
             return finish(`scr_http_req_raw_headers(${arg(0)})`);
           case "http.reqHeaderPairs":
@@ -4463,7 +4482,11 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
                 : cbT.params.length === 2 ? "scr_http_upgrade_thunk2"
                 : cbT.params.length === 1 ? "scr_http_upgrade_thunk1"
                 : "scr_http_upgrade_thunk0";
-            E.line(`scr_http_server_on_connect(${arg(0)}, ${cb.name}, &${adapter}, ${arg(2)});${E.srcComment(e.loc)}`);
+            const h2Def = p1?.kind === "union" ? E.unionsById.get(p1.unionId) : undefined;
+            const h2Adapter = cbT.params.length >= 2
+              ? h2Def?.arms.some((arm) => arm.kind === "httpRes") ? `&${E.connectResThunkFor(cbT)}` : "NULL"
+              : cbT.params.length === 1 ? "&scr_http_handler_thunk1" : "&scr_http_handler_thunk0";
+            E.line(`scr_http_server_on_connect(${arg(0)}, ${cb.name}, &${adapter}, ${h2Adapter}, ${arg(2)});${E.srcComment(e.loc)}`);
             return { name: "", type: e.type };
           }
           case "net.sockPipeRes":
@@ -4833,14 +4856,9 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             );
           }
           case "http2.createSecureServer":
-            // The allowHTTP1 compatibility server (SEMANTICS.md divergence
-            // 56): the https server with NO eager handler — 'request'
-            // listeners arrive via http.serverOnRequest. ALPN advertises
-            // http/1.1 only (scr_tls.c), so h2-capable clients negotiate
-            // down and every connection serves HTTP/1.1.
             E.usesTimers = true;
             return finish(
-              `scr_https_create_server((const char *)${arg(0)}->data, ${arg(0)}->len, (const char *)${arg(1)}->data, ${arg(1)}->len, NULL, NULL)`,
+              `scr_http2_create_secure_server_allow_http1((const char *)${arg(0)}->data, ${arg(0)}->len, (const char *)${arg(1)}->data, ${arg(1)}->len, NULL, NULL, NULL, NULL, ${arg(2)})`,
             );
           case "http2.createSecureServerH2":
             // The REAL h2-over-TLS server (no allowHTTP1): ALPN advertises
@@ -4848,7 +4866,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             // 'stream'/'session' listeners, exactly the h2c surface.
             E.usesTimers = true;
             return finish(
-              `scr_http2_create_secure_server((const char *)${arg(0)}->data, ${arg(0)}->len, (const char *)${arg(1)}->data, ${arg(1)}->len)`,
+              `scr_http2_create_secure_server((const char *)${arg(0)}->data, ${arg(0)}->len, (const char *)${arg(1)}->data, ${arg(1)}->len, ${arg(2)})`,
             );
           case "http2.createSecureServerReq":
           case "http2.createSecureServerH2Req": {
@@ -4867,8 +4885,8 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             const certKey = `(const char *)${arg(0)}->data, ${arg(0)}->len, (const char *)${arg(1)}->data, ${arg(1)}->len`;
             return finish(
               fn === "http2.createSecureServerReq"
-                ? `scr_https_create_server(${certKey}, ${cb.name}, &${adapter})`
-                : `scr_http2_create_secure_server_req(${certKey}, ${cb.name}, &${adapter})`,
+                ? `scr_http2_create_secure_server_allow_http1(${certKey}, ${cb.name}, &${adapter}, NULL, NULL, ${arg(3)})`
+                : `scr_http2_create_secure_server_req(${certKey}, ${cb.name}, &${adapter}, ${arg(3)})`,
             );
           }
           case "http2.createSecureServerDyn":
@@ -4925,7 +4943,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             }
             const answer = E.sniAnswerThunkFor(cbFuncT.params[1]);
             return finish(
-              `scr_https_create_server_sni((const char *)${arg(0)}->data, ${arg(0)}->len, (const char *)${arg(1)}->data, ${arg(1)}->len, ${cbExpr}, (void *)&${answer})`,
+              `scr_http2_create_secure_server_allow_http1((const char *)${arg(0)}->data, ${arg(0)}->len, (const char *)${arg(1)}->data, ${arg(1)}->len, NULL, NULL, ${cbExpr}, (void *)&${answer}, ${arg(3)})`,
             );
           }
           case "tls.createSecureContext":
@@ -4965,14 +4983,19 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             E.line(`scr_http_server_on_request(${arg(0)}, ${cb.name}, &${adapter}, ${arg(2)});${E.srcComment(e.loc)}`);
             return { name: "", type: e.type };
           }
-          case "http2.serverOnSessionError":
-            // 'sessionError' is an h2 SESSION event and the compatibility
-            // server never creates a session: the registration is honest
-            // dead weight. Receiver and callback temps evaluate (JS
-            // evaluates them) and release through the ordinary temp
-            // lifecycle — the closure is built, never installed, never
-            // called; no runtime call is emitted at all.
+          case "http2.serverOnSessionError": {
+            const cbT = e.args[1]!.type;
+            if (cbT.kind !== "func") throw new Error("emitter bug: sessionError listener not a func");
+            const cb = args[1]!;
+            E.moveTemp(cb);
+            const adapter = cbT.params.length === 2
+              ? "scr_http2_session_error_thunk2"
+              : cbT.params.length === 1
+                ? "scr_http2_session_error_thunk1"
+                : "scr_http2_session_error_thunk0";
+            E.line(`scr_http2_server_on_session_error(${arg(0)}, ${cb.name}, &${adapter}, ${arg(2)});${E.srcComment(e.loc)}`);
             return { name: "", type: e.type };
+          }
           case "http2.streamNoop":
             // `req.stream?.on(...)`: stream is undefined on every
             // connection the allowHTTP1 lowering accepts — the optional

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -57,7 +57,7 @@ import { cFnPtrCast, cType, releaseCallC, cStringLiteral, cDecl } from "./emit-t
 import { computeMayThrow } from "./may-throw.js";
 import { dynDesc, unionTruthyHelper, unionEqHelper, unionToStrHelper, unionJoinHelper, jsonWriteHelper, jsonIndentHelper, dynMatchHelper, dynCheckHelper, dynFuncBoxHelper, dynToStrHelper, caughtToDynHelper, toDynHelper, recordKeyGetHelper, recordKeySetHelper } from "./emit-walkers.js";
 import { VtSlot, ClassMeta, emitStructDefs, vtEntriesFor, vtSlotParams, emitVtableDecls, emitVtableInstances, emitVtAdapterDefs, emitHierarchyClassHelpers, emitClassObjs, emitCtorThunkDefs, errorVtStampLines, emitterVtStampLines, streamVtStampLines, traceAdapterC, traceArgC, boxNewC, arrNewC } from "./emit-shapes.js";
-import { emitAsyncScaffolding, childDataThunkFor, childExitThunkFor, childExitThunkFor2, closeBindThunkFor, connectSockThunkFor, closeOverrideWrapFor, dgramMsgThunkFor, dnsLookupThunkFor, fsRenameThunkFor, netLookupAnswerThunkFor, emitterInvokeThunkFor, streamCbThunkFor, streamDataThunkFor, raceAdapterFor, resolveThunkFor, sniAnswerThunkFor } from "./emit-async.js";
+import { emitAsyncScaffolding, childDataThunkFor, childExitThunkFor, childExitThunkFor2, closeBindThunkFor, connectResThunkFor, connectSockThunkFor, closeOverrideWrapFor, dgramMsgThunkFor, dnsLookupThunkFor, fsRenameThunkFor, netLookupAnswerThunkFor, emitterInvokeThunkFor, streamCbThunkFor, streamDataThunkFor, raceAdapterFor, resolveThunkFor, sniAnswerThunkFor } from "./emit-async.js";
 import { emitNpmEmbedding, islandAdapter, islandTypedAdapter } from "./emit-island.js";
 import { emitFunction, emitBlock, emitStmts, emitStmt, emitTryCatch, emitSwitch, mergeBrace, emitBranchInto, emitCondition } from "./emit-stmts.js";
 import { emitExpr } from "./emit-exprs.js";
@@ -1978,6 +1978,9 @@ export class CEmitter {
 
   connectSockThunkFor(cbT: IrType): string {
     return connectSockThunkFor(this, cbT);
+  }
+  connectResThunkFor(cbT: IrType): string {
+    return connectResThunkFor(this, cbT);
   }
 
   raceAdapterFor(from: IrType, to: IrType): string {

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -5378,6 +5378,22 @@ class LlEmitter {
         B.line(`${t} = load ${ty}, ptr ${slot}`);
         return this.own({ name: t, type: e.type });
       }
+      case "unionFuncEq": {
+        const u = this.emitExpr(e.union);
+        const f = this.emitExpr(e.func);
+        const tag = this.unionTag(u.name);
+        const tagMatch = B.tmp();
+        B.line(`${tagMatch} = icmp eq i32 ${tag}, ${e.tag}`);
+        const payload = this.unionPeek(u.name);
+        const ptrMatch = B.tmp();
+        B.line(`${ptrMatch} = icmp eq ptr ${payload}, ${f.name}`);
+        const result = B.tmp();
+        B.line(`${result} = and i1 ${tagMatch}, ${ptrMatch}`);
+        if (!e.negated) return this.own({ name: result, type: e.type });
+        const negated = B.tmp();
+        B.line(`${negated} = xor i1 ${result}, true`);
+        return this.own({ name: negated, type: e.type });
+      }
       case "nullish": {
         // `a ?? b`: logical's move/release dance with the left's runtime
         // TAG against its unit arms as the test. Pass-through shape: the

--- a/packages/compiler/src/backend/mangle.ts
+++ b/packages/compiler/src/backend/mangle.ts
@@ -228,6 +228,9 @@ export function mangleNetLookupAnswerThunk(n: number): string {
 export function mangleConnectSockThunk(n: number): string {
   return `sc_h2conn_${n}`;
 }
+export function mangleConnectResThunk(n: number): string {
+  return `sc_h2conn_res_${n}`;
+}
 
 /** Emitted EventEmitter listener invoke adapter (va_list → the listener's
  * typed parameter prefix, each retained per the callee-owns convention),

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -17,8 +17,8 @@ import type { ScrDiagnostic } from "../../diagnostics/diagnostic.js";
 import { mixinFnShapeOf } from "./lower-mixins.js";
 import { bufEncoding, dynStringReceiver, lowerArrayFromCall, lowerDynArrayFilterCall, lowerDynArrayFlatMapCall, lowerGroupByStaticCall, lowerIteratorHelperCall, lowerObjectAssignIndexShape, lowerObjectFromEntriesCall, lowerObjectIterOverIndexShape, lowerRegexMethodCall, lowerStringMethodCall, lowerTupleReadMethodCall } from "./lower-containers.js";
 import { lowerChildStreamMethodCall, lowerCreateRequireCall, lowerDirentMethodCall, lowerFileHandleMethodCall, lowerPerfHooksCall, lowerProcStreamMethodCall, lowerReflectApplyCall, lowerWatcherMethodCall } from "./lower-builtins.js";
-import { droppableStatic, lowerPromiseAllTupleCall, lowerPromiseRejectCall, probeLower, templateRawTextOf } from "./lower-exprs.js";
-import { httpClientFnBindingOf, isStreamUndefCallExpr, lowerHttpClientFnCall } from "./lower-server.js";
+import { droppableStatic, lowerAbsenceProbe, lowerPromiseAllTupleCall, lowerPromiseRejectCall, probeLower, templateRawTextOf } from "./lower-exprs.js";
+import { httpClientFnBindingOf, isStreamUndefCallExpr, lowerCompatReqStreamOptionalCall, lowerHttpClientFnCall } from "./lower-server.js";
 import { EMITTER_API_MEMBERS, exactInstanceClassOf, findGenericMethodOn, lowerClassGenericMethodCall, lowerStaticMethodCall, type ClassInfo } from "./lower-classes.js";
 import { emitterRooted, lowerEmitterMethodCall } from "./lower-emitter.js";
 import { lowerConsoleInspectArg, lowerFormatCall } from "./lower-inspect.js";
@@ -2844,27 +2844,22 @@ export function lowerCall(L: Lowerer, expr: ts.CallExpression): IrExpr {
     // lowering for the chain to guard).
     const processOptional = L.lowerProcessOptionalMethodCall(expr);
     if (processOptional) return processOptional;
+    const reqStreamOptional = lowerCompatReqStreamOptionalCall(L, expr);
+    if (reqStreamOptional) return reqStreamOptional;
     // `t.unref?.()` on a Timeout handle — same story: the method always
     // exists, so the optional call is the call.
     if (expr.questionDotToken && ts.isPropertyAccessExpression(expr.expression)) {
       const timeoutOptional = L.lowerTimeoutMethodCall(expr, expr.expression);
       if (timeoutOptional) return timeoutOptional;
     }
-    // `req.stream?.on(...)` — the http2 compatibility request's h2-only
-    // stream member, guarded. The allowHTTP1 lowering serves every
-    // connection as HTTP/1.1, where Node answers undefined for req.stream:
-    // the optional chain short-circuits, the arguments never evaluate, and
-    // the whole statement is a no-op — exactly what lowers here (a VOID
-    // no-op the emitter drops). The receiver is restricted to an
-    // identifier so no evaluation is skipped, and to statement position so
-    // no value is consumed (an unguarded or computed use meets the pointed
-    // per-member fence in lower-server.ts instead).
+    // `req.session?.m(...)` remains absent on compatibility requests. Live
+    // `req.stream` calls now pass through the normal optional-chain and h2
+    // stream lowering using lowerServerProperty's checked getter.
     if (
       ts.isPropertyAccessExpression(expr.expression) &&
       ts.isPropertyAccessExpression(expr.expression.expression) &&
       !expr.expression.expression.questionDotToken &&
-      (expr.expression.expression.name.text === "stream" ||
-        expr.expression.expression.name.text === "session") &&
+      expr.expression.expression.name.text === "session" &&
       ts.isIdentifier(expr.expression.expression.expression) &&
       L.mapTypeOf(L.typeOf(expr.expression.expression.expression))?.kind === "httpReq" &&
       L.isStdlibMember(expr.expression.expression)
@@ -3552,10 +3547,67 @@ export function lowerCall(L: Lowerer, expr: ts.CallExpression): IrExpr {
           const x = L.lowerExprExpecting(expr.arguments[0]!, F64);
           return { kind: "libCall", fn: "num.isNaN", args: [x], type: BOOL, loc };
         }
-        const s = L.lowerExprExpecting(expr.arguments[0]!, STRING);
         const radix: IrExpr = expr.arguments[1]
           ? L.lowerExprExpecting(expr.arguments[1], F64)
           : { kind: "numLit", value: 0, type: F64, loc };
+        const optional = lowerAbsenceProbe(L, expr.arguments[0]!);
+        if (optional?.type.kind === "union") {
+          const def = L.unions.get(optional.type.unionId);
+          const stringTag = def?.arms.findIndex((arm) => arm.kind === "string") ?? -1;
+          if (
+            def &&
+            stringTag >= 0 &&
+            def.arms.every((arm) => arm.kind === "string" || isUnitType(arm))
+          ) {
+            const unionT = optional.type;
+            const key = `parseInt.optional:${unionT.unionId}`;
+            let helper = L.widthHelpers.get(key);
+            if (!helper) {
+              helper = `%parseInt.optional.${L.widthHelpers.size}`;
+              L.widthHelpers.set(key, helper);
+              const value: IrExpr = { kind: "varRef", localId: "value.0", type: unionT, loc };
+              const radixRef: IrExpr = { kind: "varRef", localId: "radix.0", type: F64, loc };
+              const body: IrStmt[] = def.arms.flatMap((arm, tag): IrStmt[] =>
+                isUnitType(arm)
+                  ? [{
+                      kind: "if",
+                      cond: { kind: "unionIsTag", unionId: unionT.unionId, tag, negated: false, value, type: BOOL, loc },
+                      then: [{ kind: "return", value: { kind: "numLit", value: NaN, type: F64, loc }, loc }],
+                      else_: null,
+                      loc,
+                    }]
+                  : [],
+              );
+              body.push({
+                kind: "return",
+                value: {
+                  kind: "libCall",
+                  fn: "num.parseInt",
+                  args: [{ kind: "unionNarrow", unionId: unionT.unionId, tag: stringTag, value, type: STRING, loc }, radixRef],
+                  type: F64,
+                  loc,
+                },
+                loc,
+              });
+              L.liftedFns.push({
+                name: helper,
+                params: [
+                  { localId: "value.0", name: "value", type: unionT },
+                  { localId: "radix.0", name: "radix", type: F64 },
+                ],
+                returnType: F64,
+                locals: [
+                  { id: "value.0", name: "value", type: unionT, mutable: true },
+                  { id: "radix.0", name: "radix", type: F64, mutable: true },
+                ],
+                body,
+                loc,
+              });
+            }
+            return { kind: "call", callee: helper, args: [optional, radix], type: F64, loc };
+          }
+        }
+        const s = L.lowerExprExpecting(expr.arguments[0]!, STRING);
         return { kind: "libCall", fn: "num.parseInt", args: [s, radix], type: F64, loc };
       }
       // STATIC parseFloat/isFinite over exactly-typed arguments —

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -772,7 +772,7 @@ function lowerSplitLimitArg(L: Lowerer, node: ts.Expression | undefined, loc: Sr
     return { kind: "call", callee: helper, args: [snapshot, fnArg], type: arrayOf(fnRet), loc };
   }
 
-/** The OOB-SAFE indexed read for --npm-static package files: `xs[i]`
+/** An OOB-SAFE indexed read: `xs[i]`
    * answers the interned `elem | undefined` union — the element when `i`
    * is an integer in [0, len), JS's property-miss undefined otherwise —
    * instead of the trap divergence 4 documents for program code.
@@ -782,7 +782,7 @@ function lowerSplitLimitArg(L: Lowerer, node: ts.Expression | undefined, loc: Sr
    * (their annotations can prove bounds). Null when the element is
    * union-typed (the re-tag has no story here) — the caller keeps the
    * ordinary read. */
-  export function lowerNpmStaticSafeIndexRead(
+  export function lowerSafeIndexRead(
     L: Lowerer,
     arr: IrExpr & { type: { kind: "array" } },
     index: IrExpr,
@@ -817,6 +817,7 @@ function lowerSplitLimitArg(L: Lowerer, node: ts.Expression | undefined, loc: Sr
       };
       const body: IrStmt[] = [
         readLenStmt(arrT, loc),
+        { kind: "if", cond: { kind: "bin", op: "!==", left: i, right: i, type: BOOL, loc }, then: [{ kind: "return", value: miss, loc }], else_: null, loc },
         { kind: "if", cond: lt(i, num(0)), then: [{ kind: "return", value: miss, loc }], else_: null, loc },
         { kind: "if", cond: { kind: "bin", op: ">=", left: i, right: n, type: BOOL, loc }, then: [{ kind: "return", value: miss, loc }], else_: null, loc },
         // A fractional index is a property miss too (floor(i) < i exactly
@@ -854,6 +855,9 @@ function lowerSplitLimitArg(L: Lowerer, node: ts.Expression | undefined, loc: Sr
     }
     return { kind: "call", callee: name, args: [arr, index], type: resultT, loc };
   }
+
+  /** Backward-compatible name for the npm-static probe path. */
+  export const lowerNpmStaticSafeIndexRead = lowerSafeIndexRead;
 
 /** Interned synthetic function for one (elem, argument-shape) concat —
    * `%arr.concat.<n>(a, x0, x1, ...)`: a fresh array takes a's elements

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -779,9 +779,8 @@ function lowerSplitLimitArg(L: Lowerer, node: ts.Expression | undefined, loc: Sr
    * Package JS is inference-typed, guard-style code (`registeredArguments
    * .slice(-1)[0]`, commander's last-element probe), and the trap would
    * fire on working Node idioms; program files keep the documented trap
-   * (their annotations can prove bounds). Null when the element is
-   * union-typed (the re-tag has no story here) — the caller keeps the
-   * ordinary read. */
+   * (their annotations can prove bounds). Existing element unions retag
+   * into the canonical union with an added undefined arm. */
   export function lowerSafeIndexRead(
     L: Lowerer,
     arr: IrExpr & { type: { kind: "array" } },
@@ -789,12 +788,12 @@ function lowerSplitLimitArg(L: Lowerer, node: ts.Expression | undefined, loc: Sr
     loc: SrcLoc,
   ): IrExpr | null {
     const elem = (arr.type as IrType & { kind: "array" }).elem;
-    if (elem.kind === "union" || elem.kind === "void" || elem.kind === "dyn") return null;
-    const resultT = L.withUndefinedArm(elem);
-    if (resultT.kind !== "union") return null;
+    if (elem.kind === "void" || elem.kind === "dyn") return null;
+    const resultT = elem.kind === "union" ? L.withUndefinedArmOf(elem) : L.withUndefinedArm(elem);
+    if (!resultT || resultT.kind !== "union") return null;
     const undefTag = L.armTag(resultT.unionId, UNDEFINED_T);
-    const foundTag = L.armTag(resultT.unionId, elem);
-    if (undefTag < 0 || foundTag < 0) return null;
+    const foundTag = elem.kind === "union" ? -1 : L.armTag(resultT.unionId, elem);
+    if (undefTag < 0 || (elem.kind !== "union" && foundTag < 0)) return null;
     const arrT = arr.type;
     const key = `idxOr:${typeKey(elem)}`;
     let name = L.arrHofHelpers.get(key);
@@ -832,7 +831,9 @@ function lowerSplitLimitArg(L: Lowerer, node: ts.Expression | undefined, loc: Sr
         { kind: "varDecl", localId: "v.0", init: { kind: "arrayGet", arr: ref("a.0", arrT), index: i, type: elem, loc }, loc },
         {
           kind: "return",
-          value: { kind: "unionWrap", unionId: resultT.unionId, tag: foundTag, value: v, type: resultT, loc },
+          value: elem.kind === "union"
+            ? L.coerceToExpected(v, resultT)
+            : { kind: "unionWrap", unionId: resultT.unionId, tag: foundTag, value: v, type: resultT, loc },
           loc,
         },
       ];

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -243,6 +243,8 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
     if (ts.isNonNullExpression(expr)) {
       const inner = L.lowerExpr(expr.expression);
       if (inner.type.kind === "union") {
+        const use = runtimeOptionalUseOf(expr);
+        if (runtimeOptionalAssertionErases(L, expr, inner, use)) return inner;
         const target = L.mapTypeOf(L.typeOf(expr));
         if (target && target.kind !== "union" && !typeEquals(target, inner.type)) {
           const helper = L.narrowedArmHelper(inner.type.unionId, target, loc);
@@ -725,14 +727,33 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
         const local = L.resolveLocal(expr);
         if (local) {
           if (local.type.kind === "caught") return L.caughtRead(expr, local, loc);
-          if (L.runtimeOptionalLocals.has(local.id)) {
-            return runtimeOptionalMemberRead(L, expr, local, loc) ??
-              { kind: "varRef", localId: local.id, type: local.type, loc };
-          }
           const symbol = L.resolveValueSymbol(expr);
-          if (symbol && L.runtimeOptionalStorageLocals.has(local.id) && L.ctx.captureBySymbol.get(symbol) === local) {
-            const read = runtimeOptionalMemberRead(L, expr, local, loc);
-            if (read) return read;
+          const runtimeOptionalRoot = L.runtimeOptionalRootOf(local);
+          const active = L.runtimeOptionalLocals.has(runtimeOptionalRoot);
+          const captured = !!symbol &&
+            L.runtimeOptionalStorageLocals.has(runtimeOptionalRoot) &&
+            L.ctx.captureBySymbol.get(symbol) === local;
+          if (active || captured) {
+            const use = runtimeOptionalUseOf(expr);
+            if (use?.complex) {
+              L.unsupported("SC1090", expr, "a logical or conditional receiver containing a runtime-optional capture");
+            }
+            if (use?.optional) return { kind: "varRef", localId: local.id, type: local.type, loc };
+            if (use?.kind === "property") return runtimeOptionalReceiverRead(L, expr, local, use.access.name.text, loc);
+            if (use?.kind === "element") {
+              const key = runtimeOptionalElementKey(use.access.argumentExpression);
+              if (key === null) {
+                L.unsupported("SC1090", use.access, "a computed read from a runtime-optional capture (use a literal key)");
+              }
+              return runtimeOptionalReceiverRead(L, expr, local, key, loc);
+            }
+            if (use?.kind === "call") {
+              if (use.comma && !use.optional) {
+                L.unsupported("SC1090", use.access, "a direct call through a comma-wrapped runtime-optional capture");
+              }
+              return runtimeOptionalReceiverRead(L, expr, local, null, loc);
+            }
+            if (active || captured) return { kind: "varRef", localId: local.id, type: local.type, loc };
           }
           return L.maybeNarrow({ kind: "varRef", localId: local.id, type: local.type, loc }, expr);
       }
@@ -2285,26 +2306,29 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
    * force. TypeScript then types a direct member receiver as the plain arm,
    * even though an OOB-safe assignment may have restored undefined. Check
    * that hidden arm and throw the member-read TypeError Node would produce. */
-  function runtimeOptionalMemberRead(
+  function runtimeOptionalReceiverRead(
     L: Lowerer,
     expr: ts.Identifier,
     local: IrLocal,
+    property: string | null,
     loc: SrcLoc,
-  ): IrExpr | null {
-    const access = expr.parent;
-    if (
-      local.type.kind !== "union" ||
-      !ts.isPropertyAccessExpression(access) || access.expression !== expr ||
-      access.questionDotToken !== undefined
-    ) {
-      return null;
-    }
+  ): IrExpr {
+    if (local.type.kind !== "union") throw new Error("runtime-optional local is not union-typed");
     const narrowed = L.mapTypeOf(L.typeOf(expr));
-    if (!narrowed || narrowed.kind === "union" || isUnitType(narrowed)) return null;
+    if (!narrowed || narrowed.kind === "union" || isUnitType(narrowed)) {
+      L.unsupported("SC1090", expr, "a runtime-optional capture whose narrowed value type is not representable");
+    }
     const valueTag = L.armTag(local.type.unionId, narrowed);
     const undefTag = L.armTag(local.type.unionId, UNDEFINED_T);
-    if (valueTag < 0 || undefTag < 0) return null;
+    if (valueTag < 0 || undefTag < 0) throw new Error("runtime-optional local is missing its value or undefined arm");
+    const def = L.unions.get(local.type.unionId);
+    if (!def || def.arms.length !== 2) {
+      L.unsupported("SC1090", expr, "a direct read from a runtime-optional capture with multiple value arms");
+    }
     const ref = (): IrExpr => ({ kind: "varRef", localId: local.id, type: local.type, loc });
+    const message = property === null
+      ? `${expr.text} is not a function`
+      : `Cannot read properties of undefined (reading '${property}')`;
     return {
       kind: "ternary",
       cond: {
@@ -2319,7 +2343,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
       then: nodeThrowExpr(
         1,
         "",
-        `Cannot read properties of undefined (reading '${access.name.text}')`,
+        message,
         narrowed,
         loc,
       ),
@@ -2334,6 +2358,78 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
       type: narrowed,
       loc,
     };
+  }
+
+  type RuntimeOptionalUse =
+    | { kind: "property"; access: ts.PropertyAccessExpression; optional: boolean; complex: boolean; comma: boolean }
+    | { kind: "element"; access: ts.ElementAccessExpression; optional: boolean; complex: boolean; comma: boolean }
+    | { kind: "call"; access: ts.CallExpression; optional: boolean; complex: boolean; comma: boolean };
+
+  function runtimeOptionalUseOf(expr: ts.Expression): RuntimeOptionalUse | null {
+    let receiver = expr;
+    let complex = false;
+    let comma = false;
+    for (;;) {
+      const parent = receiver.parent;
+      if (
+        (ts.isParenthesizedExpression(parent) || ts.isAssertionExpression(parent) ||
+          ts.isSatisfiesExpression(parent) ||
+          ts.isNonNullExpression(parent)) &&
+        parent.expression === receiver
+      ) {
+        receiver = parent;
+        continue;
+      }
+      if (
+        ts.isBinaryExpression(parent) && parent.operatorToken.kind === ts.SyntaxKind.CommaToken && parent.right === receiver
+      ) {
+        comma = true;
+        receiver = parent;
+        continue;
+      }
+      if (
+        (ts.isBinaryExpression(parent) &&
+          (parent.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken ||
+            parent.operatorToken.kind === ts.SyntaxKind.BarBarToken ||
+            parent.operatorToken.kind === ts.SyntaxKind.QuestionQuestionToken) &&
+          (parent.left === receiver || parent.right === receiver)) ||
+        (ts.isConditionalExpression(parent) &&
+          (parent.condition === receiver || parent.whenTrue === receiver || parent.whenFalse === receiver))
+      ) {
+        complex = true;
+        receiver = parent;
+        continue;
+      }
+      break;
+    }
+    const access = receiver.parent;
+    if (ts.isPropertyAccessExpression(access) && access.expression === receiver) {
+      return { kind: "property", access, optional: access.questionDotToken !== undefined, complex, comma };
+    }
+    if (ts.isElementAccessExpression(access) && access.expression === receiver) {
+      return { kind: "element", access, optional: access.questionDotToken !== undefined, complex, comma };
+    }
+    if (ts.isCallExpression(access) && access.expression === receiver) {
+      return { kind: "call", access, optional: access.questionDotToken !== undefined, complex, comma };
+    }
+    return null;
+  }
+
+  function runtimeOptionalElementKey(expr: ts.Expression): string | null {
+    if (ts.isStringLiteral(expr) || ts.isNumericLiteral(expr)) return expr.text;
+    if (ts.isNoSubstitutionTemplateLiteral(expr)) return expr.text;
+    return null;
+  }
+
+  function runtimeOptionalAssertionErases(
+    L: Lowerer,
+    expr: ts.Expression,
+    inner: IrExpr,
+    use: RuntimeOptionalUse | null,
+  ): boolean {
+    if (inner.type.kind !== "union" || !use?.optional || use.complex || L.armTag(inner.type.unionId, UNDEFINED_T) < 0) return false;
+    const target = L.mapTypeOf(L.typeOf(expr));
+    return !!target && target.kind !== "union" && typeEquals(L.stripUndefinedArm(inner.type), target);
   }
 
 /** `v === undefined` / `v !== null` — the narrowing tests for unit-armed
@@ -3102,7 +3198,14 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
     if (body.type.kind === "dyn") {
       return { kind: "optChain", id, receiver, body, type: DYN, loc };
     }
-    const type = L.irTypeOf(expr);
+    let type = L.irTypeOf(expr);
+    const hiddenOptionalResult =
+      (type.kind !== "union" || L.armTag(type.unionId, UNDEFINED_T) < 0) &&
+      receiver.type.kind === "union" && L.armTag(receiver.type.unionId, UNDEFINED_T) >= 0 &&
+      body.type.kind !== "generator" && body.type.kind !== "jsval"
+        ? L.withUndefinedArmOf(body.type)
+        : null;
+    if (hiddenOptionalResult) type = hiddenOptionalResult;
     if (type.kind !== "union" || L.armTag(type.unionId, UNDEFINED_T) < 0) {
       L.unsupported(
         "SC1090",
@@ -3132,14 +3235,14 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
         // (true for &&, false for ||) — aliased-typeof narrows the left
         // PROVES under that polarity hold while it lowers (`type ===
         // 'string' && val.length > 0`, the ms entry shape).
-        const runtimeOptionalId = isAnd ? runtimeOptionalLocalId(L, e.left) : null;
+        const runtimeOptionalLocal = isAnd ? runtimeOptionalLocalOf(L, e.left) : null;
         const right = L.narrowingAliases(aliasTypeofNarrows(L, e.left, isAnd), () => {
-          if (runtimeOptionalId === null) return L.lowerCondition(e.right);
-          L.runtimeOptionalLocals.delete(runtimeOptionalId);
+          if (runtimeOptionalLocal === null) return L.lowerCondition(e.right);
+          L.runtimeOptionalLocals.delete(L.runtimeOptionalRootOf(runtimeOptionalLocal));
           try {
             return L.lowerCondition(e.right);
           } finally {
-            L.runtimeOptionalLocals.add(runtimeOptionalId);
+            L.runtimeOptionalLocals.add(L.runtimeOptionalRootOf(runtimeOptionalLocal));
           }
         });
         return {
@@ -3155,15 +3258,15 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
     return L.ensureBool(lowerAbsenceProbe(L, expr) ?? L.lowerExpr(expr), expr);
   }
 
-  function runtimeOptionalLocalId(L: Lowerer, node: ts.Expression): string | null {
+  function runtimeOptionalLocalOf(L: Lowerer, node: ts.Expression): IrLocal | null {
     let expr = node;
     while (ts.isParenthesizedExpression(expr)) expr = expr.expression;
     if (!ts.isIdentifier(expr)) return null;
     const local = L.resolveLocal(expr);
-    return local && L.runtimeOptionalLocals.has(local.id) ? local.id : null;
+    return local && L.runtimeOptionalLocals.has(L.runtimeOptionalRootOf(local)) ? local : null;
   }
 
-  export function runtimeOptionalTrueIds(L: Lowerer, node: ts.Expression): string[] {
+  export function runtimeOptionalTrueIds(L: Lowerer, node: ts.Expression): IrLocal[] {
     let expr = node;
     while (ts.isParenthesizedExpression(expr)) expr = expr.expression;
     if (
@@ -3172,17 +3275,17 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
     ) {
       return [...runtimeOptionalTrueIds(L, expr.left), ...runtimeOptionalTrueIds(L, expr.right)];
     }
-    const id = runtimeOptionalLocalId(L, expr);
-    return id === null ? [] : [id];
+    const local = runtimeOptionalLocalOf(L, expr);
+    return local === null ? [] : [local];
   }
 
-  export function withRuntimeOptionalNarrowed<T>(L: Lowerer, ids: readonly string[], fn: () => T): T {
-    if (ids.length === 0) return fn();
-    for (const id of ids) L.runtimeOptionalLocals.delete(id);
+  export function withRuntimeOptionalNarrowed<T>(L: Lowerer, locals: readonly IrLocal[], fn: () => T): T {
+    if (locals.length === 0) return fn();
+    for (const local of locals) L.runtimeOptionalLocals.delete(L.runtimeOptionalRootOf(local));
     try {
       return fn();
     } finally {
-      for (const id of ids) L.runtimeOptionalLocals.add(id);
+      for (const local of locals) L.runtimeOptionalLocals.add(L.runtimeOptionalRootOf(local));
     }
   }
 
@@ -7011,6 +7114,8 @@ export function lowerTemplate(L: Lowerer, expr: ts.TemplateExpression): IrExpr {
       if (!bridged) L.unsupported("SC1063", expr);
     }
     const inner = L.lowerExpr(expr.expression);
+    const use = runtimeOptionalUseOf(expr);
+    if (inner.type.kind === "union" && runtimeOptionalAssertionErases(L, expr, inner, use)) return inner;
     if (inner.type.kind !== "dyn" && inner.type.kind !== "jsval") {
       // A STATIC value cast `as any` is the explicit island entrance.
       const targetTs0 = L.checker.getTypeFromTypeNode(expr.type);
@@ -7271,7 +7376,8 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
           L.rejectUnresolved(expr.left, `assignment to '${expr.left.text}' (not a writable local or module global)`);
         }
         const value = L.lowerExprExpecting(expr.right, target.type);
-        if (L.runtimeOptionalStorageLocals.has(target.id)) L.runtimeOptionalLocals.add(target.id);
+        const runtimeOptionalRoot = L.runtimeOptionalRootOf(target);
+        if (L.runtimeOptionalStorageLocals.has(runtimeOptionalRoot)) L.runtimeOptionalLocals.add(runtimeOptionalRoot);
         return { kind: "assignExpr", localId: target.id, value, type: target.type, loc };
       }
       // `events.defaultMaxListeners = v` — the module-property write

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -13,7 +13,7 @@ import { cjsClassExprWholeExportOf, cjsExportAssignmentOf, cjsExportDiscardReaso
 import { ARRAY_METHODS, builtinConstLit, builtinFenceHintOf, builtinModuleConstOf, builtinModulesArrayLit, builtinModuleFnOf, CompoundOp, ISLAND_SURFACE, isChildSurfaceMember, MAP_METHODS, NARROW_FIRST, SET_METHODS, STR_METHODS, UNSUPPORTED_EXPR, sideEffectFreeOptionValue, stdlibGlobalNameOf } from "./surfaces.js";
 import { UNSUPPORTED, blockedBindingUseDiag, recordShapeMismatchDiag, requiresDynamicPackageDiag, unsupportedDiag } from "../../diagnostics/diagnostic.js";
 import { PoisonError, dynUndefinedExpr, jsFuncNameOf, neverTaintedJsType, nodeThrowExpr, own } from "./lowerer.js";
-import { IndexMergeContributor, lowerIndexMergeHelper, lowerNpmStaticSafeIndexRead, strCharsCall } from "./lower-containers.js";
+import { IndexMergeContributor, lowerIndexMergeHelper, lowerNpmStaticSafeIndexRead, lowerSafeIndexRead, strCharsCall } from "./lower-containers.js";
 import { npmStaticPackageOfPath } from "../npm-static.js";
 import { unsupportedModuleFeatureOf } from "../shared.js";
 import { fenceEnumObjectValue, lowerEnumAccess } from "./lower-enums.js";
@@ -722,10 +722,14 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
       // Union-typed bindings read through tsc's control-flow narrowing:
       // when the checker types this USE as a single arm, maybeNarrow
       // bridges the tagged representation with a unionNarrow.
-      const local = L.resolveLocal(expr);
-      if (local) {
-        if (local.type.kind === "caught") return L.caughtRead(expr, local, loc);
-        return L.maybeNarrow({ kind: "varRef", localId: local.id, type: local.type, loc }, expr);
+        const local = L.resolveLocal(expr);
+        if (local) {
+          if (local.type.kind === "caught") return L.caughtRead(expr, local, loc);
+          if (L.runtimeOptionalLocals.has(local.id)) {
+            return runtimeOptionalMemberRead(L, expr, local, loc) ??
+              { kind: "varRef", localId: local.id, type: local.type, loc };
+          }
+          return L.maybeNarrow({ kind: "varRef", localId: local.id, type: local.type, loc }, expr);
       }
       // `import x = N.y` aliases resolve transparently through globalOf/
       // fnSigOf below; their source-order guards live here (a no-op for
@@ -972,11 +976,8 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
           L.noLowering(expr.text, expr, globalHints[expr.text], sym ?? undefined);
         }
       }
-      // `declare const __VERSION__: string` — an ambient global NOTHING
-      // defines (a bundler define in the real pipeline; scriptc has no
-      // define mechanism, and neither does Node running the source —
-      // the oracle). The read compiles to exactly what Node does at the
-      // access: the catchable ReferenceError "<name> is not defined".
+      // An ambient global nothing defines compiles to exactly what Node does
+      // at the access: the catchable ReferenceError "<name> is not defined".
       // Stdlib/@types/node ambients never reach here (their chokepoint
       // is above); only user-file declares do.
       {
@@ -2063,11 +2064,17 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
       })();
       let thenRaw: IrExpr;
       let elseRaw: IrExpr;
+      const runtimeTrueIds = runtimeOptionalTrueIds(L, expr.condition);
+      const lowerTrueArm = (): IrExpr => withRuntimeOptionalNarrowed(
+        L,
+        runtimeTrueIds,
+        () => lowerArm(expr.whenTrue, ownArrayJoin ?? undefined),
+      );
       if (!ctxArray && emptyUntypedArrayArm(expr.whenTrue) && !emptyUntypedArrayArm(expr.whenFalse)) {
         elseRaw = L.lowerExpr(expr.whenFalse);
-        thenRaw = lowerArm(expr.whenTrue, elseRaw.type);
+        thenRaw = withRuntimeOptionalNarrowed(L, runtimeTrueIds, () => lowerArm(expr.whenTrue, elseRaw.type));
       } else {
-        thenRaw = lowerArm(expr.whenTrue, ownArrayJoin ?? undefined);
+        thenRaw = lowerTrueArm();
         elseRaw = lowerArm(expr.whenFalse, thenRaw.type);
       }
       // The ternary's IR type is normally the checker's own: it collapses
@@ -2266,6 +2273,61 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
       value: expr,
       type: narrowed,
       loc: expr.loc,
+    };
+  }
+
+  /** A runtime-optional slot can be assigned while a truthy guard is in
+   * force. TypeScript then types a direct member receiver as the plain arm,
+   * even though an OOB-safe assignment may have restored undefined. Check
+   * that hidden arm and throw the member-read TypeError Node would produce. */
+  function runtimeOptionalMemberRead(
+    L: Lowerer,
+    expr: ts.Identifier,
+    local: IrLocal,
+    loc: SrcLoc,
+  ): IrExpr | null {
+    const access = expr.parent;
+    if (
+      local.type.kind !== "union" ||
+      !ts.isPropertyAccessExpression(access) || access.expression !== expr ||
+      access.questionDotToken !== undefined
+    ) {
+      return null;
+    }
+    const narrowed = L.mapTypeOf(L.typeOf(expr));
+    if (!narrowed || narrowed.kind === "union" || isUnitType(narrowed)) return null;
+    const valueTag = L.armTag(local.type.unionId, narrowed);
+    const undefTag = L.armTag(local.type.unionId, UNDEFINED_T);
+    if (valueTag < 0 || undefTag < 0) return null;
+    const ref = (): IrExpr => ({ kind: "varRef", localId: local.id, type: local.type, loc });
+    return {
+      kind: "ternary",
+      cond: {
+        kind: "unionIsTag",
+        unionId: local.type.unionId,
+        tag: undefTag,
+        negated: false,
+        value: ref(),
+        type: BOOL,
+        loc,
+      },
+      then: nodeThrowExpr(
+        1,
+        "",
+        `Cannot read properties of undefined (reading '${access.name.text}')`,
+        narrowed,
+        loc,
+      ),
+      else_: {
+        kind: "unionNarrow",
+        unionId: local.type.unionId,
+        tag: valueTag,
+        value: ref(),
+        type: narrowed,
+        loc,
+      },
+      type: narrowed,
+      loc,
     };
   }
 
@@ -2531,7 +2593,7 @@ export function pureReemittable(e: IrExpr): boolean {
    * results (several non-unit arms) and defaults that change the result
    * type are fenced with narrow-first hints. */
   export function lowerNullishCoalesce(L: Lowerer, expr: ts.BinaryExpression, loc: SrcLoc): IrExpr {
-    const left = L.lowerExpr(expr.left);
+    const left = lowerAbsenceProbe(L, expr.left) ?? L.lowerExpr(expr.left);
     if (left.type.kind === "dyn") {
       // `a ?? b` on a CHECKED-DYNAMIC left: the deciding test is the
       // runtime kind (scr_dyn_is_nullish — UNDEF/NULL take the default;
@@ -3065,9 +3127,16 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
         // (true for &&, false for ||) — aliased-typeof narrows the left
         // PROVES under that polarity hold while it lowers (`type ===
         // 'string' && val.length > 0`, the ms entry shape).
-        const right = L.narrowingAliases(aliasTypeofNarrows(L, e.left, isAnd), () =>
-          L.lowerCondition(e.right),
-        );
+        const runtimeOptionalId = isAnd ? runtimeOptionalLocalId(L, e.left) : null;
+        const right = L.narrowingAliases(aliasTypeofNarrows(L, e.left, isAnd), () => {
+          if (runtimeOptionalId === null) return L.lowerCondition(e.right);
+          L.runtimeOptionalLocals.delete(runtimeOptionalId);
+          try {
+            return L.lowerCondition(e.right);
+          } finally {
+            L.runtimeOptionalLocals.add(runtimeOptionalId);
+          }
+        });
         return {
           kind: "logical",
           op: isAnd ? "&&" : "||",
@@ -3078,7 +3147,38 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
         };
       }
     }
-    return L.ensureBool(L.lowerExpr(expr), expr);
+    return L.ensureBool(lowerAbsenceProbe(L, expr) ?? L.lowerExpr(expr), expr);
+  }
+
+  function runtimeOptionalLocalId(L: Lowerer, node: ts.Expression): string | null {
+    let expr = node;
+    while (ts.isParenthesizedExpression(expr)) expr = expr.expression;
+    if (!ts.isIdentifier(expr)) return null;
+    const local = L.resolveLocal(expr);
+    return local && L.runtimeOptionalLocals.has(local.id) ? local.id : null;
+  }
+
+  export function runtimeOptionalTrueIds(L: Lowerer, node: ts.Expression): string[] {
+    let expr = node;
+    while (ts.isParenthesizedExpression(expr)) expr = expr.expression;
+    if (
+      ts.isBinaryExpression(expr) &&
+      expr.operatorToken.kind === ts.SyntaxKind.AmpersandAmpersandToken
+    ) {
+      return [...runtimeOptionalTrueIds(L, expr.left), ...runtimeOptionalTrueIds(L, expr.right)];
+    }
+    const id = runtimeOptionalLocalId(L, expr);
+    return id === null ? [] : [id];
+  }
+
+  export function withRuntimeOptionalNarrowed<T>(L: Lowerer, ids: readonly string[], fn: () => T): T {
+    if (ids.length === 0) return fn();
+    for (const id of ids) L.runtimeOptionalLocals.delete(id);
+    try {
+      return fn();
+    } finally {
+      for (const id of ids) L.runtimeOptionalLocals.add(id);
+    }
   }
 
 /** JS ToBoolean: bool passes through; f64/string get a `toBool` wrapper
@@ -6034,13 +6134,17 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
     // signature where the .d.ts says Function[], which would flatten the
     // element to a zero-parameter closure).
     const elemT = arr.type.kind === "array" ? arr.type.elem : receiverIr.elem;
-    // --npm-static package files: the OOB-SAFE read (elem | undefined)
-    // for the LAST-ELEMENT idiom — indexing a fresh slice() result
-    // (commander's `registeredArguments.slice(-1)[0]` probe), where the
-    // trap divergence would fire on working Node code and the fresh
-    // array's read can only be a probe. General indexed reads keep the
-    // documented trap (their results feed writes and member reads whose
-    // lowerings need the plain element).
+    // OOB-SAFE reads over fresh/probe array results. These expressions are
+    // commonly used to ask for a first/last match (`filter(...).sort(...)[0]`,
+    // `slice(-1)[0]`); an empty result is ordinary undefined, not a bounds
+    // failure. Downstream lowering keeps the explicit optional union, so an
+    // unchecked consumer still cannot place it into a plain element slot.
+    if (arr.type.kind === "array" && isFreshArrayProbe(expr.expression)) {
+      const safe = lowerSafeIndexRead(L, arr as IrExpr & { type: { kind: "array" } }, index, locOf(expr));
+      if (safe) return safe;
+    }
+    // --npm-static package files retain the original slice-specific route
+    // for compatibility with package-source inference.
     if (
       arr.type.kind === "array" &&
       arr.kind === "arrIntrinsic" &&
@@ -6056,6 +6160,18 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
     return L.maybeNarrow(
       { kind: "arrayGet", arr, index, type: elemT, loc: locOf(expr) },
       expr,
+    );
+  }
+
+  function isFreshArrayProbe(node: ts.Expression): boolean {
+    let current = node;
+    while (ts.isParenthesizedExpression(current)) current = current.expression;
+    return (
+      ts.isCallExpression(current) &&
+      ts.isPropertyAccessExpression(current.expression) &&
+      (current.expression.name.text === "filter" ||
+        current.expression.name.text === "slice" ||
+        current.expression.name.text === "sort")
     );
   }
 
@@ -6101,7 +6217,13 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
    * fields outside that stay fenced. Declared-only shapes support reads
    * whose key type proves membership (tsc's keyof check): all fields must
    * share the result type, and a smuggled miss traps. */
-  export function lowerRecordKeyRead(L: Lowerer, expr: ts.ElementAccessExpression, shapeId: string, shape: IrRecordShape,): IrExpr {
+  export function lowerRecordKeyRead(
+    L: Lowerer,
+    expr: ts.ElementAccessExpression,
+    shapeId: string,
+    shape: IrRecordShape,
+    includeUndefined = false,
+  ): IrExpr {
     const loc = locOf(expr);
     const keyNode = expr.argumentExpression;
     // Literal declared keys are plain field reads (narrowing included).
@@ -6168,7 +6290,7 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
     let declared: IrType | null = null;
     if (shape.indexValue) {
       declared = shape.indexValue;
-      if (L.program.getCompilerOptions().noUncheckedIndexedAccess) {
+      if (includeUndefined || L.program.getCompilerOptions().noUncheckedIndexedAccess) {
         declared = L.withUndefinedArmOf(declared);
         if (!declared) L.badType(expr, L.typeOf(expr));
       }
@@ -6195,10 +6317,70 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
         `dynamic keyed reads of '${L.fmt({ kind: "record", shapeId })}' as '${L.fmt(declared)}' (every declared field must be readable at that type)`,
       );
     }
-    return L.maybeNarrow(
-      { kind: "recordKeyGet", obj, shapeId, key, ...(overflowOnly ? { overflowOnly: true as const } : {}), type: declared, loc },
-      expr,
-    );
+    const read: IrExpr = {
+      kind: "recordKeyGet",
+      obj,
+      shapeId,
+      key,
+      ...(overflowOnly ? { overflowOnly: true as const } : {}),
+      type: declared,
+      loc,
+    };
+    return includeUndefined ? read : L.maybeNarrow(read, expr);
+  }
+
+  /** A keyed read used only to observe absence (`if (map[k])`, or the left
+   * side of `||`/`??`). JavaScript answers undefined for missing record keys
+   * and array indices even when noUncheckedIndexedAccess is disabled. Keep
+   * that value in an explicit union until the surrounding guard/default has
+   * consumed it; ordinary unchecked reads retain the typed trap. Assertions
+   * around the read are erased here because this context handles the missing
+   * arm instead of consuming it as the asserted type. */
+  export function lowerAbsenceProbe(L: Lowerer, node: ts.Expression): IrExpr | null {
+    let expr = node;
+    while (ts.isParenthesizedExpression(expr) || ts.isAsExpression(expr) || ts.isTypeAssertion(expr)) {
+      expr = expr.expression;
+    }
+    if (ts.isPropertyAccessExpression(expr)) {
+      const target = L.fieldTarget(expr);
+      if (target?.container !== "recordOvf") return null;
+      if (
+        target.fieldType.kind === "union" &&
+        L.armTag(target.fieldType.unionId, UNDEFINED_T) >= 0
+      ) {
+        return null;
+      }
+      const type = L.withUndefinedArmOf(target.fieldType);
+      if (!type) return null;
+      return {
+        kind: "recordKeyGet",
+        obj: target.obj,
+        shapeId: target.shapeId,
+        key: { kind: "strLit", value: target.field, type: STRING, loc: locOf(expr) },
+        overflowOnly: true,
+        type,
+        loc: locOf(expr),
+      };
+    }
+    if (!ts.isElementAccessExpression(expr)) return null;
+
+    const header = L.lowerHttpHeadersElement(expr);
+    if (header) return header;
+
+    const receiverT = L.mapTypeOf(L.typeOf(expr.expression));
+    if (receiverT?.kind === "record") {
+      const shape = L.shapes.get(receiverT.shapeId);
+      if (shape && !shape.tuple && shape.indexValue && shape.indexValue.kind !== "dyn") {
+        return L.lowerRecordKeyRead(expr, receiverT.shapeId, shape, true);
+      }
+      return null;
+    }
+    if (receiverT?.kind !== "array") return null;
+    const arr = L.lowerExpr(expr.expression);
+    if (arr.type.kind !== "array") return null;
+    const index = L.lowerExpr(expr.argumentExpression);
+    if (index.type.kind !== "f64") return null;
+    return lowerSafeIndexRead(L, arr as IrExpr & { type: { kind: "array" } }, index, locOf(expr));
   }
 
   /** The compile-time string spelling of a record key literal: a string
@@ -7084,6 +7266,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
           L.rejectUnresolved(expr.left, `assignment to '${expr.left.text}' (not a writable local or module global)`);
         }
         const value = L.lowerExprExpecting(expr.right, target.type);
+        if (L.runtimeOptionalStorageLocals.has(target.id)) L.runtimeOptionalLocals.add(target.id);
         return { kind: "assignExpr", localId: target.id, value, type: target.type, loc };
       }
       // `events.defaultMaxListeners = v` — the module-property write
@@ -7256,11 +7439,15 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
       L.unsupported("SC1040", expr);
     }
     if (op === ts.SyntaxKind.AmpersandAmpersandToken || op === ts.SyntaxKind.BarBarToken) {
+      if (op === ts.SyntaxKind.BarBarToken) {
+        const fallback = lowerAbsenceAwareOrChain(L, expr);
+        if (fallback) return fallback;
+      }
       // JS value semantics: `a && b` is `toBool(a) ? b : a` — the result is
       // an operand value, so both operands must share one IR kind (which is
       // also what tsc's type says, modulo literal-union collapsing that
       // mapType already handles). Mixed kinds (`n && s`) stay rejected.
-      const left = L.lowerExpr(expr.left);
+      const left = lowerAbsenceProbe(L, expr.left) ?? L.lowerExpr(expr.left);
       const right = L.lowerExpr(expr.right);
       // A LITERAL-unit left operand (a compile-time undefined/null — the
       // capability-probe members: `process.features.inspector ||
@@ -7446,8 +7633,10 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
       if (test) return test;
     }
 
-    const left = L.lowerExpr(expr.left);
-    const right = L.lowerExpr(expr.right);
+    const strictEquality = op === ts.SyntaxKind.EqualsEqualsEqualsToken ||
+      op === ts.SyntaxKind.ExclamationEqualsEqualsToken;
+    const left = strictEquality ? lowerAbsenceProbe(L, expr.left) ?? L.lowerExpr(expr.left) : L.lowerExpr(expr.left);
+    const right = strictEquality ? lowerAbsenceProbe(L, expr.right) ?? L.lowerExpr(expr.right) : L.lowerExpr(expr.right);
     if (left.type.kind === "dyn" || right.type.kind === "dyn") {
       // The narrowing unit comparisons ARE answerable on unknown: `v ===
       // undefined` / `v !== null` test the dyn node's kind directly, and
@@ -7660,6 +7849,31 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
           const ut = left.type.kind === "union" ? left.type : (right.type as IrType & { kind: "union" });
           const bothUnion = left.type.kind === "union" && right.type.kind === "union";
           const sameUnion = bothUnion && typeEquals(left.type, right.type);
+          const plainFunc = left.type.kind === "func" ? left : right.type.kind === "func" ? right : null;
+          const unionArms = L.unions.get(ut.unionId)?.arms ?? [];
+          const funcArm = unionArms.find((arm) => arm.kind === "func");
+          // `listeners()` reports original prefix callbacks, but the
+          // checker views an indexed result as function | undefined. For
+          // identity comparison, retain the original closure pointer rather
+          // than adapting it to the tuple signature.
+          if (
+            !bothUnion &&
+            plainFunc !== null &&
+            funcArm?.kind === "func" &&
+            unionArms.filter((arm) => arm.kind === "func").length === 1 &&
+            unionArms.some(isUnitType)
+          ) {
+            return {
+              kind: "unionFuncEq",
+              unionId: ut.unionId,
+              tag: L.armTag(ut.unionId, funcArm),
+              union: left.type.kind === "union" ? left : right,
+              func: plainFunc,
+              negated,
+              type: BOOL,
+              loc,
+            };
+          }
           if ((sameUnion || !bothUnion) && L.eqComparableUnion(ut.unionId)) {
             return {
               kind: "unionEq",
@@ -7749,6 +7963,43 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
         break;
     }
     L.unsupported("SC1090", expr, `operator '${ts.tokenToString(op) ?? ts.SyntaxKind[op]}'`);
+  }
+
+  function lowerAbsenceAwareOrChain(L: Lowerer, expr: ts.BinaryExpression): IrExpr | null {
+    const nodes: ts.Expression[] = [];
+    const collect = (node: ts.Expression): void => {
+      if (
+        ts.isBinaryExpression(node) &&
+        node.operatorToken.kind === ts.SyntaxKind.BarBarToken
+      ) {
+        collect(node.left);
+        collect(node.right);
+      } else {
+        nodes.push(node);
+      }
+    };
+    collect(expr);
+    if (nodes.length < 3) return null;
+    const lowered = nodes.map((node) => lowerAbsenceProbe(L, node) ?? L.lowerExpr(node));
+    if (!lowered.some((value) => value.type.kind === "union" && L.armTag(value.type.unionId, UNDEFINED_T) >= 0)) {
+      return null;
+    }
+    let result = lowered[lowered.length - 1]!;
+    for (let i = lowered.length - 2; i >= 0; i--) {
+      const left = lowered[i]!;
+      const loc = locOf(nodes[i]!);
+      if (left.type.kind === "union") {
+        const def = L.unions.get(left.type.unionId);
+        const nonUnit = def?.arms.filter((arm) => !isUnitType(arm)) ?? [];
+        if (nonUnit.length !== 1 || !typeEquals(nonUnit[0]!, result.type)) return null;
+        L.requireTruthyUnion(left.type.unionId, expr);
+        result = { kind: "orDefault", left, right: result, type: result.type, loc };
+        continue;
+      }
+      if (!typeEquals(left.type, result.type)) return null;
+      result = { kind: "logical", op: "||", left, right: result, type: result.type, loc };
+    }
+    return result;
   }
 
 /** `typeof e === "lit"` / `typeof e !== "lit"` where e is a catch

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -729,6 +729,11 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
             return runtimeOptionalMemberRead(L, expr, local, loc) ??
               { kind: "varRef", localId: local.id, type: local.type, loc };
           }
+          const symbol = L.resolveValueSymbol(expr);
+          if (symbol && L.runtimeOptionalStorageLocals.has(local.id) && L.ctx.captureBySymbol.get(symbol) === local) {
+            const read = runtimeOptionalMemberRead(L, expr, local, loc);
+            if (read) return read;
+          }
           return L.maybeNarrow({ kind: "varRef", localId: local.id, type: local.type, loc }, expr);
       }
       // `import x = N.y` aliases resolve transparently through globalOf/

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -1235,13 +1235,10 @@ function lowerNetServerMethodCall(L: Lowerer, call: ts.CallExpression,
       // HTTP CONNECT — the tunneling handover: (req, socket, head), fired
       // INSTEAD of 'request' for CONNECT-method requests (the 'upgrade'
       // machinery's twin; no listener destroys the socket, Node's
-      // default). Under the allowHTTP1 lowering the h2 compat server's
-      // 'connect' only ever fires for HTTP/1.1 CONNECT, so the second
-      // argument is ALWAYS the raw socket — a listener typing it
-      // `Http2ServerResponse | net.Socket` (portless's RFC 8441 handler)
-      // takes the union with the socket wrapped at its arm; `instanceof
-      // net.Socket` narrows it (always true at runtime here, exactly like
-      // Node's allowHTTP1 HTTP/1.1 arm).
+      // default). An allowHTTP1 server supplies a raw socket for HTTP/1.1
+      // CONNECT and an Http2ServerResponse for valid traditional/extended
+      // HTTP/2 CONNECT, so portless's union-typed listener selects the
+      // protocol arm with `instanceof net.Socket`.
       const cb = L.lowerExpr(args[1]!);
       if (cb.type.kind !== "func" || cb.type.params.length > 3) {
         L.unsupported(
@@ -1313,21 +1310,24 @@ function lowerNetServerMethodCall(L: Lowerer, call: ts.CallExpression,
       return { kind: "libCall", fn: "http.serverOnUpgrade", args: [receiver, cb, once], type: VOID, loc };
     }
     if (event === "sessionError") {
-      // 'sessionError' is an HTTP/2 SESSION event — the allowHTTP1
-      // lowering serves every connection as HTTP/1.1, so no session ever
-      // exists and the event NEVER fires (SEMANTICS.md divergence 57).
-      // The registration is honest dead weight: the callback is built and
-      // released, never called — so its parameters need no checking
-      // beyond the closure shape.
       const cb = L.lowerExpr(args[1]!);
-      if (cb.type.kind !== "func" || cb.type.ret.kind !== "void") {
+      if (cb.type.kind !== "func" || cb.type.ret.kind !== "void" || cb.type.params.length > 2) {
         L.unsupported(
           "SC1090",
           args[1]!,
-          "sessionError listeners returning a value (make the callback body a block)",
+          "sessionError listeners with more than two parameters or returning a value",
         );
       }
-      return { kind: "libCall", fn: "http2.serverOnSessionError", args: [receiver, cb], type: VOID, loc };
+      const [err, session] = cb.type.params;
+      if ((err !== undefined && !(err.kind === "object" && err.className === "%Error")) ||
+          (session !== undefined && session.kind !== "http2Session")) {
+        L.unsupported(
+          "SC1090",
+          args[1]!,
+          "sessionError listeners whose parameters are not (error: Error, session: ServerHttp2Session)",
+        );
+      }
+      return { kind: "libCall", fn: "http2.serverOnSessionError", args: [receiver, cb, once], type: VOID, loc };
     }
     L.noLowering(
       `server.${name}(${event === null ? "non-literal event" : `"${event}"`}, ...)`,
@@ -1653,7 +1653,7 @@ function lowerNetSocketMethodCall(L: Lowerer, call: ts.CallExpression,
  * slot). Null when the receiver is neither. */
 export function lowerServerMethodCall(L: Lowerer, call: ts.CallExpression,
   access: ts.PropertyAccessExpression,): IrExpr | null {
-  if (call.questionDotToken || access.questionDotToken) return null;
+  if (call.questionDotToken || (access.questionDotToken && !L.chainHandled.has(access))) return null;
   return (
     lowerServerCloseBind(L, call, access) ??
     lowerNetServerMethodCall(L, call, access) ??
@@ -1895,13 +1895,17 @@ function lowerH2SessionMethodCall(L: Lowerer, call: ts.CallExpression,
 
 /** Method calls on ClientHttp2Stream / ServerHttp2Stream receivers. */
 function lowerH2StreamMethodCall(L: Lowerer, call: ts.CallExpression,
-  access: ts.PropertyAccessExpression,): IrExpr | null {
-  if (L.mapTypeOf(L.typeOf(access.expression))?.kind !== "http2Stream") return null;
-  if (!L.isStdlibMember(access)) return null;
+  access: ts.PropertyAccessExpression, receiverOverride?: IrExpr,): IrExpr | null {
+  const compatReqStream =
+    ts.isPropertyAccessExpression(access.expression) &&
+    access.expression.name.text === "stream" &&
+    L.mapTypeOf(L.typeOf(access.expression.expression))?.kind === "httpReq";
+  if (L.mapTypeOf(L.typeOf(access.expression))?.kind !== "http2Stream" && !compatReqStream) return null;
+  if (!L.isStdlibMember(access) && !compatReqStream) return null;
   const name = access.name.text;
   const loc = locOf(call);
   const args = call.arguments;
-  const receiver = () => handleReceiver(L, access.expression, HTTP2STREAM_T);
+  const receiver = () => receiverOverride ?? handleReceiver(L, access.expression, HTTP2STREAM_T);
   if (name === "respond") {
     requireStatementPosition(L, call, "stream.respond(...)");
     const headersArg = args.length >= 1
@@ -1996,6 +2000,38 @@ function lowerH2StreamMethodCall(L: Lowerer, call: ts.CallExpression,
     "respond/write/end/close/destroy/setEncoding/resume/pause and on(...) are the lowered stream members");
 }
 
+/** A compatibility request's `req.stream?.method(...)`: the static Node
+ * type omits the HTTP/1 undefined arm, so build the runtime guard explicitly.
+ * The body receives the narrowed backing stream directly, preserving lazy
+ * argument evaluation on the HTTP/1 arm. */
+export function lowerCompatReqStreamOptionalCall(
+  L: Lowerer,
+  call: ts.CallExpression,
+): IrExpr | null {
+  if (!ts.isPropertyAccessExpression(call.expression) || !call.expression.questionDotToken) return null;
+  const stream = call.expression.expression;
+  if (!ts.isPropertyAccessExpression(stream) || stream.name.text !== "stream" ||
+      L.mapTypeOf(L.typeOf(stream.expression))?.kind !== "httpReq") return null;
+  const loc = locOf(call);
+  const unionT: IrType = { kind: "union", unionId: L.unions.intern([HTTP2STREAM_T, UNDEFINED_T]) };
+  const guarded: IrExpr = {
+    kind: "libCall",
+    fn: "http.reqH2Stream",
+    args: [handleReceiver(L, stream.expression, HTTPREQ_T)],
+    type: unionT,
+    loc,
+  };
+  const id = `chain.${L.chainCounter++}`;
+  const body = lowerH2StreamMethodCall(
+    L,
+    call,
+    call.expression,
+    { kind: "chainRecv", id, type: HTTP2STREAM_T, loc },
+  );
+  if (body === null) return null;
+  return { kind: "optChain", id, receiver: guarded, body, type: VOID, loc };
+}
+
 /** The composed `server.address().port` read — the crypto
  * randomBytes(n).toString(enc) precedent: the AddressInfo record between
  * the two reads never materializes; the runtime answers the bound port
@@ -2060,17 +2096,40 @@ export function lowerServerProperty(L: Lowerer, expr: ts.PropertyAccessExpressio
       const receiver = handleReceiver(L, expr.expression, HTTPREQ_T);
       return { kind: "libCall", fn: "http.reqStatusMessage", args: [receiver], type: L.envValueType(), loc };
     }
-    if (name === "stream" || name === "session") {
-      // Http2ServerRequest's h2-only members. On the allowHTTP1 lowering
-      // every connection is HTTP/1.1, where Node answers undefined for
-      // both — the CALL forms lower in lower-calls.ts (guarded ?. no-ops,
-      // unguarded throws Node's exact TypeError); a bare read in any
-      // other position has no undefined-typed value form here, so the
-      // fence names the compiling shapes.
+    if (name === "stream") {
+      const parent = expr.parent;
+      if (ts.isPropertyAccessExpression(parent) && parent.expression === expr &&
+          ts.isCallExpression(parent.parent) && parent.parent.expression === parent) {
+        const receiver = handleReceiver(L, expr.expression, HTTPREQ_T);
+        if (parent.questionDotToken) {
+          const type: IrType = {
+            kind: "union",
+            unionId: L.unions.intern([HTTP2STREAM_T, UNDEFINED_T]),
+          };
+          return { kind: "libCall", fn: "http.reqH2Stream", args: [receiver], type, loc };
+        }
+        return {
+          kind: "libCall",
+          fn: "http.reqH2StreamOrThrow",
+          args: [receiver, { kind: "strLit", value: parent.name.text, type: STRING, loc }],
+          type: HTTP2STREAM_T,
+          loc,
+        };
+      }
+      L.noLowering(
+        "reading 'stream' from a request outside a method call",
+        expr,
+        "call req.stream methods directly; optional calls remain undefined on HTTP/1 and use the live stream on HTTP/2",
+      );
+    }
+    if (name === "session") {
+      // Http2ServerRequest's h2-only members are not exposed through the
+      // compatibility request handle yet. The call forms retain their
+      // guarded-no-op / unguarded-TypeError stance; other reads fence.
       L.noLowering(
         `reading '${name}' (an HTTP/2-only member) from a request`,
         expr,
-        "the allowHTTP1 lowering serves every connection as HTTP/1.1, where Node answers undefined — method calls compile (req.stream?.on(...) no-ops; unguarded req.stream.on(...) throws Node's TypeError); other reads have no lowering",
+        "compatibility requests do not expose their backing h2 stream/session yet; guarded method calls no-op and other reads have no lowering",
       );
     }
     if (name === "headers") {
@@ -2096,7 +2155,7 @@ export function lowerServerProperty(L: Lowerer, expr: ts.PropertyAccessExpressio
     L.noLowering(
       "reading 'stream' (an HTTP/2-only member) from a response",
       expr,
-      "the allowHTTP1 lowering serves every connection as HTTP/1.1, where Node answers undefined — guard method calls with '?.' or drop the use",
+      "compatibility responses do not expose their backing h2 stream yet — guard method calls with '?.' or drop the use",
     );
   }
   if (recvKind === "netSocket" && expr.name.text === "encrypted") {
@@ -3177,12 +3236,10 @@ function lowerHttpsModuleCall(L: Lowerer, expr: ts.CallExpression,
   );
 }
 
-/** The h2 SESSION-tuning options of http2.createSecureServer: knobs that
- * configure HTTP/2 sessions, which the allowHTTP1 lowering never creates
- * (every connection serves HTTP/1.1 — SEMANTICS.md divergence 57). They
- * are accepted and IGNORED — Node before 22.11 ignores the streamReset
- * pair the same way — but only with LITERAL values, so nothing observable
- * (a call, a read) is silently skipped. */
+/** The h2 SESSION-tuning options of http2.createSecureServer. This slice
+ * runs most at their defaults, so they are accepted and ignored only with
+ * literal values; settings.enableConnectProtocol is parsed explicitly
+ * below because it changes the wire protocol and CONNECT dispatch. */
 const HTTP2_IGNORED_TUNING_OPTIONS: ReadonlySet<string> = new Set([
   "streamResetBurst",
   "streamResetRate",
@@ -3213,13 +3270,9 @@ function stripParensAndCasts(node: ts.Expression): ts.Expression {
   }
 }
 
-/** Module-function calls on http2 import bindings. The ONE lowered member
- * is createSecureServer with allowHTTP1: true — the honest HTTP/1.1
- * fallback: the existing TLS server + HTTP/1.1 parser, ALPN advertising
- * http/1.1 only (h2-capable clients negotiate down; h2-only clients fail
- * the handshake — SEMANTICS.md divergence 57). The handler arrives later
- * via server.on("request", ...); h2 sessions (connect, the h2c
- * createServer) and h2-only servers keep their fences. */
+/** Module-function calls on http2 import bindings. createServer lowers h2c;
+ * createSecureServer lowers h2 over TLS, with allowHTTP1 selecting one
+ * dual-ALPN server whose request/connect listeners mirror across parsers. */
 function lowerHttp2ModuleCall(L: Lowerer, expr: ts.CallExpression,
   bi: { module: string; member: string },
   loc: SrcLoc,): IrExpr {
@@ -3397,6 +3450,7 @@ function lowerHttp2ModuleCall(L: Lowerer, expr: ts.CallExpression,
     let key: IrExpr | null = null;
     let sni: IrExpr | null = null;
     let allowHttp1 = false;
+    let enableConnectProtocol = false;
     // The SNICallback value shape: (servername: string, cb) => void where
     // cb is (err: Error | null, ctx?: SecureContext) => void — cb may
     // declare fewer params (the emitted answer thunk matches its ABI),
@@ -3494,16 +3548,15 @@ function lowerHttp2ModuleCall(L: Lowerer, expr: ts.CallExpression,
       }
       const k = (prop.name as ts.Identifier | ts.StringLiteral).text;
       if (k === "allowHTTP1") {
-        // A literal true or false: true keeps the compatibility server
-        // (HTTP/1.1 only — divergence 57's remaining arm); false IS the
-        // absent default — the h2-only ALPN server below. A runtime
+        // A literal true or false: true selects the dual h2/http1 server;
+        // false IS the absent default — the h2-only ALPN server below. A runtime
         // value would pick a protocol stack dynamically — fence.
         if (initializer !== null && initializer.kind === ts.SyntaxKind.FalseKeyword) return;
         if (initializer === null || initializer.kind !== ts.SyntaxKind.TrueKeyword) {
           L.noLowering(
             "createSecureServer with a non-literal allowHTTP1 option",
             prop,
-            "allowHTTP1 picks the protocol stack (true: the HTTP/1.1 compatibility server; false/absent: the ALPN=h2 server) — spell it as a literal",
+            "allowHTTP1 picks the protocol stack (true: dual h2/http1; false/absent: ALPN=h2 only) — spell it as a literal",
           );
         }
         allowHttp1 = true;
@@ -3548,6 +3601,22 @@ function lowerHttp2ModuleCall(L: Lowerer, expr: ts.CallExpression,
           e.properties.every(
             (p) => ts.isPropertyAssignment(p) && ts.isIdentifier(p.name) && isScalarLiteral(p.initializer),
           );
+        if (k === "settings" && initializer !== null && ts.isObjectLiteralExpression(initializer)) {
+          for (const setting of initializer.properties) {
+            if (ts.isPropertyAssignment(setting) && ts.isIdentifier(setting.name) &&
+                setting.name.text === "enableConnectProtocol") {
+              if (setting.initializer.kind !== ts.SyntaxKind.TrueKeyword &&
+                  setting.initializer.kind !== ts.SyntaxKind.FalseKeyword) {
+                L.noLowering(
+                  "settings.enableConnectProtocol with a non-boolean literal",
+                  setting,
+                  "spell enableConnectProtocol as true or false",
+                );
+              }
+              enableConnectProtocol = setting.initializer.kind === ts.SyntaxKind.TrueKeyword;
+            }
+          }
+        }
         if (initializer !== null &&
             (isScalarLiteral(initializer) || isLiteralObjectOfLiterals(initializer))) {
           return;
@@ -3555,7 +3624,7 @@ function lowerHttp2ModuleCall(L: Lowerer, expr: ts.CallExpression,
         L.noLowering(
           `createSecureServer option '${k}' with a non-literal value`,
           prop,
-          "h2 session-tuning options are accepted with literal values (settings: a literal of literals) and ignored — the allowHTTP1 lowering serves HTTP/1.1 only, which has no h2 sessions to tune",
+          "h2 session-tuning options are accepted with literal values but are not applied yet",
         );
       }
       if (k === "SNICallback") {
@@ -3596,29 +3665,29 @@ function lowerHttp2ModuleCall(L: Lowerer, expr: ts.CallExpression,
         L.noLowering(
           "createSecureServer with an SNICallback and no allowHTTP1",
           optsNode,
-          "SNICallback lowers on the allowHTTP1 compatibility server — the ALPN=h2 server serves one cert/key pair",
+          "SNICallback lowers on the dual allowHTTP1 server — the h2-only server serves one cert/key pair",
         );
       }
       if (handlerNode !== null) {
         const cb = lowerRequestHandlerArg(L, handlerNode);
-        return { kind: "libCall", fn: "http2.createSecureServerH2Req", args: [cert, key, cb], type: NETSERVER_T, loc };
+        return { kind: "libCall", fn: "http2.createSecureServerH2Req", args: [cert, key, cb, boolLit(enableConnectProtocol, loc)], type: NETSERVER_T, loc };
       }
-      return { kind: "libCall", fn: "http2.createSecureServerH2", args: [cert, key], type: NETSERVER_T, loc };
+      return { kind: "libCall", fn: "http2.createSecureServerH2", args: [cert, key, boolLit(enableConnectProtocol, loc)], type: NETSERVER_T, loc };
     }
     if (sni !== null) {
-      return { kind: "libCall", fn: "http2.createSecureServerSni", args: [cert, key, sni], type: NETSERVER_T, loc };
+      return { kind: "libCall", fn: "http2.createSecureServerSni", args: [cert, key, sni, boolLit(enableConnectProtocol, loc)], type: NETSERVER_T, loc };
     }
     if (handlerNode !== null) {
       const cb = lowerRequestHandlerArg(L, handlerNode);
-      return { kind: "libCall", fn: "http2.createSecureServerReq", args: [cert, key, cb], type: NETSERVER_T, loc };
+      return { kind: "libCall", fn: "http2.createSecureServerReq", args: [cert, key, cb, boolLit(enableConnectProtocol, loc)], type: NETSERVER_T, loc };
     }
-    return { kind: "libCall", fn: "http2.createSecureServer", args: [cert, key], type: NETSERVER_T, loc };
+    return { kind: "libCall", fn: "http2.createSecureServer", args: [cert, key, boolLit(enableConnectProtocol, loc)], type: NETSERVER_T, loc };
   }
   L.noLowering(
     `http2.${bi.member}`,
     expr,
     builtinFenceHintOf("http2", bi.member) ??
-      "createSecureServer({ allowHTTP1: true, cert, key }) is the lowered http2 surface — it serves HTTP/1.1 only (ALPN never advertises h2); h2 sessions have no lowering",
+      "createSecureServer({ allowHTTP1: true, cert, key }) and the h2-only form are lowered",
     L.resolveValueSymbol(expr.expression as ts.Identifier),
   );
 }

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -22,7 +22,7 @@ import { lowerStreamUnderscoreAssign, streamClassAliasDecl, streamSidesOf } from
 import { lowerHttpResPropertyAssignment, lowerHttpServerTimeoutAssignment, lowerServerCloseOverrideAssignment } from "./lower-server.js";
 import { builtinMemberRequireDecl, builtinNamespaceDestructureModuleOf, createRequireBindingDecl, createRequireCalleeFileOf, createRequireNamespaceDecl, textCodecBindingDecl } from "./lower-builtins.js";
 import { lowerEnumDeclaration } from "./lower-enums.js";
-import { abstractPropertyDeclOf, aliasTypeofNarrows, isMatchSliceType, lowerGroupsProjection, matchResultNamedGroupsOf, probeLower, pureReemittable, symbolFieldInfo } from "./lower-exprs.js";
+import { abstractPropertyDeclOf, aliasTypeofNarrows, isMatchSliceType, lowerAbsenceProbe, lowerGroupsProjection, matchResultNamedGroupsOf, probeLower, pureReemittable, runtimeOptionalTrueIds, symbolFieldInfo, withRuntimeOptionalNarrowed } from "./lower-exprs.js";
 import { UNSUPPORTED, checkerPanicDiag, isCheckerPanic, requiresDynamicDiag } from "../../diagnostics/diagnostic.js";
 import { isParseArgsDynTypeName, isUnitOnlyTsType, unitOnlyUnion } from "../types.js";
 import { canonicalBuiltinModule, isRelativeSpecifier } from "../shared.js";
@@ -674,19 +674,24 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
       // else-branch under a FALSE one — the var/let alias narrowing the
       // checker only performs for consts (aliasTypeofNarrows).
       const then = L.narrowingAliases(aliasTypeofNarrows(L, stmt.expression, true), () =>
-        L.lowerScopedBlock(stmt.thenStatement),
+        withRuntimeOptionalNarrowed(L, runtimeOptionalTrueIds(L, stmt.expression), () =>
+          L.lowerScopedBlock(stmt.thenStatement)),
       );
       const else_ = stmt.elseStatement
         ? L.narrowingAliases(aliasTypeofNarrows(L, stmt.expression, false), () =>
             L.lowerScopedBlock(stmt.elseStatement!),
           )
         : null;
+      const narrowedAfter = falsyExitRuntimeOptionalLocal(L, stmt);
+      if (narrowedAfter !== null) L.runtimeOptionalLocals.delete(narrowedAfter);
       return { kind: "if", cond, then, else_, loc: locOf(stmt) };
     }
     if (ts.isWhileStatement(stmt)) {
       const labels = L.takeLabels();
       const cond = L.lowerCondition(stmt.expression);
-      const body = L.inCtl("loop", () => L.lowerScopedBlock(stmt.statement), labels);
+      const body = L.inCtl("loop", () =>
+        withRuntimeOptionalNarrowed(L, runtimeOptionalTrueIds(L, stmt.expression), () =>
+          L.lowerScopedBlock(stmt.statement)), labels);
       return { kind: "while", cond, body, ...(labels && { labels }), loc: locOf(stmt) };
     }
     if (ts.isDoStatement(stmt)) {
@@ -3200,7 +3205,9 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
     // later references to this name don't produce cascading errors.
     let init: IrExpr;
     try {
-      init = L.lowerExpr(decl.initializer);
+      init = immediatelyGuardedAbsenceProbe(L, decl)
+        ? (lowerAbsenceProbe(L, decl.initializer) ?? L.lowerExpr(decl.initializer))
+        : L.lowerExpr(decl.initializer);
     } catch (e) {
       if (e instanceof PoisonError) {
         const salvaged = L.mapTypeOf(L.typeOf(decl.name));
@@ -3277,16 +3284,19 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
         }
       }
     }
-    // A JS binding holding an OOB-SAFE indexed read (`elem | undefined` —
-    // the --npm-static last-element probe) where the checker spells the
-    // bare element: the binding adopts the union — the idiom's next line
-    // is the truthiness guard, which narrows it right back.
+    // An unannotated binding holding an OOB-SAFE indexed read (`elem |
+    // undefined`) where the checker spells the bare element: the binding
+    // adopts the runtime-honest union. This covers both inferred package JS
+    // and TypeScript's fresh-array probe idioms; an explicit annotation keeps
+    // the caller's checked slot contract.
+    let runtimeOptional = false;
     if (
-      type !== null && init.type.kind === "union" && isJsSourceFile(decl.getSourceFile()) &&
+      !decl.type && type !== null && init.type.kind === "union" &&
       L.armTag(init.type.unionId, UNDEFINED_T) >= 0 &&
       typeEquals(L.stripUndefinedArm(init.type), type)
     ) {
       type = init.type;
+      runtimeOptional = true;
     }
     // A JS binding whose checker type spells a FUNCTION but whose VALUE is
     // already checked-dynamic (`const cb = mustCall(fn)` — the helper's
@@ -3424,7 +3434,46 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
     // subtyping (`const p: {a: number} = wider;`) is rejected, not coerced.
     init = L.coerceInto(decl.initializer, init, type);
     const local = L.declareLocal(decl.name, decl.name.text, type, isLet);
+    if (runtimeOptional) {
+      L.runtimeOptionalLocals.add(local.id);
+      L.runtimeOptionalStorageLocals.add(local.id);
+    }
     return { kind: "varDecl", localId: local.id, init, loc: locOf(decl) };
+  }
+
+  function immediatelyGuardedAbsenceProbe(L: Lowerer, decl: ts.VariableDeclaration): boolean {
+    if (decl.type || !ts.isIdentifier(decl.name) || !decl.initializer) return false;
+    const statement = decl.parent?.parent;
+    if (!statement || !ts.isVariableStatement(statement)) return false;
+    const container = statement.parent;
+    const statements = ts.isBlock(container) || ts.isSourceFile(container) ? container.statements : null;
+    if (!statements) return false;
+    const index = statements.indexOf(statement);
+    const next = index >= 0 ? statements[index + 1] : undefined;
+    if (!next || !ts.isIfStatement(next)) return false;
+    let condition = next.expression;
+    while (ts.isParenthesizedExpression(condition)) condition = condition.expression;
+    if (!ts.isPrefixUnaryExpression(condition) || condition.operator !== ts.SyntaxKind.ExclamationToken) return false;
+    let operand = condition.operand;
+    while (ts.isParenthesizedExpression(operand)) operand = operand.expression;
+    return ts.isIdentifier(operand) && L.resolveValueSymbol(operand) === L.resolveValueSymbol(decl.name);
+  }
+
+  function falsyExitRuntimeOptionalLocal(L: Lowerer, stmt: ts.IfStatement): string | null {
+    if (stmt.elseStatement) return null;
+    let condition = stmt.expression;
+    while (ts.isParenthesizedExpression(condition)) condition = condition.expression;
+    if (!ts.isPrefixUnaryExpression(condition) || condition.operator !== ts.SyntaxKind.ExclamationToken) return null;
+    let operand = condition.operand;
+    while (ts.isParenthesizedExpression(operand)) operand = operand.expression;
+    if (!ts.isIdentifier(operand)) return null;
+    const local = L.resolveLocal(operand);
+    if (!local || !L.runtimeOptionalLocals.has(local.id)) return null;
+    const exits = ts.isReturnStatement(stmt.thenStatement) || ts.isThrowStatement(stmt.thenStatement) ||
+      (ts.isBlock(stmt.thenStatement) && stmt.thenStatement.statements.length > 0 &&
+        (ts.isReturnStatement(stmt.thenStatement.statements[stmt.thenStatement.statements.length - 1]!) ||
+          ts.isThrowStatement(stmt.thenStatement.statements[stmt.thenStatement.statements.length - 1]!)));
+    return exits ? local.id : null;
   }
 
 /** JS-exact switch (see docs/ir.md): one shared lexical scope for all case
@@ -4493,6 +4542,7 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         const target = L.resolveWritable(expr.left);
         if (!target) L.rejectUnresolved(expr.left, `assignment to '${expr.left.text}' (not a writable local or module global)`);
         const value = L.lowerExprExpecting(expr.right, target.type);
+        if (L.runtimeOptionalStorageLocals.has(target.id)) L.runtimeOptionalLocals.add(target.id);
         return { kind: "assign", localId: target.id, value, loc: locOf(expr) };
       }
       if (opKind === ts.SyntaxKind.QuestionQuestionEqualsToken) {

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -683,7 +683,7 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
           )
         : null;
       const narrowedAfter = falsyExitRuntimeOptionalLocal(L, stmt);
-      if (narrowedAfter !== null) L.runtimeOptionalLocals.delete(narrowedAfter);
+      if (narrowedAfter !== null) L.runtimeOptionalLocals.delete(L.runtimeOptionalRootOf(narrowedAfter));
       return { kind: "if", cond, then, else_, loc: locOf(stmt) };
     }
     if (ts.isWhileStatement(stmt)) {
@@ -3435,8 +3435,9 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
     init = L.coerceInto(decl.initializer, init, type);
     const local = L.declareLocal(decl.name, decl.name.text, type, isLet);
     if (runtimeOptional) {
-      L.runtimeOptionalLocals.add(local.id);
-      L.runtimeOptionalStorageLocals.add(local.id);
+      const runtimeOptionalRoot = L.runtimeOptionalRootOf(local);
+      L.runtimeOptionalLocals.add(runtimeOptionalRoot);
+      L.runtimeOptionalStorageLocals.add(runtimeOptionalRoot);
     }
     return { kind: "varDecl", localId: local.id, init, loc: locOf(decl) };
   }
@@ -3459,7 +3460,7 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
     return ts.isIdentifier(operand) && L.resolveValueSymbol(operand) === L.resolveValueSymbol(decl.name);
   }
 
-  function falsyExitRuntimeOptionalLocal(L: Lowerer, stmt: ts.IfStatement): string | null {
+  function falsyExitRuntimeOptionalLocal(L: Lowerer, stmt: ts.IfStatement): IrLocal | null {
     if (stmt.elseStatement) return null;
     let condition = stmt.expression;
     while (ts.isParenthesizedExpression(condition)) condition = condition.expression;
@@ -3468,12 +3469,12 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
     while (ts.isParenthesizedExpression(operand)) operand = operand.expression;
     if (!ts.isIdentifier(operand)) return null;
     const local = L.resolveLocal(operand);
-    if (!local || !L.runtimeOptionalLocals.has(local.id)) return null;
+    if (!local || !L.runtimeOptionalLocals.has(L.runtimeOptionalRootOf(local))) return null;
     const exits = ts.isReturnStatement(stmt.thenStatement) || ts.isThrowStatement(stmt.thenStatement) ||
       (ts.isBlock(stmt.thenStatement) && stmt.thenStatement.statements.length > 0 &&
         (ts.isReturnStatement(stmt.thenStatement.statements[stmt.thenStatement.statements.length - 1]!) ||
           ts.isThrowStatement(stmt.thenStatement.statements[stmt.thenStatement.statements.length - 1]!)));
-    return exits ? local.id : null;
+    return exits ? local : null;
   }
 
 /** JS-exact switch (see docs/ir.md): one shared lexical scope for all case
@@ -4542,7 +4543,8 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         const target = L.resolveWritable(expr.left);
         if (!target) L.rejectUnresolved(expr.left, `assignment to '${expr.left.text}' (not a writable local or module global)`);
         const value = L.lowerExprExpecting(expr.right, target.type);
-        if (L.runtimeOptionalStorageLocals.has(target.id)) L.runtimeOptionalLocals.add(target.id);
+        const runtimeOptionalRoot = L.runtimeOptionalRootOf(target);
+        if (L.runtimeOptionalStorageLocals.has(runtimeOptionalRoot)) L.runtimeOptionalLocals.add(runtimeOptionalRoot);
         return { kind: "assign", localId: target.id, value, loc: locOf(expr) };
       }
       if (opKind === ts.SyntaxKind.QuestionQuestionEqualsToken) {

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -880,6 +880,13 @@ export class Lowerer {
    * aliases, so this carries the var/let form the checker cannot.
    * Scoped strictly by narrowingAliases (lowerIf / lowerCondition). */
   readonly aliasNarrowTypes = new Map<ts.Symbol, ts.Type>();
+  /** Locals widened beyond the checker's type because an inferred indexed
+   * read can be absent at runtime. Bare reads preserve that union until a
+   * surrounding JavaScript guard/default consumes it. */
+  readonly runtimeOptionalLocals = new Set<string>();
+  /** All storage slots widened for runtime absence, including slots whose
+   * current control-flow branch has temporarily narrowed the value. */
+  readonly runtimeOptionalStorageLocals = new Set<string>();
 
   /** Runs `fn` with the given aliased-typeof narrows applied (and restored
    * after) — the branch-scoping primitive. */
@@ -7476,8 +7483,13 @@ export class Lowerer {
     return lowerElementAccess(this, expr);
   }
 
-  lowerRecordKeyRead(expr: ts.ElementAccessExpression, shapeId: string, shape: IrRecordShape): IrExpr {
-    return lowerRecordKeyRead(this, expr, shapeId, shape);
+  lowerRecordKeyRead(
+    expr: ts.ElementAccessExpression,
+    shapeId: string,
+    shape: IrRecordShape,
+    includeUndefined = false,
+  ): IrExpr {
+    return lowerRecordKeyRead(this, expr, shapeId, shape, includeUndefined);
   }
 
   lowerElementWrite(expr: ts.BinaryExpression): IrStmt {

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -883,10 +883,17 @@ export class Lowerer {
   /** Locals widened beyond the checker's type because an inferred indexed
    * read can be absent at runtime. Bare reads preserve that union until a
    * surrounding JavaScript guard/default consumes it. */
-  readonly runtimeOptionalLocals = new Set<string>();
+  readonly runtimeOptionalLocals = new Set<IrLocal>();
   /** All storage slots widened for runtime absence, including slots whose
    * current control-flow branch has temporarily narrowed the value. */
-  readonly runtimeOptionalStorageLocals = new Set<string>();
+  readonly runtimeOptionalStorageLocals = new Set<IrLocal>();
+  /** Capture entries and their origin share one mutable box. Normalize each
+   * entry to the origin so writes and flow proofs stay synchronized. */
+  readonly runtimeOptionalRoots = new Map<IrLocal, IrLocal>();
+
+  runtimeOptionalRootOf(local: IrLocal): IrLocal {
+    return this.runtimeOptionalRoots.get(local) ?? local;
+  }
 
   /** Runs `fn` with the given aliased-typeof narrows applied (and restored
    * after) — the branch-scoping primitive. */
@@ -1799,16 +1806,16 @@ export class Lowerer {
 
   /** Assignment-target resolution: a function local (possibly captured) or
    * a module global. tsc has already rejected writes to consts. */
-  resolveWritable(ident: ts.Identifier): { id: string; type: IrType } | null {
+  resolveWritable(ident: ts.Identifier): IrLocal | null {
     const local = this.resolveLocal(ident);
     if (local?.type.kind === "caught") {
       // tsc admits writes (the binding types as `unknown`), but the
       // snapshot is read-only by design — bind a new local instead.
       this.unsupported("SC1090", ident, "assignments to catch bindings");
     }
-    if (local) return { id: local.id, type: local.type };
+    if (local) return local;
     const g = this.globalOf(ident);
-    if (g) return { id: g.id, type: g.type };
+    if (g) return g;
     return null;
   }
 
@@ -6968,8 +6975,9 @@ export class Lowerer {
           ctx.captureBySymbol.set(symbol, entry);
           ctx.captures.push({ localId: entry.id, name: entry.name, type: entry.type });
           ctx.captureSources.push(parentEntry.id);
-          if (this.runtimeOptionalStorageLocals.has(parentEntry.id)) {
-            this.runtimeOptionalStorageLocals.add(entry.id);
+          const runtimeOptionalRoot = this.runtimeOptionalRootOf(parentEntry);
+          if (this.runtimeOptionalStorageLocals.has(runtimeOptionalRoot)) {
+            this.runtimeOptionalRoots.set(entry, runtimeOptionalRoot);
           }
         }
         parentEntry = entry;

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -6968,6 +6968,9 @@ export class Lowerer {
           ctx.captureBySymbol.set(symbol, entry);
           ctx.captures.push({ localId: entry.id, name: entry.name, type: entry.type });
           ctx.captureSources.push(parentEntry.id);
+          if (this.runtimeOptionalStorageLocals.has(parentEntry.id)) {
+            this.runtimeOptionalStorageLocals.add(entry.id);
+          }
         }
         parentEntry = entry;
       }

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2476,6 +2476,8 @@ export type IrLibFn =
    * period, never destroying the socket — Node's semantics). */
   | "http.reqStatusCode"
   | "http.reqSocket"
+  | "http.reqH2Stream"
+  | "http.reqH2StreamOrThrow"
   | "http.reqResume"
   /** req.rawHeaders — [name, value, name, value, ...] in arrival order,
    * names in their ORIGINAL case (Node's shape); a fresh string[] per
@@ -2707,23 +2709,16 @@ export type IrLibFn =
    * http.request). The "https." prefix keeps the TLS unit linked. */
   | "https.requestFn"
   | "https.requestFnCb"
-  /** node:http2, the compatibility slice (SEMANTICS.md divergence 57):
-   * createSecureServer is the https server WITHOUT an eager handler —
-   * the same scr_https_create_server with a NULL closure (ALPN
-   * advertises http/1.1 only; every connection serves HTTP/1.1).
-   * serverOnRequest installs 'request' listeners after creation (the
-   * http adapters pick the (req, res)/(req)/() shape; a once flag rides
-   * along; on a server with no HTTP parser the registration is dead
-   * weight, like Node's never-fired 'request' on a net server).
-   * serverOnSessionError evaluates and releases its callback — no h2
-   * session ever exists, so the event NEVER fires. */
+  /** node:http2 allowHTTP1: one TLS server advertises h2 + http/1.1 and
+   * dispatches to the matching parser after ALPN. Request listeners mirror
+   * into both compatibility lists; the remaining session/req.stream rows
+   * below retain their explicitly limited behavior. */
   | "http2.createSecureServer"
   /** createSecureServer(options, handler) — the eager COMPAT handler as
    * the first 'request' listener (Node's exact route), on both literal
-   * flavors: Req is the allowHTTP1 server (scr_https_create_server with
-   * the closure — HTTP/1.1 req/res handles), H2Req the ALPN=h2 server
-   * (the compat handles over h2 streams — scr_http2.c's layer). Args are
-   * (cert, key, cb). */
+   * flavors: Req is the dual ALPN allowHTTP1 server, H2Req the ALPN=h2-only
+   * server (both use compat handles over h2 streams). Args are
+   * (cert, key, cb, enableConnectProtocol). */
   | "http2.createSecureServerReq"
   | "http2.createSecureServerH2Req"
   /** createSecureServer with a RUNTIME options record (the divergence-66
@@ -2754,10 +2749,7 @@ export type IrLibFn =
   | "http2.createSecureServerH2"
   | "http.serverOnRequest"
   | "http2.serverOnSessionError"
-  /** The guarded h2-only stream call (`req.stream?.on(...)`): stream is
-   * undefined on every connection the allowHTTP1 lowering accepts, so
-   * the optional chain short-circuits — a VOID no-op the emitter drops
-   * (statement position enforced by the frontend). */
+  /** The guarded absent-session compatibility call remains a no-op. */
   | "http2.streamNoop"
   /** The UNGUARDED h2-only stream call (`req.stream.on(...)`): stream is
    * undefined on every connection the allowHTTP1 lowering accepts — and
@@ -4848,6 +4840,11 @@ export type IrExpr =
    * (+1); ownership of a refcounted payload MOVES into the union. Unions are
    * immutable once constructed. */
   | { kind: "unionWrap"; unionId: string; tag: number; value: IrExpr; type: IrType; loc: SrcLoc }
+  /** Strict identity comparison between a function arm of a union and a
+   * function value with a potentially different static signature. This is
+   * non-coercing: closures share one pointer representation, but the value
+   * never enters the union or becomes callable through its arm type. */
+  | { kind: "unionFuncEq"; unionId: string; tag: number; union: IrExpr; func: IrExpr; negated: boolean; type: IrType; loc: SrcLoc }
   /** Runtime test on a catch binding (`value` is a caught-typed varRef,
    * borrowed). The primitive tests ("string"/"number"/"boolean") compare
    * the snapshot's kind tag — exactly what `typeof e === "..."` observes;
@@ -6484,8 +6481,7 @@ export function moduleUsesHttpServer(mod: IrModule): boolean {
  * allowHTTP1 compatibility slice) — they must NOT pull scr_http2.c, so
  * divergence-57 binaries keep their exact link line. */
 const HTTP2_LEGACY_FNS = new Set([
-  "http2.createSecureServer", "http2.createSecureServerSni",
-  "http2.serverOnSessionError", "http2.streamNoop", "http2.streamUndefCall",
+  "http2.streamNoop", "http2.streamUndefCall",
 ]);
 
 /** True when the module uses the REAL h2 surface (scr_http2.c): any core
@@ -6978,6 +6974,7 @@ export const MAY_THROW_LIB_FNS: ReadonlySet<IrLibFn> = new Set([
   "process.stdinSetRawMode",
   // The unguarded h2-only stream call: always throws Node's TypeError.
   "http2.streamUndefCall",
+  "http.reqH2StreamOrThrow",
   // A read of a declare-d const nothing defines: always throws Node's
   // catchable ReferenceError.
   "global.undefRead",

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -472,6 +472,10 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "http.serverOnConnect": { argTypes: [NETSERVER_T, null, BOOL], result: VOID },
   "http.clientOnUpgrade": { argTypes: [HTTPCLIENTREQ_T, null, BOOL], result: VOID },
   "http.reqSocket": { argTypes: [HTTPREQ_T], result: NETSOCKET_T },
+  // reqH2Stream's program-interned Http2Stream | undefined result is
+  // checked in the special libCall cases below.
+  "http.reqH2Stream": { argTypes: [HTTPREQ_T], result: VOID },
+  "http.reqH2StreamOrThrow": { argTypes: [HTTPREQ_T, STRING], result: HTTP2STREAM_T },
   "http.reqPipeRes": { argTypes: [HTTPREQ_T, HTTPRES_T], result: VOID },
   "http.reqPipeClient": { argTypes: [HTTPREQ_T, HTTPCLIENTREQ_T], result: VOID },
   "http.reqPipeSock": { argTypes: [HTTPREQ_T, NETSOCKET_T], result: VOID },
@@ -530,8 +534,8 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "tls.createServerDynCb": { argTypes: [DYN, null], result: NETSERVER_T },
   "https.createServerDyn": { argTypes: [DYN], result: NETSERVER_T },
   "https.createServerDynCb": { argTypes: [DYN, null], result: NETSERVER_T },
-  "http2.createSecureServerReq": { argTypes: [null, null, null], result: NETSERVER_T },
-  "http2.createSecureServerH2Req": { argTypes: [null, null, null], result: NETSERVER_T },
+  "http2.createSecureServerReq": { argTypes: [null, null, null, BOOL], result: NETSERVER_T },
+  "http2.createSecureServerH2Req": { argTypes: [null, null, null, BOOL], result: NETSERVER_T },
   "http2.createSecureServerDyn": { argTypes: [DYN], result: NETSERVER_T },
   "http2.createSecureServerDynCb": { argTypes: [DYN, null], result: NETSERVER_T },
   // tls.connect(port, host, opts[, cb]) — port -1 / host "" read the
@@ -557,18 +561,17 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   // http2's allowHTTP1 compatibility server (divergence 57): cert/key
   // like tls.createServer; the 'request' handler arrives separately via
   // http.serverOnRequest (shape checked in the libCall case, like
-  // http.createServer's). serverOnSessionError's callback is any void
-  // closure — it is released unread (no h2 session ever fires it).
-  "http2.createSecureServer": { argTypes: [null, null], result: NETSERVER_T },
+  // http.createServer's). sessionError callback shape is checked below.
+  "http2.createSecureServer": { argTypes: [null, null, BOOL], result: NETSERVER_T },
   // The SNI-callback form: arg 2 is the JS SNICallback closure — a
   // `(servername, cb) => void` func, or its `| undefined` union from the
   // conditional-spread spelling (the libCall case checks the shape).
-  "http2.createSecureServerSni": { argTypes: [null, null, null], result: NETSERVER_T },
+  "http2.createSecureServerSni": { argTypes: [null, null, null, BOOL], result: NETSERVER_T },
   // The ALPN=h2 server (createSecureServer without allowHTTP1): the real
   // h2 session machinery behind the TLS handshake.
-  "http2.createSecureServerH2": { argTypes: [null, null], result: NETSERVER_T },
+  "http2.createSecureServerH2": { argTypes: [null, null, BOOL], result: NETSERVER_T },
   "http.serverOnRequest": { argTypes: [NETSERVER_T, null, BOOL], result: VOID },
-  "http2.serverOnSessionError": { argTypes: [NETSERVER_T, null], result: VOID },
+  "http2.serverOnSessionError": { argTypes: [NETSERVER_T, null, BOOL], result: VOID },
   "http2.streamNoop": { argTypes: [], result: VOID },
   "http2.streamUndefCall": { argTypes: [STRING], result: VOID },
   // The REAL h2c surface (scr_http2.c). Callback slots are null (the
@@ -1908,6 +1911,23 @@ function validateFunction(
         expectType(e.left, ut, "unionEq left");
         expectType(e.right, ut, "unionEq right");
         if (e.type.kind !== "bool") err("unionEq must be bool", e.loc);
+        break;
+      }
+      case "unionFuncEq": {
+        checkExpr(e.union);
+        checkExpr(e.func);
+        const def = unions.get(e.unionId);
+        if (!def) err(`unionFuncEq of unknown union ${e.unionId}`, e.loc);
+        expectType(e.union, { kind: "union", unionId: e.unionId }, "unionFuncEq union");
+        const arm = def?.arms[e.tag];
+        if (!Number.isInteger(e.tag) || arm?.kind !== "func") {
+          err(`unionFuncEq tag ${e.tag} must select a function arm of ${e.unionId}`, e.loc);
+        }
+        if ((def?.arms.filter((candidate) => candidate.kind === "func").length ?? 0) !== 1) {
+          err(`unionFuncEq requires exactly one function arm in ${e.unionId}`, e.loc);
+        }
+        if (e.func.type.kind !== "func") err("unionFuncEq function operand must be func", e.loc);
+        if (e.type.kind !== "bool") err("unionFuncEq must be bool", e.loc);
         break;
       }
       case "strConcat":
@@ -3655,7 +3675,12 @@ function validateFunction(
         }
         if (e.fn === "http2.serverOnSessionError") {
           const cbT = e.args[1]?.type;
-          if (cbT?.kind !== "func" || cbT.ret.kind !== "void") {
+          const ok = cbT?.kind === "func" && cbT.ret.kind === "void" &&
+            cbT.params.length <= 2 &&
+            (cbT.params[0] === undefined ||
+              (cbT.params[0].kind === "object" && cbT.params[0].className === "%Error")) &&
+            (cbT.params[1] === undefined || cbT.params[1].kind === "http2Session");
+          if (!ok) {
             err(`libCall http2.serverOnSessionError callback shape (frontend must fence)`, e.loc);
           }
           break;
@@ -3860,6 +3885,14 @@ function validateFunction(
           if (!ok) {
             err(`libCall http.reqStatusMessage must return the 'string | undefined' union`, e.loc);
           }
+          break;
+        }
+        if (e.fn === "http.reqH2Stream") {
+          const def = e.type.kind === "union" ? unions.get(e.type.unionId) : undefined;
+          const ok = def && def.arms.length === 2 &&
+            def.arms.some((a) => a.kind === "http2Stream") &&
+            def.arms.some((a) => a.kind === "undefinedT");
+          if (!ok) err(`libCall http.reqH2Stream must return the 'Http2Stream | undefined' union`, e.loc);
           break;
         }
         if (e.fn === "http.reqHeader" || e.fn === "http.resGetHeader") {

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -5506,9 +5506,27 @@
    ],
    "diags": []
   },
+  "<repo>/tests/corpus/2675-process-self-reexec.ts": {
+   "order": [
+    "<repo>/tests/corpus/2675-process-self-reexec.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2676-indexed-read-strict-equality.ts": {
+   "order": [
+    "<repo>/tests/corpus/2676-indexed-read-strict-equality.ts"
+   ],
+   "diags": []
+  },
   "<repo>/tests/corpus/2676-top-level-await-ambiguous/main.ts": {
    "order": [
     "<repo>/tests/corpus/2676-top-level-await-ambiguous/main.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2677-runtime-optional-closure.ts": {
+   "order": [
+    "<repo>/tests/corpus/2677-runtime-optional-closure.ts"
    ],
    "diags": []
   },
@@ -7645,6 +7663,12 @@
   "<repo>/tests/diagnostics/regex.ts": {
    "order": [
     "<repo>/tests/diagnostics/regex.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/diagnostics/runtime-optional-capture-chain.ts": {
+   "order": [
+    "<repo>/tests/diagnostics/runtime-optional-capture-chain.ts"
    ],
    "diags": []
   },

--- a/packages/runtime/src/scr_http.c
+++ b/packages/runtime/src/scr_http.c
@@ -112,12 +112,23 @@ static const char *scr_http_reason(int code) {
  * typedef lives in scr_runtime.h (both units name it). */
 static const ScrHttpH2Ops *scr_http_h2_ops = NULL;
 static void (*scr_http_h2_request_hook)(void *h2ctx, ScrClosure *cb /*moves*/,
+                                         void *fn, bool once) = NULL;
+static void (*scr_http_h2_connect_hook)(void *h2ctx, ScrClosure *cb /*moves*/,
+                                        void *h1_fn, void *h2_fn, bool once) = NULL;
+static void (*scr_http_h2_upgrade_hook)(void *h2ctx, ScrClosure *cb /*moves*/,
                                         void *fn, bool once) = NULL;
 
 void scr_http_set_h2_ops(const ScrHttpH2Ops *ops) { scr_http_h2_ops = ops; }
 
 void scr_http_set_h2_request_hook(void (*hook)(void *h2ctx, ScrClosure *cb, void *fn, bool once)) {
   scr_http_h2_request_hook = hook;
+}
+void scr_http_set_h2_connect_hook(void (*hook)(void *h2ctx, ScrClosure *cb,
+                                               void *h1_fn, void *h2_fn, bool once)) {
+  scr_http_h2_connect_hook = hook;
+}
+void scr_http_set_h2_upgrade_hook(void (*hook)(void *h2ctx, ScrClosure *cb, void *fn, bool once)) {
+  scr_http_h2_upgrade_hook = hook;
 }
 
 /* ── the request handle ──────────────────────────────────────────────── */
@@ -762,6 +773,27 @@ static void scr_http_buf_append(ScrHttpBuf *b, const char *s, size_t n) {
 
 static void scr_http_buf_str(ScrHttpBuf *b, const char *s) { scr_http_buf_append(b, s, strlen(s)); }
 
+static bool scr_http_header_has_token(const ScrStr *value, const char *token) {
+  size_t token_len = strlen(token);
+  for (size_t off = 0; off < value->len;) {
+    while (off < value->len &&
+           (value->data[off] == ',' || value->data[off] == ' ' || value->data[off] == '\t')) off++;
+    size_t end = off;
+    while (end < value->len && value->data[end] != ',' &&
+           value->data[end] != ' ' && value->data[end] != '\t') end++;
+    if (end - off == token_len) {
+      bool equal = true;
+      for (size_t i = 0; i < token_len && equal; i++) {
+        if (tolower((unsigned char)value->data[off + i]) != token[i]) equal = false;
+      }
+      if (equal) return true;
+    }
+    while (end < value->len && value->data[end] != ',') end++;
+    off = end;
+  }
+  return false;
+}
+
 /* Serializes and sends the head. `body_len` >= 0 fixes Content-Length
  * (the end(data)-before-head path); -1 means chunked unless the user set
  * Content-Length or Transfer-Encoding (Node's useChunkedEncodingByDefault
@@ -788,12 +820,19 @@ static void scr_http_res_send_head(ScrHttpRes *r, long long body_len) {
   if (r->status_msg) scr_http_buf_append(&b, r->status_msg->data, r->status_msg->len);
   else scr_http_buf_str(&b, scr_http_reason(status));
   scr_http_buf_str(&b, "\r\n");
+  bool user_chunked = false;
   for (size_t i = 0; i < r->nheaders; i++) {
     scr_http_buf_append(&b, r->hnames[i]->data, r->hnames[i]->len);
     scr_http_buf_str(&b, ": ");
     scr_http_buf_append(&b, r->hvalues[i]->data, r->hvalues[i]->len);
     scr_http_buf_str(&b, "\r\n");
+    bool transfer = r->hnames[i]->len == 17;
+    for (size_t j = 0; j < 17 && transfer; j++) {
+      if (tolower((unsigned char)r->hnames[i]->data[j]) != "transfer-encoding"[j]) transfer = false;
+    }
+    if (transfer && scr_http_header_has_token(r->hvalues[i], "chunked")) user_chunked = true;
   }
+  r->chunked = user_chunked;
   if (!r->no_date && !scr_http_res_has_header(r, "date")) {
     /* Node's utcDate: "Date: Wed, 16 Jul 2026 04:20:00 GMT" */
     time_t now = time(NULL);
@@ -1406,6 +1445,50 @@ static void scr_http_srv_ctx_settle(void *p) {
   scr_net_ls_drop(&ctx->connect_ls);
 }
 
+/* Combined HTTP/2 allowHTTP1 servers retain the HTTP/1 parser ctx behind
+ * their h2-facing alias. These narrow hooks let scr_http2.c mirror request
+ * listeners and settle both protocol lists without exposing the ctx shape. */
+void scr_http1_ctx_on_request(void *p, ScrClosure *cb /*moves*/, ScrHttpReqFn fn, bool once,
+                              ScrNetOnce *shared_once /*moves, nullable*/) {
+  ScrHttpSrvCtx *ctx = (ScrHttpSrvCtx *)p;
+  if (ctx == NULL || ctx->proto != SCR_NET_PROTO_HTTP1) {
+    scr_closure_release(cb);
+    scr_net_once_release(shared_once);
+    return;
+  }
+  if (shared_once != NULL) {
+    scr_net_ls_add_shared_once(&ctx->request_ls, cb, (void *)fn, shared_once);
+  } else {
+    scr_net_ls_add(&ctx->request_ls, cb, (void *)fn, once);
+  }
+}
+
+void scr_http1_ctx_on_connect(void *p, ScrClosure *cb /*moves*/, ScrHttpUpgradeFn fn, bool once,
+                              ScrNetOnce *shared_once /*moves, nullable*/) {
+  ScrHttpSrvCtx *ctx = (ScrHttpSrvCtx *)p;
+  if (ctx == NULL || ctx->proto != SCR_NET_PROTO_HTTP1) {
+    scr_closure_release(cb);
+    scr_net_once_release(shared_once);
+    return;
+  }
+  if (shared_once != NULL) {
+    scr_net_ls_add_shared_once(&ctx->connect_ls, cb, (void *)fn, shared_once);
+  } else {
+    scr_net_ls_add(&ctx->connect_ls, cb, (void *)fn, once);
+  }
+}
+
+void scr_http1_ctx_on_upgrade(void *p, ScrClosure *cb /*moves*/, ScrHttpUpgradeFn fn, bool once) {
+  ScrHttpSrvCtx *ctx = (ScrHttpSrvCtx *)p;
+  if (ctx == NULL || ctx->proto != SCR_NET_PROTO_HTTP1) {
+    scr_closure_release(cb);
+    return;
+  }
+  scr_net_ls_add(&ctx->upgrade_ls, cb, (void *)fn, once);
+}
+
+void scr_http1_ctx_settle(void *p) { scr_http_srv_ctx_settle(p); }
+
 static void scr_http_conn_drop_request(ScrHttpConn *conn, bool fire_end) {
   /* the deferred 'close' emits: res before req, Node's order */
   if (conn->res) scr_http_queue_res_close(conn->res);
@@ -1626,13 +1709,12 @@ static bool scr_http_conn_parse_head(ScrHttpConn *conn, size_t head_len) {
   /* A CONNECT request: 'connect' fires INSTEAD of 'request' — the
    * upgrade machinery's exact shape ((req, socket, head); the parser
    * steps aside; no listener destroys the socket, Node's default). The
-   * h2 compat server's HTTP/1.1 arm lands here too — under the
-   * allowHTTP1 lowering it is the ONLY arm (SEMANTICS.md divergence
-   * 57), so a portless-style listener always takes the raw socket. */
+   * h2 compat server's HTTP/1.1 arm lands here too; its HTTP/2 arm is
+   * dispatched separately with the compatibility response handle. */
   if (req->method->len == 7 && memcmp(req->method->data, "CONNECT", 7) == 0) {
     memmove(conn->buf, conn->buf + head_len, conn->len - head_len);
     conn->len -= head_len;
-    if (conn->srv->connect_ls.n == 0) {
+    if (!scr_net_ls_has_live(&conn->srv->connect_ls)) {
       scr_http_req_release(req);
       conn->len = 0;
       scr_net_sock_destroy(conn->sock);
@@ -2082,6 +2164,16 @@ ScrHttpReq *scr_http_h2_req_new(ScrNetSocket *sock /*borrowed, nullable*/,
   return req;
 }
 
+void *scr_http_req_h2_stream(ScrHttpReq *r) {
+  return r->h2_stream != NULL ? scr_http_h2_ops->retain(r->h2_stream) : NULL;
+}
+
+void *scr_http_req_h2_stream_or_throw(ScrHttpReq *r, ScrStr *member /*borrowed*/) {
+  if (r->h2_stream != NULL) return scr_http_h2_ops->retain(r->h2_stream);
+  scr_http2_stream_undef_call(member);
+  return NULL;
+}
+
 void scr_http_h2_req_line(ScrHttpReq *r, ScrStr *method /*borrowed, nullable*/,
                            ScrStr *url /*borrowed, nullable*/) {
   if (method != NULL) {
@@ -2148,23 +2240,36 @@ bool scr_http_h2_res_finished(ScrHttpRes *r) { return r->finished; }
  * server.on("upgrade", ...) below: the registration twins of on_request.
  * On a server with no HTTP parser neither list ever fires — honest dead
  * weight, Node's shape. */
-void scr_http_server_on_connect(ScrNetServer *s, ScrClosure *cb /*moves*/, ScrHttpUpgradeFn fn,
+void scr_http_server_on_connect(ScrNetServer *s, ScrClosure *cb /*moves*/,
+                                 ScrHttpUpgradeFn h1_fn, ScrHttpConnectH2Fn h2_fn,
                                  bool once) {
   ScrHttpSrvCtx *ctx = (ScrHttpSrvCtx *)scr_net_server_get_http_ctx(s);
-  if (ctx != NULL && ctx->proto != SCR_NET_PROTO_HTTP1) ctx = NULL; /* an h2 server's ctx */
+  if (ctx != NULL && ctx->proto != SCR_NET_PROTO_HTTP1) {
+    if (scr_http_h2_connect_hook != NULL && !scr_net_server_settled(s)) {
+      scr_http_h2_connect_hook(ctx, cb, (void *)h1_fn, (void *)h2_fn, once);
+      return;
+    }
+    ctx = NULL;
+  }
   if (ctx == NULL) {
     /* no HTTP parser on this server: the event can never fire (Node's
      * net server never emits 'connect' either) — honest dead weight */
     scr_closure_release(cb);
     return;
   }
-  scr_net_ls_add(&ctx->connect_ls, cb, (void *)fn, once);
+  scr_net_ls_add(&ctx->connect_ls, cb, (void *)h1_fn, once);
 }
 
 void scr_http_server_on_upgrade(ScrNetServer *s, ScrClosure *cb /*moves*/, ScrHttpUpgradeFn fn,
-                                 bool once) {
+                                  bool once) {
   ScrHttpSrvCtx *ctx = (ScrHttpSrvCtx *)scr_net_server_get_http_ctx(s);
-  if (ctx != NULL && ctx->proto != SCR_NET_PROTO_HTTP1) ctx = NULL; /* an h2 server's ctx */
+  if (ctx != NULL && ctx->proto != SCR_NET_PROTO_HTTP1) {
+    if (scr_http_h2_upgrade_hook != NULL && !scr_net_server_settled(s)) {
+      scr_http_h2_upgrade_hook(ctx, cb, (void *)fn, once);
+      return;
+    }
+    ctx = NULL;
+  }
   if (ctx == NULL) {
     scr_closure_release(cb);
     return;

--- a/packages/runtime/src/scr_http2.c
+++ b/packages/runtime/src/scr_http2.c
@@ -688,7 +688,11 @@ typedef struct ScrH2SrvCtx {
   ScrNetLs stream_ls;
   ScrNetLs session_ls;
   ScrNetLs request_ls; /* the compat (req, res) listeners — createServer's
-                        * eager handler and server.on("request", ...) */
+                         * eager handler and server.on("request", ...) */
+  ScrNetLs connect_ls; /* traditional/RFC 8441 CONNECT (req, res) listeners */
+  ScrNetLs session_error_ls; /* server 'sessionError' (err, session) */
+  void *http1_ctx;     /* borrowed: owned by the TLS wrapper's inner hook */
+  bool enable_connect_protocol;
 } ScrH2SrvCtx;
 
 /* The SETTINGS the API observes (session.localSettings/remoteSettings —
@@ -750,6 +754,7 @@ struct ScrH2Session {
   /* the API-visible settings records + the in-flight local ack */
   ScrH2Settings local_settings, remote_settings;
   bool pending_settings_ack;
+  bool error_emitted;
   ScrNetLs stream_ls, close_ls, err_ls, connect_ls, goaway_ls,
       remote_settings_ls, local_settings_ls;
 };
@@ -802,6 +807,8 @@ static void scr_h2_srv_ctx_release(ScrH2SrvCtx *ctx) {
   scr_net_ls_drop(&ctx->stream_ls);
   scr_net_ls_drop(&ctx->session_ls);
   scr_net_ls_drop(&ctx->request_ls);
+  scr_net_ls_drop(&ctx->connect_ls);
+  scr_net_ls_drop(&ctx->session_error_ls);
   free(ctx);
 }
 
@@ -947,6 +954,11 @@ static void scr_h2_send_settings(ScrH2Session *s) {
   if (s->client) {
     static const uint8_t no_push[6] = { 0x0, 0x2, 0, 0, 0, 0 };
     scr_h2_send_frame(s, SCR_H2_F_SETTINGS, 0, 0, no_push, 6);
+    return;
+  }
+  if (s->local_settings.enable_connect_protocol) {
+    static const uint8_t enable_connect[6] = { 0x0, 0x8, 0, 0, 0, 1 };
+    scr_h2_send_frame(s, SCR_H2_F_SETTINGS, 0, 0, enable_connect, 6);
     return;
   }
   scr_h2_send_frame(s, SCR_H2_F_SETTINGS, 0, 0, NULL, 0);
@@ -1233,6 +1245,8 @@ static void scr_h2_cleanup_atexit(void) {
 
 static const ScrHttpH2Ops scr_h2_compat_ops;
 static void scr_h2_request_hook(void *ctx, ScrClosure *cb, void *fn, bool once);
+static void scr_h2_connect_hook(void *ctx, ScrClosure *cb, void *h1_fn, void *h2_fn, bool once);
+static void scr_h2_upgrade_hook(void *ctx, ScrClosure *cb, void *fn, bool once);
 
 static void scr_http2_install(void) {
   static bool installed = false;
@@ -1244,6 +1258,8 @@ static void scr_http2_install(void) {
    * ops vtable and h2-tagged 'request' registrations through the hook */
   scr_http_set_h2_ops(&scr_h2_compat_ops);
   scr_http_set_h2_request_hook(&scr_h2_request_hook);
+  scr_http_set_h2_connect_hook(&scr_h2_connect_hook);
+  scr_http_set_h2_upgrade_hook(&scr_h2_upgrade_hook);
 }
 
 /* ── session lifecycle ───────────────────────────────────────────────── */
@@ -1281,6 +1297,31 @@ static void scr_h2_session_abort_streams(ScrH2Session *s) {
   }
 }
 
+static void scr_h2_session_fail(ScrH2Session *s, const char *text) {
+  if (s->error_emitted) return;
+  s->error_emitted = true;
+  ScrStr *msg = scr_str_new(text, strlen(text));
+  if (s->srv != NULL && s->srv->session_error_ls.n > 0) {
+    ScrNetL *snap;
+    size_t n = scr_net_ls_snapshot(&s->srv->session_error_ls, &snap);
+    ScrNetServer *server = s->sock ? scr_net_sock_server(s->sock) : NULL;
+    scr_dyn_this_push(server, SCR_DYNH_NET_SERVER);
+    for (size_t i = 0; i < n; i++) {
+      if (!scr_exc_pending()) {
+        ((ScrH2SessionErrorFn)snap[i].fn)(snap[i].cb, msg,
+                                          scr_http2_session_retain(s));
+      }
+      scr_closure_release(snap[i].cb);
+    }
+    scr_dyn_this_pop();
+    free(snap);
+  }
+  if (!scr_exc_pending() && s->err_ls.n > 0) {
+    scr_net_fire_err_this(&s->err_ls, msg, s, SCR_DYNH_H2_SESSION);
+  }
+  scr_str_release(msg);
+}
+
 void scr_http2_session_destroy(ScrH2Session *s) {
   if (s->destroyed) return;
   s->destroyed = true;
@@ -1303,7 +1344,7 @@ static void scr_h2_dispatch_headers(ScrH2Session *s, int32_t stream_id, uint8_t 
                                      ScrH2Headers *h);
 static void scr_h2_stream_flush(ScrH2Stream *st);
 static void scr_h2_compat_dispatch(ScrH2Session *s, ScrH2Stream *st, const ScrH2Headers *h,
-                                    bool end_stream);
+                                    bool end_stream, ScrNetLs *listeners);
 
 /* The settings record the API observes (Node's key order; maxHeaderSize
  * aliases maxHeaderListSize; customSettings not modeled — empty). +1. */
@@ -1342,8 +1383,7 @@ static bool scr_h2_on_frame(ScrH2Session *s, uint8_t type, uint8_t flags, int32_
                              const uint8_t *p, size_t n) {
   /* An open header block admits only its CONTINUATIONs. */
   if (s->hblock_active && type != SCR_H2_F_CONTINUATION) {
-    scr_http2_session_destroy(s);
-    return false;
+    goto proto_err;
   }
   switch (type) {
   case SCR_H2_F_HEADERS: {
@@ -1583,6 +1623,7 @@ static bool scr_h2_on_frame(ScrH2Session *s, uint8_t type, uint8_t flags, int32_
   return true;
 proto_err:
   scr_h2_send_goaway(s, 1 /* NGHTTP2_PROTOCOL_ERROR */);
+  scr_h2_session_fail(s, "Protocol error");
   scr_http2_session_destroy(s);
   return false;
 }
@@ -1605,6 +1646,7 @@ static void scr_h2_on_data(void *ctx, const char *buf, size_t n) {
   if (!s->client && !s->preface_done) {
     if (s->rlen - off < 24) goto done;
     if (memcmp(s->rbuf + off, SCR_H2_PREFACE, 24) != 0) {
+      scr_h2_session_fail(s, "Protocol error");
       scr_http2_session_destroy(s);
       goto done;
     }
@@ -1659,8 +1701,10 @@ static void scr_h2_on_closed(void *ctx) {
 
 static bool scr_h2_on_err(void *ctx, ScrStr *msg) {
   ScrH2Session *s = ctx;
-  if (s->err_ls.n == 0) return false; /* the socket's error story applies */
-  scr_net_fire_err_this(&s->err_ls, msg, s, SCR_DYNH_H2_SESSION);
+  if (s->err_ls.n == 0 && (s->srv == NULL || s->srv->session_error_ls.n == 0)) {
+    return false; /* the socket's error story applies */
+  }
+  scr_h2_session_fail(s, (const char *)msg->data);
   return true;
 }
 
@@ -2043,6 +2087,15 @@ static void scr_h2_dispatch_headers(ScrH2Session *s, int32_t stream_id, uint8_t 
       st->end_recv = true;
       st->state = SCR_H2_S_CLOSED_REMOTE;
     }
+    bool connect_request = false;
+    for (size_t i = 0; i < h->n; i++) {
+      ScrStr *name = h->names[i];
+      ScrStr *value = h->values[i];
+      if (name->len == 7 && memcmp(name->data, ":method", 7) == 0 &&
+          value->len == 7 && memcmp(value->data, "CONNECT", 7) == 0) {
+        connect_request = true;
+      }
+    }
     ScrArr *pairs = scr_h2_headers_pairs(h, false, NULL);
     ScrNetServer *server = s->sock ? scr_net_sock_server(s->sock) : NULL;
     if (s->srv) scr_h2_fire_stream_list(&s->srv->stream_ls, st, pairs, fl, server, SCR_DYNH_NET_SERVER);
@@ -2050,9 +2103,12 @@ static void scr_h2_dispatch_headers(ScrH2Session *s, int32_t stream_id, uint8_t 
       scr_h2_fire_stream_list(&s->stream_ls, st, pairs, fl, s, SCR_DYNH_H2_SESSION);
     }
     scr_arr_release(pairs);
-    /* the compat layer: 'request' listeners get the (req, res) pair */
-    if (!scr_exc_pending() && s->srv != NULL && s->srv->request_ls.n > 0 && !st->destroyed) {
-      scr_h2_compat_dispatch(s, st, h, end_stream);
+    /* The stream events precede their compatibility event, Node's order.
+     * Both traditional and extended CONNECT emit 'connect', never
+     * 'request'; ordinary methods retain the request path. */
+    if (!scr_exc_pending() && s->srv != NULL && !st->destroyed) {
+      ScrNetLs *listeners = connect_request ? &s->srv->connect_ls : &s->srv->request_ls;
+      if (scr_net_ls_has_live(listeners)) scr_h2_compat_dispatch(s, st, h, end_stream, listeners);
     }
     scr_http2_stream_release(st);
     return;
@@ -2171,13 +2227,57 @@ static const ScrHttpH2Ops scr_h2_compat_ops = {
  * ctx carries the h2 proto tag (the compat registration seam). */
 static void scr_h2_request_hook(void *ctx, ScrClosure *cb /*moves*/, void *fn, bool once) {
   ScrH2SrvCtx *srv = (ScrH2SrvCtx *)ctx;
-  scr_net_ls_add(&srv->request_ls, cb, fn, once);
+  ScrNetOnce *shared_once = srv->http1_ctx != NULL && once ? scr_net_once_new() : NULL;
+  if (srv->http1_ctx != NULL) {
+    scr_http1_ctx_on_request(srv->http1_ctx, scr_closure_retain(cb), (ScrHttpReqFn)fn, once,
+                             shared_once != NULL ? scr_net_once_retain(shared_once) : NULL);
+  }
+  if (shared_once != NULL) {
+    scr_net_ls_add_shared_once(&srv->request_ls, cb, fn, shared_once);
+  } else {
+    scr_net_ls_add(&srv->request_ls, cb, fn, once);
+  }
+}
+
+static void scr_h2_connect_hook(void *ctx, ScrClosure *cb /*moves*/,
+                                void *h1_fn, void *h2_fn, bool once) {
+  ScrH2SrvCtx *srv = (ScrH2SrvCtx *)ctx;
+  bool have_h1 = srv->http1_ctx != NULL;
+  bool have_h2 = h2_fn != NULL;
+  ScrNetOnce *shared_once = have_h1 && have_h2 && once ? scr_net_once_new() : NULL;
+  if (!have_h1 && !have_h2) {
+    scr_closure_release(cb);
+    return;
+  }
+  if (have_h1 && !have_h2) {
+    scr_http1_ctx_on_connect(srv->http1_ctx, cb, (ScrHttpUpgradeFn)h1_fn, once, NULL);
+    return;
+  }
+  if (srv->http1_ctx != NULL) {
+    scr_http1_ctx_on_connect(srv->http1_ctx, scr_closure_retain(cb),
+                             (ScrHttpUpgradeFn)h1_fn, once,
+                             shared_once != NULL ? scr_net_once_retain(shared_once) : NULL);
+  }
+  if (shared_once != NULL) {
+    scr_net_ls_add_shared_once(&srv->connect_ls, cb, h2_fn, shared_once);
+  } else {
+    scr_net_ls_add(&srv->connect_ls, cb, h2_fn, once);
+  }
+}
+
+static void scr_h2_upgrade_hook(void *ctx, ScrClosure *cb /*moves*/, void *fn, bool once) {
+  ScrH2SrvCtx *srv = (ScrH2SrvCtx *)ctx;
+  if (srv->http1_ctx != NULL) {
+    scr_http1_ctx_on_upgrade(srv->http1_ctx, cb, (ScrHttpUpgradeFn)fn, once);
+  } else {
+    scr_closure_release(cb);
+  }
 }
 
 /* Build the (req, res) pair over a fresh server stream and fire the
  * 'request' listeners (this = the net server, the http/1 shape). */
 static void scr_h2_compat_dispatch(ScrH2Session *s, ScrH2Stream *st, const ScrH2Headers *h,
-                                    bool end_stream) {
+                                    bool end_stream, ScrNetLs *listeners) {
   ScrHttpReq *req = scr_http_h2_req_new(s->sock, st);
   for (size_t i = 0; i < h->n; i++) {
     ScrStr *name = h->names[i];
@@ -2199,7 +2299,7 @@ static void scr_h2_compat_dispatch(ScrH2Session *s, ScrH2Stream *st, const ScrH2
    * already satisfied (settle conditions see a delivered read side) */
   if (end_stream) st->end_emitted = true;
   ScrNetL *snap;
-  size_t n = scr_net_ls_snapshot(&s->srv->request_ls, &snap);
+  size_t n = scr_net_ls_snapshot(listeners, &snap);
   ScrNetServer *server = s->sock ? scr_net_sock_server(s->sock) : NULL;
   scr_dyn_this_push(server, SCR_DYNH_NET_SERVER);
   for (size_t i = 0; i < n; i++) {
@@ -2226,6 +2326,9 @@ static void scr_h2_srv_ctx_settle(void *p) {
   scr_net_ls_drop(&ctx->stream_ls);
   scr_net_ls_drop(&ctx->session_ls);
   scr_net_ls_drop(&ctx->request_ls);
+  scr_net_ls_drop(&ctx->connect_ls);
+  scr_net_ls_drop(&ctx->session_error_ls);
+  if (ctx->http1_ctx != NULL) scr_http1_ctx_settle(ctx->http1_ctx);
 }
 
 static void scr_h2_on_connection(void *ctx, ScrNetSocket *sock) {
@@ -2234,6 +2337,7 @@ static void scr_h2_on_connection(void *ctx, ScrNetSocket *sock) {
   sess->srv = scr_h2_srv_ctx_retain(srv);
   sess->sock = scr_net_sock_retain(sock);
   sess->next_stream_id = 2; /* server-initiated ids are even (push, unused) */
+  sess->local_settings.enable_connect_protocol = srv->enable_connect_protocol;
   scr_net_sock_set_native_reader(sock, &scr_h2_on_data, &scr_h2_on_eof, &scr_h2_on_closed,
                                   sess, &scr_h2_session_ctx_free);
   scr_net_sock_set_native_events(sock, NULL, &scr_h2_on_err);
@@ -2279,19 +2383,43 @@ ScrNetServer *scr_http2_create_server_req(ScrClosure *handler /*moves*/, ScrHttp
  * tears down at establishment (Node parks it as 'unknownProtocol' and
  * destroys at the timeout — this surface destroys now). */
 ScrNetServer *scr_http2_create_secure_server(const char *cert, size_t cert_len,
-                                              const char *key, size_t key_len) {
+                                               const char *key, size_t key_len,
+                                               bool enable_connect_protocol) {
   scr_http2_install();
   ScrNetServer *s = scr_net_create_server(NULL, NULL);
   ScrH2SrvCtx *ctx = calloc(1, sizeof *ctx);
   if (!ctx) scr_h2_oom();
   ctx->proto = SCR_NET_PROTO_H2;
   ctx->rc = 1;
+  ctx->enable_connect_protocol = enable_connect_protocol;
   scr_net_server_set_http_ctx(s, ctx); /* borrowed alias: 'stream'/'session' registration */
   scr_net_server_set_proto_settle(s, &scr_h2_srv_ctx_settle);
   /* the TLS wrap owns the ctx reference (+1 moved in) and dispatches
    * established h2 connections back into scr_h2_on_connection */
   scr_tls_server_wrap_h2(s, cert, cert_len, key, key_len, &scr_h2_on_connection, ctx,
-                          &scr_h2_srv_ctx_free_v);
+                          &scr_h2_srv_ctx_free_v, NULL, NULL);
+  return s;
+}
+
+ScrNetServer *scr_http2_create_secure_server_allow_http1(
+    const char *cert, size_t cert_len, const char *key, size_t key_len,
+    ScrClosure *handler /*moves, nullable*/, ScrHttpReqFn fn,
+    ScrClosure *sni_cb /*moves, nullable*/, void *sni_answer_fn,
+    bool enable_connect_protocol) {
+  scr_http2_install();
+  ScrNetServer *s = scr_http_create_server(NULL, NULL);
+  void *http1_ctx = scr_net_server_get_http_ctx(s);
+  ScrH2SrvCtx *ctx = calloc(1, sizeof *ctx);
+  if (!ctx) scr_h2_oom();
+  ctx->proto = SCR_NET_PROTO_H2;
+  ctx->rc = 1;
+  ctx->http1_ctx = http1_ctx;
+  ctx->enable_connect_protocol = enable_connect_protocol;
+  scr_net_server_set_http_ctx(s, ctx);
+  scr_net_server_set_proto_settle(s, &scr_h2_srv_ctx_settle);
+  if (handler != NULL) scr_h2_request_hook(ctx, handler, (void *)fn, false);
+  scr_tls_server_wrap_h2(s, cert, cert_len, key, key_len, &scr_h2_on_connection, ctx,
+                          &scr_h2_srv_ctx_free_v, sni_cb, sni_answer_fn);
   return s;
 }
 
@@ -2307,10 +2435,12 @@ static ScrH2SrvCtx *scr_h2_server_ctx(ScrNetServer *s) {
  * first 'request' listener over the ALPN=h2 server — the
  * create_server_req route, secured. */
 ScrNetServer *scr_http2_create_secure_server_req(const char *cert, size_t cert_len,
-                                                  const char *key, size_t key_len,
-                                                  ScrClosure *handler /*moves, nullable*/,
-                                                  ScrHttpReqFn fn) {
-  ScrNetServer *s = scr_http2_create_secure_server(cert, cert_len, key, key_len);
+                                                   const char *key, size_t key_len,
+                                                   ScrClosure *handler /*moves, nullable*/,
+                                                   ScrHttpReqFn fn,
+                                                   bool enable_connect_protocol) {
+  ScrNetServer *s = scr_http2_create_secure_server(cert, cert_len, key, key_len,
+                                                    enable_connect_protocol);
   if (handler != NULL) {
     ScrH2SrvCtx *ctx = scr_h2_server_ctx(s);
     if (ctx != NULL) scr_net_ls_add(&ctx->request_ls, handler, (void *)fn, false);
@@ -2346,7 +2476,8 @@ ScrNetServer *scr_http2_create_secure_server_dyn(const ScrDyn *opts /*borrowed*/
       ? scr_https_create_server((const char *)cert->data, cert->len,
                                  (const char *)key->data, key->len, handler, fn)
       : scr_http2_create_secure_server_req((const char *)cert->data, cert->len,
-                                            (const char *)key->data, key->len, handler, fn);
+                                            (const char *)key->data, key->len, handler, fn,
+                                            false);
   scr_bytes_release(cert);
   scr_bytes_release(key);
   return s;
@@ -2529,6 +2660,33 @@ void scr_http2_session_on_error(ScrH2Session *s, ScrClosure *cb /*moves*/, ScrCh
     return;
   }
   scr_net_ls_add(&s->err_ls, cb, (void *)fn, once);
+}
+
+void scr_http2_server_on_session_error(ScrNetServer *s, ScrClosure *cb /*moves*/,
+                                        ScrH2SessionErrorFn fn, bool once) {
+  ScrH2SrvCtx *ctx = scr_h2_server_ctx(s);
+  if (ctx == NULL || scr_net_server_settled(s)) {
+    scr_closure_release(cb);
+    return;
+  }
+  scr_net_ls_add(&ctx->session_error_ls, cb, (void *)fn, once);
+}
+
+void scr_http2_session_error_thunk0(ScrClosure *cb, ScrStr *msg, ScrH2Session *session) {
+  (void)msg;
+  scr_http2_session_release(session);
+  ((void (*)(ScrClosure *))cb->fn)(cb);
+}
+
+void scr_http2_session_error_thunk1(ScrClosure *cb, ScrStr *msg, ScrH2Session *session) {
+  scr_http2_session_release(session);
+  ScrError *err = scr_error_new(0, msg);
+  ((void (*)(ScrClosure *, ScrError *))cb->fn)(cb, err);
+}
+
+void scr_http2_session_error_thunk2(ScrClosure *cb, ScrStr *msg, ScrH2Session *session) {
+  ScrError *err = scr_error_new(0, msg);
+  ((void (*)(ScrClosure *, ScrError *, ScrH2Session *))cb->fn)(cb, err, session);
 }
 
 void scr_http2_session_on_connect(ScrH2Session *s, ScrClosure *cb /*moves*/, ScrH2ConnectFn fn, bool once) {

--- a/packages/runtime/src/scr_lib.c
+++ b/packages/runtime/src/scr_lib.c
@@ -106,6 +106,7 @@ extern char **environ; /* env snapshot (scr_env_pairs) */
 
 static SCR_TL int scr_lib_argc = 0;
 static SCR_TL char **scr_lib_argv = NULL;
+static SCR_TL bool scr_lib_skip_reexec_arg = false;
 static SCR_TL ScrArr *scr_argv_arr = NULL;    /* interned process.argv */
 static SCR_TL ScrStr *scr_platform_str = NULL; /* interned process.platform */
 static SCR_TL ScrStr *scr_exec_path_str = NULL; /* interned process.execPath */
@@ -133,9 +134,28 @@ static void scr_lib_cleanup(void) {
  * atexit handlers (the emitted library init never calls this; keeping it out
  * the archive's objects free of any atexit reference — the K8 ambient
  * audit's bar). */
+static bool scr_lib_same_executable_arg(const char *a, const char *b) {
+  if (strcmp(a, b) == 0) return true;
+  char resolved_a[PATH_MAX], resolved_b[PATH_MAX];
+#ifdef _WIN32
+  const char *use_a = _fullpath(resolved_a, a, sizeof resolved_a) != NULL ? resolved_a : a;
+  const char *use_b = _fullpath(resolved_b, b, sizeof resolved_b) != NULL ? resolved_b : b;
+  return _stricmp(use_a, use_b) == 0;
+#else
+  const char *use_a = realpath(a, resolved_a) != NULL ? resolved_a : a;
+  const char *use_b = realpath(b, resolved_b) != NULL ? resolved_b : b;
+  return strcmp(use_a, use_b) == 0;
+#endif
+}
+
 void scr_lib_init(int argc, char **argv) {
   scr_lib_argc = argc;
   scr_lib_argv = argv;
+  /* Node self-reexecution spells `spawn(process.execPath,
+   * [process.argv[1], ...args])`. In a native binary argv[0] already IS the
+   * entry executable, so collapse that repeated first argument before
+   * exposing Node's [exec, script, ...args] process.argv shape. */
+  scr_lib_skip_reexec_arg = argc >= 2 && scr_lib_same_executable_arg(argv[0], argv[1]);
   atexit(scr_lib_cleanup);
 }
 #endif /* !SCR_LIB */
@@ -151,18 +171,21 @@ void scr_lib_session_cleanup(void) { scr_lib_cleanup(); }
 /* Raw argv accessors for the island's process shim (scr_island.c): the
  * island's process.argv must match the static world's ["scriptc",
  * argv[0], ...] shape exactly, so both build from the same stash. */
-int scr_lib_arg_count(void) { return scr_lib_argc; }
-const char *scr_lib_arg(int i) { return scr_lib_argv[i]; }
+int scr_lib_arg_count(void) { return scr_lib_argc - (scr_lib_skip_reexec_arg ? 1 : 0); }
+const char *scr_lib_arg(int i) {
+  return scr_lib_argv[i + (scr_lib_skip_reexec_arg && i > 0 ? 1 : 0)];
+}
 
 ScrArr *scr_process_argv(void) {
   if (!scr_argv_arr) {
     /* ["scriptc", argv[0], argv[1], ...]: positions and length line up
      * with Node's [node-path, script-path, ...args]; the argv[0]/argv[1]
      * VALUES diverge (SEMANTICS.md). */
-    scr_argv_arr = scr_arr_new(SCR_ELEM_STR, (size_t)scr_lib_argc + 1);
+    int argc = scr_lib_arg_count();
+    scr_argv_arr = scr_arr_new(SCR_ELEM_STR, (size_t)argc + 1);
     scr_arr_push_ref(scr_argv_arr, scr_str_new("scriptc", 7));
-    for (int i = 0; i < scr_lib_argc; i++) {
-      const char *a = scr_lib_argv[i];
+    for (int i = 0; i < argc; i++) {
+      const char *a = scr_lib_arg(i);
       scr_arr_push_ref(scr_argv_arr, scr_str_new(a, strlen(a)));
     }
   }

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -283,6 +283,27 @@ static const char *scr_net_errname(int err) {
  * The types live in scr_runtime.h: scr_http.c reuses the whole family
  * for its request-body listener lists. */
 
+struct ScrNetOnce {
+  size_t rc;
+  bool fired;
+};
+
+ScrNetOnce *scr_net_once_new(void) {
+  ScrNetOnce *once = calloc(1, sizeof *once);
+  if (!once) scr_net_oom();
+  once->rc = 1;
+  return once;
+}
+
+ScrNetOnce *scr_net_once_retain(ScrNetOnce *once) {
+  once->rc++;
+  return once;
+}
+
+void scr_net_once_release(ScrNetOnce *once) {
+  if (once != NULL && --once->rc == 0) free(once);
+}
+
 void scr_net_ls_add(ScrNetLs *l, ScrClosure *cb, void *fn, bool once) {
   if (l->n == l->cap) {
     l->cap = l->cap ? l->cap * 2 : 2;
@@ -292,11 +313,28 @@ void scr_net_ls_add(ScrNetLs *l, ScrClosure *cb, void *fn, bool once) {
   l->ls[l->n].cb = cb;
   l->ls[l->n].fn = fn;
   l->ls[l->n].once = once;
+  l->ls[l->n].shared_once = NULL;
   l->n++;
 }
 
+void scr_net_ls_add_shared_once(ScrNetLs *l, ScrClosure *cb, void *fn,
+                                ScrNetOnce *once /*moves*/) {
+  scr_net_ls_add(l, cb, fn, true);
+  l->ls[l->n - 1].shared_once = once;
+}
+
+bool scr_net_ls_has_live(const ScrNetLs *l) {
+  for (size_t i = 0; i < l->n; i++) {
+    if (l->ls[i].shared_once == NULL || !l->ls[i].shared_once->fired) return true;
+  }
+  return false;
+}
+
 void scr_net_ls_drop(ScrNetLs *l) {
-  for (size_t i = 0; i < l->n; i++) scr_closure_release(l->ls[i].cb);
+  for (size_t i = 0; i < l->n; i++) {
+    scr_closure_release(l->ls[i].cb);
+    scr_net_once_release(l->ls[i].shared_once);
+  }
   free(l->ls);
   l->ls = NULL;
   l->n = l->cap = 0;
@@ -314,22 +352,32 @@ size_t scr_net_ls_snapshot(ScrNetLs *l, ScrNetL **out) {
   }
   ScrNetL *snap = malloc(n * sizeof *snap);
   if (!snap) scr_net_oom();
-  for (size_t i = 0; i < n; i++) {
-    snap[i] = l->ls[i];
-    scr_closure_retain(snap[i].cb);
-  }
-  /* remove the once entries from the live list */
+  size_t nsnap = 0;
   size_t w = 0;
   for (size_t i = 0; i < l->n; i++) {
+    ScrNetL entry = l->ls[i];
+    bool emit = entry.shared_once == NULL || !entry.shared_once->fired;
+    if (emit) {
+      if (entry.shared_once != NULL) entry.shared_once->fired = true;
+      snap[nsnap] = entry;
+      snap[nsnap].shared_once = NULL;
+      scr_closure_retain(snap[nsnap].cb);
+      nsnap++;
+    }
     if (l->ls[i].once) {
       scr_closure_release(l->ls[i].cb);
+      scr_net_once_release(l->ls[i].shared_once);
     } else {
       l->ls[w++] = l->ls[i];
     }
   }
   l->n = w;
+  if (nsnap == 0) {
+    free(snap);
+    snap = NULL;
+  }
   *out = snap;
-  return n;
+  return nsnap;
 }
 
 /* Fire a zero-payload event list (end/close/connect/listening) with the

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5072,10 +5072,13 @@ typedef void (*ScrNetDataFn)(ScrClosure *cb, ScrBytes *chunk);    /* borrowed */
 
 /* The listener-list family (snapshot firing, once-before-run): owned by
  * scr_net.c, reused by scr_http.c for the request-body event lists. */
+typedef struct ScrNetOnce ScrNetOnce;
+
 typedef struct {
   ScrClosure *cb; /* owned */
   void *fn;       /* adapter with the event's firing ABI */
   bool once;
+  ScrNetOnce *shared_once; /* owned, nullable: one once registration mirrored across lists */
 } ScrNetL;
 
 typedef struct {
@@ -5084,6 +5087,12 @@ typedef struct {
 } ScrNetLs;
 
 void scr_net_ls_add(ScrNetLs *l, ScrClosure *cb, void *fn, bool once);
+ScrNetOnce *scr_net_once_new(void); /* +1 */
+ScrNetOnce *scr_net_once_retain(ScrNetOnce *once); /* +1 */
+void scr_net_once_release(ScrNetOnce *once);
+void scr_net_ls_add_shared_once(ScrNetLs *l, ScrClosure *cb, void *fn,
+                                ScrNetOnce *once /*moves*/);
+bool scr_net_ls_has_live(const ScrNetLs *l);
 void scr_net_ls_drop(ScrNetLs *l);
 size_t scr_net_ls_snapshot(ScrNetLs *l, ScrNetL **out);
 void scr_net_fire0(ScrNetLs *l);
@@ -5410,7 +5419,7 @@ void scr_tls_sock_on_session(ScrNetSocket *s, ScrClosure *cb /*moves*/, void *fn
  * the https-authority client wrap. scr_http2.c calls both directly —
  * every http2-using binary links the TLS unit (the moduleUsesTls
  * switch), so no registration indirection is needed. */
-void scr_tls_server_wrap_h2(ScrNetServer *s, const char *cert, size_t cert_len, const char *key, size_t key_len, ScrNetNativeConnFn h2_conn, void *h2_ctx /*moves*/, void (*h2_ctx_free)(void *));
+void scr_tls_server_wrap_h2(ScrNetServer *s, const char *cert, size_t cert_len, const char *key, size_t key_len, ScrNetNativeConnFn h2_conn, void *h2_ctx /*moves*/, void (*h2_ctx_free)(void *), ScrClosure *sni_cb /*moves, nullable*/, void *sni_answer_fn);
 void scr_tls_h2_client_wrap(ScrNetSocket *sock, ScrStr *host /*borrowed*/, bool reject_unauthorized, const char *ca /*borrowed, len 0 = none*/, size_t ca_len);
 
 /* ── tls.SecureContext + the SNI callback (scr_tls.c) ─────────────────
@@ -5483,6 +5492,7 @@ bool scr_tls_ca_default_override(const char **pem, size_t *len, uint64_t *gen);
 typedef struct ScrHttpReq ScrHttpReq;
 typedef struct ScrHttpRes ScrHttpRes;
 typedef void (*ScrHttpReqFn)(ScrClosure *cb, ScrHttpReq *req, ScrHttpRes *res); /* both +1 */
+typedef void (*ScrHttpConnectH2Fn)(ScrClosure *cb, ScrHttpReq *req, ScrHttpRes *res); /* both +1 */
 /* 'upgrade' listeners, both sides: (req-or-res, socket, head) — all +1.
  * The parser steps aside (native reader cleared) and the socket is the
  * listener's raw stream; `head` carries bytes read past the 101/request
@@ -5525,10 +5535,16 @@ typedef struct ScrHttpH2Ops {
 void scr_http_set_h2_ops(const ScrHttpH2Ops *ops);
 void scr_http_set_h2_request_hook(void (*hook)(void *h2ctx, ScrClosure *cb /*moves*/,
                                                void *fn, bool once));
+void scr_http_set_h2_connect_hook(void (*hook)(void *h2ctx, ScrClosure *cb /*moves*/,
+                                               void *h1_fn, void *h2_fn, bool once));
+void scr_http_set_h2_upgrade_hook(void (*hook)(void *h2ctx, ScrClosure *cb /*moves*/,
+                                               void *fn, bool once));
 
 /* The compat pair, built by scr_http2.c per server stream. */
 ScrHttpReq *scr_http_h2_req_new(ScrNetSocket *sock /*borrowed, nullable*/,
                                  void *stream /*borrowed, nullable*/); /* +1 */
+void *scr_http_req_h2_stream(ScrHttpReq *r); /* +1 or NULL */
+void *scr_http_req_h2_stream_or_throw(ScrHttpReq *r, ScrStr *member /*borrowed*/); /* +1 */
 void scr_http_h2_req_line(ScrHttpReq *r, ScrStr *method /*borrowed, nullable*/,
                            ScrStr *url /*borrowed, nullable*/);
 void scr_http_h2_req_header(ScrHttpReq *r, ScrStr *name /*borrowed*/, ScrStr *value /*borrowed*/);
@@ -5563,6 +5579,12 @@ void scr_http2_stream_undef_call(ScrStr *member);
  * server) the closure releases unregistered: 'request' never fires
  * there, like Node. */
 void scr_http_server_on_request(ScrNetServer *s, ScrClosure *cb /*moves*/, ScrHttpReqFn fn, bool once);
+void scr_http1_ctx_on_request(void *ctx, ScrClosure *cb /*moves*/, ScrHttpReqFn fn, bool once,
+                              ScrNetOnce *shared_once /*moves, nullable*/);
+void scr_http1_ctx_on_connect(void *ctx, ScrClosure *cb /*moves*/, ScrHttpUpgradeFn fn, bool once,
+                              ScrNetOnce *shared_once /*moves, nullable*/);
+void scr_http1_ctx_on_upgrade(void *ctx, ScrClosure *cb /*moves*/, ScrHttpUpgradeFn fn, bool once);
+void scr_http1_ctx_settle(void *ctx);
 ScrStr *scr_http_req_url(ScrHttpReq *r);      /* +1 */
 ScrStr *scr_http_req_method(ScrHttpReq *r);   /* +1 */
 ScrStr *scr_http_req_header(ScrHttpReq *r, ScrStr *name /*borrowed*/); /* +1 or NULL (undefined arm) */
@@ -5610,10 +5632,10 @@ void scr_http_server_join_duplicate_headers(ScrNetServer *s);
 void scr_http_handler_thunk0(ScrClosure *cb, ScrHttpReq *req, ScrHttpRes *res);
 void scr_http_handler_thunk1(ScrClosure *cb, ScrHttpReq *req, ScrHttpRes *res);
 void scr_http_handler_thunk2(ScrClosure *cb, ScrHttpReq *req, ScrHttpRes *res);
-/* server.on("connect", ...) — HTTP CONNECT, the upgrade twin: fired
- * INSTEAD of 'request' for CONNECT-method requests with (req, socket,
- * head); no listener destroys the socket. */
-void scr_http_server_on_connect(ScrNetServer *s, ScrClosure *cb /*moves*/, ScrHttpUpgradeFn fn,
+/* server.on("connect", ...) — fired instead of 'request' for CONNECT.
+ * HTTP/1 uses (req, socket, head); HTTP/2 compatibility uses (req, res). */
+void scr_http_server_on_connect(ScrNetServer *s, ScrClosure *cb /*moves*/,
+                                 ScrHttpUpgradeFn h1_fn, ScrHttpConnectH2Fn h2_fn,
                                  bool once);
 void scr_http_server_on_upgrade(ScrNetServer *s, ScrClosure *cb /*moves*/, ScrHttpUpgradeFn fn, bool once);
 ScrArr *scr_http_req_raw_headers(ScrHttpReq *r); /* +1 — [name, value, ...], arrival order/case */
@@ -5758,6 +5780,8 @@ enum { SCR_NET_PROTO_HTTP1 = 1, SCR_NET_PROTO_H2 = 2 };
 
 typedef struct ScrH2Session ScrH2Session;
 typedef struct ScrH2Stream ScrH2Stream;
+typedef void (*ScrH2SessionErrorFn)(ScrClosure *cb, ScrStr *msg,
+                                    ScrH2Session *session); /* session +1 */
 
 typedef void (*ScrH2StreamFn)(ScrClosure *cb, ScrH2Stream *st, ScrArr *pairs, double flags); /* st, pairs +1 */
 typedef void (*ScrH2RespFn)(ScrClosure *cb, ScrArr *pairs, double status, double flags);     /* pairs +1 */
@@ -5784,11 +5808,12 @@ ScrNetServer *scr_http2_create_server_req(ScrClosure *handler /*moves*/, ScrHttp
 /* The REAL h2-over-TLS server (http2.createSecureServer({ cert, key })):
  * the same session machinery behind an mbedTLS handshake whose ALPN
  * advertises h2 alone — protocol-identical after establishment. */
-ScrNetServer *scr_http2_create_secure_server(const char *cert, size_t cert_len, const char *key, size_t key_len); /* +1 */
+ScrNetServer *scr_http2_create_secure_server(const char *cert, size_t cert_len, const char *key, size_t key_len, bool enable_connect_protocol); /* +1 */
+ScrNetServer *scr_http2_create_secure_server_allow_http1(const char *cert, size_t cert_len, const char *key, size_t key_len, ScrClosure *handler /*moves, nullable*/, ScrHttpReqFn fn, ScrClosure *sni_cb /*moves, nullable*/, void *sni_answer_fn, bool enable_connect_protocol); /* +1 */
 /* createSecureServer(options, handler): the eager COMPAT handler as the
  * first 'request' listener over the ALPN=h2 server (the createServerReq
  * route, secured). */
-ScrNetServer *scr_http2_create_secure_server_req(const char *cert, size_t cert_len, const char *key, size_t key_len, ScrClosure *handler /*moves, nullable*/, ScrHttpReqFn fn); /* +1 */
+ScrNetServer *scr_http2_create_secure_server_req(const char *cert, size_t cert_len, const char *key, size_t key_len, ScrClosure *handler /*moves, nullable*/, ScrHttpReqFn fn, bool enable_connect_protocol); /* +1 */
 /* createSecureServer with a RUNTIME options record (the divergence-66
  * stance): allowHTTP1 picks the flavor at runtime, cert/key ride the
  * shared TLS server walk (out-of-bounds members throw the catchable
@@ -5818,6 +5843,11 @@ void scr_http2_session_close(ScrH2Session *s, ScrClosure *cb /*moves, nullable*/
 void scr_http2_session_destroy(ScrH2Session *s);
 void scr_http2_session_on_close(ScrH2Session *s, ScrClosure *cb /*moves*/, bool once);
 void scr_http2_session_on_error(ScrH2Session *s, ScrClosure *cb /*moves*/, ScrChildErrFn fn, bool once);
+void scr_http2_server_on_session_error(ScrNetServer *s, ScrClosure *cb /*moves*/,
+                                       ScrH2SessionErrorFn fn, bool once);
+void scr_http2_session_error_thunk0(ScrClosure *cb, ScrStr *msg, ScrH2Session *session);
+void scr_http2_session_error_thunk1(ScrClosure *cb, ScrStr *msg, ScrH2Session *session);
+void scr_http2_session_error_thunk2(ScrClosure *cb, ScrStr *msg, ScrH2Session *session);
 void scr_http2_session_on_connect(ScrH2Session *s, ScrClosure *cb /*moves*/, ScrH2ConnectFn fn, bool once);
 void scr_http2_session_on_stream(ScrH2Session *s, ScrClosure *cb /*moves*/, ScrH2StreamFn fn, bool once);
 void scr_http2_session_on_goaway(ScrH2Session *s, ScrClosure *cb /*moves*/, ScrH2GoawayFn fn, bool once);

--- a/packages/runtime/src/scr_tls.c
+++ b/packages/runtime/src/scr_tls.c
@@ -276,6 +276,7 @@ typedef struct ScrTlsSrv {
  * the handshake with no_application_protocol — Node's h2-only split). */
 static const char *SCR_TLS_ALPN_HTTP11[] = {"http/1.1", NULL};
 static const char *SCR_TLS_ALPN_H2[] = {"h2", NULL};
+static const char *SCR_TLS_ALPN_H2_HTTP11[] = {"h2", "http/1.1", NULL};
 
 static ScrTlsSrv *scr_tls_srv_new(const char *cert, size_t cert_len, const char *key,
                                    size_t key_len, bool alpn_http11) {
@@ -864,7 +865,8 @@ static void scr_tls_on_established(void *tctx) {
     const char *alpn = mbedtls_ssl_get_alpn_protocol(&t->ssl);
     if (alpn != NULL && strcmp(alpn, "h2") == 0) {
       t->srv->h2_conn(t->srv->h2_ctx, t->sock);
-    } else if (alpn != NULL && t->srv->inner_conn != NULL && strcmp(alpn, "http/1.1") == 0) {
+    } else if (t->srv->inner_conn != NULL &&
+               (alpn == NULL || strcmp(alpn, "http/1.1") == 0)) {
       t->srv->inner_conn(t->srv->inner_ctx, t->sock);
     } else {
       scr_net_sock_transport_error(t->sock, NULL);
@@ -1593,13 +1595,20 @@ ScrNetSocket *scr_tls_connect_dyn(double port, ScrStr *host /*borrowed, nullable
 void scr_tls_server_wrap_h2(ScrNetServer *s, const char *cert, size_t cert_len,
                              const char *key, size_t key_len,
                              ScrNetNativeConnFn h2_conn, void *h2_ctx /*moves*/,
-                             void (*h2_ctx_free)(void *)) {
+                             void (*h2_ctx_free)(void *),
+                             ScrClosure *sni_cb /*moves, nullable*/, void *sni_answer_fn) {
   ScrTlsSrv *srv = scr_tls_srv_new(cert, cert_len, key, key_len, false);
-  mbedtls_ssl_conf_alpn_protocols(&srv->conf, SCR_TLS_ALPN_H2);
   srv->h2_conn = h2_conn;
   srv->h2_ctx = h2_ctx;
   srv->h2_ctx_free = h2_ctx_free;
   scr_net_server_get_native_conn(s, &srv->inner_conn, &srv->inner_ctx, &srv->inner_ctx_free);
+  mbedtls_ssl_conf_alpn_protocols(
+      &srv->conf, srv->inner_conn != NULL ? SCR_TLS_ALPN_H2_HTTP11 : SCR_TLS_ALPN_H2);
+  if (sni_cb != NULL) {
+    srv->sni_cb = sni_cb;
+    srv->sni_answer_fn = sni_answer_fn;
+    mbedtls_ssl_conf_sni(&srv->conf, &scr_tls_f_sni, NULL);
+  }
   scr_net_server_set_native_conn(s, &scr_tls_srv_on_conn, srv, &scr_tls_srv_release_v);
   scr_net_server_defer_connections(s); /* 'connection'/'secureConnection' wait for the handshake */
 }

--- a/scripts/sandbox-test.mjs
+++ b/scripts/sandbox-test.mjs
@@ -153,7 +153,10 @@ const hostInvariantContractPattern = [
 // Logically portable acceptance suites whose oracle lives in an external
 // worktree that is intentionally not uploaded. Run them locally in both
 // flavors, sharding suites whose individual cases are independently addressable.
-const localLaneFiles = ["tests/harness/prettier-e2e.test.ts"];
+const localLaneFiles = [
+  "tests/harness/prettier-e2e.test.ts",
+  "tests/harness/portless-e2e.test.ts",
+];
 const localCaseShardedFiles = ["tests/harness/vercel-e2e.test.ts"];
 
 const { values } = parseArgs({

--- a/tests/corpus/2675-process-self-reexec.ts
+++ b/tests/corpus/2675-process-self-reexec.ts
@@ -1,0 +1,10 @@
+import { spawnSync } from "node:child_process";
+
+if (process.argv.at(2) === "child") {
+  console.log(`child args: ${process.argv.slice(2).join(",")}`);
+} else {
+  const child = spawnSync(process.execPath, [process.argv[1], "child"], { encoding: "utf8" });
+  console.log(`status: ${child.status}`);
+  console.log(child.stdout);
+  console.log(child.stderr);
+}

--- a/tests/corpus/2676-indexed-read-strict-equality.ts
+++ b/tests/corpus/2676-indexed-read-strict-equality.ts
@@ -1,0 +1,5 @@
+const values: string[] = [];
+
+console.log(values[1] === "present");
+console.log(values[1] !== "present");
+console.log(values[1] === undefined);

--- a/tests/corpus/2677-runtime-optional-closure.ts
+++ b/tests/corpus/2677-runtime-optional-closure.ts
@@ -1,0 +1,29 @@
+function run(values: string[]): void {
+  let value = values[0];
+  if (!value) return;
+
+  const printLength = () => {
+    {
+      const value = "shadow";
+      if (value.length === 0) return;
+    }
+    console.log(value.length);
+  };
+
+  value = values.slice(1)[0];
+  printLength();
+}
+
+try {
+  run(["first"]);
+} catch (error) {
+  console.log(error instanceof TypeError, (error as Error).message);
+}
+
+function capturedNarrow(values: string[]): () => string {
+  let value = values[0];
+  if (!value) return () => "fallback";
+  return () => value;
+}
+
+console.log(capturedNarrow(["kept"])());

--- a/tests/corpus/2677-runtime-optional-closure.ts
+++ b/tests/corpus/2677-runtime-optional-closure.ts
@@ -27,3 +27,146 @@ function capturedNarrow(values: string[]): () => string {
 }
 
 console.log(capturedNarrow(["kept"])());
+
+function capturedOptionalChain(values: string[]): void {
+  let value = values[0];
+  if (!value) return;
+  const printLength = () => {
+    console.log("property", value?.length);
+    console.log("element", (value)?.[0]);
+    console.log("comma", (values.length, value)?.length);
+  };
+  value = values.slice(1)[0];
+  printLength();
+}
+
+capturedOptionalChain(["first"]);
+capturedOptionalChain(["first", "second"]);
+
+function capturedOptionalCall(callbacks: (() => string)[]): void {
+  let callback = callbacks[0];
+  if (!callback) return;
+  const call = () => console.log(callback?.());
+  callback = callbacks.slice(1)[0];
+  call();
+}
+
+capturedOptionalCall([() => "called"]);
+capturedOptionalCall([() => "first", () => "second"]);
+
+function capturedUnionResult(values: { payload: string | number }[]): void {
+  let value = values[0];
+  if (!value) return;
+  const printPayload = () => console.log(value?.payload);
+  value = values.slice(1)[0];
+  printPayload();
+}
+
+capturedUnionResult([{ payload: "first" }]);
+capturedUnionResult([{ payload: "first" }, { payload: 2 }]);
+
+function wrappedDirectRead(values: string[]): void {
+  let value = values[0];
+  if (!value) return;
+  const read = () => console.log((value).length);
+  value = values.slice(1)[0];
+  read();
+}
+
+try {
+  wrappedDirectRead(["first"]);
+} catch (error) {
+  console.log("wrapped", error instanceof TypeError, (error as Error).message);
+}
+
+function directCapturedCall(callbacks: (() => void)[]): void {
+  let callback = callbacks[0];
+  if (!callback) return;
+  const call = () => (callback as () => void)();
+  callback = callbacks.slice(1)[0];
+  call();
+}
+
+try {
+  directCapturedCall([() => console.log("called")]);
+} catch (error) {
+  console.log("direct call", error instanceof TypeError, (error as Error).message);
+}
+
+function assertedOptionalChain(values: string[]): void {
+  let value = values[0];
+  if (!value) return;
+  const read = () => console.log("asserted", (value as string)?.length, (value!)?.length);
+  value = values.slice(1)[0];
+  read();
+}
+
+assertedOptionalChain(["first"]);
+assertedOptionalChain(["first", "second"]);
+
+function unrelatedCapture(): void {
+  let value: string | number = "plain";
+  if (typeof value === "string") {
+    const read = () => value?.length;
+    console.log("unrelated", read());
+  }
+}
+
+function aliasedCapture(values: string[]): void {
+  let value = values[0];
+  if (!value) return;
+  const read = () => {
+    const copy = value;
+    console.log(copy.length);
+  };
+  value = values.slice(1)[0];
+  read();
+}
+
+try {
+  aliasedCapture(["first"]);
+} catch (error) {
+  console.log("alias", error instanceof TypeError, (error as Error).message);
+}
+aliasedCapture(["first", "second"]);
+
+function ordinaryAssertion(value: string | number): void {
+  console.log("ordinary assertion", (value as string)?.length);
+}
+
+ordinaryAssertion("plain");
+
+unrelatedCapture();
+
+function directCapturedElement(values: string[][]): void {
+  let value = values[0];
+  if (!value) return;
+  const read = () => console.log(value[0]);
+  value = values.slice(1)[0];
+  read();
+}
+
+try {
+  directCapturedElement([["first"]]);
+} catch (error) {
+  console.log("direct element", error instanceof TypeError, (error as Error).message);
+}
+
+const unionValues: (string | number)[] = ["first", 2];
+console.log("union probe", unionValues.slice(2)[0] ?? "missing", unionValues.slice(0)[0], unionValues.slice(1)[0]);
+
+function captureMutationThenOuterRead(values: string[]): void {
+  let value = values[0];
+  if (!value) return;
+  const clear = () => {
+    value = values.slice(1)[0];
+  };
+  clear();
+  console.log(value.length);
+}
+
+try {
+  captureMutationThenOuterRead(["first"]);
+} catch (error) {
+  console.log("capture mutation", error instanceof TypeError, (error as Error).message);
+}

--- a/tests/diagnostics/runtime-optional-capture-chain.ts
+++ b/tests/diagnostics/runtime-optional-capture-chain.ts
@@ -1,0 +1,56 @@
+function logical(values: string[], present: string): void {
+  let value = values[0];
+  if (!value) return;
+  const read = () => console.log((present && value)?.length);
+  value = values.slice(1)[0];
+  read();
+}
+
+function conditional(values: string[], present: boolean): void {
+  let value = values[0];
+  if (!value) return;
+  const read = () => console.log((present ? value : value)?.length);
+  value = values.slice(1)[0];
+  read();
+}
+
+function defaults(values: string[]): void {
+  let value = values[0];
+  if (!value) return;
+  const readOr = () => console.log((value || "fallback")?.length);
+  const readNullish = () => console.log((value ?? "fallback")?.length);
+  value = values.slice(1)[0];
+  readOr();
+  readNullish();
+}
+
+function condition(values: string[]): void {
+  let value = values[0];
+  if (!value) return;
+  const read = () => console.log((value ? "yes" : "no")?.length);
+  value = values.slice(1)[0];
+  read();
+}
+
+function multipleArms(values: (string | number)[]): void {
+  let value = values[0];
+  if (!value) return;
+  value = 1 as unknown as string;
+  const read = () => console.log(value.length);
+  read();
+}
+
+function commaCall(callbacks: (() => void)[], mark: () => void): void {
+  let callback = callbacks[0];
+  if (!callback) return;
+  const call = () => (mark(), callback)();
+  callback = callbacks.slice(1)[0];
+  call();
+}
+
+logical(["first"], "yes");
+conditional(["first"], true);
+defaults(["first"]);
+condition(["first"]);
+multipleArms(["first"]);
+commaCall([() => {}], () => {});

--- a/tests/fixtures/server/cases/http-user-chunked/driver.mjs
+++ b/tests/fixtures/server/cases/http-user-chunked/driver.mjs
@@ -1,0 +1,21 @@
+import { connect } from "node:net";
+
+const port = Number(process.argv[2]);
+
+function rawGet(path) {
+  return new Promise((resolve, reject) => {
+    const socket = connect(port, "127.0.0.1", () => {
+      socket.write(`GET ${path} HTTP/1.1\r\nHost: localhost\r\nConnection: close\r\n\r\n`);
+    });
+    const chunks = [];
+    socket.on("data", (chunk) => chunks.push(chunk));
+    socket.on("close", () => {
+      const response = Buffer.concat(chunks).toString("utf8");
+      resolve(response.slice(response.indexOf("\r\n\r\n") + 4));
+    });
+    socket.on("error", reject);
+  });
+}
+
+console.log(JSON.stringify(await rawGet("/chunked")));
+console.log(JSON.stringify(await rawGet("/extension")));

--- a/tests/fixtures/server/cases/http-user-chunked/main.ts
+++ b/tests/fixtures/server/cases/http-user-chunked/main.ts
@@ -1,0 +1,17 @@
+import * as http from "node:http";
+
+const server = http.createServer((_req, res) => {
+  const extension = _req.url === "/extension";
+  res.writeHead(200, {
+    "content-type": "text/plain",
+    "transfer-encoding": extension ? "xchunked" : "chunked",
+  });
+  res.write("hello ");
+  res.end("world");
+  if (extension) server.close(() => console.log("server closed"));
+});
+
+server.listen(0, () => {
+  console.log("listening");
+  process.stderr.write(`PORT ${server.address().port}\n`);
+});

--- a/tests/fixtures/server/cases/http2-session-error/driver.mjs
+++ b/tests/fixtures/server/cases/http2-session-error/driver.mjs
@@ -1,0 +1,14 @@
+import { connect } from "node:net";
+
+const port = Number(process.argv[2]);
+
+await new Promise((resolve, reject) => {
+  // An invalid preface is synchronously rejected by every supported Node
+  // release, unlike malformed post-handshake frames whose timing varies.
+  const socket = connect(port, "127.0.0.1", () => socket.write("x".repeat(24)));
+  socket.on("data", () => {});
+  socket.on("error", reject);
+  socket.on("close", resolve);
+});
+
+console.log("driver done");

--- a/tests/fixtures/server/cases/http2-session-error/main.ts
+++ b/tests/fixtures/server/cases/http2-session-error/main.ts
@@ -1,0 +1,14 @@
+import * as http2 from "node:http2";
+
+const server = http2.createServer();
+
+server.on("sessionError", (_error: Error, session: http2.ServerHttp2Session) => {
+  console.log("session error");
+  session.destroy();
+  server.close(() => console.log("server closed"));
+});
+
+server.listen(0, () => {
+  console.log("listening");
+  process.stderr.write(`PORT ${server.address().port}\n`);
+});

--- a/tests/fixtures/server/cases/http2-session-preface-error/driver.mjs
+++ b/tests/fixtures/server/cases/http2-session-preface-error/driver.mjs
@@ -1,0 +1,10 @@
+import { connect } from "node:net";
+
+const port = Number(process.argv[2]);
+
+await new Promise((resolve, reject) => {
+  const socket = connect(port, "127.0.0.1", () => socket.write("x".repeat(24)));
+  socket.on("data", () => {});
+  socket.on("error", reject);
+  socket.on("close", resolve);
+});

--- a/tests/fixtures/server/cases/http2-session-preface-error/main.ts
+++ b/tests/fixtures/server/cases/http2-session-preface-error/main.ts
@@ -1,0 +1,13 @@
+import * as http2 from "node:http2";
+
+const server = http2.createServer();
+
+server.on("sessionError", () => {
+  console.log("session error");
+  server.close(() => console.log("server closed"));
+});
+
+server.listen(0, () => {
+  console.log("listening");
+  process.stderr.write(`PORT ${server.address().port}\n`);
+});

--- a/tests/harness/__snapshots__/http2-module.ts.txt
+++ b/tests/harness/__snapshots__/http2-module.ts.txt
@@ -1,4 +1,4 @@
-http2-module.ts:24:13 - error SC1090: using the result of the 'stream.on(...)' call (stream is always undefined on this HTTP/1.1 lowering — call it as its own statement) is not supported yet
+http2-module.ts:24:13 - error SC1090: using the result of stream.on(...) (the result is void here — call it as its own statement) is not supported yet
 
   23 |   // differential's http2-hello).
   24 |   const r = req.stream.on("error", () => {});

--- a/tests/harness/__snapshots__/node-types-fenced.txt
+++ b/tests/harness/__snapshots__/node-types-fenced.txt
@@ -147,7 +147,7 @@ fenced.ts:72:71 - error SC2020: 'createSecureServer option 'streamResetBurst' wi
      |                                                                       ^~~~~~~~~~~~~~~~~~~~~~~
   73 | http2.connect("https://localhost");
 
-  hint: h2 session-tuning options are accepted with literal values (settings: a literal of literals) and ignored — the allowHTTP1 lowering serves HTTP/1.1 only, which has no h2 sessions to tune
+  hint: h2 session-tuning options are accepted with literal values but are not applied yet
 
 fenced.ts:79:1 - error SC2020: 'crypto.generateKeyPair' is typed by @types/node but has no scriptc lowering yet
 

--- a/tests/harness/__snapshots__/runtime-optional-capture-chain.ts.txt
+++ b/tests/harness/__snapshots__/runtime-optional-capture-chain.ts.txt
@@ -1,0 +1,48 @@
+runtime-optional-capture-chain.ts:4:46 - error SC1090: a logical or conditional receiver containing a runtime-optional capture is not supported yet
+
+  3 |   if (!value) return;
+  4 |   const read = () => console.log((present && value)?.length);
+    |                                              ^~~~~
+  5 |   value = values.slice(1)[0];
+
+runtime-optional-capture-chain.ts:12:45 - error SC1090: a logical or conditional receiver containing a runtime-optional capture is not supported yet
+
+  11 |   if (!value) return;
+  12 |   const read = () => console.log((present ? value : value)?.length);
+     |                                             ^~~~~
+  13 |   value = values.slice(1)[0];
+
+runtime-optional-capture-chain.ts:20:37 - error SC1090: a logical or conditional receiver containing a runtime-optional capture is not supported yet
+
+  19 |   if (!value) return;
+  20 |   const readOr = () => console.log((value || "fallback")?.length);
+     |                                     ^~~~~
+  21 |   const readNullish = () => console.log((value ?? "fallback")?.length);
+
+runtime-optional-capture-chain.ts:21:42 - error SC1090: a logical or conditional receiver containing a runtime-optional capture is not supported yet
+
+  20 |   const readOr = () => console.log((value || "fallback")?.length);
+  21 |   const readNullish = () => console.log((value ?? "fallback")?.length);
+     |                                          ^~~~~
+  22 |   value = values.slice(1)[0];
+
+runtime-optional-capture-chain.ts:30:35 - error SC1090: a logical or conditional receiver containing a runtime-optional capture is not supported yet
+
+  29 |   if (!value) return;
+  30 |   const read = () => console.log((value ? "yes" : "no")?.length);
+     |                                   ^~~~~
+  31 |   value = values.slice(1)[0];
+
+runtime-optional-capture-chain.ts:39:34 - error SC1090: a direct read from a runtime-optional capture with multiple value arms are not supported yet
+
+  38 |   value = 1 as unknown as string;
+  39 |   const read = () => console.log(value.length);
+     |                                  ^~~~~
+  40 |   read();
+
+runtime-optional-capture-chain.ts:46:22 - error SC1090: a direct call through a comma-wrapped runtime-optional capture is not supported yet
+
+  45 |   if (!callback) return;
+  46 |   const call = () => (mark(), callback)();
+     |                      ^~~~~~~~~~~~~~~~~~~~
+  47 |   callback = callbacks.slice(1)[0];

--- a/tests/harness/portless-e2e.test.ts
+++ b/tests/harness/portless-e2e.test.ts
@@ -1,0 +1,149 @@
+/* Portless end-to-end: compile the real external checkout and run its proxy
+ * and alias workflows without Node at runtime. This follows the optional
+ * external-suite convention used by prettier-e2e and vercel-e2e: the suite
+ * skips when the checkout is absent and SCRIPTC_PORTLESS_ROOT overrides the
+ * default location.
+ *
+ * SETUP:
+ *   git clone https://github.com/vercel-labs/portless.git ~/Developer/portless-scratch
+ *   git -C ~/Developer/portless-scratch checkout d42c741ac67d20a0b6e1f8f5b4192136de34fa03
+ *   pnpm -C ~/Developer/portless-scratch install --frozen-lockfile
+ *
+ * Portless owns any build-time version stamping. Scriptc deliberately does
+ * not provide bundler-style constant substitution. */
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { cp, mkdtemp, rm, symlink } from "node:fs/promises";
+import { createServer, request } from "node:http";
+import { homedir, tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, describe, expect, test } from "vitest";
+import { compile } from "@scriptc/compiler";
+
+const portlessRoot = process.env["SCRIPTC_PORTLESS_ROOT"] ?? join(homedir(), "Developer/portless-scratch");
+const portlessPackage = join(portlessRoot, "packages/portless");
+const sourceEntry = join(portlessPackage, "src/cli.ts");
+const suite = existsSync(sourceEntry) ? describe : describe.skip;
+const cleanup: Array<() => void | Promise<void>> = [];
+
+afterAll(async () => {
+  for (const fn of cleanup.splice(0).reverse()) await fn();
+});
+
+function childEnv(overrides: Record<string, string>): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+  for (const key of [
+    "PATH", "HOME", "TMPDIR", "TMP", "TEMP", "LANG", "LC_ALL",
+    "ASAN_OPTIONS", "LSAN_OPTIONS", "UBSAN_OPTIONS", "DYLD_LIBRARY_PATH", "LD_LIBRARY_PATH",
+  ]) {
+    if (process.env[key] !== undefined) env[key] = process.env[key];
+  }
+  return { ...env, ...overrides };
+}
+
+function terminate(child: ReturnType<typeof spawn>): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return Promise.resolve();
+  return new Promise((resolve) => {
+    child.once("close", () => resolve());
+    child.kill("SIGTERM");
+  });
+}
+
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      if (address === null || typeof address === "string") return reject(new Error("no TCP address"));
+      server.close(() => resolve(address.port));
+    });
+  });
+}
+
+function get(port: number, host: string): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const req = request({ hostname: "127.0.0.1", port, headers: { host } }, (res) => {
+      const chunks: Buffer[] = [];
+      res.on("data", (chunk: Buffer) => chunks.push(chunk));
+      res.on("end", () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString("utf8") }));
+    });
+    req.once("error", reject);
+    req.end();
+  });
+}
+
+async function waitForProxy(port: number): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    try {
+      await get(port, "missing.localhost");
+      return;
+    } catch {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+  }
+  throw new Error("native Portless proxy did not start");
+}
+
+suite("Portless acceptance", () => {
+  test("builds and proxies a live alias without Node at runtime", async () => {
+    const work = await mkdtemp(join(tmpdir(), "scriptc-portless-"));
+    cleanup.push(() => rm(work, { recursive: true, force: true }));
+    const pkg = JSON.parse(readFileSync(join(portlessRoot, "packages/portless/package.json"), "utf8")) as { version: string };
+    const shadowPackage = join(work, "checkout");
+    await cp(portlessPackage, shadowPackage, {
+      recursive: true,
+      filter: (source) => source !== join(portlessPackage, "node_modules"),
+    });
+    await symlink(join(portlessPackage, "node_modules"), join(shadowPackage, "node_modules"),
+                  process.platform === "win32" ? "junction" : "dir");
+    const entry = join(shadowPackage, "src/cli.ts");
+    const source = readFileSync(entry, "utf8");
+    const stamped = source.replace(
+      /^(?:declare const __VERSION__: string;|const __VERSION__ = .*;)$/m,
+      `const __VERSION__ = ${JSON.stringify(pkg.version)};`,
+    );
+    if (stamped === source && !source.includes(`const __VERSION__ = ${JSON.stringify(pkg.version)};`)) {
+      throw new Error("Portless __VERSION__ declaration was not found");
+    }
+    writeFileSync(entry, stamped);
+    const binary = join(work, "portless");
+    const built = await compile(entry, {
+      outDir: work,
+      outPath: binary,
+      backend: "c",
+      sanitize: process.env["SCRIPTC_SAN"] === "1",
+    });
+    expect(built.ok).toBe(true);
+    if (!built.ok) return;
+
+    const proxyPort = await freePort();
+    const backendPort = await freePort();
+    const stateDir = join(work, "state");
+    const env = childEnv({ PORTLESS_STATE_DIR: stateDir, PORTLESS_SYNC_HOSTS: "0" });
+    const proxy = spawn(binary, ["proxy", "start", "--no-tls", "-p", String(proxyPort), "--foreground"], {
+      cwd: portlessRoot,
+      env,
+      stdio: "ignore",
+    });
+    cleanup.push(() => terminate(proxy));
+    await waitForProxy(proxyPort);
+
+    const backend = createServer((_req, res) => res.end("native-portless-ok"));
+    await new Promise<void>((resolve, reject) => {
+      backend.once("error", reject);
+      backend.listen(backendPort, "127.0.0.1", resolve);
+    });
+    cleanup.push(() => new Promise<void>((resolve) => backend.close(() => resolve())));
+
+    const alias = spawn(binary, ["alias", "app", String(backendPort), "-p", String(proxyPort)], {
+      cwd: portlessRoot,
+      env,
+      stdio: "ignore",
+    });
+    const aliasCode = await new Promise<number | null>((resolve) => alias.once("close", resolve));
+    expect(aliasCode).toBe(0);
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    await expect(get(proxyPort, "app.localhost")).resolves.toEqual({ status: 200, body: "native-portless-ok" });
+  }, 300_000);
+});


### PR DESCRIPTION
## What we did

- Add the compiler and runtime support required to build the real Portless CLI as a fully static native binary and run its proxy, alias, framework, parallel-registration, and process-cleanup workflows without Node.
- Support Portless's dual HTTP/1.1 and HTTP/2 secure-server graph, including ALPN dispatch, shared request/connect listeners, HTTP/2 CONNECT responses, `enableConnectProtocol` settings, `req.stream` access, session errors, and the required ownership and lifecycle handling.
- Lower Portless's indexed absence probes, strict indexed comparisons, optional chains, server options, and container patterns. Preserve Node-style self-reexecution and correctly frame forwarded chunked responses.
- Add focused corpus and server differentials plus an isolated-copy acceptance harness that builds and exercises the pinned Portless checkout without modifying it.

## Validation

- `pnpm --filter @scriptc/compiler build`
- Portless acceptance against pinned `d42c741` in plain and sanitized modes
- Focused plain and sanitized differentials for CONNECT, HTTP/2 session errors and invalid prefaces, explicit chunked framing, self-reexecution, and indexed strict equality
- Fully static native Portless binary linked only to macOS `libSystem`, with no Node or JavaScript engine dependency
- Official Portless e2e suite against the native CLI: 13 files and 16 tests passed, including framework proxies, parallel registration, process groups, SIGKILL recovery, and prune cleanup
- Final scoped review found no blocking issues

The sandbox gate could not start because `SCRIPTC_SANDBOX_IMAGE` was unavailable. The documented full local fallback was attempted, but this machine produced unrelated cache-fixture failures and pinned Node `24.15.0` oracle mismatches under Node `24.18.0`.

## What we decided was out of scope

- Broader HTTP/2 client policy, lifecycle compatibility, protocol validation, listener overloads, and unrelated HTTP/2 completeness.
- General runtime-optional soundness beyond the Portless paths. Making that mechanism generally sound requires function-scoped tracking so reused local IDs cannot leak optional state between functions, assignment-aware tracking so writing a definitely present value clears hidden undefined state, and correct preservation across generators, modules, and `finally` blocks. That larger cross-cutting change remains a dedicated follow-up.
- Removing the self-reexecution heuristic's inherent ambiguity. A direct invocation whose first user argument canonically names the executable is currently treated as Node's repeated script slot and collapsed. An explicit native reexec marker can address that in future work.