### PR TITLE
Lower AbortController for fetch cancellation

### DIFF
--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -2930,6 +2930,8 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             );
             return result;
           }
+          case "fetch.abortControllerNew":
+            return finish(`scr_fetch_abort_controller_new()`);
           case "fetch.abortTimeout":
             E.usesTimers = true;
             return finish(`scr_fetch_abort_timeout(${arg(0)})`);

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -493,6 +493,7 @@ const LIB_FN_SYMS: Record<string, string> = {
   "fetch.responseJson": "scr_fetch_response_json",
   "fetch.responseText": "scr_fetch_response_text",
   "fetch.responseBytes": "scr_fetch_response_bytes",
+  "fetch.abortControllerNew": "scr_fetch_abort_controller_new",
   "fetch.abortTimeout": "scr_fetch_abort_timeout",
   "fetch.abortNow": "scr_fetch_abort_now",
   "fetch.abortAny": "scr_fetch_abort_any",

--- a/packages/compiler/src/compat/fetch-profile.ts
+++ b/packages/compiler/src/compat/fetch-profile.ts
@@ -283,6 +283,27 @@ export const NODE24_FETCH_COMPAT_PROFILE = {
       evidence: [fixture("static"), fixture("static-coercion"), fixture("static-network-error")],
     },
     {
+      id: "stdlib.abort-controller.constructor",
+      name: "AbortController constructor",
+      kind: "constructor",
+      facets: ["argument-evaluation", "identity", "state-machine", "surplus-arguments"],
+      evidence: [fixture("static-controller")],
+    },
+    {
+      id: "stdlib.abort-controller.signal",
+      name: "AbortController.signal",
+      kind: "property",
+      facets: ["identity", "property-read", "state-machine"],
+      evidence: [fixture("static-controller")],
+    },
+    {
+      id: "stdlib.abort-controller.abort",
+      name: "AbortController.abort",
+      kind: "method",
+      facets: ["callback-order", "identity", "liveness", "state-machine", "surplus-arguments"],
+      evidence: [fixture("static-controller")],
+    },
+    {
       id: "stdlib.abort-signal.abort",
       name: "AbortSignal.abort",
       kind: "static-method",
@@ -501,26 +522,23 @@ export const NODE24_FETCH_COMPAT_PROFILE = {
     entries: [
       staticEntry("stdlib.fetch", "globalThis", "fetch", "global"),
 
-      unsupportedEntry(
+      staticEntry(
         "stdlib.abort-controller.constructor",
         "AbortController",
         "constructor",
         "constructor",
-        typedInterfaceUnsupported,
       ),
-      unsupportedEntry(
+      staticEntry(
         "stdlib.abort-controller.signal",
         "AbortController",
         "signal",
         "prototype",
-        typedInterfaceUnsupported,
       ),
-      unsupportedEntry(
+      staticEntry(
         "stdlib.abort-controller.abort",
         "AbortController",
         "abort",
         "prototype",
-        typedInterfaceUnsupported,
       ),
       outOfScopeEntry(
         "stdlib.abort-controller.symbol.toStringTag",

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -1738,6 +1738,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
       // The lib fence's PROPERTY chokepoint: a stdlib-declared member that
       // no lowering above claimed ([1,2].entries, Math.SQRT2, Promise.all,
       // re.exec as a value, ...) reports SC2020 here.
+      L.fenceStaticAbortControllerMemberRead(expr);
       L.fenceStaticResponseMember(expr, "read");
       L.fenceStaticHeadersMember(expr, "read");
       L.fenceStaticReadableStreamMember(expr, "read");
@@ -5643,6 +5644,7 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
     // spellings. Fence a statically-known unsupported key before the generic
     // checked-dynamic element-read path can turn it into a runtime missing
     // member.
+    L.fenceStaticAbortControllerMemberRead(expr);
     L.fenceStaticResponseMember(expr, "read");
     L.fenceStaticHeadersMember(expr, "read");
     L.fenceStaticReadableStreamMember(expr, "read");

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -2132,6 +2132,67 @@ export function lowerStaticFetchCompanionCall(
   return null;
 }
 
+/** `AbortController.abort(reason?)` mutates the native signal shared with
+ * `.signal` and fetch. Preserve a mutable reason's identity just like
+ * `AbortSignal.abort(reason)`; surplus arguments still evaluate in order and
+ * are ignored by the runtime operation. */
+export function lowerStaticAbortControllerCall(
+  L: Lowerer,
+  call: ts.CallExpression,
+): IrExpr | null {
+  const access = call.expression;
+  if (
+    L.dynamic ||
+    call.questionDotToken ||
+    call.arguments.some((argument) => ts.isSpreadElement(argument)) ||
+    (!ts.isPropertyAccessExpression(access) &&
+      !ts.isElementAccessExpression(access)) ||
+    access.questionDotToken ||
+    staticResponseMemberName(L, access) !== "abort"
+  ) {
+    return null;
+  }
+  const receiverTs = L.checker.getBaseTypeOfLiteralType(
+    L.typeOf(access.expression),
+  );
+  const symbol = receiverTs.getAliasSymbol() ?? receiverTs.getSymbol();
+  if (
+    symbol?.name !== "AbortController" ||
+    !L.checker.declarationsOf(symbol).some(
+      (d) =>
+        ts.isInterfaceDeclaration(d) &&
+        L.isStdlibFile(d.getSourceFile()),
+    )
+  ) {
+    return null;
+  }
+  const receiver = L.lowerExpr(access.expression);
+  if (receiver.type.kind !== "dyn") return null;
+  const loc = locOf(call);
+  const args = call.arguments.map((argument, index) =>
+    index === 0
+      ? lowerLiveWebValue(L, argument)
+      : L.lowerExprExpecting(argument, DYN)
+  );
+  return lowerStaticFixedFetchMethodCall(
+    L,
+    call,
+    access,
+    "abort",
+    receiver,
+    args,
+    (receiverRef, argumentRefs) => ({
+      kind: "dynInvoke",
+      recv: receiverRef,
+      method: "abort",
+      calleeName: access.getText(),
+      args: argumentRefs,
+      type: DYN,
+      loc,
+    }),
+  );
+}
+
 /** Controller chunks and error reasons are dyn-handle calls, but unlike a
  * general checked-dynamic boundary the Web Streams contract preserves their
  * object identity for the reader/source callbacks that observe them. */
@@ -2310,6 +2371,65 @@ export function lowerStaticAbortSignalListenerCall(
       loc,
     }),
   );
+}
+
+/** `new AbortController()`. Static builds create a native controller handle
+ * over the same signal state consumed by fetch; dynamic builds construct the
+ * island Web object. JavaScript accepts surplus constructor arguments, so
+ * both tiers evaluate them even though AbortController ignores their values. */
+export function lowerAbortControllerNew(
+  L: Lowerer,
+  expr: ts.NewExpression,
+): IrExpr | null {
+  if (
+    !ts.isIdentifier(expr.expression) ||
+    expr.expression.text !== "AbortController"
+  ) {
+    return null;
+  }
+  const symbol = L.resolveValueSymbol(expr.expression);
+  if (!symbol || !L.isStdlibSymbol(symbol)) return null;
+  const args = expr.arguments ?? [];
+  if (args.some((argument) => ts.isSpreadElement(argument))) return null;
+  const loc = locOf(expr);
+  if (L.dynamic) {
+    const ctor: IrExpr = {
+      kind: "jsOp",
+      op: "globalGet",
+      name: "AbortController",
+      args: [],
+      type: JSVAL,
+      loc,
+    };
+    return {
+      kind: "jsOp",
+      op: "construct",
+      args: [ctor, ...args.map((argument) =>
+        L.jsvalIn(L.lowerExpr(argument), argument)
+      )],
+      type: JSVAL,
+      loc,
+    };
+  }
+  const result: IrExpr = {
+    kind: "libCall",
+    fn: "fetch.abortControllerNew",
+    args: [],
+    type: DYN,
+    loc,
+  };
+  if (args.length === 0) return result;
+  return {
+    kind: "seqExpr",
+    stmts: args.map((argument): IrStmt => ({
+      kind: "exprStmt",
+      expr: L.lowerExpr(argument),
+      loc: locOf(argument),
+    })),
+    result,
+    type: DYN,
+    loc,
+  };
 }
 
 /** `new ReadableStream(source?)`. Static builds box the source record into

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -1950,21 +1950,20 @@ export function fenceStaticReadableStreamMember(
  * ambient globals have no first-class constructor-object representation;
  * claim the direct calls by declaration provenance before the general
  * member-call path tries to lower the receiver as a value. */
-function staticCallWithSurplusArgs(
+function staticFirstArgWithSurplusArgs(
   L: Lowerer,
   call: ts.CallExpression,
   first: IrExpr,
-  result: (first: IrExpr) => IrExpr,
 ): IrExpr {
   const loc = locOf(call);
-  if (call.arguments.length === 1) return result(first);
+  if (call.arguments.length <= 1) return first;
   const firstLocal = L.declareHiddenLocal("%fetchArg", first.type);
-  const firstRef = (): IrExpr => ({
+  const firstRef: IrExpr = {
     kind: "varRef",
     localId: firstLocal.id,
     type: first.type,
     loc,
-  });
+  };
   const stmts: IrStmt[] = [
     { kind: "varDecl", localId: firstLocal.id, init: first, loc },
   ];
@@ -1984,8 +1983,22 @@ function staticCallWithSurplusArgs(
       : L.lowerExpr(argument);
     stmts.push({ kind: "exprStmt", expr: discarded, loc: discarded.loc });
   }
-  const answer = result(firstRef());
-  return { kind: "seqExpr", stmts, result: answer, type: answer.type, loc };
+  return {
+    kind: "seqExpr",
+    stmts,
+    result: firstRef,
+    type: first.type,
+    loc,
+  };
+}
+
+function staticCallWithSurplusArgs(
+  L: Lowerer,
+  call: ts.CallExpression,
+  first: IrExpr,
+  result: (first: IrExpr) => IrExpr,
+): IrExpr {
+  return result(staticFirstArgWithSurplusArgs(L, call, first));
 }
 
 export function lowerStaticFetchCompanionCall(
@@ -2169,11 +2182,10 @@ export function lowerStaticAbortControllerCall(
   const receiver = L.lowerExpr(access.expression);
   if (receiver.type.kind !== "dyn") return null;
   const loc = locOf(call);
-  const args = call.arguments.map((argument, index) =>
-    index === 0
-      ? lowerLiveWebValue(L, argument)
-      : L.lowerExprExpecting(argument, DYN)
-  );
+  const first = call.arguments[0]
+    ? lowerLiveWebValue(L, call.arguments[0])
+    : dynUndefinedExpr(loc);
+  const args = [staticFirstArgWithSurplusArgs(L, call, first)];
   return lowerStaticFixedFetchMethodCall(
     L,
     call,

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -1374,6 +1374,32 @@ export function fenceStaticHeadersMember(
   );
 }
 
+/** The native AbortController handle dispatches `abort()` directly and
+ * exposes `.signal` as data, but it has no first-class function value for
+ * the prototype method. Fence method extraction before the checked-dynamic
+ * keyed-read fallback can silently answer `undefined`. Dynamic builds use
+ * the engine's real AbortController object and retain ordinary method reads. */
+export function fenceStaticAbortControllerMemberRead(
+  L: Lowerer,
+  access: StaticResponseAccess,
+): IrExpr | null {
+  if (L.dynamic) return null;
+  const symbol = isStdlibFetchInterface(
+    L,
+    access.expression,
+    "AbortController",
+  );
+  if (!symbol) return null;
+  const members = fetchAccessMemberNames(L, access);
+  if (members === null || !members.includes("abort")) return null;
+  L.noLowering(
+    "AbortController.abort through method extraction in a static build",
+    access,
+    "call controller.abort(...) directly; the native AbortController handle does not expose abort as a first-class function value",
+    symbol,
+  );
+}
+
 function isStdlibFetchInterface(
   L: Lowerer,
   node: ts.Node,

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -97,7 +97,7 @@ import { lowerArrayMethodCall, lowerBufferStaticCall, lowerBytesMethodCall, lowe
 import { lowerStreamModuleCall } from "./lower-stream.js";
 import { lowerEmitOverrideSpec, type EmitSpecCtx, type EmitSpecRequest } from "./lower-emitter.js";
 import { builtinImportOf, createRequireBindingDecl, createRequireNamespaceDecl, createRequireSpecOf, stripTypeCasts, lowerBuiltinModuleCall, lowerFsToUnixTimestampCall, lowerFsLadderCall, lowerChildArgsArg, lowerSpawnSyncCall, lowerSpawnCall, lowerExecSyncCall, recordToEnvPairs, lowerJsonMethodCall, fencedBuiltinImportOf, lowerCryptoComposedCall, lowerUrlMethodCall, lowerSearchParamsMethodCall, lowerStatsMethodCall, lowerChildMethodCall, lowerAtomicsCall, lowerBuiltinExtraProperty, promisifiedExecFileDecl, lowerExecFileAsyncCall, execFileAsyncHelper, lowerStringDecoderMethodCall, strdecHelper, lowerReadlineMethodCall, lowerDcChannelMethodCall, lowerDcChannelProperty, lowerAlsMethodCall, lowerDcTracingChannelMethodCall, lowerDcTracingChannelProperty, lowerJsonProperty, lowerErrorCodeProperty, lowerProcessProperty, isProcessEnv, envValueType, lowerProcessEnvGet, lowerProcessMethodCall, lowerProcessOptionalMethodCall, lowerTimeoutMethodCall, envSnapshotHelper, isConsoleLog, consoleCallMember, lowerNumberStaticCall, lowerNumberStaticProperty, lowerDateCall, lowerTextCodecCall, lowerCryptoModuleCall, lowerFsConstantsProperty, lowerBuiltinConstantsProperty, builtinConstantBindingOf, builtinConstantsDestructureDecl, lowerProcessStreamProperty, lowerStringStaticCall, lowerStringLastIndexOfCall, lowerPromiseStaticCall, textCodecBindingClassOf } from "./lower-builtins.js";
-import { fenceFetchObjectAssignment, fenceFetchObjectBinding, fenceStaticHeadersIteration, fenceStaticHeadersMember, fenceStaticReadableStreamMember, fenceStaticResponseMember, fenceUnsupportedFetchConstructorMember, isIslandExpr, islandFuncValueFence, islandRegexpOf, jsvalIn, requireDynamicApi, islandGlobalFnOf, lowerAbortControllerNew, lowerDynamicHeadersIteratorCall, lowerDynamicHeadersSpread, lowerDynamicImportCall, lowerFetchCall, lowerFetchElementMethodCall, lowerResponseNew, lowerStaticFetchCompanionCall, lowerStaticAbortControllerCall, lowerStaticAbortSignalListenerCall, lowerStaticReadableStreamCancelCall, lowerStaticReadableStreamControllerCall, lowerStaticReadableStreamNew, lowerStaticReadableStreamReaderCall, lowerStaticResponseCall, lowerIslandMethodCall, lowerMathProperty, npmPackageOf, npmMemberFence, npmPackageOfSymbol } from "./lower-island.js";
+import { fenceFetchObjectAssignment, fenceFetchObjectBinding, fenceStaticAbortControllerMemberRead, fenceStaticHeadersIteration, fenceStaticHeadersMember, fenceStaticReadableStreamMember, fenceStaticResponseMember, fenceUnsupportedFetchConstructorMember, isIslandExpr, islandFuncValueFence, islandRegexpOf, jsvalIn, requireDynamicApi, islandGlobalFnOf, lowerAbortControllerNew, lowerDynamicHeadersIteratorCall, lowerDynamicHeadersSpread, lowerDynamicImportCall, lowerFetchCall, lowerFetchElementMethodCall, lowerResponseNew, lowerStaticFetchCompanionCall, lowerStaticAbortControllerCall, lowerStaticAbortSignalListenerCall, lowerStaticReadableStreamCancelCall, lowerStaticReadableStreamControllerCall, lowerStaticReadableStreamNew, lowerStaticReadableStreamReaderCall, lowerStaticResponseCall, lowerIslandMethodCall, lowerMathProperty, npmPackageOf, npmMemberFence, npmPackageOfSymbol } from "./lower-island.js";
 import { lowerHttpHeadersElement, lowerNetModuleCall, lowerServerMethodCall, lowerServerProperty, lowerTlsRootCertificates } from "./lower-server.js";
 import { lowerDgramDnsModuleCall, lowerDgramMethodCall } from "./lower-dgram.js";
 import { lowerNodeTestModuleCall, lowerTestDirectCall, lowerTestMethodCall, lowerTestCtxProperty } from "./lower-test.js";
@@ -2846,6 +2846,12 @@ export class Lowerer {
     use: "read" | "call",
   ): IrExpr | null {
     return fenceStaticHeadersMember(this, access, use);
+  }
+
+  fenceStaticAbortControllerMemberRead(
+    access: ts.PropertyAccessExpression | ts.ElementAccessExpression,
+  ): IrExpr | null {
+    return fenceStaticAbortControllerMemberRead(this, access);
   }
 
   fenceStaticHeadersIteration(node: ts.Node): void {

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -97,7 +97,7 @@ import { lowerArrayMethodCall, lowerBufferStaticCall, lowerBytesMethodCall, lowe
 import { lowerStreamModuleCall } from "./lower-stream.js";
 import { lowerEmitOverrideSpec, type EmitSpecCtx, type EmitSpecRequest } from "./lower-emitter.js";
 import { builtinImportOf, createRequireBindingDecl, createRequireNamespaceDecl, createRequireSpecOf, stripTypeCasts, lowerBuiltinModuleCall, lowerFsToUnixTimestampCall, lowerFsLadderCall, lowerChildArgsArg, lowerSpawnSyncCall, lowerSpawnCall, lowerExecSyncCall, recordToEnvPairs, lowerJsonMethodCall, fencedBuiltinImportOf, lowerCryptoComposedCall, lowerUrlMethodCall, lowerSearchParamsMethodCall, lowerStatsMethodCall, lowerChildMethodCall, lowerAtomicsCall, lowerBuiltinExtraProperty, promisifiedExecFileDecl, lowerExecFileAsyncCall, execFileAsyncHelper, lowerStringDecoderMethodCall, strdecHelper, lowerReadlineMethodCall, lowerDcChannelMethodCall, lowerDcChannelProperty, lowerAlsMethodCall, lowerDcTracingChannelMethodCall, lowerDcTracingChannelProperty, lowerJsonProperty, lowerErrorCodeProperty, lowerProcessProperty, isProcessEnv, envValueType, lowerProcessEnvGet, lowerProcessMethodCall, lowerProcessOptionalMethodCall, lowerTimeoutMethodCall, envSnapshotHelper, isConsoleLog, consoleCallMember, lowerNumberStaticCall, lowerNumberStaticProperty, lowerDateCall, lowerTextCodecCall, lowerCryptoModuleCall, lowerFsConstantsProperty, lowerBuiltinConstantsProperty, builtinConstantBindingOf, builtinConstantsDestructureDecl, lowerProcessStreamProperty, lowerStringStaticCall, lowerStringLastIndexOfCall, lowerPromiseStaticCall, textCodecBindingClassOf } from "./lower-builtins.js";
-import { fenceFetchObjectAssignment, fenceFetchObjectBinding, fenceStaticHeadersIteration, fenceStaticHeadersMember, fenceStaticReadableStreamMember, fenceStaticResponseMember, fenceUnsupportedFetchConstructorMember, isIslandExpr, islandFuncValueFence, islandRegexpOf, jsvalIn, requireDynamicApi, islandGlobalFnOf, lowerDynamicHeadersIteratorCall, lowerDynamicHeadersSpread, lowerDynamicImportCall, lowerFetchCall, lowerFetchElementMethodCall, lowerResponseNew, lowerStaticFetchCompanionCall, lowerStaticAbortSignalListenerCall, lowerStaticReadableStreamCancelCall, lowerStaticReadableStreamControllerCall, lowerStaticReadableStreamNew, lowerStaticReadableStreamReaderCall, lowerStaticResponseCall, lowerIslandMethodCall, lowerMathProperty, npmPackageOf, npmMemberFence, npmPackageOfSymbol } from "./lower-island.js";
+import { fenceFetchObjectAssignment, fenceFetchObjectBinding, fenceStaticHeadersIteration, fenceStaticHeadersMember, fenceStaticReadableStreamMember, fenceStaticResponseMember, fenceUnsupportedFetchConstructorMember, isIslandExpr, islandFuncValueFence, islandRegexpOf, jsvalIn, requireDynamicApi, islandGlobalFnOf, lowerAbortControllerNew, lowerDynamicHeadersIteratorCall, lowerDynamicHeadersSpread, lowerDynamicImportCall, lowerFetchCall, lowerFetchElementMethodCall, lowerResponseNew, lowerStaticFetchCompanionCall, lowerStaticAbortControllerCall, lowerStaticAbortSignalListenerCall, lowerStaticReadableStreamCancelCall, lowerStaticReadableStreamControllerCall, lowerStaticReadableStreamNew, lowerStaticReadableStreamReaderCall, lowerStaticResponseCall, lowerIslandMethodCall, lowerMathProperty, npmPackageOf, npmMemberFence, npmPackageOfSymbol } from "./lower-island.js";
 import { lowerHttpHeadersElement, lowerNetModuleCall, lowerServerMethodCall, lowerServerProperty, lowerTlsRootCertificates } from "./lower-server.js";
 import { lowerDgramDnsModuleCall, lowerDgramMethodCall } from "./lower-dgram.js";
 import { lowerNodeTestModuleCall, lowerTestDirectCall, lowerTestMethodCall, lowerTestCtxProperty } from "./lower-test.js";
@@ -7552,6 +7552,7 @@ export class Lowerer {
       lowerFfiCall(this, expr) ??
       lowerFetchCall(this, expr) ??
       lowerStaticFetchCompanionCall(this, expr) ??
+      lowerStaticAbortControllerCall(this, expr) ??
       lowerStaticAbortSignalListenerCall(this, expr) ??
       lowerStaticReadableStreamCancelCall(this, expr) ??
       lowerStaticReadableStreamControllerCall(this, expr) ??
@@ -7745,7 +7746,7 @@ export class Lowerer {
       const arg = this.lowerExpr(expr.arguments[0]!);
       return { kind: "jsOp", op: "construct", args: [ctor, arg], type: JSVAL, loc };
     }
-    return lowerResponseNew(this, expr) ?? lowerStaticReadableStreamNew(this, expr) ?? lowerNew(this, expr);
+    return lowerAbortControllerNew(this, expr) ?? lowerResponseNew(this, expr) ?? lowerStaticReadableStreamNew(this, expr) ?? lowerNew(this, expr);
   }
 
   lowerFieldRead(expr: ts.PropertyAccessExpression): IrExpr | null {

--- a/packages/compiler/src/frontend/types.ts
+++ b/packages/compiler/src/frontend/types.ts
@@ -11,7 +11,7 @@ export { typeKey };
 
 /** The ambient TYPE names of the fetch slice. Under --dynamic their
  * values live in the embedded engine and map to island handles (jsval).
- * Static fetch gives Response, RequestInit, AbortSignal, response
+ * Static fetch gives Response, RequestInit, AbortController/AbortSignal, response
  * Headers, and the readable Web Streams slice native checked-dynamic
  * handle representations. The Headers constructor itself remains
  * dynamic-only even though response.headers is native.
@@ -23,6 +23,7 @@ export const ISLAND_AMBIENT_TYPES = [
   "RequestInit",
   "Event",
   "EventTarget",
+  "AbortController",
   "AbortSignal",
   "Headers",
   "ReadableStream",

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -1621,6 +1621,7 @@ export type IrLibFn =
   | "fetch.responseJson"
   | "fetch.responseText"
   | "fetch.responseBytes"
+  | "fetch.abortControllerNew"
   | "fetch.abortTimeout"
   | "fetch.abortNow"
   | "fetch.abortAny"

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -88,6 +88,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "fetch.responseJson": { argTypes: [DYN], result: { kind: "promise", inner: DYN } },
   "fetch.responseText": { argTypes: [DYN], result: { kind: "promise", inner: STRING } },
   "fetch.responseBytes": { argTypes: [DYN], result: { kind: "promise", inner: BYTES_U8 } },
+  "fetch.abortControllerNew": { argTypes: [], result: DYN },
   "fetch.abortTimeout": { argTypes: [DYN], result: DYN },
   "fetch.abortNow": { argTypes: [DYN], result: DYN },
   "fetch.abortAny": { argTypes: [DYN], result: DYN },

--- a/packages/compiler/surface-manifest.json
+++ b/packages/compiler/surface-manifest.json
@@ -1870,25 +1870,22 @@
       "id": "stdlib.abort-controller.abort",
       "kind": "stdlib",
       "name": "AbortController.abort",
-      "status": "unsupported",
-      "code": "SC2020",
-      "note": "Node 24.15.0 / Undici 7.24.4; typed source has no compiler bridge for this interface in either tier"
+      "status": "static",
+      "note": "Node 24.15.0 / Undici 7.24.4; facets: callback-order, identity, liveness, state-machine, surplus-arguments; differential evidence: fixture:static-controller"
     },
     {
       "id": "stdlib.abort-controller.constructor",
       "kind": "stdlib",
       "name": "AbortController constructor",
-      "status": "unsupported",
-      "code": "SC2020",
-      "note": "Node 24.15.0 / Undici 7.24.4; typed source has no compiler bridge for this interface in either tier"
+      "status": "static",
+      "note": "Node 24.15.0 / Undici 7.24.4; facets: argument-evaluation, identity, state-machine, surplus-arguments; differential evidence: fixture:static-controller"
     },
     {
       "id": "stdlib.abort-controller.signal",
       "kind": "stdlib",
       "name": "AbortController.signal",
-      "status": "unsupported",
-      "code": "SC2020",
-      "note": "Node 24.15.0 / Undici 7.24.4; typed source has no compiler bridge for this interface in either tier"
+      "status": "static",
+      "note": "Node 24.15.0 / Undici 7.24.4; facets: identity, property-read, state-machine; differential evidence: fixture:static-controller"
     },
     {
       "id": "stdlib.abort-signal.abort",

--- a/packages/runtime/src/scr_fetch.c
+++ b/packages/runtime/src/scr_fetch.c
@@ -156,6 +156,10 @@ struct SfSignal {
   bool aborted;
   ScrDyn *reason;
   ScrError *error_reason;
+  bool reason_self;
+  ScrDynHandleTag reason_self_tag;
+  bool reason_tracked;
+  SfSignal *reason_next;
   ScrDyn *onabort;
   size_t onabort_order;
   SfAbortListener *listeners;
@@ -319,9 +323,10 @@ struct SfTransfer {
 
 static SfTransfer *sf_live;
 /* Weak registries: owners unlink themselves on destruction. They let the
- * fetch teardown sever native→callback edges before final cycle collection,
- * including an otherwise-untraceable callback→captured-handle backedge. */
+ * fetch teardown sever opaque native→dyn edges before final cycle collection,
+ * including otherwise-untraceable callback/reason→handle backedges. */
 static SfSignal *sf_callback_signals;
+static SfSignal *sf_reason_signals;
 static SfStream *sf_callback_streams;
 
 static void sf_oom(void) {
@@ -429,6 +434,53 @@ static void sf_signal_untrack_callbacks(SfSignal *s) {
   s->callbacks_next = NULL;
 }
 
+static void sf_signal_track_reason(SfSignal *s) {
+  if (s->reason_tracked) return;
+  s->reason_tracked = true;
+  s->reason_next = sf_reason_signals;
+  sf_reason_signals = s;
+}
+
+static void sf_signal_untrack_reason(SfSignal *s) {
+  if (!s->reason_tracked) return;
+  for (SfSignal **at = &sf_reason_signals; *at;
+       at = &(*at)->reason_next) {
+    if (*at == s) {
+      *at = s->reason_next;
+      break;
+    }
+  }
+  s->reason_tracked = false;
+  s->reason_next = NULL;
+}
+
+/* A controller may abort with itself or its own signal as the reason.
+ * Those handles point back to this SfSignal, so retaining their ScrDyn box
+ * would create an opaque RC cycle. Remember the identity as tag + pointer
+ * instead and mint an equivalent handle whenever the reason is observed;
+ * checked-dynamic strict equality uses that same pair. Other reasons stay
+ * strongly owned and join the teardown registry so larger reason/handle
+ * cycles can be severed once no Web object remains observable. */
+static ScrDyn *sf_signal_reason_ref(SfSignal *s) {
+  if (s->reason_self) {
+    return scr_dyn_new_handle(s, s->reason_self_tag);
+  }
+  return scr_dyn_retain(s->reason);
+}
+
+static void sf_signal_drop_reason(SfSignal *s) {
+  ScrDyn *reason = s->reason;
+  ScrError *error_reason = s->error_reason;
+  sf_signal_untrack_reason(s);
+  s->reason = NULL;
+  s->error_reason = NULL;
+  s->reason_self = false;
+  scr_error_release(error_reason);
+  /* May release a handle that owns s and destroy it reentrantly. All s
+   * fields used by this cleanup are therefore cleared before this call. */
+  scr_dyn_release(reason);
+}
+
 static SfSignal *sf_signal_new(void) {
   SfSignal *s = calloc(1, sizeof *s);
   if (!s) sf_oom();
@@ -491,8 +543,7 @@ static void sf_signal_release(SfSignal *s) {
   free(s->source_watches);
   free(s->sources);
   sf_signal_drop_callbacks(s);
-  scr_dyn_release(s->reason);
-  scr_error_release(s->error_reason);
+  sf_signal_drop_reason(s);
   free(s);
 }
 
@@ -877,7 +928,16 @@ static void sf_signal_abort_full(SfSignal *s, ScrDyn *reason,
                                  ScrError *error_reason) {
   if (s->aborted) return;
   s->aborted = true;
-  s->reason = scr_dyn_retain(reason);
+  if (reason && reason->kind == SCR_DYN_HANDLE &&
+      reason->v.handle.ptr == s &&
+      (reason->v.handle.tag == SCR_DYNH_ABORT_SIGNAL ||
+       reason->v.handle.tag == SCR_DYNH_ABORT_CONTROLLER)) {
+    s->reason_self = true;
+    s->reason_self_tag = reason->v.handle.tag;
+  } else {
+    s->reason = scr_dyn_retain(reason);
+    sf_signal_track_reason(s);
+  }
   s->error_reason = error_reason ? scr_error_retain(error_reason) : NULL;
   while (s->watchers) {
     SfSignalWatch *w = s->watchers;
@@ -976,7 +1036,9 @@ ScrDyn *scr_fetch_abort_now(ScrDyn *reason) {
 
 static void sf_any_source_abort(SfSignalWatch *w, SfSignal *source) {
   SfSignal *out = (SfSignal *)w->owner;
-  sf_signal_abort_full(out, source->reason, source->error_reason);
+  ScrDyn *reason = sf_signal_reason_ref(source);
+  sf_signal_abort_full(out, reason, source->error_reason);
+  scr_dyn_release(reason);
 }
 
 ScrDyn *scr_fetch_abort_any(ScrDyn *signals) {
@@ -1005,7 +1067,9 @@ ScrDyn *scr_fetch_abort_any(ScrDyn *signals) {
     }
     out->sources[i] = sf_signal_retain(source);
     if (source->aborted) {
-      sf_signal_abort_full(out, source->reason, source->error_reason);
+      ScrDyn *reason = sf_signal_reason_ref(source);
+      sf_signal_abort_full(out, reason, source->error_reason);
+      scr_dyn_release(reason);
     } else {
       out->source_watches[i] =
           sf_signal_watch(source, out, &sf_any_source_abort);
@@ -1120,7 +1184,9 @@ static ScrDyn *sf_signal_invoke(void *ptr, ScrDyn *self, const char *method,
   SfSignal *s = ptr;
   if (strcmp(method, "throwIfAborted") == 0) {
     if (s->aborted) {
-      sf_throw_dyn_reason(s->reason);
+      ScrDyn *reason = sf_signal_reason_ref(s);
+      sf_throw_dyn_reason(reason);
+      scr_dyn_release(reason);
       return NULL;
     }
     return scr_dyn_retain(scr_dyn_undefined());
@@ -1241,7 +1307,7 @@ static ScrDyn *sf_signal_get(void *ptr, const char *key, size_t len) {
   SfSignal *s = ptr;
   if (sf_name(key, len, "aborted")) return scr_dyn_new_bool(s->aborted);
   if (sf_name(key, len, "reason")) {
-    return s->aborted ? scr_dyn_retain(s->reason)
+    return s->aborted ? sf_signal_reason_ref(s)
                       : scr_dyn_retain(scr_dyn_undefined());
   }
   if (sf_name(key, len, "onabort")) {
@@ -3311,6 +3377,7 @@ static void sf_reject_reason(SfTransfer *t, ScrDyn *reason) {
 static void sf_transfer_abort_watch(SfSignalWatch *w, SfSignal *signal) {
   SfTransfer *t = w->owner;
   if (t->done) return;
+  ScrDyn *reason = sf_signal_reason_ref(signal);
   if (t->request_stream && t->request_stream->request_owner == t) {
     SfStream *request = t->request_stream;
     request->request_owner = NULL;
@@ -3322,11 +3389,12 @@ static void sf_transfer_abort_watch(SfSignalWatch *w, SfSignal *signal) {
   }
   if (t->client) scr_http_client_destroy(t->client);
   if (t->response_sent && t->response_stream) {
-    sf_stream_error(t->response_stream, signal->reason);
+    sf_stream_error(t->response_stream, reason);
     sf_settle(t);
   } else {
-    sf_reject_reason(t, signal->reason);
+    sf_reject_reason(t, reason);
   }
+  scr_dyn_release(reason);
 }
 
 static void sf_transfer_stream_error(SfTransfer *t, ScrDyn *reason) {
@@ -5323,7 +5391,9 @@ ScrPromise *scr_fetch_static(ScrStr *url, ScrDyn *init) {
     scr_arr_release(headers);
     scr_str_release(method);
     scr_url_release(u);
-    sf_reject_promise_reason(promise, signal->reason);
+    ScrDyn *reason = sf_signal_reason_ref(signal);
+    sf_reject_promise_reason(promise, reason);
+    scr_dyn_release(reason);
     return promise;
   }
 
@@ -5406,6 +5476,9 @@ static void sf_teardown(void) {
   }
   while (sf_callback_signals) {
     sf_signal_drop_callbacks(sf_callback_signals);
+  }
+  while (sf_reason_signals) {
+    sf_signal_drop_reason(sf_reason_signals);
   }
   sf_proxy_snapshot_free();
 }

--- a/packages/runtime/src/scr_fetch.c
+++ b/packages/runtime/src/scr_fetch.c
@@ -1016,6 +1016,47 @@ ScrDyn *scr_fetch_abort_any(ScrDyn *signals) {
   return boxed;
 }
 
+/* AbortController is a distinct public handle over the same native signal
+ * state fetch and AbortSignal.any observe. Reading `.signal` boxes that
+ * state with the AbortSignal tag, so repeated reads preserve JS identity
+ * through the checked-dynamic handle equality rule (tag + pointer). */
+ScrDyn *scr_fetch_abort_controller_new(void) {
+  SfSignal *s = sf_signal_new();
+  ScrDyn *out = scr_dyn_new_handle(s, SCR_DYNH_ABORT_CONTROLLER);
+  sf_signal_release(s);
+  return out;
+}
+
+static ScrDyn *sf_abort_controller_invoke(
+    void *ptr, ScrDyn *self, const char *method, ScrDyn *const *args,
+    size_t argc, const char *what) {
+  SfSignal *s = ptr;
+  if (strcmp(method, "abort") == 0) {
+    if (!s->aborted) {
+      ScrDyn *reason = argc > 0 ? args[0] : NULL;
+      if (!reason || reason->kind == SCR_DYN_UNDEF) {
+        sf_signal_abort_default(s, false);
+      } else {
+        ScrError *e = sf_is_error_dyn(reason) ? scr_error_from_dyn(reason) : NULL;
+        sf_signal_abort_full(s, reason, e);
+        scr_error_release(e);
+      }
+    }
+    return scr_dyn_retain(scr_dyn_undefined());
+  }
+  (void)self;
+  sf_not_function(what);
+  return NULL;
+}
+
+static ScrDyn *sf_abort_controller_get(
+    void *ptr, const char *key, size_t len) {
+  if (sf_name(key, len, "signal")) {
+    return scr_dyn_new_handle(ptr, SCR_DYNH_ABORT_SIGNAL);
+  }
+  return NULL;
+}
+
 static bool sf_signal_listener_options(
     ScrDyn *const *args, size_t argc, bool *capture, bool *once,
     SfSignal **option_signal) {
@@ -5323,6 +5364,9 @@ static bool sf_no_set(void *ptr, const char *key, size_t len,
 static const ScrDynHandleOps sf_signal_ops = {
     "AbortSignal", &sf_signal_retain_v, &sf_signal_release_v,
     &sf_signal_invoke, &sf_signal_get, &sf_signal_set, NULL};
+static const ScrDynHandleOps sf_abort_controller_ops = {
+    "AbortController", &sf_signal_retain_v, &sf_signal_release_v,
+    &sf_abort_controller_invoke, &sf_abort_controller_get, &sf_no_set, NULL};
 static const ScrDynHandleOps sf_stream_ops = {
     "ReadableStream", &sf_stream_retain_v, &sf_stream_release_v,
     &sf_stream_invoke, &sf_stream_get, &sf_no_set, NULL};
@@ -5374,6 +5418,8 @@ void scr_fetch_install(void) {
   sf_proxy_snapshot();
   scr_net_install();
   scr_dyn_handle_install(SCR_DYNH_ABORT_SIGNAL, &sf_signal_ops);
+  scr_dyn_handle_install(SCR_DYNH_ABORT_CONTROLLER,
+                         &sf_abort_controller_ops);
   scr_dyn_handle_install(SCR_DYNH_WEB_STREAM, &sf_stream_ops);
   scr_dyn_handle_install(SCR_DYNH_WEB_READER, &sf_reader_ops);
   scr_dyn_handle_install(SCR_DYNH_WEB_CONTROLLER, &sf_controller_ops);

--- a/packages/runtime/src/scr_json.c
+++ b/packages/runtime/src/scr_json.c
@@ -1638,7 +1638,7 @@ ScrStr *scr_dyn_to_string(const ScrDyn *d, const ScrStr *enc) {
     return scr_str_new("[object Object]", 15);
   case SCR_DYN_HANDLE:
     if (d->v.handle.tag >= SCR_DYNH_ABORT_SIGNAL &&
-        d->v.handle.tag <= SCR_DYNH_EVENT) {
+        d->v.handle.tag <= SCR_DYNH_ABORT_CONTROLLER) {
       ScrJsonBuf b;
       scr_jb_init(&b);
       scr_jb_puts(&b, "[object ");

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -2760,6 +2760,7 @@ typedef enum {
   SCR_DYNH_FETCH_RESPONSE, /* native static-fetch Response */
   SCR_DYNH_FETCH_HEADERS, /* native static-fetch response Headers */
   SCR_DYNH_EVENT,          /* native static-fetch abort Event */
+  SCR_DYNH_ABORT_CONTROLLER, /* native static-fetch AbortController */
   SCR_DYNH_COUNT,
 } ScrDynHandleTag;
 
@@ -3958,6 +3959,7 @@ ScrDyn *scr_fetch_response_new(ScrDyn *body, ScrDyn *init); /* borrowed args; +1
 ScrPromise *scr_fetch_response_json(ScrDyn *response); /* +1 promise<dyn> */
 ScrPromise *scr_fetch_response_text(ScrDyn *response); /* +1 promise<dyn> */
 ScrPromise *scr_fetch_response_bytes(ScrDyn *response); /* +1 promise<dyn> */
+ScrDyn *scr_fetch_abort_controller_new(void); /* +1 AbortController handle */
 /* Borrowed number; +1 AbortSignal handle or NULL pending. */
 ScrDyn *scr_fetch_abort_timeout(ScrDyn *delay);
 ScrDyn *scr_fetch_abort_now(ScrDyn *reason); /* borrowed reason; +1 handle */

--- a/tests/fixtures/fetch/cases/user-fetch/main.ts
+++ b/tests/fixtures/fetch/cases/user-fetch/main.ts
@@ -180,6 +180,17 @@ async function main(baseUrl: string, refusedUrl: string): Promise<void> {
     if (e instanceof Error) console.log("timeout:", e.name, e.message);
   }
 
+  // Typed user code can also cancel imperatively under --dynamic; this
+  // exercises the compiler bridge into the island's AbortController.
+  const controller = new AbortController();
+  setTimeout(() => controller.abort(), 20);
+  try {
+    await fetch(`${baseUrl}/slow`, { signal: controller.signal });
+    console.log("controller: resolved");
+  } catch (e) {
+    if (e instanceof Error) console.log("controller:", e.name, e.message);
+  }
+
   // A 101 is handed to the HTTP client's upgrade path rather than its
   // response path. fetch rejects it instead of leaving the promise pending.
   try {

--- a/tests/fixtures/fetch/static-controller/main.mts
+++ b/tests/fixtures/fetch/static-controller/main.mts
@@ -49,6 +49,72 @@ const surplusController = new AbortController(constructorSurplus());
 surplusController.abort(undefined, abortSurplus());
 console.log("controller surplus:", surplusEffects);
 
+let ignoredMapEffect = "";
+function ignoredMapSurplus(): Map<string, string> {
+  ignoredMapEffect = "map";
+  return new Map<string, string>();
+}
+const mapSurplusController = new AbortController();
+// @ts-expect-error JavaScript evaluates and ignores every surplus argument.
+mapSurplusController.abort(undefined, ignoredMapSurplus());
+console.log(
+  "controller map surplus:",
+  ignoredMapEffect,
+  mapSurplusController.signal.aborted,
+);
+
+const selfReasonController = new AbortController();
+selfReasonController.abort(selfReasonController);
+console.log(
+  "controller self reason:",
+  selfReasonController.signal.reason === selfReasonController,
+);
+
+const signalReasonController = new AbortController();
+const ownSignalReason = signalReasonController.signal;
+signalReasonController.abort(ownSignalReason);
+console.log(
+  "controller signal reason:",
+  ownSignalReason.reason === ownSignalReason,
+);
+
+const leftReasonController = new AbortController();
+const rightReasonController = new AbortController();
+leftReasonController.abort(rightReasonController);
+rightReasonController.abort(leftReasonController);
+console.log(
+  "controller mutual reasons:",
+  leftReasonController.signal.reason === rightReasonController,
+  rightReasonController.signal.reason === leftReasonController,
+);
+
+const watchedReasonController = new AbortController();
+const watchedReasonSignal = AbortSignal.any([watchedReasonController.signal]);
+watchedReasonController.abort(watchedReasonController);
+let watchedThrowMatches = false;
+try {
+  watchedReasonSignal.throwIfAborted();
+} catch (error) {
+  watchedThrowMatches = error === watchedReasonController;
+}
+console.log(
+  "controller propagated reason:",
+  watchedReasonSignal.reason === watchedReasonController,
+  watchedThrowMatches,
+);
+
+try {
+  await fetch(`${process.argv[2]}/slow`, {
+    signal: selfReasonController.signal,
+  });
+  console.log("controller pre-aborted fetch unexpectedly resolved");
+} catch (error) {
+  console.log(
+    "controller pre-aborted fetch reason:",
+    error === selfReasonController,
+  );
+}
+
 const fetchController = new AbortController();
 setTimeout(() => fetchController.abort(new Error("manual timeout")), 20);
 try {

--- a/tests/fixtures/fetch/static-controller/main.mts
+++ b/tests/fixtures/fetch/static-controller/main.mts
@@ -1,0 +1,62 @@
+const controller = new AbortController();
+const signal = controller.signal;
+console.log(
+  "controller initial:",
+  signal.aborted,
+  controller.signal === signal,
+);
+
+const reason = { value: 1 };
+let eventCalls = 0;
+signal.addEventListener("abort", (event) => {
+  eventCalls++;
+  console.log(
+    "controller event:",
+    event.type,
+    event.target === signal,
+    (signal.reason as { value: number }) === reason,
+  );
+});
+controller.abort(reason);
+controller.abort(new Error("ignored"));
+const observedReason = signal.reason as { value: number };
+observedReason.value = 2;
+console.log(
+  "controller final:",
+  signal.aborted,
+  eventCalls,
+  observedReason === reason,
+  reason.value,
+);
+
+const computedController = new AbortController();
+const abortMember: "abort" = "abort";
+computedController[abortMember]("computed reason");
+console.log("computed abort:", computedController.signal.reason);
+
+let surplusEffects = "";
+function constructorSurplus(): number {
+  surplusEffects += "ctor ";
+  return 1;
+}
+function abortSurplus(): number {
+  surplusEffects += "abort";
+  return 2;
+}
+// @ts-expect-error JavaScript accepts and evaluates surplus constructor arguments.
+const surplusController = new AbortController(constructorSurplus());
+// @ts-expect-error JavaScript also evaluates surplus abort() arguments.
+surplusController.abort(undefined, abortSurplus());
+console.log("controller surplus:", surplusEffects);
+
+const fetchController = new AbortController();
+setTimeout(() => fetchController.abort(new Error("manual timeout")), 20);
+try {
+  await fetch(`${process.argv[2]}/slow`, {
+    signal: fetchController.signal,
+  });
+  console.log("controller fetch unexpectedly resolved");
+} catch (error) {
+  const caught = error as Error;
+  console.log("controller fetch:", caught.name, caught.message);
+}

--- a/tests/fixtures/node-types/fenced.ts
+++ b/tests/fixtures/node-types/fenced.ts
@@ -15,10 +15,9 @@ const timer = setInterval(() => {
 timer.unref();
 timer.refresh();
 timer.close();
-/* The web-platform globals ride in with @types/node (undici):
- * AbortController fences, while fetch and a typed RequestInit lower. */
-const controller = new AbortController();
-controller.abort();
+/* The web-platform globals ride in with @types/node (undici). Fetch,
+ * AbortController, and a typed RequestInit lower; wider Response members
+ * below retain their profile fences. */
 const fetchInit: RequestInit = {
   method: "POST",
   headers: { "content-type": "application/json" },

--- a/tests/harness/__snapshots__/node-types-fenced.txt
+++ b/tests/harness/__snapshots__/node-types-fenced.txt
@@ -37,222 +37,195 @@ fenced.ts:17:1 - error SC2020: 'Timeout.close' is typed by @types/node but has n
   16 | timer.refresh();
   17 | timer.close();
      | ^~~~~~~~~~~~~
-  18 | /* The web-platform globals ride in with @types/node (undici):
+  18 | /* The web-platform globals ride in with @types/node (undici). Fetch,
 
   hint: unref(), ref(), hasRef(), and refresh() are the supported Timeout methods
 
-fenced.ts:20:7 - error SC2020: 'AbortController' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:29:15 - error SC2020: 'Response.type in a static build' is typed by @types/node but has no scriptc lowering yet
 
-  19 |  * AbortController fences, while fetch and a typed RequestInit lower. */
-  20 | const controller = new AbortController();
-     |       ^~~~~~~~~~
-  21 | controller.abort();
-
-  hint: the type checker sees everything @types/node declares, but only the supported surface compiles (https://scriptc.dev/limitations)
-
-fenced.ts:20:20 - error SC2020: 'new AbortController' is typed by @types/node but has no scriptc lowering yet
-
-  19 |  * AbortController fences, while fetch and a typed RequestInit lower. */
-  20 | const controller = new AbortController();
-     |                    ^~~~~~~~~~~~~~~~~~~~~
-  21 | controller.abort();
-
-  hint: the type checker sees everything @types/node declares, but only the supported surface compiles (https://scriptc.dev/limitations)
-
-fenced.ts:21:1 - error SC2020: 'AbortController.abort' is typed by @types/node but has no scriptc lowering yet
-
-  20 | const controller = new AbortController();
-  21 | controller.abort();
-     | ^~~~~~~~~~~~~~~~
-  22 | const fetchInit: RequestInit = {
-
-  hint: the type checker sees everything @types/node declares, but only the supported surface compiles (https://scriptc.dev/limitations)
-
-fenced.ts:30:15 - error SC2020: 'Response.type in a static build' is typed by @types/node but has no scriptc lowering yet
-
-  29 |   const response = await fetch(url);
-  30 |   console.log(response.type);
+  28 |   const response = await fetch(url);
+  29 |   console.log(response.type);
      |               ^~~~~~~~~~~~~
-  31 |   response.clone();
+  30 |   response.clone();
 
   hint: the native static Response surface is status/ok/statusText/url/redirected/headers/body/bodyUsed plus json(), text(), and bytes(); use --dynamic for the wider Web API
 
-fenced.ts:31:3 - error SC2020: 'Response.clone' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:30:3 - error SC2020: 'Response.clone' is typed by @types/node but has no scriptc lowering yet
 
-  30 |   console.log(response.type);
-  31 |   response.clone();
+  29 |   console.log(response.type);
+  30 |   response.clone();
      |   ^~~~~~~~~~~~~~
-  32 | }
+  31 | }
 
   hint: the dynamic fetch bridge does not implement this Response operation
 
-fenced.ts:34:21 - error SC2020: 'ReadableStream.from() over Set<number> iterables' is part of the standard library types but has no scriptc lowering yet
+fenced.ts:33:21 - error SC2020: 'ReadableStream.from() over Set<number> iterables' is part of the standard library types but has no scriptc lowering yet
 
-  33 | void inspectResponse;
-  34 | ReadableStream.from(new Set([1, 2]));
+  32 | void inspectResponse;
+  33 | ReadableStream.from(new Set([1, 2]));
      |                     ^~~~~~~~~~~~~~~
-  35 | /* Members of SUPPORTED builtin modules beyond the lowered tables: they
+  34 | /* Members of SUPPORTED builtin modules beyond the lowered tables: they
 
   hint: arrays, Uint8Array, and strings are supported — spread other synchronous iterables into an array first: [...iterable]
 
-fenced.ts:41:1 - error SC2020: 'fs.watchFile' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:40:1 - error SC2020: 'fs.watchFile' is typed by @types/node but has no scriptc lowering yet
 
-  40 | import { win32 } from "path";
-  41 | watchFile("x", () => {});
+  39 | import { win32 } from "path";
+  40 | watchFile("x", () => {});
      | ^~~~~~~~~~~~~~~~~~~~~~~~
-  42 | console.log(cpus().length);
+  41 | console.log(cpus().length);
 
   hint: the type checker sees everything @types/node declares, but only the supported surface compiles (https://scriptc.dev/limitations)
 
-fenced.ts:42:13 - error SC2020: 'CpuInfo[].length' is part of the standard library types but has no scriptc lowering yet
+fenced.ts:41:13 - error SC2020: 'CpuInfo[].length' is part of the standard library types but has no scriptc lowering yet
 
-  41 | watchFile("x", () => {});
-  42 | console.log(cpus().length);
+  40 | watchFile("x", () => {});
+  41 | console.log(cpus().length);
      |             ^~~~~~~~~~~~~
-  43 | console.log(win32.sep);
+  42 | console.log(win32.sep);
 
   hint: the type checker sees the full standard library, but only the supported surface compiles (https://scriptc.dev/limitations)
 
-fenced.ts:43:13 - error SC2020: 'PlatformPath.sep' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:42:13 - error SC2020: 'PlatformPath.sep' is typed by @types/node but has no scriptc lowering yet
 
-  42 | console.log(cpus().length);
-  43 | console.log(win32.sep);
+  41 | console.log(cpus().length);
+  42 | console.log(win32.sep);
      |             ^~~~~~~~~
-  44 | /* URL members beyond the supported getters (protocol/pathname/href/
+  43 | /* URL members beyond the supported getters (protocol/pathname/href/
 
   hint: the type checker sees everything @types/node declares, but only the supported surface compiles (https://scriptc.dev/limitations)
 
-fenced.ts:49:13 - error SC2020: 'URL.hash' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:48:13 - error SC2020: 'URL.hash' is typed by @types/node but has no scriptc lowering yet
 
-  48 | const u = new URL("https://example.com/x?a=1");
-  49 | console.log(u.hash);
+  47 | const u = new URL("https://example.com/x?a=1");
+  48 | console.log(u.hash);
      |             ^~~~~~
-  50 | u.searchParams.get("a");
+  49 | u.searchParams.get("a");
 
   hint: protocol, pathname, href, host, hostname, search, searchParams, and toString() are the supported URL members
 
-fenced.ts:56:13 - error SC2020: 'deflateSync of 'string' data' is part of the standard library types but has no scriptc lowering yet
+fenced.ts:55:13 - error SC2020: 'deflateSync of 'string' data' is part of the standard library types but has no scriptc lowering yet
 
-  55 | import { deflateSync, gzipSync } from "zlib";
-  56 | deflateSync("data");
+  54 | import { deflateSync, gzipSync } from "zlib";
+  55 | deflateSync("data");
      |             ^~~~~~
-  57 | gzipSync("data");
+  56 | gzipSync("data");
 
   hint: zlib works on Buffers: deflateSync(Buffer.from(s, "utf8"))
 
-fenced.ts:57:1 - error SC2020: 'zlib.gzipSync' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:56:1 - error SC2020: 'zlib.gzipSync' is typed by @types/node but has no scriptc lowering yet
 
-  56 | deflateSync("data");
-  57 | gzipSync("data");
+  55 | deflateSync("data");
+  56 | gzipSync("data");
      | ^~~~~~~~~~~~~~~~
-  58 | /* The http2 compatibility slice's @types/node-world fences (divergence
+  57 | /* The http2 compatibility slice's @types/node-world fences (divergence
 
   hint: deflateSync and inflateSync are the lowered zlib surface
 
-fenced.ts:66:71 - error SC2020: 'a createSecureServer SNICallback of 'undefined' values' is part of the standard library types but has no scriptc lowering yet
+fenced.ts:65:71 - error SC2020: 'a createSecureServer SNICallback of 'undefined' values' is part of the standard library types but has no scriptc lowering yet
 
-  65 | import * as http2 from "node:http2";
-  66 | http2.createSecureServer({ allowHTTP1: true, cert: "pem", key: "pem", SNICallback: undefined });
+  64 | import * as http2 from "node:http2";
+  65 | http2.createSecureServer({ allowHTTP1: true, cert: "pem", key: "pem", SNICallback: undefined });
      |                                                                       ^~~~~~~~~~~~~~~~~~~~~~
-  67 | http2.createSecureServer({
+  66 | http2.createSecureServer({
 
   hint: SNICallback lowers as a direct option or the conditional spread ...(x ? { SNICallback: x } : {}) — the callback is (servername, cb) => void with cb: (err: Error | null, ctx?: tls.SecureContext) => void
 
-fenced.ts:71:3 - error SC2020: 'createSecureServer options with a conditional spread' is part of the standard library types but has no scriptc lowering yet
+fenced.ts:70:3 - error SC2020: 'createSecureServer options with a conditional spread' is part of the standard library types but has no scriptc lowering yet
 
-  70 |   key: "pem",
-  71 |   ...(1 ? { SNICallback: undefined } : {}),
+  69 |   key: "pem",
+  70 |   ...(1 ? { SNICallback: undefined } : {}),
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  72 | });
+  71 | });
 
   hint: the lowered conditional spread is exactly ...(x ? { SNICallback: x } : {}) — the included value must BE the condition
 
-fenced.ts:73:71 - error SC2020: 'createSecureServer option 'streamResetBurst' with a non-literal value' is part of the standard library types but has no scriptc lowering yet
+fenced.ts:72:71 - error SC2020: 'createSecureServer option 'streamResetBurst' with a non-literal value' is part of the standard library types but has no scriptc lowering yet
 
-  72 | });
-  73 | http2.createSecureServer({ allowHTTP1: true, cert: "pem", key: "pem", streamResetBurst: 1 + 0 });
+  71 | });
+  72 | http2.createSecureServer({ allowHTTP1: true, cert: "pem", key: "pem", streamResetBurst: 1 + 0 });
      |                                                                       ^~~~~~~~~~~~~~~~~~~~~~~
-  74 | http2.connect("https://localhost");
+  73 | http2.connect("https://localhost");
 
   hint: h2 session-tuning options are accepted with literal values (settings: a literal of literals) and ignored — the allowHTTP1 lowering serves HTTP/1.1 only, which has no h2 sessions to tune
 
-fenced.ts:80:1 - error SC2020: 'crypto.generateKeyPair' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:79:1 - error SC2020: 'crypto.generateKeyPair' is typed by @types/node but has no scriptc lowering yet
 
-  79 | import { createCipheriv, generateKeyPair, pbkdf2Sync, setFips } from "node:crypto";
-  80 | generateKeyPair("rsa", { modulusLength: 2048 }, () => {});
+  78 | import { createCipheriv, generateKeyPair, pbkdf2Sync, setFips } from "node:crypto";
+  79 | generateKeyPair("rsa", { modulusLength: 2048 }, () => {});
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  81 | createCipheriv("aes-128-cbc", Buffer.alloc(16), Buffer.alloc(16));
+  80 | createCipheriv("aes-128-cbc", Buffer.alloc(16), Buffer.alloc(16));
 
   hint: asymmetric-key operations need a public-key stack (bignum, RSA/EC/EdDSA math) and a KeyObject value model — neither exists in the static runtime, so no faithful lowering can be small; the lowered crypto surface is hashing, randomness, and the introspection statics
 
-fenced.ts:81:1 - error SC2020: 'crypto.createCipheriv' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:80:1 - error SC2020: 'crypto.createCipheriv' is typed by @types/node but has no scriptc lowering yet
 
-  80 | generateKeyPair("rsa", { modulusLength: 2048 }, () => {});
-  81 | createCipheriv("aes-128-cbc", Buffer.alloc(16), Buffer.alloc(16));
+  79 | generateKeyPair("rsa", { modulusLength: 2048 }, () => {});
+  80 | createCipheriv("aes-128-cbc", Buffer.alloc(16), Buffer.alloc(16));
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  82 | pbkdf2Sync("pw", "salt", 100000, 64, "sha512");
+  81 | pbkdf2Sync("pw", "salt", 100000, 64, "sha512");
 
   hint: symmetric ciphers need a cipher stack the static runtime does not vendor — the lowered crypto surface is hashing, randomness, and the introspection statics
 
-fenced.ts:82:1 - error SC2020: 'crypto.pbkdf2Sync' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:81:1 - error SC2020: 'crypto.pbkdf2Sync' is typed by @types/node but has no scriptc lowering yet
 
-  81 | createCipheriv("aes-128-cbc", Buffer.alloc(16), Buffer.alloc(16));
-  82 | pbkdf2Sync("pw", "salt", 100000, 64, "sha512");
+  80 | createCipheriv("aes-128-cbc", Buffer.alloc(16), Buffer.alloc(16));
+  81 | pbkdf2Sync("pw", "salt", 100000, 64, "sha512");
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  83 | setFips(false);
+  82 | setFips(false);
 
   hint: key-derivation functions have no lowering yet — the lowered crypto surface is hashing, randomness, and the introspection statics
 
-fenced.ts:83:1 - error SC2020: 'crypto.setFips' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:82:1 - error SC2020: 'crypto.setFips' is typed by @types/node but has no scriptc lowering yet
 
-  82 | pbkdf2Sync("pw", "salt", 100000, 64, "sha512");
-  83 | setFips(false);
+  81 | pbkdf2Sync("pw", "salt", 100000, 64, "sha512");
+  82 | setFips(false);
      | ^~~~~~~~~~~~~~
-  84 | fetch("https://example.invalid/", {
+  83 | fetch("https://example.invalid/", {
 
   hint: a compiled binary has no FIPS provider to enable, and Node itself throws on setFips(true) in a non-FIPS build — getFips() answers 0 here
 
-fenced.ts:85:3 - error SC2020: 'RequestInit option 'integrity' in a static build' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:84:3 - error SC2020: 'RequestInit option 'integrity' in a static build' is typed by @types/node but has no scriptc lowering yet
 
-  84 | fetch("https://example.invalid/", {
-  85 |   integrity: "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
+  83 | fetch("https://example.invalid/", {
+  84 |   integrity: "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=",
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  86 | });
+  85 | });
 
   hint: neither compiler tier preserves this RequestInit member's conversion or transport behavior
 
-fenced.ts:89:3 - error SC2020: 'ReadableStream.tee' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:88:3 - error SC2020: 'ReadableStream.tee' is typed by @types/node but has no scriptc lowering yet
 
-  88 |   const body = (await fetch(url)).body!;
-  89 |   body.tee();
+  87 |   const body = (await fetch(url)).body!;
+  88 |   body.tee();
      |   ^~~~~~~~
-  90 |   const tee = body.tee;
+  89 |   const tee = body.tee;
 
   hint: the dynamic Web Streams bridge exposes only an explicit unsupported stub for this operation
 
-fenced.ts:90:15 - error SC2020: 'ReadableStream.tee' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:89:15 - error SC2020: 'ReadableStream.tee' is typed by @types/node but has no scriptc lowering yet
 
-  89 |   body.tee();
-  90 |   const tee = body.tee;
+  88 |   body.tee();
+  89 |   const tee = body.tee;
      |               ^~~~~~~~
-  91 |   body["tee"]();
+  90 |   body["tee"]();
 
   hint: the dynamic Web Streams bridge exposes only an explicit unsupported stub for this operation
 
-fenced.ts:91:3 - error SC2020: 'ReadableStream.tee' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:90:3 - error SC2020: 'ReadableStream.tee' is typed by @types/node but has no scriptc lowering yet
 
-  90 |   const tee = body.tee;
-  91 |   body["tee"]();
+  89 |   const tee = body.tee;
+  90 |   body["tee"]();
      |   ^~~~~~~~~~~
-  92 |   const bracketTee = body["tee"];
+  91 |   const bracketTee = body["tee"];
 
   hint: the dynamic Web Streams bridge exposes only an explicit unsupported stub for this operation
 
-fenced.ts:92:22 - error SC2020: 'ReadableStream.tee' is typed by @types/node but has no scriptc lowering yet
+fenced.ts:91:22 - error SC2020: 'ReadableStream.tee' is typed by @types/node but has no scriptc lowering yet
 
-  91 |   body["tee"]();
-  92 |   const bracketTee = body["tee"];
+  90 |   body["tee"]();
+  91 |   const bracketTee = body["tee"];
      |                      ^~~~~~~~~~~
-  93 | }
+  92 | }
 
   hint: the dynamic Web Streams bridge exposes only an explicit unsupported stub for this operation

--- a/tests/harness/fetch.test.ts
+++ b/tests/harness/fetch.test.ts
@@ -175,6 +175,7 @@ describe(`static fetch differential${sanitize ? " (sanitized)" : ""}`, () => {
   const staticCases = [
     "static",
     "static-coercion",
+    "static-controller",
     "static-stream",
     "static-stream-this",
     "static-listener-this",

--- a/tests/harness/surface-manifest.test.ts
+++ b/tests/harness/surface-manifest.test.ts
@@ -565,6 +565,33 @@ test("fetch interface object bindings retain the inventory fence code", () => {
   expect(dynamic.diagnostics.filter((d) => d.code === "SC2020")).toHaveLength(2);
 });
 
+test("static AbortController method reads fence instead of yielding undefined", () => {
+  const file = probeFile({
+    id: "stdlib.abort-controller.method-read-fence",
+    source:
+      '/// <reference types="node" />\n' +
+      'const controller = new AbortController();\n' +
+      'void controller.abort;\n' +
+      'void controller["abort"];\n' +
+      'void controller.signal;\n',
+  });
+  const { coverage } = analyze(file);
+  expect(coverage.preflightFailed).toBe(false);
+  expect([...new Set(coverage.diagnostics.map((d) => d.code))]).toEqual(["SC2020"]);
+  expect(coverage.diagnostics).toHaveLength(2);
+  expect(
+    coverage.diagnostics.every((d) =>
+      d.message.includes(
+        "AbortController.abort through method extraction in a static build",
+      )
+    ),
+  ).toBe(true);
+
+  const dynamic = analyze(file, { dynamic: true }).coverage;
+  expect(dynamic.diagnostics.map((d) => `${d.code}: ${d.message}`)).toEqual([]);
+  expect(dynamic.stats.statementsFailed).toBe(0);
+});
+
 test("static fetch data properties remain destructurable in JavaScript", () => {
   const dir = join(probeRoot, "fetch-static-data-binding");
   mkdirSync(dir, { recursive: true });

--- a/tests/harness/surface-manifest.test.ts
+++ b/tests/harness/surface-manifest.test.ts
@@ -117,6 +117,10 @@ const PROBES: Probe[] = [
   { id: "stdlib.number.toFixed", source: "const n = 1.2345;\nconsole.log(n.toFixed(2));\n" },
   { id: "stdlib.abort-signal.timeout", source: "const signal = AbortSignal.timeout(1000);\nconsole.log(signal.aborted);\n" },
   {
+    id: "stdlib.abort-controller.constructor",
+    source: "const controller = new AbortController();\ncontroller.abort();\nconsole.log(controller.signal.aborted);\n",
+  },
+  {
     id: "stdlib.readable-stream.constructor",
     source: "const stream = new ReadableStream<number>();\nconsole.log(stream.locked);\n",
   },


### PR DESCRIPTION
- Add static and dynamic lowering for construction, signal access, and abort calls
- Back controllers with native signal state shared by fetch
- Cover cancellation semantics across C, LLVM, diagnostics, and surface tests