### PR TITLE
perf(compiler): specialize typed-array element access

### DIFF
--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -474,6 +474,63 @@ function dynPromiseAdapter(
 
 
 
+/** True when evaluating an index/value expression cannot overwrite a bytes
+ * binding. This deliberately small whitelist enables borrowed receivers in
+ * typed-array hot loops while side-effecting/calling shapes retain the full
+ * snapshot ownership required by JS evaluation order. */
+export function isStableBytesOperand(e: IrExpr): boolean {
+  switch (e.kind) {
+    case "numLit":
+    case "boolLit":
+    case "varRef":
+    case "incDec":
+      return true;
+    case "assignExpr":
+      // The enclosing bytes receiver has bytes type, while assignExpr here
+      // must produce the numeric index/value, so it cannot target that
+      // receiver binding.
+      return isStableBytesOperand(e.value);
+    case "bin":
+      return isStableBytesOperand(e.left) && isStableBytesOperand(e.right);
+    case "unary":
+    case "toBool":
+      return isStableBytesOperand(e.operand);
+    case "logical":
+      return isStableBytesOperand(e.left) && isStableBytesOperand(e.right);
+    case "ternary":
+      return (
+        isStableBytesOperand(e.cond) &&
+        isStableBytesOperand(e.then) &&
+        isStableBytesOperand(e.else_)
+      );
+    case "bytesIntrinsic":
+      return (
+        (e.method === "get" || e.method === "length" || e.method === "byteLength") &&
+        e.receiver.kind === "varRef" &&
+        e.args.every(isStableBytesOperand)
+      );
+    default:
+      return false;
+  }
+}
+
+/** Evaluate a bytes receiver as a borrow when it is a direct, unboxed
+ * binding and all later operands are stable. The binding's scope/global
+ * owner then keeps the value alive, avoiding retain/release traffic around
+ * every indexed access. Any uncertain shape falls back to an owned temp. */
+export function emitBytesReceiver(E: CEmitter, receiver: IrExpr, following: IrExpr[]): Temp {
+  if (receiver.kind === "varRef" && following.every(isStableBytesOperand)) {
+    const local = E.currentLocals.get(receiver.localId);
+    if (local && !local.boxed) {
+      return E.newBorrowedTemp(receiver.type, mangleLocal(receiver.localId));
+    }
+    if (!local && E.globalsById.has(receiver.localId)) {
+      return E.newBorrowedTemp(receiver.type, mangleGlobal(receiver.localId));
+    }
+  }
+  return E.emitExpr(receiver);
+}
+
 export function emitExpr(E: CEmitter, e: IrExpr): Temp {
     switch (e.kind) {
       case "numLit":
@@ -1492,17 +1549,32 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           E.emitPendingCheck();
           return t;
         }
-        const r = E.emitExpr(e.receiver);
-        const args = e.args.map((a) => E.emitExpr(a));
         const method = e.method;
+        const directElementAccess = method === "length" || method === "byteLength" || method === "get";
+        const r = directElementAccess
+          ? emitBytesReceiver(E, e.receiver, e.args)
+          : E.emitExpr(e.receiver);
+        const args = e.args.map((a) => E.emitExpr(a));
         switch (method) {
           case "length":
-            return E.newTemp(e.type, `scr_bytes_len(${r.name})`);
+            return E.newTemp(e.type, `(double)${r.name}->len`);
           case "byteLength":
-            return E.newTemp(e.type, `scr_bytes_byte_len(${r.name})`);
+            if (e.receiver.type.kind !== "bytes") {
+              throw new Error("emitter bug: bytesIntrinsic byteLength on non-bytes");
+            }
+            return E.newTemp(
+              e.type,
+              `(double)(${r.name}->len * ${e.receiver.type.elem === "u8" ? "1" : "4"})`,
+            );
           case "get":
             // Any invalid index traps (the array runtime's discipline).
-            return E.newTemp(e.type, `scr_bytes_get(${r.name}, ${args[0]!.name})`);
+            if (e.receiver.type.kind !== "bytes") {
+              throw new Error("emitter bug: bytesIntrinsic get on non-bytes");
+            }
+            return E.newTemp(
+              e.type,
+              `${E.bytesElementHelper("get", e.receiver.type.elem)}(${r.name}, ${args[0]!.name})`,
+            );
           case "slice":
             // Omitted relative indices default like string slice: start 0,
             // end +Infinity (math.h is always included). Fresh copy, +1.

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -474,11 +474,11 @@ function dynPromiseAdapter(
 
 
 
-/** True when evaluating an index/value expression cannot overwrite a bytes
- * binding. This deliberately small whitelist enables borrowed receivers in
- * typed-array hot loops while side-effecting/calling shapes retain the full
- * snapshot ownership required by JS evaluation order. */
-export function isStableBytesOperand(e: IrExpr): boolean {
+/** True when evaluating an index/value expression cannot overwrite the bytes
+ * receiver binding. This deliberately small whitelist enables borrowed
+ * receivers in typed-array hot loops while side-effecting/calling shapes
+ * retain the full snapshot ownership required by JS evaluation order. */
+export function isStableBytesOperand(e: IrExpr, receiverLocalId: string): boolean {
   switch (e.kind) {
     case "numLit":
     case "boolLit":
@@ -486,28 +486,33 @@ export function isStableBytesOperand(e: IrExpr): boolean {
     case "incDec":
       return true;
     case "assignExpr":
-      // The enclosing bytes receiver has bytes type, while assignExpr here
-      // must produce the numeric index/value, so it cannot target that
-      // receiver binding.
-      return isStableBytesOperand(e.value);
+      // An assignment nested under truthiness/ternary can still produce the
+      // numeric index/value while overwriting the bytes-typed receiver.
+      return e.localId !== receiverLocalId && isStableBytesOperand(e.value, receiverLocalId);
     case "bin":
-      return isStableBytesOperand(e.left) && isStableBytesOperand(e.right);
+      return (
+        isStableBytesOperand(e.left, receiverLocalId) &&
+        isStableBytesOperand(e.right, receiverLocalId)
+      );
     case "unary":
     case "toBool":
-      return isStableBytesOperand(e.operand);
+      return isStableBytesOperand(e.operand, receiverLocalId);
     case "logical":
-      return isStableBytesOperand(e.left) && isStableBytesOperand(e.right);
+      return (
+        isStableBytesOperand(e.left, receiverLocalId) &&
+        isStableBytesOperand(e.right, receiverLocalId)
+      );
     case "ternary":
       return (
-        isStableBytesOperand(e.cond) &&
-        isStableBytesOperand(e.then) &&
-        isStableBytesOperand(e.else_)
+        isStableBytesOperand(e.cond, receiverLocalId) &&
+        isStableBytesOperand(e.then, receiverLocalId) &&
+        isStableBytesOperand(e.else_, receiverLocalId)
       );
     case "bytesIntrinsic":
       return (
         (e.method === "get" || e.method === "length" || e.method === "byteLength") &&
         e.receiver.kind === "varRef" &&
-        e.args.every(isStableBytesOperand)
+        e.args.every((arg) => isStableBytesOperand(arg, receiverLocalId))
       );
     default:
       return false;
@@ -519,7 +524,10 @@ export function isStableBytesOperand(e: IrExpr): boolean {
  * owner then keeps the value alive, avoiding retain/release traffic around
  * every indexed access. Any uncertain shape falls back to an owned temp. */
 export function emitBytesReceiver(E: CEmitter, receiver: IrExpr, following: IrExpr[]): Temp {
-  if (receiver.kind === "varRef" && following.every(isStableBytesOperand)) {
+  if (
+    receiver.kind === "varRef" &&
+    following.every((operand) => isStableBytesOperand(operand, receiver.localId))
+  ) {
     const local = E.currentLocals.get(receiver.localId);
     if (local && !local.boxed) {
       return E.newBorrowedTemp(receiver.type, mangleLocal(receiver.localId));

--- a/packages/compiler/src/backend/emission/emit-stmts.ts
+++ b/packages/compiler/src/backend/emission/emit-stmts.ts
@@ -8,6 +8,7 @@ import { mangleField, mangleGlobal, mangleLocal, mangleRawParam } from "../mangl
 import { BOOL, CAUGHT, IrExpr, IrStmt, RUNTIME_ERROR_CLASSES, isRefCounted } from "../../ir/nodes.js";
 import { boxAccess, cDecl, cStringLiteral, elemAccess, vAdapters } from "./emit-types.js";
 import { OVERFLOW_MEMBER } from "./emit-shapes.js";
+import { emitBytesReceiver } from "./emit-exprs.js";
 
 
 
@@ -367,12 +368,17 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
       }
       case "bytesSet": {
         // Typed-array element write: same evaluation order as arraySet;
-        // the value is a scalar (the runtime coerces JS-exactly), so no
-        // ownership moves. Any invalid index traps — no append.
-        const arr = E.emitExpr(s.arr);
+        // the value is a scalar (the inline kind-specific accessor coerces
+        // JS-exactly), so no ownership moves. Any invalid index traps — no
+        // append. The IR carries the element kind; do not rediscover it in
+        // the generic runtime accessor on every loop iteration.
+        const arr = emitBytesReceiver(E, s.arr, [s.index, s.value]);
         const idx = E.emitExpr(s.index);
         const v = E.emitExpr(s.value);
-        E.line(`scr_bytes_set(${arr.name}, ${idx.name}, ${v.name});${E.srcComment(s.loc)}`);
+        if (s.arr.type.kind !== "bytes") throw new Error("emitter bug: bytesSet on non-bytes");
+        E.line(
+          `${E.bytesElementHelper("set", s.arr.type.elem)}(${arr.name}, ${idx.name}, ${v.name});${E.srcComment(s.loc)}`,
+        );
         break;
       }
       case "fieldSet":

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -21,6 +21,7 @@
  * the mangled form and every statement carries a `source line` comment.
  */
 import type {
+  IrBytesElem,
   IrGlobal,
   IrRecordShape,
   IrExpr,
@@ -83,6 +84,10 @@ export class CEmitter {
   tempCounter = 0;
   /** Interned string literals: UTF-8 text → static symbol name. */
   readonly literals = new Map<string, string>();
+  /** Kind-specialized typed-array access helpers actually used by this
+   * program. Keeping these in the generated TU means unrelated binaries do
+   * not pay even debug/link metadata for byte-loop fast paths. */
+  readonly bytesElementHelpers = new Set<`${"get" | "set"}:${IrBytesElem}`>();
   /** Interned unit-armed union instances: "unionId:tag" → static symbol.
    * A unit arm (undefined/null) has no payload, so every instance of one
    * (union, tag) pair is identical — ONE immortal (rc == SIZE_MAX) static
@@ -559,6 +564,7 @@ export class CEmitter {
       `#include <stdlib.h>`,
       ``,
     ];
+    out.push(...this.emitBytesElementHelpers());
     // Struct defs render into their own buffer BEFORE the unit-instance
     // table flushes: class newFns point undefined-armed union fields at
     // interned unit instances (fields start as JS's undefined, not NULL),
@@ -1300,6 +1306,76 @@ export class CEmitter {
 
   /* ── plumbing ─────────────────────────────────────────────────────── */
 
+  bytesElementHelper(op: "get" | "set", elem: IrBytesElem): string {
+    this.bytesElementHelpers.add(`${op}:${elem}`);
+    return `sc_bytes_${op}_${elem}`;
+  }
+
+  private emitBytesElementHelpers(): string[] {
+    if (this.bytesElementHelpers.size === 0) return [];
+    const out = [
+      `/* Typed-array hot paths specialized from the IR element kind. */`,
+      `static inline size_t sc_bytes_index_checked(const ScrBytes *b, double i) {`,
+      `  if (!(i >= 0.0 && i < (double)b->len)) { (void)scr_bytes_get(b, i); return 0; }`,
+      `  size_t idx = (size_t)i;`,
+      `  if ((double)idx != i) { (void)scr_bytes_get(b, i); return 0; }`,
+      `  return idx;`,
+      `}`,
+    ];
+    if ([...this.bytesElementHelpers].some((key) => key.startsWith("set:") && key !== "set:f32")) {
+      out.push(
+        `static inline uint32_t sc_bytes_coerce_u32(double v) {`,
+        `  if (v >= -9007199254740992.0 && v <= 9007199254740992.0) return (uint32_t)(int64_t)v;`,
+        `  if (v != v || isinf(v)) return 0;`,
+        `  double t = fmod(trunc(v), 4294967296.0);`,
+        `  if (t < 0) t += 4294967296.0;`,
+        `  return (uint32_t)t;`,
+        `}`,
+      );
+    }
+    for (const elem of ["u8", "u32", "i32", "f32"] as const) {
+      if (this.bytesElementHelpers.has(`get:${elem}`)) {
+        if (elem === "u8") {
+          out.push(
+            `static inline double sc_bytes_get_u8(const ScrBytes *b, double i) {`,
+            `  return (double)b->data[sc_bytes_index_checked(b, i)];`,
+            `}`,
+          );
+        } else {
+          const valueType = elem === "f32" ? "float" : elem === "i32" ? "int32_t" : "uint32_t";
+          out.push(
+            `static inline double sc_bytes_get_${elem}(const ScrBytes *b, double i) {`,
+            `  ${valueType} v;`,
+            `  memcpy(&v, b->data + sc_bytes_index_checked(b, i) * 4, 4);`,
+            `  return (double)v;`,
+            `}`,
+          );
+        }
+      }
+      if (this.bytesElementHelpers.has(`set:${elem}`)) {
+        if (elem === "u8") {
+          out.push(
+            `static inline void sc_bytes_set_u8(ScrBytes *b, double i, double v) {`,
+            `  b->data[sc_bytes_index_checked(b, i)] = (uint8_t)sc_bytes_coerce_u32(v);`,
+            `}`,
+          );
+        } else {
+          const valueType = elem === "f32" ? "float" : "uint32_t";
+          const init = elem === "f32" ? `(float)v` : `sc_bytes_coerce_u32(v)`;
+          out.push(
+            `static inline void sc_bytes_set_${elem}(ScrBytes *b, double i, double v) {`,
+            `  size_t idx = sc_bytes_index_checked(b, i);`,
+            `  ${valueType} stored = ${init};`,
+            `  memcpy(b->data + idx * 4, &stored, 4);`,
+            `}`,
+          );
+        }
+      }
+    }
+    out.push("");
+    return out;
+  }
+
   line(text: string): void {
     this.lines.push("  ".repeat(this.indent) + text);
   }
@@ -1319,6 +1395,15 @@ export class CEmitter {
     const name = `sc_t${this.tempCounter++}`;
     this.line(`${cDecl(type, name)} = ${init};`);
     if (isRefCounted(type)) this.currentFrame().push({ name, type });
+    return { name, type };
+  }
+
+  /** A borrowed compiler temp. Used only when a surrounding operation has
+   * proved that evaluation cannot overwrite the owning binding before the
+   * temp's last use. Unlike newTemp, this does not join the release frame. */
+  newBorrowedTemp(type: IrType, init: string): Temp {
+    const name = `sc_t${this.tempCounter++}`;
+    this.line(`${cDecl(type, name)} = ${init};`);
     return { name, type };
   }
 

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -9310,10 +9310,10 @@ class LlEmitter {
     }
   }
 
-  /** Whether an index/value expression can overwrite a bytes binding.
-   * Kept deliberately conservative; uncertain or calling shapes retain the
-   * ordinary owned-receiver snapshot. */
-  private isStableBytesOperand(e: IrExpr): boolean {
+  /** Whether an index/value expression can overwrite the bytes receiver
+   * binding. Kept deliberately conservative; uncertain or calling shapes
+   * retain the ordinary owned-receiver snapshot. */
+  private isStableBytesOperand(e: IrExpr, receiverLocalId: string): boolean {
     switch (e.kind) {
       case "numLit":
       case "boolLit":
@@ -9321,27 +9321,36 @@ class LlEmitter {
       case "incDec":
         return true;
       case "assignExpr":
-        // A numeric index/value assignment cannot target the bytes-typed
-        // receiver binding.
-        return this.isStableBytesOperand(e.value);
+        // A bytes assignment nested under truthiness/ternary can still
+        // produce the numeric index/value expected by the outer access.
+        return (
+          e.localId !== receiverLocalId &&
+          this.isStableBytesOperand(e.value, receiverLocalId)
+        );
       case "bin":
-        return this.isStableBytesOperand(e.left) && this.isStableBytesOperand(e.right);
+        return (
+          this.isStableBytesOperand(e.left, receiverLocalId) &&
+          this.isStableBytesOperand(e.right, receiverLocalId)
+        );
       case "unary":
       case "toBool":
-        return this.isStableBytesOperand(e.operand);
+        return this.isStableBytesOperand(e.operand, receiverLocalId);
       case "logical":
-        return this.isStableBytesOperand(e.left) && this.isStableBytesOperand(e.right);
+        return (
+          this.isStableBytesOperand(e.left, receiverLocalId) &&
+          this.isStableBytesOperand(e.right, receiverLocalId)
+        );
       case "ternary":
         return (
-          this.isStableBytesOperand(e.cond) &&
-          this.isStableBytesOperand(e.then) &&
-          this.isStableBytesOperand(e.else_)
+          this.isStableBytesOperand(e.cond, receiverLocalId) &&
+          this.isStableBytesOperand(e.then, receiverLocalId) &&
+          this.isStableBytesOperand(e.else_, receiverLocalId)
         );
       case "bytesIntrinsic":
         return (
           (e.method === "get" || e.method === "length" || e.method === "byteLength") &&
           e.receiver.kind === "varRef" &&
-          e.args.every((a) => this.isStableBytesOperand(a))
+          e.args.every((arg) => this.isStableBytesOperand(arg, receiverLocalId))
         );
       default:
         return false;
@@ -9351,7 +9360,10 @@ class LlEmitter {
   /** Borrow a direct, unboxed bytes binding when later operands are stable.
    * Its scope/global owner keeps it alive through the access. */
   private emitBytesReceiver(receiver: IrExpr, following: IrExpr[]): LlValue {
-    if (receiver.kind === "varRef" && following.every((e) => this.isStableBytesOperand(e))) {
+    if (
+      receiver.kind === "varRef" &&
+      following.every((operand) => this.isStableBytesOperand(operand, receiver.localId))
+    ) {
       const b = this.binding(receiver.localId);
       if (b.kind !== "boxed") {
         const value = this.B.tmp();

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -61,6 +61,7 @@
  * the island surface (jsval/jsExit — the engine bridge).
  */
 import type {
+  IrBytesElem,
   IrExpr,
   IrFfiImport,
   IrFunction,
@@ -1343,6 +1344,11 @@ class LlEmitter {
       // scr_runtime.h's natural alignment: kind at 8, f64 at 16, b at 24,
       // payload at 32).
       `%ScrCaught = type { i64, i32, double, i8, ptr, ptr, ptr, ptr }`,
+      // ScrBytes { rc, len, elem(i32+pad), data, backing }. Indexed
+      // typed-array access GEPs through this directly: the IR type already
+      // fixes elem, so the hot path needs neither a runtime kind load nor
+      // the generic scr_bytes_get/set call.
+      `%ScrBytes = type { i64, i64, i32, ptr, ptr }`,
       // The capture box { rc, kind, obj_retain, obj_release, obj_trace,
       // slot } — TDZ reads peek the payload slot (offset 40) directly.
       `%ScrBox = type { i64, i32, ptr, ptr, ptr, i64 }`,
@@ -3178,13 +3184,15 @@ class LlEmitter {
       }
       case "bytesSet": {
         // Typed-array element write: same evaluation order as arraySet;
-        // the value is a scalar (the runtime coerces JS-exactly), so no
-        // ownership moves. Any invalid index traps — no append.
-        const arr = this.emitExpr(s.arr);
+        // the value is a scalar (the kind-specific inline path coerces
+        // JS-exactly), so no ownership moves. Any invalid index traps — no
+        // append. IrBytesElem is static, so never rediscover it through the
+        // generic runtime switch in a hot loop.
+        const arr = this.emitBytesReceiver(s.arr, [s.index, s.value]);
         const idx = this.emitExpr(s.index);
         const v = this.emitExpr(s.value);
-        this.declare(`declare void @scr_bytes_set(ptr, double, double)`);
-        B.line(`call void @scr_bytes_set(ptr ${arr.name}, double ${idx.name}, double ${v.name})`);
+        if (s.arr.type.kind !== "bytes") throw new Error("llvm emitter bug: bytesSet on non-bytes");
+        this.emitBytesSet(s.arr.type.elem, arr.name, idx.name, v.name);
         break;
       }
       case "fieldSet":
@@ -9302,6 +9310,251 @@ class LlEmitter {
     }
   }
 
+  /** Whether an index/value expression can overwrite a bytes binding.
+   * Kept deliberately conservative; uncertain or calling shapes retain the
+   * ordinary owned-receiver snapshot. */
+  private isStableBytesOperand(e: IrExpr): boolean {
+    switch (e.kind) {
+      case "numLit":
+      case "boolLit":
+      case "varRef":
+      case "incDec":
+        return true;
+      case "assignExpr":
+        // A numeric index/value assignment cannot target the bytes-typed
+        // receiver binding.
+        return this.isStableBytesOperand(e.value);
+      case "bin":
+        return this.isStableBytesOperand(e.left) && this.isStableBytesOperand(e.right);
+      case "unary":
+      case "toBool":
+        return this.isStableBytesOperand(e.operand);
+      case "logical":
+        return this.isStableBytesOperand(e.left) && this.isStableBytesOperand(e.right);
+      case "ternary":
+        return (
+          this.isStableBytesOperand(e.cond) &&
+          this.isStableBytesOperand(e.then) &&
+          this.isStableBytesOperand(e.else_)
+        );
+      case "bytesIntrinsic":
+        return (
+          (e.method === "get" || e.method === "length" || e.method === "byteLength") &&
+          e.receiver.kind === "varRef" &&
+          e.args.every((a) => this.isStableBytesOperand(a))
+        );
+      default:
+        return false;
+    }
+  }
+
+  /** Borrow a direct, unboxed bytes binding when later operands are stable.
+   * Its scope/global owner keeps it alive through the access. */
+  private emitBytesReceiver(receiver: IrExpr, following: IrExpr[]): LlValue {
+    if (receiver.kind === "varRef" && following.every((e) => this.isStableBytesOperand(e))) {
+      const b = this.binding(receiver.localId);
+      if (b.kind !== "boxed") {
+        const value = this.B.tmp();
+        this.B.line(`${value} = load ptr, ptr ${b.slot}`);
+        return { name: value, type: receiver.type };
+      }
+    }
+    return this.emitExpr(receiver);
+  }
+
+  /** Bounds-check a typed-array element index without an out-of-line call
+   * on the valid path. The range test rejects NaN/infinity before fptoui;
+   * the integer round trip then rejects fractions. The error block retains
+   * the runtime's exact trap text. Leaves the builder in the valid block. */
+  private emitBytesIndex(receiver: string, index: string): string {
+    const B = this.B;
+    const lenPtr = B.tmp();
+    const len = B.tmp();
+    const lenF64 = B.tmp();
+    const nonnegative = B.tmp();
+    const belowLen = B.tmp();
+    const inRange = B.tmp();
+    B.line(`${lenPtr} = getelementptr inbounds %ScrBytes, ptr ${receiver}, i64 0, i32 1`);
+    B.line(`${len} = load i64, ptr ${lenPtr}`);
+    B.line(`${lenF64} = uitofp i64 ${len} to double`);
+    B.line(`${nonnegative} = fcmp oge double ${index}, ${f64Lit(0)}`);
+    B.line(`${belowLen} = fcmp olt double ${index}, ${lenF64}`);
+    B.line(`${inRange} = and i1 ${nonnegative}, ${belowLen}`);
+
+    const rangeOk = B.newLabel("bytes.index.range");
+    const invalid = B.newLabel("bytes.index.invalid");
+    const valid = B.newLabel("bytes.index.valid");
+    B.condBr(inRange, rangeOk, invalid);
+
+    B.startBlock(rangeOk);
+    const idx = B.tmp();
+    const roundTrip = B.tmp();
+    const integral = B.tmp();
+    B.line(`${idx} = fptoui double ${index} to i64`);
+    B.line(`${roundTrip} = uitofp i64 ${idx} to double`);
+    B.line(`${integral} = fcmp oeq double ${roundTrip}, ${index}`);
+    B.condBr(integral, valid, invalid);
+
+    B.startBlock(invalid);
+    this.declare(`declare double @scr_bytes_get(ptr, double)`);
+    B.line(`call double @scr_bytes_get(ptr ${receiver}, double ${index})`);
+    B.terminate("unreachable");
+
+    B.startBlock(valid);
+    return idx;
+  }
+
+  /** Load the raw data pointer from ScrBytes after the bounds check. */
+  private emitBytesData(receiver: string): string {
+    const p = this.B.tmp();
+    const data = this.B.tmp();
+    this.B.line(`${p} = getelementptr inbounds %ScrBytes, ptr ${receiver}, i64 0, i32 3`);
+    this.B.line(`${data} = load ptr, ptr ${p}`);
+    return data;
+  }
+
+  /** Static typed-array length/byteLength load. */
+  private emitBytesLength(elem: IrBytesElem, receiver: string, bytes: boolean): LlValue {
+    const B = this.B;
+    const p = B.tmp();
+    const len = B.tmp();
+    B.line(`${p} = getelementptr inbounds %ScrBytes, ptr ${receiver}, i64 0, i32 1`);
+    B.line(`${len} = load i64, ptr ${p}`);
+    const count = bytes && elem !== "u8" ? B.tmp() : len;
+    if (count !== len) B.line(`${count} = shl i64 ${len}, 2`);
+    const out = B.tmp();
+    B.line(`${out} = uitofp i64 ${count} to double`);
+    return { name: out, type: F64 };
+  }
+
+  /** Kind-specialized typed-array load. */
+  private emitBytesGet(elem: IrBytesElem, receiver: string, index: string): LlValue {
+    const B = this.B;
+    const idx = this.emitBytesIndex(receiver, index);
+    const data = this.emitBytesData(receiver);
+    const p = B.tmp();
+    if (elem === "u8") {
+      const raw = B.tmp();
+      const wide = B.tmp();
+      const out = B.tmp();
+      B.line(`${p} = getelementptr inbounds i8, ptr ${data}, i64 ${idx}`);
+      B.line(`${raw} = load i8, ptr ${p}, align 1`);
+      B.line(`${wide} = zext i8 ${raw} to i32`);
+      B.line(`${out} = uitofp i32 ${wide} to double`);
+      return { name: out, type: F64 };
+    }
+    if (elem === "f32") {
+      const raw = B.tmp();
+      const out = B.tmp();
+      B.line(`${p} = getelementptr inbounds float, ptr ${data}, i64 ${idx}`);
+      B.line(`${raw} = load float, ptr ${p}, align 1`);
+      B.line(`${out} = fpext float ${raw} to double`);
+      return { name: out, type: F64 };
+    }
+    const raw = B.tmp();
+    const out = B.tmp();
+    B.line(`${p} = getelementptr inbounds i32, ptr ${data}, i64 ${idx}`);
+    B.line(`${raw} = load i32, ptr ${p}, align 1`);
+    B.line(`${out} = ${elem === "i32" ? "sitofp" : "uitofp"} i32 ${raw} to double`);
+    return { name: out, type: F64 };
+  }
+
+  /** ToUint32/ToInt32 coercion with the overwhelmingly common finite,
+   * exactly-representable JS-number range on a cast-only path. Exceptional
+   * and huge values remain inline in the program TU so unrelated runtime
+   * binaries do not acquire another exported helper. */
+  private emitBytesU32(value: string): string {
+    const B = this.B;
+    const aboveMin = B.tmp();
+    const belowMax = B.tmp();
+    const fast = B.tmp();
+    B.line(`${aboveMin} = fcmp oge double ${value}, ${f64Lit(-9007199254740992)}`);
+    B.line(`${belowMax} = fcmp ole double ${value}, ${f64Lit(9007199254740992)}`);
+    B.line(`${fast} = and i1 ${aboveMin}, ${belowMax}`);
+
+    const fastLabel = B.newLabel("bytes.coerce.fast");
+    const slowLabel = B.newLabel("bytes.coerce.slow");
+    const done = B.newLabel("bytes.coerce.done");
+    B.condBr(fast, fastLabel, slowLabel);
+
+    B.startBlock(fastLabel);
+    const signed = B.tmp();
+    const fastU32 = B.tmp();
+    B.line(`${signed} = fptosi double ${value} to i64`);
+    B.line(`${fastU32} = trunc i64 ${signed} to i32`);
+    B.br(done);
+
+    B.startBlock(slowLabel);
+    const ordered = B.tmp();
+    const belowInf = B.tmp();
+    const aboveNegInf = B.tmp();
+    const finiteRange = B.tmp();
+    const finite = B.tmp();
+    B.line(`${ordered} = fcmp ord double ${value}, ${value}`);
+    B.line(`${belowInf} = fcmp olt double ${value}, ${F64_INF}`);
+    B.line(`${aboveNegInf} = fcmp ogt double ${value}, ${f64Lit(-Infinity)}`);
+    B.line(`${finiteRange} = and i1 ${belowInf}, ${aboveNegInf}`);
+    B.line(`${finite} = and i1 ${ordered}, ${finiteRange}`);
+    const finiteLabel = B.newLabel("bytes.coerce.finite");
+    const nonfiniteLabel = B.newLabel("bytes.coerce.nonfinite");
+    const slowDone = B.newLabel("bytes.coerce.slow.done");
+    B.condBr(finite, finiteLabel, nonfiniteLabel);
+
+    B.startBlock(finiteLabel);
+    this.declare(`declare double @llvm.trunc.f64(double)`);
+    const truncated = B.tmp();
+    const residue = B.tmp();
+    const negative = B.tmp();
+    const wrapped = B.tmp();
+    const normalized = B.tmp();
+    const finiteU32 = B.tmp();
+    B.line(`${truncated} = call double @llvm.trunc.f64(double ${value})`);
+    B.line(`${residue} = frem double ${truncated}, ${f64Lit(4294967296)}`);
+    B.line(`${negative} = fcmp olt double ${residue}, ${f64Lit(0)}`);
+    B.line(`${wrapped} = fadd double ${residue}, ${f64Lit(4294967296)}`);
+    B.line(`${normalized} = select i1 ${negative}, double ${wrapped}, double ${residue}`);
+    B.line(`${finiteU32} = fptoui double ${normalized} to i32`);
+    B.br(slowDone);
+
+    B.startBlock(nonfiniteLabel);
+    B.br(slowDone);
+
+    B.startBlock(slowDone);
+    const slowU32 = B.tmp();
+    B.line(`${slowU32} = phi i32 [ ${finiteU32}, %${finiteLabel} ], [ 0, %${nonfiniteLabel} ]`);
+    B.br(done);
+
+    B.startBlock(done);
+    const out = B.tmp();
+    B.line(`${out} = phi i32 [ ${fastU32}, %${fastLabel} ], [ ${slowU32}, %${slowDone} ]`);
+    return out;
+  }
+
+  /** Kind-specialized typed-array store. */
+  private emitBytesSet(elem: IrBytesElem, receiver: string, index: string, value: string): void {
+    const B = this.B;
+    const idx = this.emitBytesIndex(receiver, index);
+    const stored = elem === "f32" ? null : this.emitBytesU32(value);
+    const data = this.emitBytesData(receiver);
+    const p = B.tmp();
+    if (elem === "u8") {
+      const byte = B.tmp();
+      B.line(`${byte} = trunc i32 ${stored!} to i8`);
+      B.line(`${p} = getelementptr inbounds i8, ptr ${data}, i64 ${idx}`);
+      B.line(`store i8 ${byte}, ptr ${p}, align 1`);
+      return;
+    }
+    if (elem === "f32") {
+      const narrowed = B.tmp();
+      B.line(`${narrowed} = fptrunc double ${value} to float`);
+      B.line(`${p} = getelementptr inbounds float, ptr ${data}, i64 ${idx}`);
+      B.line(`store float ${narrowed}, ptr ${p}, align 1`);
+      return;
+    }
+    B.line(`${p} = getelementptr inbounds i32, ptr ${data}, i64 ${idx}`);
+    B.line(`store i32 ${stored!}, ptr ${p}, align 1`);
+  }
+
   /** The bytesIntrinsic surface (emit-exprs.ts's switch, .ll flavored).
    * Receiver and args are borrowed frame temps; string/bytes results come
    * back +1. The MAY_THROW methods get the standard pending check after
@@ -9347,18 +9600,30 @@ class LlEmitter {
         : call("scr_bytes_write_var", "double (ptr, double, double, double, i1 zeroext, i1 zeroext)",
             `ptr ${r0.name}, double ${rest[0]!.name}, double ${rest[1]!.name}, double ${rest[2]!.name}, i1 ${spec.sign}, i1 ${spec.le}`, false, true);
     }
-    const r = this.emitExpr(e.receiver);
-    const args = e.args.map((a) => this.emitExpr(a));
     const method = e.method;
+    const directElementAccess = method === "length" || method === "byteLength" || method === "get";
+    const r = directElementAccess
+      ? this.emitBytesReceiver(e.receiver, e.args)
+      : this.emitExpr(e.receiver);
+    const args = e.args.map((a) => this.emitExpr(a));
     const NAN = f64Lit(NaN);
     switch (method) {
       case "length":
-        return call("scr_bytes_len", "double (ptr)", `ptr ${r.name}`, false, false);
+        if (e.receiver.type.kind !== "bytes") {
+          throw new Error("llvm emitter bug: bytesIntrinsic length on non-bytes");
+        }
+        return this.emitBytesLength(e.receiver.type.elem, r.name, false);
       case "byteLength":
-        return call("scr_bytes_byte_len", "double (ptr)", `ptr ${r.name}`, false, false);
+        if (e.receiver.type.kind !== "bytes") {
+          throw new Error("llvm emitter bug: bytesIntrinsic byteLength on non-bytes");
+        }
+        return this.emitBytesLength(e.receiver.type.elem, r.name, true);
       case "get":
         // Any invalid index traps (the array runtime's discipline).
-        return call("scr_bytes_get", "double (ptr, double)", `ptr ${r.name}, double ${args[0]!.name}`, false, false);
+        if (e.receiver.type.kind !== "bytes") {
+          throw new Error("llvm emitter bug: bytesIntrinsic get on non-bytes");
+        }
+        return this.emitBytesGet(e.receiver.type.elem, r.name, args[0]!.name);
       case "slice":
         return call(
           "scr_bytes_slice",

--- a/packages/compiler/test/bytes-element-emission.test.ts
+++ b/packages/compiler/test/bytes-element-emission.test.ts
@@ -1,0 +1,114 @@
+import { expect, test } from "vitest";
+import { emitModule } from "../src/backend/emission/emitter.js";
+import { emitLlvmModule } from "../src/backend/llvm/emitter.js";
+import { F64, VOID, bytesOf, type IrBytesElem, type IrExpr, type IrLocal, type IrModule, type IrStmt } from "../src/ir/nodes.js";
+import { validateModule } from "../src/ir/validate.js";
+
+const loc = { file: "bytes-hot-loop.ts", start: 0, end: 0 };
+const elems: IrBytesElem[] = ["u8", "u32", "i32", "f32"];
+
+function fixture(): IrModule {
+  const locals: IrLocal[] = [];
+  const body: IrStmt[] = [];
+  const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
+  for (const [n, elem] of elems.entries()) {
+    const type = bytesOf(elem);
+    const localId = `b.${n}`;
+    const ref = (): IrExpr => ({ kind: "varRef", localId, type, loc });
+    locals.push({ id: localId, name: `b${n}`, type, mutable: false });
+    body.push(
+      {
+        kind: "varDecl",
+        localId,
+        init: { kind: "bytesNew", source: num(1), type, loc },
+        loc,
+      },
+      { kind: "bytesSet", arr: ref(), index: num(0), value: num(n + 1), loc },
+      {
+        kind: "exprStmt",
+        expr: {
+          kind: "bytesIntrinsic",
+          method: "get",
+          receiver: ref(),
+          args: [num(0)],
+          type: F64,
+          loc,
+        },
+        loc,
+      },
+    );
+  }
+
+  return {
+    irVersion: 3,
+    sourceFile: loc.file,
+    entry: "__main",
+    functions: [{ name: "__main", params: [], returnType: VOID, locals, body, loc }],
+  };
+}
+
+function sideEffectFixture(): IrModule {
+  const mod = fixture();
+  mod.functions.unshift({
+    name: "sideIndex",
+    params: [],
+    returnType: F64,
+    locals: [],
+    body: [{ kind: "return", value: { kind: "numLit", value: 0, type: F64, loc }, loc }],
+    loc,
+  });
+  mod.functions.find((fn) => fn.name === "__main")!.body.push({
+    kind: "exprStmt",
+    expr: {
+      kind: "bytesIntrinsic",
+      method: "get",
+      receiver: { kind: "varRef", localId: "b.0", type: bytesOf("u8"), loc },
+      args: [{ kind: "call", callee: "sideIndex", args: [], type: F64, loc }],
+      type: F64,
+      loc,
+    },
+    loc,
+  });
+  return mod;
+}
+
+test("C emission specializes typed-array element access by static element kind", () => {
+  const mod = fixture();
+  expect(validateModule(mod)).toEqual([]);
+  const c = emitModule(mod);
+  for (const elem of elems) {
+    expect(c).toContain(`sc_bytes_get_${elem}(`);
+    expect(c).toContain(`sc_bytes_set_${elem}(`);
+  }
+  // The only generic calls are the shared cold invalid-index trap funnel.
+  expect(c.match(/\bscr_bytes_get\(/g)).toHaveLength(2);
+  expect(c).not.toMatch(/\bscr_bytes_set\(/);
+  expect(c).not.toContain("scr_bytes_retain(");
+});
+
+test("LLVM emission performs typed-array element access directly on the valid path", () => {
+  const mod = fixture();
+  expect(validateModule(mod)).toEqual([]);
+  const ll = emitLlvmModule(mod);
+  expect(ll).toContain("%ScrBytes = type { i64, i64, i32, ptr, ptr }");
+  expect(ll).toContain("getelementptr inbounds i8");
+  expect(ll).toContain("getelementptr inbounds i32");
+  expect(ll).toContain("getelementptr inbounds float");
+  expect(ll).toContain("bytes.index.invalid");
+  // The generic getter is only the shared cold trap funnel for invalid indices.
+  expect(ll).toContain("call double @scr_bytes_get");
+  expect(ll).not.toContain("@scr_bytes_set(");
+  expect(ll).not.toContain("@scr_bytes_retain_v");
+});
+
+test("side-effecting indices retain the receiver snapshot", () => {
+  const mod = sideEffectFixture();
+  expect(validateModule(mod)).toEqual([]);
+  const c = emitModule(mod);
+  const ll = emitLlvmModule(mod);
+  expect(c).toContain("scr_bytes_retain(sc_l_b_0)");
+  expect(ll).toContain("call ptr @scr_bytes_retain_v");
+  expect(c.match(/\bscr_bytes_get\(/g)).toHaveLength(2);
+  expect(ll).toContain("call double @scr_bytes_get");
+});

--- a/packages/compiler/test/bytes-element-emission.test.ts
+++ b/packages/compiler/test/bytes-element-emission.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "vitest";
 import { emitModule } from "../src/backend/emission/emitter.js";
 import { emitLlvmModule } from "../src/backend/llvm/emitter.js";
-import { F64, VOID, bytesOf, type IrBytesElem, type IrExpr, type IrLocal, type IrModule, type IrStmt } from "../src/ir/nodes.js";
+import { BOOL, F64, VOID, bytesOf, type IrBytesElem, type IrExpr, type IrLocal, type IrModule, type IrStmt } from "../src/ir/nodes.js";
 import { validateModule } from "../src/ir/validate.js";
 
 const loc = { file: "bytes-hot-loop.ts", start: 0, end: 0 };
@@ -39,6 +39,101 @@ function fixture(): IrModule {
       },
     );
   }
+
+  locals.push({ id: "index", name: "index", type: F64, mutable: true });
+  body.push(
+    { kind: "varDecl", localId: "index", init: num(1), loc },
+    {
+      kind: "exprStmt",
+      expr: {
+        kind: "bytesIntrinsic",
+        method: "get",
+        receiver: { kind: "varRef", localId: "b.0", type: bytesOf("u8"), loc },
+        args: [
+          {
+            kind: "assignExpr",
+            localId: "index",
+            value: num(0),
+            type: F64,
+            loc,
+          },
+        ],
+        type: F64,
+        loc,
+      },
+      loc,
+    },
+  );
+
+  return {
+    irVersion: 3,
+    sourceFile: loc.file,
+    entry: "__main",
+    functions: [{ name: "__main", params: [], returnType: VOID, locals, body, loc }],
+  };
+}
+
+function receiverReassignmentFixture(): IrModule {
+  const bytes = bytesOf("u8");
+  const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+  const ref = (localId: string): IrExpr => ({ kind: "varRef", localId, type: bytes, loc });
+  const replacementCondition = (receiverId: string, replacementId: string): IrExpr => ({
+    kind: "toBool",
+    operand: {
+      kind: "assignExpr",
+      localId: receiverId,
+      value: ref(replacementId),
+      type: bytes,
+      loc,
+    },
+    type: BOOL,
+    loc,
+  });
+  const numericTernary = (cond: IrExpr, thenValue: number, elseValue: number): IrExpr => ({
+    kind: "ternary",
+    cond,
+    then: num(thenValue),
+    else_: num(elseValue),
+    type: F64,
+    loc,
+  });
+  const locals: IrLocal[] = [
+    { id: "read", name: "read", type: bytes, mutable: true },
+    { id: "readReplacement", name: "readReplacement", type: bytes, mutable: false },
+    { id: "write", name: "write", type: bytes, mutable: true },
+    { id: "writeReplacement", name: "writeReplacement", type: bytes, mutable: false },
+  ];
+  const declareBytes = (localId: string): IrStmt => ({
+    kind: "varDecl",
+    localId,
+    init: { kind: "bytesNew", source: num(1), type: bytes, loc },
+    loc,
+  });
+  const body: IrStmt[] = [
+    declareBytes("read"),
+    declareBytes("readReplacement"),
+    {
+      kind: "exprStmt",
+      expr: {
+        kind: "bytesIntrinsic",
+        method: "get",
+        receiver: ref("read"),
+        args: [numericTernary(replacementCondition("read", "readReplacement"), 0, 0)],
+        type: F64,
+        loc,
+      },
+      loc,
+    },
+    declareBytes("write"),
+    declareBytes("writeReplacement"),
+    {
+      kind: "bytesSet",
+      arr: ref("write"),
+      index: num(0),
+      value: numericTernary(replacementCondition("write", "writeReplacement"), 55, 66),
+      loc,
+    },
+  ];
 
   return {
     irVersion: 3,
@@ -111,4 +206,16 @@ test("side-effecting indices retain the receiver snapshot", () => {
   expect(ll).toContain("call ptr @scr_bytes_retain_v");
   expect(c.match(/\bscr_bytes_get\(/g)).toHaveLength(2);
   expect(ll).toContain("call double @scr_bytes_get");
+});
+
+test("receiver assignments nested in numeric operands retain the receiver snapshot", () => {
+  const mod = receiverReassignmentFixture();
+  expect(validateModule(mod)).toEqual([]);
+  const c = emitModule(mod);
+  const ll = emitLlvmModule(mod);
+  expect(c).toContain("scr_bytes_retain(sc_l_read)");
+  expect(c).toContain("scr_bytes_retain(sc_l_write)");
+  // Two receiver snapshots plus two retains per yielded bytes assignment
+  // (one for the RHS temp and one for the binding's stored reference).
+  expect(ll.match(/call ptr @scr_bytes_retain_v/g)).toHaveLength(6);
 });

--- a/packages/compiler/test/llvm-runtime-abi.test.ts
+++ b/packages/compiler/test/llvm-runtime-abi.test.ts
@@ -5,7 +5,7 @@
  * type-checks its calls against the header), but a .ll `declare` is taken
  * on faith by the linker, so a disagreement is silent UB that can run
  * clean under one toolchain and misbehave under another. This test kills
- * the class mechanically, from three directions:
+ * the class mechanically, from four directions:
  *
  *  1. Source scan: every fully-literal `declare ... @scr_*` template
  *     string in the backend/llvm sources is checked against the header.
@@ -21,14 +21,23 @@
  *     data symbol. This is what catches a two-string name skew (table
  *     says scr_foo_bar, runtime defines scr_foobar) at test time instead
  *     of at the user's link step.
+ *  4. Structural layout: compile-time C assertions pin every ScrBytes
+ *     size/alignment/offset fact used by LLVM's direct typed-array GEPs.
+ *     A runtime-header layout edit therefore fails here instead of becoming
+ *     silent cross-language memory corruption.
  *
  * The header parser fails LOUDLY on any C type it cannot map so it can
  * never silently fall behind the header. */
-import { mkdtemp, readdir, readFile } from "node:fs/promises";
+import { execFile } from "node:child_process";
+import { mkdtemp, readdir, readFile, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { promisify } from "node:util";
 import { describe, expect, test } from "vitest";
+import { resolveCc, runtimeSrcDir } from "../src/backend/cc.js";
 import { compile } from "../src/index.js";
+
+const execFileAsync = promisify(execFile);
 
 const repoRoot = join(import.meta.dirname, "../../..");
 const headerPath = join(repoRoot, "packages/runtime/src/scr_runtime.h");
@@ -215,6 +224,44 @@ function checkDeclare(d: LlDeclare, protos: Map<string, CProto>): string | undef
 }
 
 describe("LLVM backend declares match scr_runtime.h prototypes", () => {
+  test("ScrBytes structural type matches the C runtime layout", async () => {
+    const outDir = await mkdtemp(join(tmpdir(), "scriptc-llvm-layout-"));
+    const cPath = join(outDir, "scr-bytes-layout.c");
+    const objectPath = join(outDir, "scr-bytes-layout.o");
+    await writeFile(
+      cPath,
+      `#include <stddef.h>
+#include <stdint.h>
+#include "scr_runtime.h"
+
+/* LLVM emits: %ScrBytes = type { i64, i64, i32, ptr, ptr }.
+ * Keep every ABI fact used by its field-index GEPs explicit here. */
+_Static_assert(sizeof(size_t) == 8, "LLVM ScrBytes expects 64-bit size_t");
+_Static_assert(sizeof(void *) == 8, "LLVM ScrBytes expects 64-bit pointers");
+_Static_assert(sizeof(ScrBytesElem) == 4, "LLVM ScrBytes elem field is i32");
+_Static_assert(_Alignof(ScrBytes) == 8, "LLVM ScrBytes alignment changed");
+_Static_assert(sizeof(ScrBytes) == 40, "LLVM ScrBytes size changed");
+_Static_assert(offsetof(ScrBytes, rc) == 0, "LLVM ScrBytes.rc offset changed");
+_Static_assert(offsetof(ScrBytes, len) == 8, "LLVM ScrBytes.len offset changed");
+_Static_assert(offsetof(ScrBytes, elem) == 16, "LLVM ScrBytes.elem offset changed");
+_Static_assert(offsetof(ScrBytes, data) == 24, "LLVM ScrBytes.data offset changed");
+_Static_assert(offsetof(ScrBytes, backing) == 32, "LLVM ScrBytes.backing offset changed");
+`,
+    );
+    const driver = resolveCc();
+    await execFileAsync(driver.argv[0]!, [
+      ...driver.argv.slice(1),
+      ...driver.targetArgs,
+      "-std=c11",
+      "-I",
+      runtimeSrcDir(),
+      "-c",
+      cPath,
+      "-o",
+      objectPath,
+    ]);
+  });
+
   test("every literal declare in the backend sources", async () => {
     const { protos } = await parseHeader();
     const failures: string[] = [];

--- a/tests/corpus/1400-typedarray-basics.ts
+++ b/tests/corpus/1400-typedarray-basics.ts
@@ -85,3 +85,16 @@ function replaceWriteOrder(): number {
 }
 writeOrder[0] = replaceWriteOrder();
 console.log("write-order", writeOrder[0]);
+
+// Assignment expressions can hide the receiver overwrite beneath a boolean
+// condition while the enclosing ternary still produces a numeric operand.
+let nestedReadOrder = new Uint8Array([66]);
+const nestedReadReplacement = new Uint8Array([77]);
+const nestedReadBeforeReplace =
+  nestedReadOrder[(nestedReadOrder = nestedReadReplacement) ? 0 : 0];
+console.log("nested-read-order", nestedReadBeforeReplace, nestedReadOrder[0]);
+
+let nestedWriteOrder = new Uint8Array([88]);
+const nestedWriteReplacement = new Uint8Array([99]);
+nestedWriteOrder[0] = (nestedWriteOrder = nestedWriteReplacement) ? 55 : 66;
+console.log("nested-write-order", nestedWriteOrder[0]);

--- a/tests/corpus/1400-typedarray-basics.ts
+++ b/tests/corpus/1400-typedarray-basics.ts
@@ -17,7 +17,19 @@ for (const v of vals) {
 
 const u = new Uint32Array(2);
 console.log("ulen", u.length, u.byteLength);
-const uvals = [-1, 4294967296, 4294967301, 4.9, nan];
+const uvals = [
+  -1,
+  4294967296,
+  4294967301,
+  4.9,
+  nan,
+  inf,
+  -inf,
+  9007199254740992,
+  9007199254740994,
+  1e100,
+  -1e100,
+];
 for (const v of uvals) {
   u[1] = v;
   console.log("u32", u[1]);
@@ -54,3 +66,22 @@ console.log("copy", seeded[0], copy[0]);
 
 const useed = new Uint32Array([4294967295, 7]);
 console.log("useed", useed[0], useed[1]);
+
+// Receiver evaluation snapshots the old bytes before a later index/value
+// expression overwrites its only binding. The optimized direct-binding
+// borrow is intentionally disabled for these side-effecting operands.
+let readOrder = new Uint8Array([11]);
+function replaceReadOrder(): number {
+  readOrder = new Uint8Array([22]);
+  return 0;
+}
+const readBeforeReplace = readOrder[replaceReadOrder()];
+console.log("read-order", readBeforeReplace, readOrder[0]);
+
+let writeOrder = new Uint8Array([33]);
+function replaceWriteOrder(): number {
+  writeOrder = new Uint8Array([44]);
+  return 55;
+}
+writeOrder[0] = replaceWriteOrder();
+console.log("write-order", writeOrder[0]);


### PR DESCRIPTION
- Lower typed-array reads, writes, and lengths directly by IR element kind.
- Preserve coercion, bounds, and receiver lifetime semantics across C and LLVM.
- Cover emission, ABI layout, and Node-differential behavior.