### PR TITLE
Support static util.parseArgs

### DIFF
--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -1584,6 +1584,41 @@ declare module "util" {
     format?: unknown,
     ...args: unknown[]
   ): string;
+  export type ParseArgsOptionsType = "boolean" | "string";
+  export interface ParseArgsOptionDescriptor {
+    type: ParseArgsOptionsType;
+    multiple?: boolean;
+    short?: string;
+    default?: string | boolean | string[] | boolean[];
+  }
+  export interface ParseArgsOptionsConfig {
+    [longOption: string]: ParseArgsOptionDescriptor;
+  }
+  export interface ParseArgsConfig {
+    args?: readonly string[];
+    options?: ParseArgsOptionsConfig;
+    strict?: boolean;
+    allowPositionals?: boolean;
+    allowNegative?: boolean;
+    tokens?: boolean;
+  }
+  export type ParseArgsToken =
+    | {
+        kind: "option";
+        index: number;
+        name: string;
+        rawName: string;
+        value: string | undefined;
+        inlineValue: boolean | undefined;
+      }
+    | { kind: "positional"; index: number; value: string }
+    | { kind: "option-terminator"; index: number };
+  export interface ParseArgsResult {
+    values: { [longOption: string]: undefined | string | boolean | Array<string | boolean> };
+    positionals: string[];
+    tokens?: ParseArgsToken[];
+  }
+  export function parseArgs(config?: ParseArgsConfig): ParseArgsResult;
   /* util.getCallSites (Node ≥22.9): the captured-frame slice harness
    * code reads. No stack bookkeeping exists in a compiled binary — every
    * reached call fences per site. */

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -305,6 +305,9 @@ export interface CcOptions {
    * line (escape-only programs ride the always-linked component encoder
    * and never flip this). */
   qs?: boolean;
+  /** The program uses static util.parseArgs (index.ts detects its libCall):
+   * compiles scr_util.c, a pure checked-dynamic data transform. */
+  parseArgs?: boolean;
   /** The program uses the node:stream class surface (moduleUsesStream on
    * the IR): compiles scr_stream.c into the binary — always alongside
    * scr_events_emitter.c, which moduleUsesEmitter answers true for
@@ -3086,6 +3089,7 @@ export async function compileC(opts: CcOptions): Promise<void> {
     ...(opts.symbol ? [rt(join(rtDir, "scr_symbol.c"))] : []),
     ...(opts.searchParams ? [rt(join(rtDir, "scr_url_params.c"))] : []),
     ...(opts.qs ? [rt(join(rtDir, "scr_qs.c"))] : []),
+    ...(opts.parseArgs ? [rt(join(rtDir, "scr_util.c"))] : []),
     ...(opts.stream ? [rt(join(rtDir, "scr_stream.c"))] : []),
     // The readiness-poller backends (scr_platform.h): kqueue on macOS/BSD,
     // epoll on Linux, WSAPoll on Windows — each TU is empty off its

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -3488,6 +3488,10 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             );
             return dict;
           }
+          // node:util.parseArgs (scr_util.c): checked-dynamic config in,
+          // checked-dynamic result out; may throw a coded TypeError.
+          case "util.parseArgs":
+            return finish(`scr_util_parse_args(${arg(0)})`);
           // Stats (scr_lib.c): statSync throws like the other sync fs
           // calls; the getters are pure reads.
           case "fs.openSync":

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -10593,9 +10593,14 @@ class LlEmitter {
         for (const field of fields) {
           const index = shape.fields.indexOf(field) + 1;
           const fieldPtr = B.tmp();
-          const fieldValue = B.tmp();
+          let fieldValue = B.tmp();
           B.line(`${fieldPtr} = getelementptr inbounds %${mangleRecordStruct(t.shapeId)}, ptr %p, i64 0, i32 ${index}`);
           B.line(`${fieldValue} = load ${llFieldType(field.type)}, ptr ${fieldPtr}`);
+          if (llFieldType(field.type) === "i8") {
+            const boolValue = B.tmp();
+            B.line(`${boolValue} = trunc i8 ${fieldValue} to i1`);
+            fieldValue = boolValue;
+          }
           const boxed = this.streamTypedRefBoxValue(
             B,
             field.type,
@@ -10620,9 +10625,14 @@ class LlEmitter {
         for (const field of fields) {
           const index = shape.fields.indexOf(field) + 1;
           const fieldPtr = B.tmp();
-          const fieldValue = B.tmp();
+          let fieldValue = B.tmp();
           B.line(`${fieldPtr} = getelementptr inbounds %${mangleRecordStruct(t.shapeId)}, ptr %p, i64 0, i32 ${index}`);
           B.line(`${fieldValue} = load ${llFieldType(field.type)}, ptr ${fieldPtr}`);
+          if (llFieldType(field.type) === "i8") {
+            const boolValue = B.tmp();
+            B.line(`${boolValue} = trunc i8 ${fieldValue} to i1`);
+            fieldValue = boolValue;
+          }
           const boxed = this.streamTypedRefBoxValue(
             B,
             field.type,

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -175,6 +175,7 @@ function llStrBytes(text: string): string {
  * Throwing members (MAY_THROW_LIB_FNS) and everything unlisted refuse by
  * name. */
 const LIB_FN_SYMS: Record<string, string> = {
+  "util.parseArgs": "scr_util_parse_args",
   "math.maxArr": "scr_math_max_arr",
   "math.minArr": "scr_math_min_arr",
   "math.min": "scr_math_min",

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -22,7 +22,7 @@ import { lowerSocketInstanceOf, lowerTlsRootCertificates } from "./lower-server.
 import { findGenericMethodOn, lowerStaticFieldRead } from "./lower-classes.js";
 import { bindingNeverReassigned, implicitMonoFile, lowerTaggedTemplate, nullishGenericBindingUnitOf, objLitGenericFnInfoOf, objLitGenericFnNodeOf, requireObjLitGenericReceiver } from "./lower-calls.js";
 import { mixinFnOfCallee } from "./lower-mixins.js";
-import { isConstAssertionTypeNode, isGenericCallableMemberType, underConstAssertion, unitOnlyUnion } from "../types.js";
+import { isConstAssertionTypeNode, isGenericCallableMemberType, isParseArgsDynTypeName, underConstAssertion, unitOnlyUnion } from "../types.js";
 import { lowerYield } from "./lower-generators.js";
 import { lowerStreamProperty, lowerStreamStateProperty, streamSidesOf } from "./lower-stream.js";
 
@@ -98,6 +98,31 @@ export function abstractPropertyDeclOf(L: Lowerer, expr: ts.PropertyAccessExpres
         ts.isPropertyDeclaration(d) &&
         ts.getModifiers(d)?.some((m) => m.kind === ts.SyntaxKind.AbstractKeyword) === true,
     );
+}
+
+/** A field declared by node:util's parseArgs checked-dynamic type family.
+ * Narrowing a ParseArgsToken exposes one anonymous union arm, so its alias
+ * identity no longer reaches mapType; declaration ancestry is the stable
+ * provenance check. */
+function isParseArgsDynProperty(L: Lowerer, expr: ts.PropertyAccessExpression): boolean {
+  const sym = L.checker.getSymbolAtLocation(expr.name);
+  if (!sym) return false;
+  return L.checker.declarationsOf(sym).some((d) => {
+    if (!L.isStdlibFile(d.getSourceFile())) return false;
+    let inParseArgsType = false;
+    for (let node: ts.Node | undefined = d.parent; node; node = node.parent) {
+      if (
+        (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node)) &&
+        isParseArgsDynTypeName(node.name.text)
+      ) {
+        inParseArgsType = true;
+      }
+      if (ts.isModuleDeclaration(node) && ts.isStringLiteral(node.name)) {
+        return inParseArgsType && (node.name.text === "util" || node.name.text === "node:util");
+      }
+    }
+    return false;
+  });
 }
 
 export function lowerExpr(L: Lowerer, expr: ts.Expression): IrExpr {
@@ -1716,6 +1741,35 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
         if (ambientRoot !== null) {
           const t = ambientUndefReadType(L, expr) ?? contextualUndefReadType(L, expr);
           if (t) return nsUndefRead(L, ambientRoot.text, expr, t);
+        }
+      }
+      // parseArgs results/tokens live in the checked-dynamic tree. A token
+      // discriminant check narrows its checker type to one anonymous arm,
+      // whose ambient property symbols would otherwise hit SC2020 before
+      // the generic dyn receiver path below. Provenance is limited to the
+      // node:util parseArgs family; every other stdlib member keeps its
+      // ordinary surface fence.
+      if (isParseArgsDynProperty(L, expr)) {
+        const recv = L.lowerExpr(expr.expression);
+        if (recv.type.kind === "dyn") {
+          const key: IrExpr = {
+            kind: "strLit",
+            value: expr.name.text,
+            type: STRING,
+            loc: locOf(expr.name),
+          };
+          const opt = chainGuardedByQuestionDot(expr.expression);
+          return L.maybeNarrow(
+            {
+              kind: "dynKeyGet",
+              key,
+              ...(opt ? { optional: true as const } : {}),
+              value: recv,
+              type: DYN,
+              loc,
+            },
+            expr,
+          );
         }
       }
       // A member read through a NULLISH generic binding (`const i: I<A &

--- a/packages/compiler/src/frontend/lowering/lower-inspect.ts
+++ b/packages/compiler/src/frontend/lowering/lower-inspect.ts
@@ -36,7 +36,7 @@
 import * as ts from "../ts7/adapter.js";
 import type { Lowerer } from "./lowerer.js";
 import { isJsSourceFile } from "../program.js";
-import { BOOL, DYN, F64, IrExpr, IrStmt, IrType, RUNTIME_ERROR_CLASSES, STRING, SrcLoc, shapeHasAccessorSlots, typeKey } from "../../ir/nodes.js";
+import { BOOL, DYN, F64, IrExpr, IrStmt, IrType, RUNTIME_ERROR_CLASSES, STRING, SrcLoc, canConvertToDyn, canDynCheckTo, shapeHasAccessorSlots, typeKey } from "../../ir/nodes.js";
 import type { ClassInfo } from "./lower-classes.js";
 import { pureReemittable } from "./lower-exprs.js";
 
@@ -1348,11 +1348,65 @@ export function lowerUtilModuleCall(
       return lowerFormatCall(L, expr, loc, false);
     case "formatWithOptions":
       return lowerFormatCall(L, expr, loc, true);
+    case "parseArgs":
+      return lowerParseArgsCall(L, expr, loc);
     case "getCallSites":
       return lowerGetCallSitesCall(L, expr, loc);
     default:
       return null;
   }
+}
+
+/** util.parseArgs(config?): the configuration is ordinary JSON-safe data,
+ * so it crosses into the runtime as a checked-dynamic tree. The native
+ * parser returns the same tree-shaped result Node does (including token
+ * variants and a null-prototype values object); statically typed member
+ * reads leave that tree through the ordinary dyn checks. */
+function lowerParseArgsCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc): IrExpr {
+  if (expr.arguments.length > 1 || expr.arguments.some(ts.isSpreadElement)) {
+    L.noLowering(
+      `util.parseArgs with ${expr.arguments.length} arguments`,
+      expr,
+      "the lowered form is parseArgs() or parseArgs(config)",
+    );
+  }
+
+  let config: IrExpr;
+  const configNode = expr.arguments[0];
+  if (!configNode) {
+    config = { kind: "dynObjLit", fields: [], type: DYN, loc };
+  } else {
+    const raw = L.lowerExpr(configNode);
+    if (raw.type.kind === "dyn") {
+      config = raw;
+    } else if (raw.type.kind === "jsval") {
+      config = { kind: "dynFromJsval", value: raw, type: DYN, loc };
+    } else if (canConvertToDyn(raw.type, (id) => L.shapes.get(id), (id) => L.unions.get(id))) {
+      config = { kind: "dynFrom", value: raw, type: DYN, loc };
+    } else {
+      L.noLowering(
+        `util.parseArgs with a '${L.fmt(raw.type)}' configuration`,
+        configNode,
+        "pass the documented JSON-safe config object (args/options and boolean flags)",
+      );
+    }
+  }
+
+  const parsed: IrExpr = {
+    kind: "libCall",
+    fn: "util.parseArgs",
+    args: [config],
+    type: DYN,
+    loc,
+  };
+  const result = L.mapTypeOf(L.typeOf(expr));
+  if (
+    result !== null && result.kind !== "dyn" && result.kind !== "jsval" && result.kind !== "void" &&
+    canDynCheckTo(result, (id) => L.shapes.get(id), (id) => L.unions.get(id))
+  ) {
+    return { kind: "dynCheck", value: parsed, type: result, loc };
+  }
+  return parsed;
 }
 
 /** util.getCallSites() in a JS source: compiled binaries keep no runtime

--- a/packages/compiler/src/frontend/lowering/lower-inspect.ts
+++ b/packages/compiler/src/frontend/lowering/lower-inspect.ts
@@ -1382,7 +1382,20 @@ function lowerParseArgsCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc): I
     } else if (raw.type.kind === "jsval") {
       config = { kind: "dynFromJsval", value: raw, type: DYN, loc };
     } else if (canConvertToDyn(raw.type, (id) => L.shapes.get(id), (id) => L.unions.get(id))) {
-      config = { kind: "dynFrom", value: raw, type: DYN, loc };
+      // parseArgs assigns descriptor default arrays directly into the
+      // returned values object. Keep mutable config composites in typed-ref
+      // capsules so that default arrays can leave the dyn result as the
+      // original static reference; the runtime still snapshots `args` and
+      // the option schema before parsing, matching Node's synchronous read.
+      const liveRef = raw.type.kind === "record" || raw.type.kind === "array" ||
+        raw.type.kind === "bytes";
+      config = {
+        kind: "dynFrom",
+        value: raw,
+        ...(liveRef ? { liveRef: true as const } : {}),
+        type: DYN,
+        loc,
+      };
     } else {
       L.noLowering(
         `util.parseArgs with a '${L.fmt(raw.type)}' configuration`,

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -1060,7 +1060,7 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
 /** Whether a checker type belongs to node:util.parseArgs's dyn-backed
  * declaration family. Module ancestry disambiguates short private helper
  * names such as `Token` from names in other standard-library modules. */
-function isParseArgsDynCheckerType(L: Lowerer, type: ts.Type): boolean {
+export function isParseArgsDynCheckerType(L: Lowerer, type: ts.Type): boolean {
   const widened = L.checker.getBaseTypeOfLiteralType(type);
   const declarationBelongs = (d: ts.Node): boolean => {
     if (!L.isStdlibFile(d.getSourceFile())) return false;

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -24,7 +24,7 @@ import { builtinMemberRequireDecl, builtinNamespaceDestructureModuleOf, createRe
 import { lowerEnumDeclaration } from "./lower-enums.js";
 import { abstractPropertyDeclOf, aliasTypeofNarrows, isMatchSliceType, lowerGroupsProjection, matchResultNamedGroupsOf, probeLower, pureReemittable, symbolFieldInfo } from "./lower-exprs.js";
 import { UNSUPPORTED, checkerPanicDiag, isCheckerPanic, requiresDynamicDiag } from "../../diagnostics/diagnostic.js";
-import { isUnitOnlyTsType, unitOnlyUnion } from "../types.js";
+import { isParseArgsDynTypeName, isUnitOnlyTsType, unitOnlyUnion } from "../types.js";
 import { canonicalBuiltinModule, isRelativeSpecifier } from "../shared.js";
 import { probeNodeRequireRefusal } from "../npm.js";
 
@@ -1057,6 +1057,42 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
     ];
   }
 
+/** Whether a checker type belongs to node:util.parseArgs's dyn-backed
+ * declaration family. Module ancestry disambiguates short private helper
+ * names such as `Token` from names in other standard-library modules. */
+function isParseArgsDynCheckerType(L: Lowerer, type: ts.Type): boolean {
+  const widened = L.checker.getBaseTypeOfLiteralType(type);
+  const declarationBelongs = (d: ts.Node): boolean => {
+    if (!L.isStdlibFile(d.getSourceFile())) return false;
+    let inParseArgsType = false;
+    for (let node: ts.Node | undefined = d.parent; node; node = node.parent) {
+      if (
+        (ts.isTypeAliasDeclaration(node) || ts.isInterfaceDeclaration(node)) &&
+        isParseArgsDynTypeName(node.name.text)
+      ) {
+        inParseArgsType = true;
+      }
+      if (ts.isModuleDeclaration(node) && ts.isStringLiteral(node.name)) {
+        return inParseArgsType && (node.name.text === "util" || node.name.text === "node:util");
+      }
+    }
+    return false;
+  };
+  const sym = widened.getAliasSymbol() ?? widened.getSymbol();
+  if (
+    sym && isParseArgsDynTypeName(sym.name) &&
+    L.checker.declarationsOf(sym).some(declarationBelongs)
+  ) {
+    return true;
+  }
+  // A discriminant check erases the token alias and leaves one anonymous
+  // object arm. Its properties still point into the parseArgs alias, which
+  // is the same stable signal the dotted-member bridge uses.
+  return L.checker.getPropertiesOfType(widened).some((p) =>
+    L.checker.declarationsOf(p).some(declarationBelongs),
+  );
+}
+
 /** Destructuring declarations, desugared as sugar over indexed/field
    * reads: the initializer evaluates ONCE into a hidden temp, then each
    * bound name declares (or assigns its pre-registered module global) from
@@ -1086,6 +1122,8 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
       if (tokenBound !== null) return tokenBound;
     }
     let init = L.lowerExpr(decl.initializer);
+    const parseArgsDynObject =
+      init.type.kind === "dyn" && isParseArgsDynCheckerType(L, L.typeOf(decl.initializer));
     // A TS `any`-origin source whose lowered value is NOT a destructurable
     // shape (`var { x } = <any>0` — the cast erases to the f64; a dyn
     // value — the checked-dynamic tree has no destructure): JS reads the properties off
@@ -1247,6 +1285,7 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
       isLet,
       out,
       dynSpell,
+      parseArgsDynObject,
     );
     return out;
   }
@@ -1258,7 +1297,8 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
     srcType: IrType,
     isLet: boolean,
     out: IrStmt[],
-    dynSpell?: string,): void {
+    dynSpell?: string,
+    allowDynObject = false,): void {
     if (ts.isArrayBindingPattern(pattern)) {
       L.fenceStaticHeadersIteration(pattern);
       // Tuple sources: each position is a field read of the tuple's record
@@ -1575,8 +1615,14 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
     // default applied exactly when the read answers undefined (lazily,
     // like a defaulted parameter). Bindings are dyn (the checker's `any`),
     // nested object patterns recurse through this same branch. TS files
-    // keep the fence — annotations exist there.
-    if (srcType.kind === "dyn" && isJsSourceFile(pattern.getSourceFile())) {
+    // keep the fence — annotations exist there. node:util.parseArgs is the
+    // scoped TypeScript exception: its declared result/token types are
+    // deliberately carried by the checked-dynamic tree, so their ordinary
+    // object patterns use the same exact keyed-read desugar.
+    if (
+      srcType.kind === "dyn" &&
+      (isJsSourceFile(pattern.getSourceFile()) || allowDynObject)
+    ) {
       for (const el of pattern.elements) {
         if (el.name === undefined) continue;
         const loc = locOf(el);
@@ -1616,7 +1662,7 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
             loc,
           };
         }
-        L.bindPatternTarget(el.name, value, isLet, out);
+        L.bindPatternTarget(el.name, value, isLet, out, allowDynObject);
       }
       return;
     }
@@ -2771,7 +2817,8 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
   export function bindPatternTarget(L: Lowerer, name: ts.BindingName,
     value: IrExpr,
     isLet: boolean,
-    out: IrStmt[],): void {
+    out: IrStmt[],
+    allowDynObject = false,): void {
     const loc = value.loc;
     if (ts.isIdentifier(name)) {
       const symbol = L.checker.getSymbolAtLocation(name);
@@ -2821,6 +2868,8 @@ export function lowerStmt(L: Lowerer, stmt: ts.Statement): IrStmt | IrStmt[] | n
       value.type,
       isLet,
       out,
+      undefined,
+      allowDynObject,
     );
   }
 

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -7145,7 +7145,8 @@ export class Lowerer {
     srcType: IrType,
     isLet: boolean,
     out: IrStmt[],
-    dynSpell?: string,): void {
+    dynSpell?: string,
+    allowDynObject = false,): void {
     if (ts.isObjectBindingPattern(pattern)) {
       fenceFetchObjectBinding(this, pattern);
     }
@@ -7219,7 +7220,7 @@ export class Lowerer {
       }
       return;
     }
-    return lowerBindingPattern(this, pattern, srcRef, srcType, isLet, out, dynSpell);
+    return lowerBindingPattern(this, pattern, srcRef, srcType, isLet, out, dynSpell, allowDynObject);
   }
 
   checkBindingElement(el: ts.BindingElement, allowDefault = false): void {
@@ -7229,8 +7230,9 @@ export class Lowerer {
   bindPatternTarget(name: ts.BindingName,
     value: IrExpr,
     isLet: boolean,
-    out: IrStmt[],): void {
-    return bindPatternTarget(this, name, value, isLet, out);
+    out: IrStmt[],
+    allowDynObject = false,): void {
+    return bindPatternTarget(this, name, value, isLet, out, allowDynObject);
   }
 
   lowerVarDeclList(list: ts.VariableDeclarationList): IrStmt | null {

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -104,7 +104,7 @@ import { lowerNodeTestModuleCall, lowerTestDirectCall, lowerTestMethodCall, lowe
 import { lowerAssertModuleCall, lowerAssertDirectCall } from "./lower-assert.js";
 import { lowerUtilModuleCall } from "./lower-inspect.js";
 import { lowerComptime, comptimeBakeable, rejectComptimeCaptures, comptimeValueToIr } from "./lower-comptime.js";
-import { lowerStmts, noteBlockedBindings, isBlockedBinding, lowerScopedBlock, predeclareForwardCapture, predeclareForwardFnDecl, predeclareForwardVar, rejectJumpCrossingFinally, lowerStmt, lowerVarStatement, lowerDestructuringDecl, lowerDestructuringAssignParts, lowerBindingPattern, lowerJsvalBindingPattern, checkBindingElement, bindPatternTarget, lowerVarDeclList, lowerVarDecl, lowerSwitch, lowerTry, lowerExprStatement, lowerForOf, lowerForStatement } from "./lower-stmts.js";
+import { lowerStmts, noteBlockedBindings, isBlockedBinding, lowerScopedBlock, predeclareForwardCapture, predeclareForwardFnDecl, predeclareForwardVar, rejectJumpCrossingFinally, lowerStmt, lowerVarStatement, lowerDestructuringDecl, lowerDestructuringAssignParts, lowerBindingPattern, lowerJsvalBindingPattern, checkBindingElement, bindPatternTarget, isParseArgsDynCheckerType, lowerVarDeclList, lowerVarDecl, lowerSwitch, lowerTry, lowerExprStatement, lowerForOf, lowerForStatement } from "./lower-stmts.js";
 import { FieldTarget, lowerDynObjectLiteral, lowerExpr, maybeNarrow, lowerUnitComparison, lowerNullishCoalesce, lowerOptionalChain, finishOptionalChain, lowerCondition, ensureBool, requireTruthyUnion, eqComparableUnion, lowerIntrinsicProperty, lowerArrayLiteral, lowerObjectLiteral, lowerShorthandValue, rejectThisInObjectMethod, lowerElementAccess, lowerElementWrite, lowerRecordKeyRead, ensureString, lowerTemplate, lowerAsExpression, lowerPrefixUnary, lowerBinary, lowerCaughtTypeofTest, caughtRead, caughtLocalOf, caughtToString, lowerInstanceOf, lowerRegexLiteral, lowerFieldRead, lowerUnionProperty, fieldTarget, fieldGetExpr, fieldSetStmt, lowerFieldCompound, uniqueSymbolKeyOf, foldedStringKeyOf } from "./lower-exprs.js";
 import type { ExpandoMember } from "./lower-expando.js";
 import { lowerRecordFieldCall, lowerObjectMethodCall } from "./lower-calls.js";
@@ -7149,6 +7149,11 @@ export class Lowerer {
     allowDynObject = false,): void {
     if (ts.isObjectBindingPattern(pattern)) {
       fenceFetchObjectBinding(this, pattern);
+      // parseArgs's declaration family deliberately maps to dyn. Infer the
+      // scoped bridge at the binding site as well as at initializer-backed
+      // declarations, covering parameter and for-of element patterns.
+      allowDynObject ||= srcType.kind === "dyn" &&
+        isParseArgsDynCheckerType(this, this.typeOf(pattern));
     }
     // An ISLAND source (`const { readFileSync } = await import("fs")` —
     // a namespace handle, or any 'any'-typed object): each bound name is

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -685,14 +685,19 @@ export const BUILTIN_MODULE_FNS: Record<string, Record<string, BuiltinModuleFn |
     execFileSync: { fn: "cp.execSync", params: [STRING, arrayOf(STRING)], result: STRING },
     execSync: { fn: "cp.execSync", params: [STRING], result: STRING },
   },
-  // node:util lowers through TWO paths, neither tabled here: promisify
+  // node:util lowers through dedicated paths: promisify
   // only in the const-binding-over-execFile shape — recognized in
   // lowerVarDecl / collectGlobals BEFORE any call lowering runs — and
-  // inspect/format/formatWithOptions through the util spoke
+  // inspect/format/formatWithOptions plus parseArgs through the util spoke
   // (lower-inspect.ts: per-type synthesized traversal helpers,
-  // compile-time format strings), which both dispatch paths try before
-  // the member fence below.
-  util: {},
+  // compile-time format strings, checked-dynamic config/result for
+  // parseArgs), which both dispatch paths try before the generic table.
+  // parseArgs is tabled as well so the generated surface manifest records
+  // the dedicated static member; the spoke owns its optional arity and
+  // call-site-specific result type before this canonical signature is used.
+  util: {
+    parseArgs: { fn: "util.parseArgs", params: [DYN], result: DYN },
+  },
   // node:string_decoder's surface is the StringDecoder CLASS — new/write/
   // end are special-cased (lowerNew + lowerStringDecoderMethodCall); no
   // function members exist to table.

--- a/packages/compiler/src/frontend/types.ts
+++ b/packages/compiler/src/frontend/types.ts
@@ -34,6 +34,33 @@ export const ISLAND_AMBIENT_TYPES = [
   "ReadableStreamReadDoneResult",
 ] as const;
 
+/** node:util.parseArgs's public and @types/node helper type names. Values
+ * behind this surface use the checked-dynamic tree; see mapTypeInner. */
+const PARSE_ARGS_DYN_TYPES = new Set([
+  "ParseArgsConfig",
+  "ParseArgsOptionDescriptor",
+  "ParseArgsOptionsConfig",
+  "ParseArgsResult",
+  "ParseArgsToken",
+  "ParsedResults",
+  "PreciseParsedResults",
+  "ParsedValues",
+  "ParsedPositionals",
+  "ParsedTokens",
+  "ParsedOptionToken",
+  "ParsedPositionalToken",
+  "PreciseTokenForOptions",
+  "TokenForOptions",
+  "OptionToken",
+  "Token",
+]);
+
+/** True for the parseArgs type family that deliberately rides dyn. Exported
+ * for the property-read bridge after TypeScript narrows a token union arm. */
+export function isParseArgsDynTypeName(name: string): boolean {
+  return PARSE_ARGS_DYN_TYPES.has(name);
+}
+
 /** The frontend's record-shape interner. Records are monomorphic structural
  * shapes: fields sorted by name form the canonical identity, and two types
  * with the same canonical field list share one shapeId (and later one C
@@ -727,6 +754,28 @@ function mapTypeInner(type: ts.Type, ctx: TypeMapperCtx): IrType | null {
   if (flags & ts.TypeFlags.Number) return F64;
   if (flags & ts.TypeFlags.String) return STRING;
   if (flags & ts.TypeFlags.Boolean || flags & ts.TypeFlags.BooleanLiteral) return BOOL;
+  // node:util.parseArgs config/results are declaration-heavy conditional
+  // and discriminated-union types over a value that is naturally a checked-
+  // dynamic tree. Keep the named public surface (plus @types/node's private
+  // helper aliases that survive instantiation) in that representation:
+  // typed member reads still exit through ordinary dyn checks, while the
+  // runtime can preserve the three token variants and null-prototype values
+  // object without inventing one false static record shape. Provenance keeps
+  // user aliases with the same names on the normal structural path.
+  {
+    const parseArgsSym = widened.getAliasSymbol() ?? widened.getSymbol();
+    if (
+      parseArgsSym &&
+      PARSE_ARGS_DYN_TYPES.has(parseArgsSym.name) &&
+      checker.declarationsOf(parseArgsSym).some(
+        (d) =>
+          ctx.isStdlibFile(d.getSourceFile()) &&
+          isDeclaredInAmbientModule(d as ts.Declaration, "util"),
+      )
+    ) {
+      return DYN;
+    }
+  }
   // The lib's BOXED wrapper interfaces used as TYPES (`const n: Number =
   // 5`): every value such a slot can hold IS the primitive — `new
   // Number(...)` construction is fenced, so no box object ever exists —

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -21,7 +21,7 @@ import {
 import { validateSidecar } from "./library/sidecar-validate.js";
 import { entryFunctionExports, type EntryExportInfo } from "./frontend/lib-exports.js";
 import { entryContractFacts, type ContractFacts } from "./frontend/lib-contract.js";
-import { moduleLibAsyncSurface, moduleLibNondeterministicSurface, moduleEmbedsBuiltin, moduleEmbedsCompressedNpm, moduleUsesAssert, moduleUsesCopying, moduleUsesDc, moduleUsesDgram, moduleUsesDynAsync, moduleUsesDynInvoke, moduleUsesEmitter, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesInspect, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesQs, moduleUsesRegex, moduleUsesSearchParams, moduleUsesStream, moduleUsesSymbol, moduleUsesTls, moduleUsesTlsCa, moduleUsesZlib, type IrLibSection, type IrModule, type IrRecordShape, type IrType, type SrcLoc } from "./ir/nodes.js";
+import { moduleLibAsyncSurface, moduleLibNondeterministicSurface, moduleEmbedsBuiltin, moduleEmbedsCompressedNpm, moduleUsesAssert, moduleUsesCopying, moduleUsesDc, moduleUsesDgram, moduleUsesDynAsync, moduleUsesDynInvoke, moduleUsesEmitter, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesInspect, moduleUsesNet, moduleUsesNodeTest, moduleUsesParseArgs, moduleUsesProcessEvents, moduleUsesQs, moduleUsesRegex, moduleUsesSearchParams, moduleUsesStream, moduleUsesSymbol, moduleUsesTls, moduleUsesTlsCa, moduleUsesZlib, type IrLibSection, type IrModule, type IrRecordShape, type IrType, type SrcLoc } from "./ir/nodes.js";
 import { serializeModule } from "./ir/serialize.js";
 import { validateModule } from "./ir/validate.js";
 import { canonicalBuiltinModule, checkPreflight, isNodeTypesPath, loadProgram, locOf, requiresOf, resolveNpmImport, type LoadResult } from "./frontend/program.js";
@@ -855,6 +855,8 @@ export async function compile(entryPath: string, opts: CompileOptions): Promise<
       // The link switch for scr_qs.c: the qs.* libCalls that live there
       // (parse/stringify/unescape; escape rides the always-linked encoder).
       qs: moduleUsesQs(lowered.module),
+      // The static node:util parseArgs implementation (scr_util.c).
+      parseArgs: moduleUsesParseArgs(lowered.module),
       // The link switch for scr_stream.c: the node:stream class surface on
       // the IR (stream libCalls or the %Readable-family class defs).
       stream: moduleUsesStream(lowered.module),

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2001,6 +2001,11 @@ export type IrLibFn =
   | "qs.stringify"
   | "qs.escape"
   | "qs.unescape"
+  /** node:util.parseArgs: one checked-dynamic config object in, one
+   * checked-dynamic ParsedResults tree out. Statically typed member reads
+   * validate their values when leaving that tree. The native parser may
+   * throw Node's coded validation/grammar TypeErrors. */
+  | "util.parseArgs"
   /** ES Symbol values (scr_symbol.c — link-gated by moduleUsesSymbol).
    * sym.new: `Symbol(desc)` — a fresh runtime-unique identity (+1) whose
    * one arg is the description string (borrowed); sym.newAnon is the
@@ -6090,6 +6095,28 @@ export function moduleUsesQs(mod: IrModule): boolean {
   return found;
 }
 
+/** True when the module uses native util.parseArgs — the link switch for
+ * scr_util.c. The implementation is a pure checked-dynamic data transform,
+ * cross-platform and independent of the island's node:util shim. */
+export function moduleUsesParseArgs(mod: IrModule): boolean {
+  let found = false;
+  const visit = (v: unknown): void => {
+    if (found || v === null || typeof v !== "object") return;
+    if (Array.isArray(v)) {
+      for (const item of v) visit(item);
+      return;
+    }
+    const node = v as { kind?: unknown; fn?: unknown };
+    if (node.kind === "libCall" && node.fn === "util.parseArgs") {
+      found = true;
+      return;
+    }
+    for (const key of Object.keys(v)) visit((v as Record<string, unknown>)[key]);
+  };
+  visit(mod);
+  return found;
+}
+
 /** True when the module contains any fs.watch/watcher.* libCall — the
  * link switch that pulls scr_watch.c into the binary and has the emitted
  * main call scr_watch_install (cc.ts + emitter; the scr_net gating
@@ -6752,6 +6779,7 @@ export const MAY_THROW_LIB_FNS: ReadonlySet<IrLibFn> = new Set([
   "island.import",
   "island.castFail",
   "json.parse",
+  "util.parseArgs",
   // decodeURIComponent throws the spec's URIError on bad hex/invalid
   // UTF-8 octets (encodeURIComponent never throws — see the IrLibFn doc).
   "str.decodeUriComponent",

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -284,6 +284,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "qs.stringify": { argTypes: [DYN, STRING, STRING], result: STRING },
   "qs.escape": { argTypes: [STRING], result: STRING },
   "qs.unescape": { argTypes: [STRING], result: STRING },
+  "util.parseArgs": { argTypes: [DYN], result: DYN },
   "fs.statSync": { argTypes: [STRING], result: STATS_T },
   "fs.lstatSync": { argTypes: [STRING], result: STATS_T },
   "fs.openSync": { argTypes: [STRING, STRING], result: F64 },

--- a/packages/compiler/surface-manifest.json
+++ b/packages/compiler/surface-manifest.json
@@ -1772,6 +1772,12 @@
       "note": "recognized module (bare and node:-prefixed specifiers)"
     },
     {
+      "id": "node-builtin.util.parseArgs",
+      "kind": "node-builtin",
+      "name": "util.parseArgs",
+      "status": "static"
+    },
+    {
       "id": "node-builtin.util.promisify",
       "kind": "node-builtin",
       "name": "util.promisify",

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -5514,6 +5514,24 @@
    ],
    "diags": []
   },
+  "<repo>/tests/corpus/2678-util-parseargs.ts": {
+   "order": [
+    "<repo>/tests/corpus/2678-util-parseargs.ts"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2679-util-parseargs-cjs.cjs": {
+   "order": [
+    "<repo>/tests/corpus/2679-util-parseargs-cjs.cjs"
+   ],
+   "diags": []
+  },
+  "<repo>/tests/corpus/2680-util-parseargs-default.ts": {
+   "order": [
+    "<repo>/tests/corpus/2680-util-parseargs-default.ts"
+   ],
+   "diags": []
+  },
   "<repo>/tests/corpus/300-if-else.ts": {
    "order": [
     "<repo>/tests/corpus/300-if-else.ts"

--- a/packages/compiler/test/ts7/baselines/order-parity.json
+++ b/packages/compiler/test/ts7/baselines/order-parity.json
@@ -5532,6 +5532,12 @@
    ],
    "diags": []
   },
+  "<repo>/tests/corpus/2681-util-parseargs-dynamic.js": {
+   "order": [
+    "<repo>/tests/corpus/2681-util-parseargs-dynamic.js"
+   ],
+   "diags": []
+  },
   "<repo>/tests/corpus/300-if-else.ts": {
    "order": [
     "<repo>/tests/corpus/300-if-else.ts"

--- a/packages/runtime/src/scr_json.c
+++ b/packages/runtime/src/scr_json.c
@@ -1390,7 +1390,8 @@ ScrStr *scr_dyn_typeof(const ScrDyn *d) {
 /* ── JSON.stringify over a dyn value (util.format's %j) ───────────────
  * The RUNTIME walk the type-directed serializers deliberately avoid for
  * static values — a dyn value has no static type, so the checked-dynamic tree's own kinds
- * drive it, JS-exactly: insertion-ordered objects with undefined/function
+ * drive it, JS-exactly: objects in OrdinaryOwnPropertyKeys order (array
+ * indices ascending, then other strings in insertion order) with undefined/function
  * members OMITTED, arrays rendering those as null, Buffer's toJSON shape
  * ({"type":"Buffer","data":[...]}), shortest-roundtrip numbers, escaped
  * strings. HANDLE values fence loudly (Node walks own enumerable props
@@ -1418,23 +1419,26 @@ static bool scr_dyn_json_write(ScrJsonBuf *b, const ScrDyn *d) {
   case SCR_DYN_OBJ: {
     scr_jb_putc(b, '{');
     bool first = true;
-    for (size_t i = 0; i < d->v.obj.len; i++) {
+    ScrDyn *entries = scr_dyn_obj_entries(d);
+    for (size_t i = 0; i < entries->v.arr.len; i++) {
+      const ScrDyn *pair = entries->v.arr.items[i];
+      const ScrDyn *key = pair->v.arr.items[0];
+      const ScrDyn *value = pair->v.arr.items[1];
       ScrJsonBuf probe;
       scr_jb_init(&probe);
-      if (!scr_dyn_json_write(&probe, d->v.obj.entries[i].value)) {
+      if (!scr_dyn_json_write(&probe, value)) {
         scr_jb_dispose(&probe);
         continue; /* undefined/function members drop, like Node */
       }
       if (!first) scr_jb_putc(b, ',');
       first = false;
-      ScrStr *k = scr_str_new(d->v.obj.entries[i].key, d->v.obj.entries[i].key_len);
-      scr_jb_put_json_str(b, k);
-      scr_str_release(k);
+      scr_jb_put_json_str(b, key->v.str);
       scr_jb_putc(b, ':');
       ScrStr *body = scr_jb_finish(&probe);
       scr_jb_write(b, body->data, body->len);
       scr_str_release(body);
     }
+    scr_dyn_release(entries);
     scr_jb_putc(b, '}');
     return true;
   }

--- a/packages/runtime/src/scr_json.c
+++ b/packages/runtime/src/scr_json.c
@@ -94,6 +94,10 @@ static void scr_jb_write(ScrJsonBuf *b, const char *s, size_t n) {
   b->len += n;
 }
 
+void scr_jb_put_str(ScrJsonBuf *b, const ScrStr *s) {
+  scr_jb_write(b, s->data, s->len);
+}
+
 void scr_jb_puts(ScrJsonBuf *b, const char *s) { scr_jb_write(b, s, strlen(s)); }
 
 void scr_jb_put_f64(ScrJsonBuf *b, double v) {

--- a/packages/runtime/src/scr_json.c
+++ b/packages/runtime/src/scr_json.c
@@ -990,10 +990,18 @@ void scr_throw_arg_type(const ScrStr *argname, const ScrStr *expected, const Scr
 void scr_dyn_arg_type_fail(const char *argname, const char *expected, const ScrDyn *got) {
   char detail[64];
   const char *d = scr_dyn_specific_type(got, detail, sizeof detail);
-  char msg[224];
-  int len = snprintf(msg, sizeof msg,
-                     "The \"%s\" argument must be %s. Received %s", argname, expected, d);
-  scr_throw_error_msg_code(SCR_ERR_TYPE, msg, (size_t)len, "ERR_INVALID_ARG_TYPE");
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "The \"");
+  scr_jb_puts(&b, argname);
+  scr_jb_puts(&b, "\" argument must be ");
+  scr_jb_puts(&b, expected);
+  scr_jb_puts(&b, ". Received ");
+  scr_jb_puts(&b, d);
+  ScrStr *msg = scr_jb_finish(&b);
+  scr_throw_error_msg_code(SCR_ERR_TYPE, msg->data, msg->len,
+                           "ERR_INVALID_ARG_TYPE");
+  scr_str_release(msg);
 }
 
 /* The property flavor of the same ladder — Node renders option-bag
@@ -1003,10 +1011,18 @@ void scr_dyn_arg_type_fail(const char *argname, const char *expected, const ScrD
 void scr_dyn_prop_type_fail(const char *name, const char *expected, const ScrDyn *got) {
   char detail[64];
   const char *d = scr_dyn_specific_type(got, detail, sizeof detail);
-  char msg[224];
-  int len = snprintf(msg, sizeof msg,
-                     "The \"%s\" property must be %s. Received %s", name, expected, d);
-  scr_throw_error_msg_code(SCR_ERR_TYPE, msg, (size_t)len, "ERR_INVALID_ARG_TYPE");
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "The \"");
+  scr_jb_puts(&b, name);
+  scr_jb_puts(&b, "\" property must be ");
+  scr_jb_puts(&b, expected);
+  scr_jb_puts(&b, ". Received ");
+  scr_jb_puts(&b, d);
+  ScrStr *msg = scr_jb_finish(&b);
+  scr_throw_error_msg_code(SCR_ERR_TYPE, msg->data, msg->len,
+                           "ERR_INVALID_ARG_TYPE");
+  scr_str_release(msg);
 }
 
 /* The compiler-resolved property-typed throw (error.propTypeThrow —
@@ -1055,11 +1071,19 @@ const char *scr_dyn_inspect_lite(const ScrDyn *v, char *buf, size_t cap) {
 void scr_dyn_arg_value_fail(const char *name, const char *reason, const ScrDyn *got) {
   char insp[64];
   const char *d = scr_dyn_inspect_lite(got, insp, sizeof insp);
-  char msg[256];
-  int len = snprintf(msg, sizeof msg, "The %s '%s' %s. Received %s",
-                     strchr(name, '.') != NULL ? "property" : "argument", name,
-                     reason != NULL ? reason : "is invalid", d);
-  scr_throw_error_msg_code(SCR_ERR_TYPE, msg, (size_t)len, "ERR_INVALID_ARG_VALUE");
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "The ");
+  scr_jb_puts(&b, strchr(name, '.') != NULL ? "property '" : "argument '");
+  scr_jb_puts(&b, name);
+  scr_jb_puts(&b, "' ");
+  scr_jb_puts(&b, reason != NULL ? reason : "is invalid");
+  scr_jb_puts(&b, ". Received ");
+  scr_jb_puts(&b, d);
+  ScrStr *msg = scr_jb_finish(&b);
+  scr_throw_error_msg_code(SCR_ERR_TYPE, msg->data, msg->len,
+                           "ERR_INVALID_ARG_VALUE");
+  scr_str_release(msg);
 }
 
 /* The deferred JS lowering fence, thrown from a ladder's post-validation

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -720,6 +720,12 @@ void scr_qs_parse_into(ScrMap *out, const ScrStr *qs, const ScrStr *sep,
                        const ScrStr *eq, double max_keys, uint32_t str_tag,
                        uint32_t arr_tag);
 
+/* node:util.parseArgs — the static checked-dynamic boundary. `config` is
+ * the documented JSON-safe configuration object; the returned dyn tree is
+ * a fresh ParsedResults object whose `values` child has null prototype.
+ * Borrows config; returns +1, or NULL with a Node-coded TypeError pending. */
+struct ScrDyn *scr_util_parse_args(const struct ScrDyn *config);
+
 /* querystring.stringify — Node's stringify over a borrowed dyn value (the
  * frontend dynFroms the typed record; JS-world dyn values pass straight
  * through). Non-object dyn values answer "" like Node; object keys iterate in
@@ -3397,6 +3403,8 @@ typedef struct {
 } ScrJsonBuf;
 
 void scr_jb_init(ScrJsonBuf *b);
+/* Append one borrowed runtime string verbatim (no JSON quoting). */
+void scr_jb_put_str(ScrJsonBuf *b, const ScrStr *s);
 /* Push a container onto the circular-detection stack before serializing
  * its members. If `v` is already ON the stack, throws V8's exact
  * "Converting circular structure to JSON" TypeError (the --> starting at /

--- a/packages/runtime/src/scr_util.c
+++ b/packages/runtime/src/scr_util.c
@@ -1,0 +1,573 @@
+/* node:util's engine-free static surface. parseArgs crosses the typed
+ * frontend through the checked-dynamic tree: the config is JSON-safe data,
+ * and the result is the ordinary Node-shaped { values, positionals,
+ * tokens? } tree. This keeps the parser independent of every emitted
+ * record/union layout while the frontend's dynCheck restores the precise
+ * ParsedResults<T> type at the call site.
+ *
+ * The grammar follows Node 24's util.parseArgs/tokenizeArgs: long options,
+ * grouped shorts, inline/separate string values, strict=false unknowns,
+ * -- termination, negative booleans, multiple/default accumulation, and
+ * token metadata. All input nodes are borrowed; the result owns fresh or
+ * retained children. Validation/grammar failures leave a coded TypeError
+ * pending and return NULL. */
+#include "scr_runtime.h"
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static const ScrDyn *pa_member(const ScrDyn *obj, const char *key) {
+  if (!obj || obj->kind != SCR_DYN_OBJ) return NULL;
+  const ScrDyn *v = scr_dyn_obj_get(obj, key, strlen(key));
+  return v && v->kind != SCR_DYN_UNDEF ? v : NULL;
+}
+
+static bool pa_str_eq_bytes(const ScrStr *s, const char *p, size_t n) {
+  return s && s->len == n && memcmp(s->data, p, n) == 0;
+}
+
+static bool pa_str_eq_c(const ScrStr *s, const char *p) {
+  return pa_str_eq_bytes(s, p, strlen(p));
+}
+
+static ScrStr *pa_str_bytes(const char *p, size_t n) {
+  return scr_str_new(p, n);
+}
+
+static ScrDyn *pa_dyn_str(const ScrStr *s) {
+  return scr_dyn_new_str((ScrStr *)s);
+}
+
+static ScrDyn *pa_dyn_str_bytes(const char *p, size_t n) {
+  ScrStr *s = pa_str_bytes(p, n);
+  ScrDyn *d = pa_dyn_str(s);
+  scr_str_release(s);
+  return d;
+}
+
+static char *pa_path(const char *prefix, const char *name, size_t name_len,
+                     const char *suffix) {
+  size_t pn = strlen(prefix), sn = strlen(suffix);
+  char *out = malloc(pn + name_len + sn + 1);
+  if (!out) {
+    fputs("scriptc: out of memory\n", stderr);
+    abort();
+  }
+  memcpy(out, prefix, pn);
+  memcpy(out + pn, name, name_len);
+  memcpy(out + pn + name_len, suffix, sn + 1);
+  return out;
+}
+
+static void pa_throw_text(ScrJsonBuf *b, const char *code) {
+  ScrStr *msg = scr_jb_finish(b);
+  scr_throw_error_msg_code(SCR_ERR_TYPE, msg->data, msg->len, code);
+  scr_str_release(msg);
+}
+
+static void pa_unknown(const ScrStr *raw) {
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "Unknown option '");
+  scr_jb_put_str(&b, raw);
+  scr_jb_puts(&b, "'");
+  pa_throw_text(&b, "ERR_PARSE_ARGS_UNKNOWN_OPTION");
+}
+
+static void pa_missing_long(const ScrStr *raw) {
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "Option '");
+  scr_jb_put_str(&b, raw);
+  scr_jb_puts(&b, " <value>' argument missing");
+  pa_throw_text(&b, "ERR_PARSE_ARGS_INVALID_OPTION_VALUE");
+}
+
+static void pa_missing_short(const ScrStr *raw, const ScrStr *name) {
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "Option '");
+  scr_jb_put_str(&b, raw);
+  scr_jb_puts(&b, ", --");
+  scr_jb_put_str(&b, name);
+  scr_jb_puts(&b, " <value>' argument missing");
+  pa_throw_text(&b, "ERR_PARSE_ARGS_INVALID_OPTION_VALUE");
+}
+
+static void pa_ambiguous(const ScrStr *raw, const ScrStr *name,
+                         bool is_short) {
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "Option '");
+  scr_jb_put_str(&b, raw);
+  scr_jb_puts(&b, "' argument is ambiguous.\nDid you forget to specify the option argument for '");
+  scr_jb_put_str(&b, raw);
+  scr_jb_puts(&b, "'?\nTo specify an option argument starting with a dash use '--");
+  scr_jb_put_str(&b, name);
+  scr_jb_puts(&b, "=-XYZ'");
+  if (is_short) {
+    scr_jb_puts(&b, " or '");
+    scr_jb_put_str(&b, raw);
+    scr_jb_puts(&b, "-XYZ'");
+  }
+  scr_jb_puts(&b, ".");
+  pa_throw_text(&b, "ERR_PARSE_ARGS_INVALID_OPTION_VALUE");
+}
+
+static void pa_takes_no_value(const ScrStr *raw) {
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "Option '");
+  scr_jb_put_str(&b, raw);
+  scr_jb_puts(&b, "' does not take an argument");
+  pa_throw_text(&b, "ERR_PARSE_ARGS_INVALID_OPTION_VALUE");
+}
+
+static void pa_unexpected(const ScrStr *arg) {
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "Unexpected argument '");
+  scr_jb_put_str(&b, arg);
+  scr_jb_puts(&b, "'. This command does not take positional arguments");
+  pa_throw_text(&b, "ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL");
+}
+
+/* A config boolean with Node's default/validation rule. */
+static bool pa_config_bool(const ScrDyn *config, const char *name,
+                           bool fallback, bool *ok) {
+  const ScrDyn *v = pa_member(config, name);
+  if (!v) return fallback;
+  if (v->kind == SCR_DYN_BOOL) return v->v.b;
+  scr_dyn_arg_type_fail(name, "of type boolean", v);
+  *ok = false;
+  return fallback;
+}
+
+/* Descriptor type: 1 string, 0 boolean, -1 malformed. Descriptors were
+ * validated once before parsing, so parsing calls only see 0/1. */
+static int pa_desc_type(const ScrDyn *desc) {
+  const ScrDyn *v = pa_member(desc, "type");
+  if (!v || v->kind != SCR_DYN_STR) return -1;
+  if (pa_str_eq_c(v->v.str, "string")) return 1;
+  if (pa_str_eq_c(v->v.str, "boolean")) return 0;
+  return -1;
+}
+
+static bool pa_desc_multiple(const ScrDyn *desc) {
+  const ScrDyn *v = pa_member(desc, "multiple");
+  return v && v->kind == SCR_DYN_BOOL && v->v.b;
+}
+
+static bool pa_default_value_ok(const ScrDyn *v, int type) {
+  return type == 1 ? v->kind == SCR_DYN_STR : v->kind == SCR_DYN_BOOL;
+}
+
+/* Validate the option schema up front, as Node does even when args is
+ * empty. Static TypeScript callers already satisfy this ladder; it keeps
+ * JS/unknown crossings catchable and prevents malformed dyn reads. */
+static bool pa_validate_options(const ScrDyn *options) {
+  if (!options) return true; /* null/undefined mean {} */
+  if (options->kind != SCR_DYN_OBJ) {
+    scr_dyn_arg_type_fail("options", "of type object", options);
+    return false;
+  }
+  for (size_t i = 0; i < options->v.obj.len; i++) {
+    const ScrDynEntry *entry = &options->v.obj.entries[i];
+    const ScrDyn *desc = entry->value;
+    char *base = pa_path("options.", entry->key, entry->key_len, "");
+    if (desc->kind != SCR_DYN_OBJ) {
+      scr_dyn_prop_type_fail(base, "of type object", desc);
+      free(base);
+      return false;
+    }
+    const ScrDyn *typev = pa_member(desc, "type");
+    int type = pa_desc_type(desc);
+    if (type < 0) {
+      char *path = pa_path(base, "", 0, ".type");
+      scr_dyn_prop_type_fail(path, "('string|boolean')",
+                             typev ? typev : scr_dyn_undefined());
+      free(path);
+      free(base);
+      return false;
+    }
+    const ScrDyn *shortv = pa_member(desc, "short");
+    if (shortv) {
+      char *path = pa_path(base, "", 0, ".short");
+      if (shortv->kind != SCR_DYN_STR) {
+        scr_dyn_prop_type_fail(path, "of type string", shortv);
+        free(path);
+        free(base);
+        return false;
+      }
+      if (scr_str_utf16_len(shortv->v.str) != 1) {
+        scr_dyn_arg_value_fail(path, "must be a single character", shortv);
+        free(path);
+        free(base);
+        return false;
+      }
+      free(path);
+    }
+    const ScrDyn *multiplev = pa_member(desc, "multiple");
+    if (multiplev && multiplev->kind != SCR_DYN_BOOL) {
+      char *path = pa_path(base, "", 0, ".multiple");
+      scr_dyn_prop_type_fail(path, "of type boolean", multiplev);
+      free(path);
+      free(base);
+      return false;
+    }
+    const ScrDyn *def = pa_member(desc, "default");
+    if (def) {
+      char *path = pa_path(base, "", 0, ".default");
+      if (pa_desc_multiple(desc)) {
+        if (def->kind != SCR_DYN_ARR) {
+          scr_dyn_prop_type_fail(path, "an instance of Array", def);
+          free(path);
+          free(base);
+          return false;
+        }
+        for (size_t j = 0; j < def->v.arr.len; j++) {
+          if (!pa_default_value_ok(def->v.arr.items[j], type)) {
+            char suffix[48];
+            snprintf(suffix, sizeof suffix, "[%zu]", j);
+            char *item_path = pa_path(path, "", 0, suffix);
+            scr_dyn_prop_type_fail(item_path,
+                                   type ? "of type string" : "of type boolean",
+                                   def->v.arr.items[j]);
+            free(item_path);
+            free(path);
+            free(base);
+            return false;
+          }
+        }
+      } else if (!pa_default_value_ok(def, type)) {
+        scr_dyn_prop_type_fail(path,
+                               type ? "of type string" : "of type boolean", def);
+        free(path);
+        free(base);
+        return false;
+      }
+      free(path);
+    }
+    free(base);
+  }
+  return true;
+}
+
+static const ScrDyn *pa_find_long(const ScrDyn *options, const ScrStr *name) {
+  if (!options) return NULL;
+  return scr_dyn_obj_get(options, name->data, name->len);
+}
+
+static const ScrDyn *pa_find_short(const ScrDyn *options, const ScrStr *short_name,
+                                   const char **long_name, size_t *long_len) {
+  if (!options) return NULL;
+  for (size_t i = 0; i < options->v.obj.len; i++) {
+    const ScrDynEntry *entry = &options->v.obj.entries[i];
+    const ScrDyn *shortv = pa_member(entry->value, "short");
+    if (shortv && shortv->kind == SCR_DYN_STR &&
+        shortv->v.str->len == short_name->len &&
+        memcmp(shortv->v.str->data, short_name->data, short_name->len) == 0) {
+      *long_name = entry->key;
+      *long_len = entry->key_len;
+      return entry->value;
+    }
+  }
+  return NULL;
+}
+
+static ScrDyn *pa_option_token(const ScrStr *name, const ScrStr *raw,
+                               size_t index, const ScrStr *value, int inline_value) {
+  ScrDyn *token = scr_dyn_new_obj();
+  scr_dyn_obj_set(token, "kind", 4, pa_dyn_str_bytes("option", 6));
+  scr_dyn_obj_set(token, "name", 4, pa_dyn_str(name));
+  scr_dyn_obj_set(token, "rawName", 7, pa_dyn_str(raw));
+  scr_dyn_obj_set(token, "index", 5, scr_dyn_new_num((double)index));
+  scr_dyn_obj_set(token, "value", 5,
+                  value ? pa_dyn_str(value) : scr_dyn_retain(scr_dyn_undefined()));
+  scr_dyn_obj_set(token, "inlineValue", 11,
+                  inline_value < 0 ? scr_dyn_retain(scr_dyn_undefined())
+                                   : scr_dyn_new_bool(inline_value != 0));
+  return token;
+}
+
+static void pa_store(ScrDyn *values, ScrDyn *tokens, const ScrDyn *desc,
+                     const ScrStr *name, const ScrStr *raw, size_t index,
+                     const ScrStr *value, bool flag_value, int inline_value) {
+  ScrDyn *stored = value ? pa_dyn_str(value) : scr_dyn_new_bool(flag_value);
+  if (desc && pa_desc_multiple(desc)) {
+    ScrDyn *arr = scr_dyn_obj_get(values, name->data, name->len);
+    if (!arr) {
+      arr = scr_dyn_new_arr();
+      scr_dyn_obj_set(values, name->data, name->len, arr);
+    }
+    scr_dyn_arr_push(arr, stored);
+  } else {
+    scr_dyn_obj_set(values, name->data, name->len, stored);
+  }
+  if (tokens) {
+    scr_dyn_arr_push(tokens,
+                     pa_option_token(name, raw, index, value, inline_value));
+  }
+}
+
+static void pa_positional(ScrDyn *positionals, ScrDyn *tokens,
+                          const ScrStr *value, size_t index) {
+  scr_dyn_arr_push(positionals, pa_dyn_str(value));
+  if (!tokens) return;
+  ScrDyn *token = scr_dyn_new_obj();
+  scr_dyn_obj_set(token, "kind", 4, pa_dyn_str_bytes("positional", 10));
+  scr_dyn_obj_set(token, "index", 5, scr_dyn_new_num((double)index));
+  scr_dyn_obj_set(token, "value", 5, pa_dyn_str(value));
+  scr_dyn_arr_push(tokens, token);
+}
+
+static ScrDyn *pa_default_args(void) {
+  ScrDyn *args = scr_dyn_new_arr();
+  int argc = scr_lib_arg_count();
+  /* Raw argv[0] is the executable. process.argv's synthetic first two
+   * entries occupy it plus "scriptc", so slice(2) begins at raw argv[1]. */
+  for (int i = 1; i < argc; i++) {
+    const char *arg = scr_lib_arg(i);
+    scr_dyn_arr_push(args, pa_dyn_str_bytes(arg, strlen(arg)));
+  }
+  return args;
+}
+
+ScrDyn *scr_util_parse_args(const ScrDyn *config) {
+  bool ok = true;
+  /* Omitted config is lowered as {}, while an explicit undefined takes the
+   * default parameter just as Node does. Null keeps Object(null)'s useful
+   * failure; other primitive/array wrappers have no config members. */
+  if (!config || config->kind == SCR_DYN_NULL) {
+    static const char msg[] = "Cannot convert undefined or null to object";
+    scr_throw_error_msg(SCR_ERR_TYPE, msg, sizeof msg - 1);
+    return NULL;
+  }
+  const ScrDyn *cfg = config->kind == SCR_DYN_OBJ ? config : NULL;
+  bool strict = pa_config_bool(cfg, "strict", true, &ok);
+  bool allow_positionals = pa_config_bool(cfg, "allowPositionals", !strict, &ok);
+  bool allow_negative = pa_config_bool(cfg, "allowNegative", false, &ok);
+  bool return_tokens = pa_config_bool(cfg, "tokens", false, &ok);
+  if (!ok) return NULL;
+
+  const ScrDyn *options = pa_member(cfg, "options");
+  if (options && options->kind == SCR_DYN_NULL) options = NULL;
+  if (!pa_validate_options(options)) return NULL;
+
+  ScrDyn *owned_args = NULL;
+  const ScrDyn *args = pa_member(cfg, "args");
+  if (!args || args->kind == SCR_DYN_NULL) {
+    owned_args = pa_default_args();
+    args = owned_args;
+  } else if (args->kind != SCR_DYN_ARR) {
+    scr_dyn_arg_type_fail("args", "an instance of Array", args);
+    return NULL;
+  }
+  for (size_t i = 0; i < args->v.arr.len; i++) {
+    if (args->v.arr.items[i]->kind != SCR_DYN_STR) {
+      char name[48];
+      snprintf(name, sizeof name, "args[%zu]", i);
+      scr_dyn_prop_type_fail(name, "of type string", args->v.arr.items[i]);
+      scr_dyn_release(owned_args);
+      return NULL;
+    }
+  }
+
+  ScrDyn *result = scr_dyn_new_obj();
+  ScrDyn *values = scr_dyn_new_obj_null_proto();
+  ScrDyn *positionals = scr_dyn_new_arr();
+  ScrDyn *tokens = return_tokens ? scr_dyn_new_arr() : NULL;
+  bool after_terminator = false;
+
+  for (size_t i = 0; i < args->v.arr.len; i++) {
+    const ScrStr *arg = args->v.arr.items[i]->v.str;
+    if (after_terminator) {
+      pa_positional(positionals, tokens, arg, i);
+      continue;
+    }
+    if (pa_str_eq_c(arg, "--")) {
+      after_terminator = true;
+      if (tokens) {
+        ScrDyn *token = scr_dyn_new_obj();
+        scr_dyn_obj_set(token, "kind", 4,
+                        pa_dyn_str_bytes("option-terminator", 17));
+        scr_dyn_obj_set(token, "index", 5, scr_dyn_new_num((double)i));
+        scr_dyn_arr_push(tokens, token);
+      }
+      continue;
+    }
+
+    if (arg->len >= 2 && arg->data[0] == '-' && arg->data[1] == '-') {
+      size_t eq = arg->len;
+      /* `--=x` is the option named "=x", not an empty option with an
+       * inline value. An equals separator is recognized only after at
+       * least one name byte, matching Node's tokenizer. */
+      for (size_t j = 3; j < arg->len; j++) {
+        if (arg->data[j] == '=') { eq = j; break; }
+      }
+      ScrStr *name = pa_str_bytes(arg->data + 2, eq - 2);
+      ScrStr *raw = pa_str_bytes(arg->data, eq);
+      const ScrDyn *desc = pa_find_long(options, name);
+      if (eq < arg->len) {
+        if (strict && !desc) {
+          pa_unknown(raw);
+          scr_str_release(raw);
+          scr_str_release(name);
+          goto fail;
+        }
+        if (strict && pa_desc_type(desc) == 0) {
+          pa_takes_no_value(raw);
+          scr_str_release(raw);
+          scr_str_release(name);
+          goto fail;
+        }
+        ScrStr *value = pa_str_bytes(arg->data + eq + 1, arg->len - eq - 1);
+        pa_store(values, tokens, desc, name, raw, i, value, true, 1);
+        scr_str_release(value);
+      } else if (desc && pa_desc_type(desc) == 1) {
+        if (i + 1 < args->v.arr.len) {
+          const ScrStr *value = args->v.arr.items[++i]->v.str;
+          if (strict && value->len > 1 && value->data[0] == '-') {
+            pa_ambiguous(raw, name, false);
+            scr_str_release(raw);
+            scr_str_release(name);
+            goto fail;
+          }
+          pa_store(values, tokens, desc, name, raw, i - 1, value, true, 0);
+        } else if (strict) {
+          pa_missing_long(raw);
+          scr_str_release(raw);
+          scr_str_release(name);
+          goto fail;
+        } else {
+          pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+        }
+      } else if (allow_negative && name->len > 3 &&
+                 memcmp(name->data, "no-", 3) == 0) {
+        ScrStr *positive = pa_str_bytes(name->data + 3, name->len - 3);
+        const ScrDyn *positive_desc = pa_find_long(options, positive);
+        if (positive_desc && pa_desc_type(positive_desc) == 0) {
+          pa_store(values, tokens, positive_desc, positive, raw, i,
+                   NULL, false, -1);
+          scr_str_release(positive);
+        } else {
+          scr_str_release(positive);
+          if (strict && !desc) {
+            pa_unknown(raw);
+            scr_str_release(raw);
+            scr_str_release(name);
+            goto fail;
+          }
+          pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+        }
+      } else {
+        if (strict && !desc) {
+          pa_unknown(raw);
+          scr_str_release(raw);
+          scr_str_release(name);
+          goto fail;
+        }
+        pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+      }
+      scr_str_release(raw);
+      scr_str_release(name);
+      continue;
+    }
+
+    if (arg->len > 1 && arg->data[0] == '-') {
+      double units = scr_str_utf16_len((ScrStr *)arg);
+      for (double at = 1; at < units; at++) {
+        ScrStr *short_name = scr_str_char_at((ScrStr *)arg, at);
+        const char *long_bytes = short_name->data;
+        size_t long_len = short_name->len;
+        const ScrDyn *desc = pa_find_short(options, short_name,
+                                           &long_bytes, &long_len);
+        ScrStr *name = pa_str_bytes(long_bytes, long_len);
+        char *raw_bytes = malloc(short_name->len + 1);
+        if (!raw_bytes) {
+          fputs("scriptc: out of memory\n", stderr);
+          abort();
+        }
+        raw_bytes[0] = '-';
+        memcpy(raw_bytes + 1, short_name->data, short_name->len);
+        ScrStr *raw = pa_str_bytes(raw_bytes, short_name->len + 1);
+        free(raw_bytes);
+        if (strict && !desc) {
+          pa_unknown(raw);
+          scr_str_release(raw);
+          scr_str_release(name);
+          scr_str_release(short_name);
+          goto fail;
+        }
+        if (desc && pa_desc_type(desc) == 1) {
+          if (at + 1 < units) {
+            ScrStr *value = scr_str_slice((ScrStr *)arg, at + 1, INFINITY);
+            pa_store(values, tokens, desc, name, raw, i, value, true, 1);
+            scr_str_release(value);
+          } else if (i + 1 < args->v.arr.len) {
+            const ScrStr *value = args->v.arr.items[++i]->v.str;
+            if (strict && value->len > 1 && value->data[0] == '-') {
+              pa_ambiguous(raw, name, true);
+              scr_str_release(raw);
+              scr_str_release(name);
+              scr_str_release(short_name);
+              goto fail;
+            }
+            pa_store(values, tokens, desc, name, raw, i - 1, value, true, 0);
+          } else if (strict) {
+            pa_missing_short(raw, name);
+            scr_str_release(raw);
+            scr_str_release(name);
+            scr_str_release(short_name);
+            goto fail;
+          } else {
+            pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+          }
+          scr_str_release(raw);
+          scr_str_release(name);
+          scr_str_release(short_name);
+          break;
+        }
+        pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+        scr_str_release(raw);
+        scr_str_release(name);
+        scr_str_release(short_name);
+      }
+      continue;
+    }
+
+    if (strict && !allow_positionals) {
+      pa_unexpected(arg);
+      goto fail;
+    }
+    pa_positional(positionals, tokens, arg, i);
+  }
+
+  if (options) {
+    for (size_t i = 0; i < options->v.obj.len; i++) {
+      const ScrDynEntry *entry = &options->v.obj.entries[i];
+      if (scr_dyn_obj_get(values, entry->key, entry->key_len)) continue;
+      const ScrDyn *def = pa_member(entry->value, "default");
+      if (def) {
+        scr_dyn_obj_set(values, entry->key, entry->key_len,
+                        scr_dyn_retain((ScrDyn *)def));
+      }
+    }
+  }
+
+  scr_dyn_obj_set(result, "values", 6, values);
+  scr_dyn_obj_set(result, "positionals", 11, positionals);
+  if (tokens) scr_dyn_obj_set(result, "tokens", 6, tokens);
+  scr_dyn_release(owned_args);
+  return result;
+
+fail:
+  scr_dyn_release(tokens);
+  scr_dyn_release(positionals);
+  scr_dyn_release(values);
+  scr_dyn_release(result);
+  scr_dyn_release(owned_args);
+  return NULL;
+}

--- a/packages/runtime/src/scr_util.c
+++ b/packages/runtime/src/scr_util.c
@@ -200,94 +200,105 @@ static bool pa_default_value_ok(const ScrDyn *v, int type) {
   return type == 1 ? v->kind == SCR_DYN_STR : v->kind == SCR_DYN_BOOL;
 }
 
+static bool pa_validate_option(const ScrStr *name, const ScrDyn *desc) {
+  char *base = pa_path("options.", name->data, name->len, "");
+  if (desc->kind != SCR_DYN_OBJ) {
+    scr_dyn_prop_type_fail(base, "of type object", desc);
+    free(base);
+    return false;
+  }
+  const ScrDyn *typev = pa_member(desc, "type");
+  int type = pa_desc_type(desc);
+  if (type < 0) {
+    char *path = pa_path(base, "", 0, ".type");
+    scr_dyn_prop_type_fail(path, "('string|boolean')",
+                           typev ? typev : scr_dyn_undefined());
+    free(path);
+    free(base);
+    return false;
+  }
+  const ScrDyn *shortv = pa_own_member(desc, "short");
+  if (shortv) {
+    char *path = pa_path(base, "", 0, ".short");
+    if (shortv->kind != SCR_DYN_STR) {
+      scr_dyn_prop_type_fail(path, "of type string", shortv);
+      free(path);
+      free(base);
+      return false;
+    }
+    if (scr_str_utf16_len(shortv->v.str) != 1) {
+      scr_dyn_arg_value_fail(path, "must be a single character", shortv);
+      free(path);
+      free(base);
+      return false;
+    }
+    free(path);
+  }
+  const ScrDyn *multiplev = pa_own_member(desc, "multiple");
+  if (multiplev && multiplev->kind != SCR_DYN_BOOL) {
+    char *path = pa_path(base, "", 0, ".multiple");
+    scr_dyn_prop_type_fail(path, "of type boolean", multiplev);
+    free(path);
+    free(base);
+    return false;
+  }
+  const ScrDyn *def = pa_member(desc, "default");
+  if (def) {
+    char *path = pa_path(base, "", 0, ".default");
+    if (pa_desc_multiple(desc)) {
+      if (def->kind != SCR_DYN_ARR) {
+        scr_dyn_prop_type_fail(path, "an instance of Array", def);
+        free(path);
+        free(base);
+        return false;
+      }
+      for (size_t j = 0; j < def->v.arr.len; j++) {
+        if (!pa_default_value_ok(def->v.arr.items[j], type)) {
+          char suffix[48];
+          snprintf(suffix, sizeof suffix, "[%zu]", j);
+          char *item_path = pa_path(path, "", 0, suffix);
+          scr_dyn_prop_type_fail(item_path,
+                                 type ? "of type string" : "of type boolean",
+                                 def->v.arr.items[j]);
+          free(item_path);
+          free(path);
+          free(base);
+          return false;
+        }
+      }
+    } else if (!pa_default_value_ok(def, type)) {
+      scr_dyn_prop_type_fail(path,
+                             type ? "of type string" : "of type boolean", def);
+      free(path);
+      free(base);
+      return false;
+    }
+    free(path);
+  }
+  free(base);
+  return true;
+}
+
 /* Validate the option schema up front, as Node does even when args is
- * empty. Static TypeScript callers already satisfy this ladder; it keeps
- * JS/unknown crossings catchable and prevents malformed dyn reads. */
+ * empty. Object.entries supplies JS own-key order (array-index names first),
+ * which controls both validation precedence and duplicate-short lookup. */
 static bool pa_validate_options(const ScrDyn *options) {
   if (!options) return true; /* null/undefined mean {} */
   if (options->kind != SCR_DYN_OBJ) {
     scr_dyn_arg_type_fail("options", "of type object", options);
     return false;
   }
-  for (size_t i = 0; i < options->v.obj.len; i++) {
-    const ScrDynEntry *entry = &options->v.obj.entries[i];
-    const ScrDyn *desc = entry->value;
-    char *base = pa_path("options.", entry->key, entry->key_len, "");
-    if (desc->kind != SCR_DYN_OBJ) {
-      scr_dyn_prop_type_fail(base, "of type object", desc);
-      free(base);
+  ScrDyn *entries = scr_dyn_obj_entries(options);
+  for (size_t i = 0; i < entries->v.arr.len; i++) {
+    const ScrDyn *pair = entries->v.arr.items[i];
+    const ScrStr *name = pair->v.arr.items[0]->v.str;
+    const ScrDyn *desc = pair->v.arr.items[1];
+    if (!pa_validate_option(name, desc)) {
+      scr_dyn_release(entries);
       return false;
     }
-    const ScrDyn *typev = pa_member(desc, "type");
-    int type = pa_desc_type(desc);
-    if (type < 0) {
-      char *path = pa_path(base, "", 0, ".type");
-      scr_dyn_prop_type_fail(path, "('string|boolean')",
-                             typev ? typev : scr_dyn_undefined());
-      free(path);
-      free(base);
-      return false;
-    }
-    const ScrDyn *shortv = pa_own_member(desc, "short");
-    if (shortv) {
-      char *path = pa_path(base, "", 0, ".short");
-      if (shortv->kind != SCR_DYN_STR) {
-        scr_dyn_prop_type_fail(path, "of type string", shortv);
-        free(path);
-        free(base);
-        return false;
-      }
-      if (scr_str_utf16_len(shortv->v.str) != 1) {
-        scr_dyn_arg_value_fail(path, "must be a single character", shortv);
-        free(path);
-        free(base);
-        return false;
-      }
-      free(path);
-    }
-    const ScrDyn *multiplev = pa_own_member(desc, "multiple");
-    if (multiplev && multiplev->kind != SCR_DYN_BOOL) {
-      char *path = pa_path(base, "", 0, ".multiple");
-      scr_dyn_prop_type_fail(path, "of type boolean", multiplev);
-      free(path);
-      free(base);
-      return false;
-    }
-    const ScrDyn *def = pa_member(desc, "default");
-    if (def) {
-      char *path = pa_path(base, "", 0, ".default");
-      if (pa_desc_multiple(desc)) {
-        if (def->kind != SCR_DYN_ARR) {
-          scr_dyn_prop_type_fail(path, "an instance of Array", def);
-          free(path);
-          free(base);
-          return false;
-        }
-        for (size_t j = 0; j < def->v.arr.len; j++) {
-          if (!pa_default_value_ok(def->v.arr.items[j], type)) {
-            char suffix[48];
-            snprintf(suffix, sizeof suffix, "[%zu]", j);
-            char *item_path = pa_path(path, "", 0, suffix);
-            scr_dyn_prop_type_fail(item_path,
-                                   type ? "of type string" : "of type boolean",
-                                   def->v.arr.items[j]);
-            free(item_path);
-            free(path);
-            free(base);
-            return false;
-          }
-        }
-      } else if (!pa_default_value_ok(def, type)) {
-        scr_dyn_prop_type_fail(path,
-                               type ? "of type string" : "of type boolean", def);
-        free(path);
-        free(base);
-        return false;
-      }
-      free(path);
-    }
-    free(base);
   }
+  scr_dyn_release(entries);
   return true;
 }
 
@@ -296,20 +307,34 @@ static const ScrDyn *pa_find_long(const ScrDyn *options, const ScrStr *name) {
   return scr_dyn_obj_get(options, name->data, name->len);
 }
 
-static const ScrDyn *pa_find_short(const ScrDyn *options, const ScrStr *short_name,
-                                   const char **long_name, size_t *long_len) {
-  if (!options) return NULL;
-  for (size_t i = 0; i < options->v.obj.len; i++) {
-    const ScrDynEntry *entry = &options->v.obj.entries[i];
-    const ScrDyn *shortv = pa_member(entry->value, "short");
+static bool pa_is_negative_name(const ScrStr *name) {
+  return name->len >= 3 && memcmp(name->data, "no-", 3) == 0;
+}
+
+static const ScrDyn *pa_find_short(const ScrDyn *options,
+                                   const ScrStr *short_name,
+                                   ScrStr **long_name) {
+  if (!options) {
+    *long_name = pa_str_bytes(short_name->data, short_name->len);
+    return NULL;
+  }
+  ScrDyn *entries = scr_dyn_obj_entries(options);
+  for (size_t i = 0; i < entries->v.arr.len; i++) {
+    const ScrDyn *pair = entries->v.arr.items[i];
+    const ScrStr *name = pair->v.arr.items[0]->v.str;
+    const ScrDyn *desc = pair->v.arr.items[1];
+    const ScrDyn *shortv = pa_member(desc, "short");
     if (shortv && shortv->kind == SCR_DYN_STR &&
         shortv->v.str->len == short_name->len &&
         memcmp(shortv->v.str->data, short_name->data, short_name->len) == 0) {
-      *long_name = entry->key;
-      *long_len = entry->key_len;
-      return entry->value;
+      *long_name = pa_str_bytes(name->data, name->len);
+      const ScrDyn *found = pa_find_long(options, name);
+      scr_dyn_release(entries);
+      return found;
     }
   }
+  scr_dyn_release(entries);
+  *long_name = pa_str_bytes(short_name->data, short_name->len);
   return NULL;
 }
 
@@ -331,10 +356,13 @@ static ScrDyn *pa_option_token(const ScrStr *name, const ScrStr *raw,
 
 static void pa_store(ScrDyn *values, ScrDyn *tokens, const ScrDyn *desc,
                      const ScrStr *name, const ScrStr *raw, size_t index,
-                     const ScrDyn *value, bool flag_value, int inline_value) {
+                     const ScrDyn *value, bool flag_value, int inline_value,
+                     bool withhold_proto) {
   /* Node deliberately withholds this key from the null-prototype values
-   * dictionary. The already-tokenized occurrence remains observable. */
-  if (pa_str_eq_c(name, "__proto__")) {
+   * dictionary when it was the ORIGINAL option name. A normalized
+   * `--no-__proto__` passes this check before normalization in Node and is
+   * therefore stored safely on the null-prototype dictionary. */
+  if (withhold_proto && pa_str_eq_c(name, "__proto__")) {
     if (tokens) {
       scr_dyn_arr_push(tokens,
                        pa_option_token(name, raw, index, value, inline_value));
@@ -363,16 +391,15 @@ static void pa_store_flag(ScrDyn *values, ScrDyn *tokens,
                           const ScrDyn *options, const ScrDyn *desc,
                           const ScrStr *name, const ScrStr *raw, size_t index,
                           bool allow_negative) {
-  if (allow_negative && name->len > 3 &&
-      memcmp(name->data, "no-", 3) == 0) {
+  if (allow_negative && pa_is_negative_name(name)) {
     ScrStr *positive = pa_str_bytes(name->data + 3, name->len - 3);
     const ScrDyn *positive_desc = pa_find_long(options, positive);
     pa_store(values, tokens, positive_desc, positive, raw, index,
-             NULL, false, -1);
+             NULL, false, -1, false);
     scr_str_release(positive);
     return;
   }
-  pa_store(values, tokens, desc, name, raw, index, NULL, true, -1);
+  pa_store(values, tokens, desc, name, raw, index, NULL, true, -1, true);
 }
 
 static void pa_positional(ScrDyn *positionals, ScrDyn *tokens,
@@ -388,13 +415,15 @@ static void pa_positional(ScrDyn *positionals, ScrDyn *tokens,
 
 static ScrDyn *pa_default_args(void) {
   ScrDyn *args = scr_dyn_new_arr();
-  int argc = scr_lib_arg_count();
-  /* Raw argv[0] is the executable. process.argv's synthetic first two
-   * entries occupy it plus "scriptc", so slice(2) begins at raw argv[1]. */
-  for (int i = 1; i < argc; i++) {
-    const char *arg = scr_lib_arg(i);
-    scr_dyn_arr_push(args, pa_dyn_str_bytes(arg, strlen(arg)));
+  ScrArr *argv = scr_process_argv();
+  /* Read the ONE live interned process.argv array: user pushes, pops, and
+   * replacements before parseArgs() are observable exactly as slice(2). */
+  for (size_t i = 2; i < argv->len; i++) {
+    ScrStr *arg = scr_arr_get_ref(argv, (double)i);
+    scr_dyn_arr_push(args, pa_dyn_str(arg));
+    scr_str_release(arg);
   }
+  scr_arr_release(argv);
   return args;
 }
 
@@ -436,6 +465,27 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
   if (!pa_validate_options(options)) {
     scr_dyn_release(owned_args);
     return NULL;
+  }
+
+  /* Node tokenizes the complete input before applying strict usage checks.
+   * In the checked-dynamic alphabet, the only tokenizer-time exception is
+   * a nullish argument before `--` (other non-strings become positionals),
+   * so preflight that failure before the processing pass below. */
+  bool scan_after_terminator = false;
+  for (size_t i = 0; i < args->v.arr.len; i++) {
+    const ScrDyn *arg_value = args->v.arr.items[i];
+    if (scan_after_terminator) continue;
+    if (arg_value->kind == SCR_DYN_STR &&
+        pa_str_eq_c(arg_value->v.str, "--")) {
+      scan_after_terminator = true;
+      continue;
+    }
+    if (arg_value->kind == SCR_DYN_NULL ||
+        arg_value->kind == SCR_DYN_UNDEF) {
+      pa_nullish_arg_length(arg_value);
+      scr_dyn_release(owned_args);
+      return NULL;
+    }
   }
 
   ScrDyn *result = scr_dyn_new_obj();
@@ -481,31 +531,51 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
 
     if (arg->len >= 2 && arg->data[0] == '-' && arg->data[1] == '-') {
       size_t eq = arg->len;
-      /* `--=x` is the option named "=x", not an empty option with an
-       * inline value. An equals separator is recognized only after at
-       * least one name byte, matching Node's tokenizer. */
+      bool has_inline_value = false;
+      /* The presence test starts after one name byte, so `--=x` stays the
+       * lone option "=x". Once present, Node splits at the FIRST equals:
+       * `--==x` therefore has the empty name and value "=x". */
       for (size_t j = 3; j < arg->len; j++) {
-        if (arg->data[j] == '=') { eq = j; break; }
+        if (arg->data[j] == '=') { has_inline_value = true; break; }
+      }
+      if (has_inline_value) {
+        for (size_t j = 2; j < arg->len; j++) {
+          if (arg->data[j] == '=') { eq = j; break; }
+        }
       }
       ScrStr *name = pa_str_bytes(arg->data + 2, eq - 2);
       ScrStr *raw = pa_str_bytes(arg->data, eq);
       const ScrDyn *desc = pa_find_long(options, name);
       if (eq < arg->len) {
-        if (strict && !desc) {
+        ScrStr *checked_name = NULL;
+        const ScrDyn *checked_desc = desc;
+        if (strict && !checked_desc && allow_negative &&
+            pa_is_negative_name(name)) {
+          checked_name = pa_str_bytes(name->data + 3, name->len - 3);
+          const ScrDyn *positive_desc = pa_find_long(options, checked_name);
+          if (positive_desc && pa_desc_type(positive_desc) == 0) {
+            checked_desc = positive_desc;
+          }
+        }
+        if (strict && !checked_desc) {
           pa_unknown(raw, allow_positionals);
+          scr_str_release(checked_name);
           scr_str_release(raw);
           scr_str_release(name);
           goto fail;
         }
-        if (strict && pa_desc_type(desc) == 0) {
-          pa_takes_no_value(desc, name);
+        if (strict && pa_desc_type(checked_desc) == 0) {
+          pa_takes_no_value(checked_desc,
+                            checked_name ? checked_name : name);
+          scr_str_release(checked_name);
           scr_str_release(raw);
           scr_str_release(name);
           goto fail;
         }
+        scr_str_release(checked_name);
         ScrStr *value = pa_str_bytes(arg->data + eq + 1, arg->len - eq - 1);
         ScrDyn *dyn_value = pa_dyn_str(value);
-        pa_store(values, tokens, desc, name, raw, i, dyn_value, true, 1);
+        pa_store(values, tokens, desc, name, raw, i, dyn_value, true, 1, true);
         scr_dyn_release(dyn_value);
         scr_str_release(value);
       } else if (desc && pa_desc_type(desc) == 1) {
@@ -526,29 +596,27 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
             scr_str_release(name);
             goto fail;
           }
-          pa_store(values, tokens, desc, name, raw, i - 1, next, true, 0);
+          pa_store(values, tokens, desc, name, raw, i - 1, next, true, 0, true);
         } else if (strict) {
           pa_missing_value(desc, name);
           scr_str_release(raw);
           scr_str_release(name);
           goto fail;
         } else {
-          if (allow_negative && name->len > 3 &&
-              memcmp(name->data, "no-", 3) == 0) {
+          if (allow_negative && pa_is_negative_name(name)) {
             ScrStr *positive = pa_str_bytes(name->data + 3, name->len - 3);
             const ScrDyn *positive_desc = pa_find_long(options, positive);
             pa_store(values, tokens, positive_desc, positive, raw, i,
-                     NULL, false, -1);
+                     NULL, false, -1, false);
             scr_str_release(positive);
           } else {
-            pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+            pa_store(values, tokens, desc, name, raw, i, NULL, true, -1, true);
           }
         }
       } else {
         ScrStr *positive = NULL;
         const ScrDyn *positive_desc = NULL;
-        const bool negative = allow_negative && name->len > 3 &&
-                              memcmp(name->data, "no-", 3) == 0;
+        const bool negative = allow_negative && pa_is_negative_name(name);
         if (negative) {
           positive = pa_str_bytes(name->data + 3, name->len - 3);
           positive_desc = pa_find_long(options, positive);
@@ -563,10 +631,10 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
         }
         if (negative) {
           pa_store(values, tokens, positive_desc, positive, raw, i,
-                   NULL, false, -1);
+                   NULL, false, -1, false);
           scr_str_release(positive);
         } else {
-          pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+          pa_store(values, tokens, desc, name, raw, i, NULL, true, -1, true);
         }
       }
       scr_str_release(raw);
@@ -578,11 +646,8 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
       double units = scr_str_utf16_len((ScrStr *)arg);
       for (double at = 1; at < units; at++) {
         ScrStr *short_name = scr_str_char_at((ScrStr *)arg, at);
-        const char *long_bytes = short_name->data;
-        size_t long_len = short_name->len;
-        const ScrDyn *desc = pa_find_short(options, short_name,
-                                           &long_bytes, &long_len);
-        ScrStr *name = pa_str_bytes(long_bytes, long_len);
+        ScrStr *name = NULL;
+        const ScrDyn *desc = pa_find_short(options, short_name, &name);
         char *raw_bytes = malloc(short_name->len + 1);
         if (!raw_bytes) {
           fputs("scriptc: out of memory\n", stderr);
@@ -603,7 +668,7 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
           if (at + 1 < units) {
             ScrStr *value = scr_str_slice((ScrStr *)arg, at + 1, INFINITY);
             ScrDyn *dyn_value = pa_dyn_str(value);
-            pa_store(values, tokens, desc, name, raw, i, dyn_value, true, 1);
+            pa_store(values, tokens, desc, name, raw, i, dyn_value, true, 1, true);
             scr_dyn_release(dyn_value);
             scr_str_release(value);
           } else if (i + 1 < args->v.arr.len &&
@@ -625,7 +690,7 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
               scr_str_release(short_name);
               goto fail;
             }
-            pa_store(values, tokens, desc, name, raw, i - 1, value, true, 0);
+            pa_store(values, tokens, desc, name, raw, i - 1, value, true, 0, true);
           } else if (strict) {
             pa_missing_value(desc, name);
             scr_str_release(raw);
@@ -658,17 +723,20 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
   }
 
   if (options) {
-    for (size_t i = 0; i < options->v.obj.len; i++) {
-      const ScrDynEntry *entry = &options->v.obj.entries[i];
-      if (entry->key_len == 9 &&
-          memcmp(entry->key, "__proto__", 9) == 0) continue;
-      if (scr_dyn_obj_get(values, entry->key, entry->key_len)) continue;
-      const ScrDyn *def = pa_member(entry->value, "default");
+    ScrDyn *entries = scr_dyn_obj_entries(options);
+    for (size_t i = 0; i < entries->v.arr.len; i++) {
+      const ScrDyn *pair = entries->v.arr.items[i];
+      const ScrStr *name = pair->v.arr.items[0]->v.str;
+      const ScrDyn *desc = pair->v.arr.items[1];
+      if (pa_str_eq_c(name, "__proto__")) continue;
+      if (scr_dyn_obj_get(values, name->data, name->len)) continue;
+      const ScrDyn *def = pa_member(desc, "default");
       if (def) {
-        scr_dyn_obj_set(values, entry->key, entry->key_len,
+        scr_dyn_obj_set(values, name->data, name->len,
                         scr_dyn_retain((ScrDyn *)def));
       }
     }
+    scr_dyn_release(entries);
   }
 
   scr_dyn_obj_set(result, "values", 6, values);

--- a/packages/runtime/src/scr_util.c
+++ b/packages/runtime/src/scr_util.c
@@ -311,6 +311,20 @@ static bool pa_is_negative_name(const ScrStr *name) {
   return name->len >= 3 && memcmp(name->data, "no-", 3) == 0;
 }
 
+/* Node recognizes an inline long-option value only when an '=' occurs
+ * after at least one name code unit, then splits at the first '='. */
+static size_t pa_long_eq(const ScrStr *arg) {
+  bool has_inline_value = false;
+  for (size_t j = 3; j < arg->len; j++) {
+    if (arg->data[j] == '=') { has_inline_value = true; break; }
+  }
+  if (!has_inline_value) return arg->len;
+  for (size_t j = 2; j < arg->len; j++) {
+    if (arg->data[j] == '=') return j;
+  }
+  return arg->len;
+}
+
 static const ScrDyn *pa_find_short(const ScrDyn *options,
                                    const ScrStr *short_name,
                                    ScrStr **long_name) {
@@ -427,6 +441,174 @@ static ScrDyn *pa_default_args(void) {
   return args;
 }
 
+/* Copy an engine-backed array into the native dyn alphabet without using
+ * its iterator. Node's parseArgs takes args with Array.prototype.slice,
+ * so indexed Gets (including holes -> undefined) and the live length are
+ * the relevant semantics; an overridden Symbol.iterator is not. */
+static ScrDyn *pa_materialize_js_array(const ScrDyn *value) {
+  if (value->kind != SCR_DYN_JSVAL ||
+      !scr_dyn_jsval_ops()->is_array(value->v.jsval.cell)) {
+    return scr_dyn_retain((ScrDyn *)value);
+  }
+  ScrStr *length_key = scr_str_new("length", 6);
+  ScrDyn *length = scr_dyn_jsval_ops()->key_get(value->v.jsval.cell,
+                                                length_key);
+  scr_str_release(length_key);
+  if (!length) return NULL;
+  if (length->kind != SCR_DYN_NUM || !isfinite(length->v.num) ||
+      length->v.num < 0) {
+    scr_dyn_release(length);
+    return scr_dyn_retain((ScrDyn *)value); /* defensive: real arrays cannot */
+  }
+  size_t len = (size_t)length->v.num;
+  scr_dyn_release(length);
+  ScrDyn *out = scr_dyn_new_arr();
+  for (size_t i = 0; i < len; i++) {
+    char index[32];
+    int n = snprintf(index, sizeof index, "%zu", i);
+    ScrStr *key = scr_str_new(index, (size_t)n);
+    ScrDyn *item = scr_dyn_jsval_ops()->key_get(value->v.jsval.cell, key);
+    scr_str_release(key);
+    if (!item) {
+      scr_dyn_release(out);
+      return NULL;
+    }
+    scr_dyn_arr_push(out, item);
+  }
+  return out;
+}
+
+/* Own-member read with an owned answer. Native config objects are already
+ * inert dyn data; engine-backed configs route Object.hasOwn + Get through
+ * the island so a normal `any` config can enter the native parser. */
+static ScrDyn *pa_owned_member(const ScrDyn *obj, const char *key) {
+  if (obj->kind == SCR_DYN_OBJ) {
+    const ScrDyn *value = pa_own_member(obj, key);
+    return value ? scr_dyn_retain((ScrDyn *)value) : NULL;
+  }
+  if (obj->kind != SCR_DYN_JSVAL) return NULL;
+  ScrStr *name = scr_str_new(key, strlen(key));
+  int own = scr_dyn_jsval_ops()->has_own(obj->v.jsval.cell, name);
+  if (own != 1) {
+    scr_str_release(name);
+    return NULL;
+  }
+  ScrDyn *value = scr_dyn_jsval_ops()->key_get(obj->v.jsval.cell, name);
+  scr_str_release(name);
+  return value;
+}
+
+static ScrDyn *pa_materialize_descriptor(const ScrDyn *desc) {
+  if (desc->kind == SCR_DYN_JSVAL &&
+      scr_dyn_jsval_ops()->is_array(desc->v.jsval.cell)) {
+    return pa_materialize_js_array(desc);
+  }
+  if (desc->kind != SCR_DYN_OBJ && desc->kind != SCR_DYN_JSVAL) {
+    return scr_dyn_retain((ScrDyn *)desc);
+  }
+  if (desc->kind == SCR_DYN_JSVAL &&
+      !scr_dyn_isl_typeof_is(desc, "object")) {
+    return scr_dyn_retain((ScrDyn *)desc);
+  }
+  static const char *const fields[] = {"type", "short", "multiple", "default"};
+  ScrDyn *out = scr_dyn_new_obj();
+  for (size_t i = 0; i < sizeof fields / sizeof fields[0]; i++) {
+    ScrDyn *value = pa_owned_member(desc, fields[i]);
+    if (!value) {
+      if (scr_exc_pending()) { scr_dyn_release(out); return NULL; }
+      continue;
+    }
+    ScrDyn *native = pa_materialize_js_array(value);
+    scr_dyn_release(value);
+    if (!native) { scr_dyn_release(out); return NULL; }
+    scr_dyn_obj_set(out, fields[i], strlen(fields[i]), native);
+  }
+  return out;
+}
+
+static ScrDyn *pa_materialize_options(const ScrDyn *options) {
+  if (options->kind == SCR_DYN_JSVAL &&
+      scr_dyn_jsval_ops()->is_array(options->v.jsval.cell)) {
+    return pa_materialize_js_array(options);
+  }
+  if (options->kind != SCR_DYN_OBJ && options->kind != SCR_DYN_JSVAL) {
+    return scr_dyn_retain((ScrDyn *)options);
+  }
+  if (options->kind == SCR_DYN_JSVAL &&
+      !scr_dyn_isl_typeof_is(options, "object")) {
+    return scr_dyn_retain((ScrDyn *)options);
+  }
+  ScrDyn *entries = scr_dyn_obj_entries(options);
+  if (!entries) return NULL;
+  ScrDyn *out = scr_dyn_new_obj();
+  for (size_t i = 0; i < entries->v.arr.len; i++) {
+    const ScrDyn *pair = entries->v.arr.items[i];
+    const ScrStr *name = pair->v.arr.items[0]->v.str;
+    ScrDyn *desc = pa_materialize_descriptor(pair->v.arr.items[1]);
+    if (!desc) {
+      scr_dyn_release(out);
+      scr_dyn_release(entries);
+      return NULL;
+    }
+    scr_dyn_obj_set(out, name->data, name->len, desc);
+  }
+  scr_dyn_release(entries);
+  return out;
+}
+
+/* Normalize the documented config members only. This is intentionally a
+ * snapshot, matching parseArgs's synchronous reads, while preserving own
+ * property presence (including explicit undefined) across the island. */
+static ScrDyn *pa_materialize_config(const ScrDyn *config) {
+  if (config->kind != SCR_DYN_OBJ && config->kind != SCR_DYN_JSVAL) {
+    return scr_dyn_retain((ScrDyn *)config);
+  }
+  static const char *const fields[] = {
+    "args", "strict", "allowPositionals", "tokens", "allowNegative", "options",
+  };
+  ScrDyn *out = scr_dyn_new_obj();
+  for (size_t i = 0; i < sizeof fields / sizeof fields[0]; i++) {
+    ScrDyn *value = pa_owned_member(config, fields[i]);
+    if (!value) {
+      if (scr_exc_pending()) { scr_dyn_release(out); return NULL; }
+      continue;
+    }
+    ScrDyn *native = strcmp(fields[i], "options") == 0
+                         ? pa_materialize_options(value)
+                         : pa_materialize_js_array(value);
+    scr_dyn_release(value);
+    if (!native) { scr_dyn_release(out); return NULL; }
+    scr_dyn_obj_set(out, fields[i], strlen(fields[i]), native);
+  }
+  return out;
+}
+
+/* Whether tokenizing this string argument consumes the next array item as
+ * a separate value. This mirrors the greedy string-option cases only; the
+ * processing pass below still owns usage validation and token storage. */
+static bool pa_consumes_next(const ScrDyn *options, const ScrStr *arg) {
+  if (arg->len >= 2 && arg->data[0] == '-' && arg->data[1] == '-') {
+    size_t eq = pa_long_eq(arg);
+    if (eq < arg->len) return false;
+    ScrStr *name = pa_str_bytes(arg->data + 2, eq - 2);
+    const ScrDyn *desc = pa_find_long(options, name);
+    bool consumes = desc && pa_desc_type(desc) == 1;
+    scr_str_release(name);
+    return consumes;
+  }
+  if (arg->len <= 1 || arg->data[0] != '-') return false;
+  double units = scr_str_utf16_len((ScrStr *)arg);
+  for (double at = 1; at < units; at++) {
+    ScrStr *short_name = scr_str_char_at((ScrStr *)arg, at);
+    ScrStr *name = NULL;
+    const ScrDyn *desc = pa_find_short(options, short_name, &name);
+    scr_str_release(name);
+    scr_str_release(short_name);
+    if (desc && pa_desc_type(desc) == 1) return at + 1 >= units;
+  }
+  return false;
+}
+
 ScrDyn *scr_util_parse_args(const ScrDyn *config) {
   /* Omitted config is lowered as {}, while an explicit undefined takes the
    * default parameter just as Node does. Null keeps Object(null)'s useful
@@ -436,7 +618,9 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
     scr_throw_error_msg(SCR_ERR_TYPE, msg, sizeof msg - 1);
     return NULL;
   }
-  const ScrDyn *cfg = config->kind == SCR_DYN_OBJ ? config : NULL;
+  ScrDyn *owned_config = pa_materialize_config(config);
+  if (!owned_config) return NULL;
+  const ScrDyn *cfg = owned_config->kind == SCR_DYN_OBJ ? owned_config : NULL;
   /* Node validates the args container before every flag and before the
    * option schema. Its element values are intentionally not prevalidated:
    * non-string values can still become loose-mode positional tokens. */
@@ -447,23 +631,25 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
     args = owned_args;
   } else if (args->kind != SCR_DYN_ARR) {
     scr_dyn_arg_type_fail("args", "an instance of Array", args);
+    scr_dyn_release(owned_config);
     return NULL;
   }
 
   bool ok = true;
   bool strict = pa_config_bool(cfg, "strict", true, &ok);
-  if (!ok) { scr_dyn_release(owned_args); return NULL; }
+  if (!ok) { scr_dyn_release(owned_args); scr_dyn_release(owned_config); return NULL; }
   bool allow_positionals = pa_config_bool(cfg, "allowPositionals", !strict, &ok);
-  if (!ok) { scr_dyn_release(owned_args); return NULL; }
+  if (!ok) { scr_dyn_release(owned_args); scr_dyn_release(owned_config); return NULL; }
   bool return_tokens = pa_config_bool(cfg, "tokens", false, &ok);
-  if (!ok) { scr_dyn_release(owned_args); return NULL; }
+  if (!ok) { scr_dyn_release(owned_args); scr_dyn_release(owned_config); return NULL; }
   bool allow_negative = pa_config_bool(cfg, "allowNegative", false, &ok);
-  if (!ok) { scr_dyn_release(owned_args); return NULL; }
+  if (!ok) { scr_dyn_release(owned_args); scr_dyn_release(owned_config); return NULL; }
 
   const ScrDyn *options = pa_member(cfg, "options");
   if (options && options->kind == SCR_DYN_NULL) options = NULL;
   if (!pa_validate_options(options)) {
     scr_dyn_release(owned_args);
+    scr_dyn_release(owned_config);
     return NULL;
   }
 
@@ -475,16 +661,23 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
   for (size_t i = 0; i < args->v.arr.len; i++) {
     const ScrDyn *arg_value = args->v.arr.items[i];
     if (scan_after_terminator) continue;
-    if (arg_value->kind == SCR_DYN_STR &&
-        pa_str_eq_c(arg_value->v.str, "--")) {
-      scan_after_terminator = true;
-      continue;
-    }
     if (arg_value->kind == SCR_DYN_NULL ||
         arg_value->kind == SCR_DYN_UNDEF) {
       pa_nullish_arg_length(arg_value);
       scr_dyn_release(owned_args);
+      scr_dyn_release(owned_config);
       return NULL;
+    }
+    if (arg_value->kind != SCR_DYN_STR) continue;
+    if (pa_str_eq_c(arg_value->v.str, "--")) {
+      scan_after_terminator = true;
+      continue;
+    }
+    if (pa_consumes_next(options, arg_value->v.str) &&
+        i + 1 < args->v.arr.len &&
+        args->v.arr.items[i + 1]->kind != SCR_DYN_NULL &&
+        args->v.arr.items[i + 1]->kind != SCR_DYN_UNDEF) {
+      i++;
     }
   }
 
@@ -530,19 +723,10 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
     }
 
     if (arg->len >= 2 && arg->data[0] == '-' && arg->data[1] == '-') {
-      size_t eq = arg->len;
-      bool has_inline_value = false;
+      size_t eq = pa_long_eq(arg);
       /* The presence test starts after one name byte, so `--=x` stays the
        * lone option "=x". Once present, Node splits at the FIRST equals:
        * `--==x` therefore has the empty name and value "=x". */
-      for (size_t j = 3; j < arg->len; j++) {
-        if (arg->data[j] == '=') { has_inline_value = true; break; }
-      }
-      if (has_inline_value) {
-        for (size_t j = 2; j < arg->len; j++) {
-          if (arg->data[j] == '=') { eq = j; break; }
-        }
-      }
       ScrStr *name = pa_str_bytes(arg->data + 2, eq - 2);
       ScrStr *raw = pa_str_bytes(arg->data, eq);
       const ScrDyn *desc = pa_find_long(options, name);
@@ -743,6 +927,7 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
   scr_dyn_obj_set(result, "positionals", 11, positionals);
   if (tokens) scr_dyn_obj_set(result, "tokens", 6, tokens);
   scr_dyn_release(owned_args);
+  scr_dyn_release(owned_config);
   return result;
 
 fail:
@@ -751,5 +936,6 @@ fail:
   scr_dyn_release(values);
   scr_dyn_release(result);
   scr_dyn_release(owned_args);
+  scr_dyn_release(owned_config);
   return NULL;
 }

--- a/packages/runtime/src/scr_util.c
+++ b/packages/runtime/src/scr_util.c
@@ -18,9 +18,16 @@
 #include <stdlib.h>
 #include <string.h>
 
-static const ScrDyn *pa_member(const ScrDyn *obj, const char *key) {
+static const ScrDyn *pa_own_member(const ScrDyn *obj, const char *key) {
   if (!obj || obj->kind != SCR_DYN_OBJ) return NULL;
-  const ScrDyn *v = scr_dyn_obj_get(obj, key, strlen(key));
+  return scr_dyn_obj_get(obj, key, strlen(key));
+}
+
+/* The ordinary optional-member read: absent and explicit undefined both
+ * answer no value. Descriptor fields whose validation depends on own
+ * presence use pa_own_member directly. */
+static const ScrDyn *pa_member(const ScrDyn *obj, const char *key) {
+  const ScrDyn *v = pa_own_member(obj, key);
   return v && v->kind != SCR_DYN_UNDEF ? v : NULL;
 }
 
@@ -67,31 +74,37 @@ static void pa_throw_text(ScrJsonBuf *b, const char *code) {
   scr_str_release(msg);
 }
 
-static void pa_unknown(const ScrStr *raw) {
+static void pa_unknown(const ScrStr *raw, bool allow_positionals) {
   ScrJsonBuf b;
   scr_jb_init(&b);
   scr_jb_puts(&b, "Unknown option '");
   scr_jb_put_str(&b, raw);
   scr_jb_puts(&b, "'");
+  if (allow_positionals) {
+    scr_jb_puts(&b, ". To specify a positional argument starting with a '-', place it at the end of the command after '--', as in '-- \"");
+    scr_jb_put_str(&b, raw);
+    scr_jb_putc(&b, '"');
+  }
   pa_throw_text(&b, "ERR_PARSE_ARGS_UNKNOWN_OPTION");
 }
 
-static void pa_missing_long(const ScrStr *raw) {
-  ScrJsonBuf b;
-  scr_jb_init(&b);
-  scr_jb_puts(&b, "Option '");
-  scr_jb_put_str(&b, raw);
-  scr_jb_puts(&b, " <value>' argument missing");
-  pa_throw_text(&b, "ERR_PARSE_ARGS_INVALID_OPTION_VALUE");
+static void pa_option_label(ScrJsonBuf *b, const ScrDyn *desc,
+                            const ScrStr *name) {
+  const ScrDyn *shortv = pa_member(desc, "short");
+  if (shortv && shortv->kind == SCR_DYN_STR && shortv->v.str->len > 0) {
+    scr_jb_putc(b, '-');
+    scr_jb_put_str(b, shortv->v.str);
+    scr_jb_puts(b, ", ");
+  }
+  scr_jb_puts(b, "--");
+  scr_jb_put_str(b, name);
 }
 
-static void pa_missing_short(const ScrStr *raw, const ScrStr *name) {
+static void pa_missing_value(const ScrDyn *desc, const ScrStr *name) {
   ScrJsonBuf b;
   scr_jb_init(&b);
   scr_jb_puts(&b, "Option '");
-  scr_jb_put_str(&b, raw);
-  scr_jb_puts(&b, ", --");
-  scr_jb_put_str(&b, name);
+  pa_option_label(&b, desc, name);
   scr_jb_puts(&b, " <value>' argument missing");
   pa_throw_text(&b, "ERR_PARSE_ARGS_INVALID_OPTION_VALUE");
 }
@@ -116,11 +129,11 @@ static void pa_ambiguous(const ScrStr *raw, const ScrStr *name,
   pa_throw_text(&b, "ERR_PARSE_ARGS_INVALID_OPTION_VALUE");
 }
 
-static void pa_takes_no_value(const ScrStr *raw) {
+static void pa_takes_no_value(const ScrDyn *desc, const ScrStr *name) {
   ScrJsonBuf b;
   scr_jb_init(&b);
   scr_jb_puts(&b, "Option '");
-  scr_jb_put_str(&b, raw);
+  pa_option_label(&b, desc, name);
   scr_jb_puts(&b, "' does not take an argument");
   pa_throw_text(&b, "ERR_PARSE_ARGS_INVALID_OPTION_VALUE");
 }
@@ -134,11 +147,34 @@ static void pa_unexpected(const ScrStr *arg) {
   pa_throw_text(&b, "ERR_PARSE_ARGS_UNEXPECTED_POSITIONAL");
 }
 
+static void pa_unexpected_dyn(const ScrDyn *arg) {
+  if (arg->kind == SCR_DYN_STR) {
+    pa_unexpected(arg->v.str);
+    return;
+  }
+  ScrStr *shown = scr_dyn_format_j(arg);
+  if (!shown) return;
+  pa_unexpected(shown);
+  scr_str_release(shown);
+}
+
+static void pa_nullish_arg_length(const ScrDyn *arg) {
+  const char *kind = arg->kind == SCR_DYN_NULL ? "null" : "undefined";
+  ScrJsonBuf b;
+  scr_jb_init(&b);
+  scr_jb_puts(&b, "Cannot read properties of ");
+  scr_jb_puts(&b, kind);
+  scr_jb_puts(&b, " (reading 'length')");
+  ScrStr *msg = scr_jb_finish(&b);
+  scr_throw_error_msg(SCR_ERR_TYPE, msg->data, msg->len);
+  scr_str_release(msg);
+}
+
 /* A config boolean with Node's default/validation rule. */
 static bool pa_config_bool(const ScrDyn *config, const char *name,
                            bool fallback, bool *ok) {
   const ScrDyn *v = pa_member(config, name);
-  if (!v) return fallback;
+  if (!v || v->kind == SCR_DYN_NULL) return fallback;
   if (v->kind == SCR_DYN_BOOL) return v->v.b;
   scr_dyn_arg_type_fail(name, "of type boolean", v);
   *ok = false;
@@ -192,7 +228,7 @@ static bool pa_validate_options(const ScrDyn *options) {
       free(base);
       return false;
     }
-    const ScrDyn *shortv = pa_member(desc, "short");
+    const ScrDyn *shortv = pa_own_member(desc, "short");
     if (shortv) {
       char *path = pa_path(base, "", 0, ".short");
       if (shortv->kind != SCR_DYN_STR) {
@@ -209,7 +245,7 @@ static bool pa_validate_options(const ScrDyn *options) {
       }
       free(path);
     }
-    const ScrDyn *multiplev = pa_member(desc, "multiple");
+    const ScrDyn *multiplev = pa_own_member(desc, "multiple");
     if (multiplev && multiplev->kind != SCR_DYN_BOOL) {
       char *path = pa_path(base, "", 0, ".multiple");
       scr_dyn_prop_type_fail(path, "of type boolean", multiplev);
@@ -278,14 +314,15 @@ static const ScrDyn *pa_find_short(const ScrDyn *options, const ScrStr *short_na
 }
 
 static ScrDyn *pa_option_token(const ScrStr *name, const ScrStr *raw,
-                               size_t index, const ScrStr *value, int inline_value) {
+                               size_t index, const ScrDyn *value, int inline_value) {
   ScrDyn *token = scr_dyn_new_obj();
   scr_dyn_obj_set(token, "kind", 4, pa_dyn_str_bytes("option", 6));
   scr_dyn_obj_set(token, "name", 4, pa_dyn_str(name));
   scr_dyn_obj_set(token, "rawName", 7, pa_dyn_str(raw));
   scr_dyn_obj_set(token, "index", 5, scr_dyn_new_num((double)index));
   scr_dyn_obj_set(token, "value", 5,
-                  value ? pa_dyn_str(value) : scr_dyn_retain(scr_dyn_undefined()));
+                  value ? scr_dyn_retain((ScrDyn *)value)
+                        : scr_dyn_retain(scr_dyn_undefined()));
   scr_dyn_obj_set(token, "inlineValue", 11,
                   inline_value < 0 ? scr_dyn_retain(scr_dyn_undefined())
                                    : scr_dyn_new_bool(inline_value != 0));
@@ -294,8 +331,18 @@ static ScrDyn *pa_option_token(const ScrStr *name, const ScrStr *raw,
 
 static void pa_store(ScrDyn *values, ScrDyn *tokens, const ScrDyn *desc,
                      const ScrStr *name, const ScrStr *raw, size_t index,
-                     const ScrStr *value, bool flag_value, int inline_value) {
-  ScrDyn *stored = value ? pa_dyn_str(value) : scr_dyn_new_bool(flag_value);
+                     const ScrDyn *value, bool flag_value, int inline_value) {
+  /* Node deliberately withholds this key from the null-prototype values
+   * dictionary. The already-tokenized occurrence remains observable. */
+  if (pa_str_eq_c(name, "__proto__")) {
+    if (tokens) {
+      scr_dyn_arr_push(tokens,
+                       pa_option_token(name, raw, index, value, inline_value));
+    }
+    return;
+  }
+  ScrDyn *stored = value ? scr_dyn_retain((ScrDyn *)value)
+                         : scr_dyn_new_bool(flag_value);
   if (desc && pa_desc_multiple(desc)) {
     ScrDyn *arr = scr_dyn_obj_get(values, name->data, name->len);
     if (!arr) {
@@ -312,14 +359,30 @@ static void pa_store(ScrDyn *values, ScrDyn *tokens, const ScrDyn *desc,
   }
 }
 
+static void pa_store_flag(ScrDyn *values, ScrDyn *tokens,
+                          const ScrDyn *options, const ScrDyn *desc,
+                          const ScrStr *name, const ScrStr *raw, size_t index,
+                          bool allow_negative) {
+  if (allow_negative && name->len > 3 &&
+      memcmp(name->data, "no-", 3) == 0) {
+    ScrStr *positive = pa_str_bytes(name->data + 3, name->len - 3);
+    const ScrDyn *positive_desc = pa_find_long(options, positive);
+    pa_store(values, tokens, positive_desc, positive, raw, index,
+             NULL, false, -1);
+    scr_str_release(positive);
+    return;
+  }
+  pa_store(values, tokens, desc, name, raw, index, NULL, true, -1);
+}
+
 static void pa_positional(ScrDyn *positionals, ScrDyn *tokens,
-                          const ScrStr *value, size_t index) {
-  scr_dyn_arr_push(positionals, pa_dyn_str(value));
+                          const ScrDyn *value, size_t index) {
+  scr_dyn_arr_push(positionals, scr_dyn_retain((ScrDyn *)value));
   if (!tokens) return;
   ScrDyn *token = scr_dyn_new_obj();
   scr_dyn_obj_set(token, "kind", 4, pa_dyn_str_bytes("positional", 10));
   scr_dyn_obj_set(token, "index", 5, scr_dyn_new_num((double)index));
-  scr_dyn_obj_set(token, "value", 5, pa_dyn_str(value));
+  scr_dyn_obj_set(token, "value", 5, scr_dyn_retain((ScrDyn *)value));
   scr_dyn_arr_push(tokens, token);
 }
 
@@ -336,7 +399,6 @@ static ScrDyn *pa_default_args(void) {
 }
 
 ScrDyn *scr_util_parse_args(const ScrDyn *config) {
-  bool ok = true;
   /* Omitted config is lowered as {}, while an explicit undefined takes the
    * default parameter just as Node does. Null keeps Object(null)'s useful
    * failure; other primitive/array wrappers have no config members. */
@@ -346,16 +408,9 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
     return NULL;
   }
   const ScrDyn *cfg = config->kind == SCR_DYN_OBJ ? config : NULL;
-  bool strict = pa_config_bool(cfg, "strict", true, &ok);
-  bool allow_positionals = pa_config_bool(cfg, "allowPositionals", !strict, &ok);
-  bool allow_negative = pa_config_bool(cfg, "allowNegative", false, &ok);
-  bool return_tokens = pa_config_bool(cfg, "tokens", false, &ok);
-  if (!ok) return NULL;
-
-  const ScrDyn *options = pa_member(cfg, "options");
-  if (options && options->kind == SCR_DYN_NULL) options = NULL;
-  if (!pa_validate_options(options)) return NULL;
-
+  /* Node validates the args container before every flag and before the
+   * option schema. Its element values are intentionally not prevalidated:
+   * non-string values can still become loose-mode positional tokens. */
   ScrDyn *owned_args = NULL;
   const ScrDyn *args = pa_member(cfg, "args");
   if (!args || args->kind == SCR_DYN_NULL) {
@@ -365,14 +420,22 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
     scr_dyn_arg_type_fail("args", "an instance of Array", args);
     return NULL;
   }
-  for (size_t i = 0; i < args->v.arr.len; i++) {
-    if (args->v.arr.items[i]->kind != SCR_DYN_STR) {
-      char name[48];
-      snprintf(name, sizeof name, "args[%zu]", i);
-      scr_dyn_prop_type_fail(name, "of type string", args->v.arr.items[i]);
-      scr_dyn_release(owned_args);
-      return NULL;
-    }
+
+  bool ok = true;
+  bool strict = pa_config_bool(cfg, "strict", true, &ok);
+  if (!ok) { scr_dyn_release(owned_args); return NULL; }
+  bool allow_positionals = pa_config_bool(cfg, "allowPositionals", !strict, &ok);
+  if (!ok) { scr_dyn_release(owned_args); return NULL; }
+  bool return_tokens = pa_config_bool(cfg, "tokens", false, &ok);
+  if (!ok) { scr_dyn_release(owned_args); return NULL; }
+  bool allow_negative = pa_config_bool(cfg, "allowNegative", false, &ok);
+  if (!ok) { scr_dyn_release(owned_args); return NULL; }
+
+  const ScrDyn *options = pa_member(cfg, "options");
+  if (options && options->kind == SCR_DYN_NULL) options = NULL;
+  if (!pa_validate_options(options)) {
+    scr_dyn_release(owned_args);
+    return NULL;
   }
 
   ScrDyn *result = scr_dyn_new_obj();
@@ -382,11 +445,28 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
   bool after_terminator = false;
 
   for (size_t i = 0; i < args->v.arr.len; i++) {
-    const ScrStr *arg = args->v.arr.items[i]->v.str;
+    const ScrDyn *arg_value = args->v.arr.items[i];
     if (after_terminator) {
-      pa_positional(positionals, tokens, arg, i);
+      if (!allow_positionals) {
+        pa_unexpected_dyn(arg_value);
+        goto fail;
+      }
+      pa_positional(positionals, tokens, arg_value, i);
       continue;
     }
+    if (arg_value->kind == SCR_DYN_NULL || arg_value->kind == SCR_DYN_UNDEF) {
+      pa_nullish_arg_length(arg_value);
+      goto fail;
+    }
+    if (arg_value->kind != SCR_DYN_STR) {
+      if (!allow_positionals) {
+        pa_unexpected_dyn(arg_value);
+        goto fail;
+      }
+      pa_positional(positionals, tokens, arg_value, i);
+      continue;
+    }
+    const ScrStr *arg = arg_value->v.str;
     if (pa_str_eq_c(arg, "--")) {
       after_terminator = true;
       if (tokens) {
@@ -412,64 +492,82 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
       const ScrDyn *desc = pa_find_long(options, name);
       if (eq < arg->len) {
         if (strict && !desc) {
-          pa_unknown(raw);
+          pa_unknown(raw, allow_positionals);
           scr_str_release(raw);
           scr_str_release(name);
           goto fail;
         }
         if (strict && pa_desc_type(desc) == 0) {
-          pa_takes_no_value(raw);
+          pa_takes_no_value(desc, name);
           scr_str_release(raw);
           scr_str_release(name);
           goto fail;
         }
         ScrStr *value = pa_str_bytes(arg->data + eq + 1, arg->len - eq - 1);
-        pa_store(values, tokens, desc, name, raw, i, value, true, 1);
+        ScrDyn *dyn_value = pa_dyn_str(value);
+        pa_store(values, tokens, desc, name, raw, i, dyn_value, true, 1);
+        scr_dyn_release(dyn_value);
         scr_str_release(value);
       } else if (desc && pa_desc_type(desc) == 1) {
-        if (i + 1 < args->v.arr.len) {
-          const ScrStr *value = args->v.arr.items[++i]->v.str;
-          if (strict && value->len > 1 && value->data[0] == '-') {
+        const ScrDyn *next = i + 1 < args->v.arr.len
+                                 ? args->v.arr.items[i + 1] : NULL;
+        if (next && next->kind != SCR_DYN_NULL && next->kind != SCR_DYN_UNDEF) {
+          i++;
+          if (strict && next->kind != SCR_DYN_STR) {
+            pa_missing_value(desc, name);
+            scr_str_release(raw);
+            scr_str_release(name);
+            goto fail;
+          }
+          if (strict && next->kind == SCR_DYN_STR &&
+              next->v.str->len > 1 && next->v.str->data[0] == '-') {
             pa_ambiguous(raw, name, false);
             scr_str_release(raw);
             scr_str_release(name);
             goto fail;
           }
-          pa_store(values, tokens, desc, name, raw, i - 1, value, true, 0);
+          pa_store(values, tokens, desc, name, raw, i - 1, next, true, 0);
         } else if (strict) {
-          pa_missing_long(raw);
+          pa_missing_value(desc, name);
           scr_str_release(raw);
           scr_str_release(name);
           goto fail;
         } else {
-          pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+          if (allow_negative && name->len > 3 &&
+              memcmp(name->data, "no-", 3) == 0) {
+            ScrStr *positive = pa_str_bytes(name->data + 3, name->len - 3);
+            const ScrDyn *positive_desc = pa_find_long(options, positive);
+            pa_store(values, tokens, positive_desc, positive, raw, i,
+                     NULL, false, -1);
+            scr_str_release(positive);
+          } else {
+            pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+          }
         }
-      } else if (allow_negative && name->len > 3 &&
-                 memcmp(name->data, "no-", 3) == 0) {
-        ScrStr *positive = pa_str_bytes(name->data + 3, name->len - 3);
-        const ScrDyn *positive_desc = pa_find_long(options, positive);
-        if (positive_desc && pa_desc_type(positive_desc) == 0) {
+      } else {
+        ScrStr *positive = NULL;
+        const ScrDyn *positive_desc = NULL;
+        const bool negative = allow_negative && name->len > 3 &&
+                              memcmp(name->data, "no-", 3) == 0;
+        if (negative) {
+          positive = pa_str_bytes(name->data + 3, name->len - 3);
+          positive_desc = pa_find_long(options, positive);
+        }
+        if (strict && !desc &&
+            (!negative || !positive_desc || pa_desc_type(positive_desc) != 0)) {
+          pa_unknown(raw, allow_positionals);
+          scr_str_release(positive);
+          scr_str_release(raw);
+          scr_str_release(name);
+          goto fail;
+        }
+        if (negative) {
           pa_store(values, tokens, positive_desc, positive, raw, i,
                    NULL, false, -1);
           scr_str_release(positive);
         } else {
-          scr_str_release(positive);
-          if (strict && !desc) {
-            pa_unknown(raw);
-            scr_str_release(raw);
-            scr_str_release(name);
-            goto fail;
-          }
           pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
         }
-      } else {
-        if (strict && !desc) {
-          pa_unknown(raw);
-          scr_str_release(raw);
-          scr_str_release(name);
-          goto fail;
-        }
-        pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
       }
       scr_str_release(raw);
       scr_str_release(name);
@@ -495,7 +593,7 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
         ScrStr *raw = pa_str_bytes(raw_bytes, short_name->len + 1);
         free(raw_bytes);
         if (strict && !desc) {
-          pa_unknown(raw);
+          pa_unknown(raw, allow_positionals);
           scr_str_release(raw);
           scr_str_release(name);
           scr_str_release(short_name);
@@ -504,11 +602,23 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
         if (desc && pa_desc_type(desc) == 1) {
           if (at + 1 < units) {
             ScrStr *value = scr_str_slice((ScrStr *)arg, at + 1, INFINITY);
-            pa_store(values, tokens, desc, name, raw, i, value, true, 1);
+            ScrDyn *dyn_value = pa_dyn_str(value);
+            pa_store(values, tokens, desc, name, raw, i, dyn_value, true, 1);
+            scr_dyn_release(dyn_value);
             scr_str_release(value);
-          } else if (i + 1 < args->v.arr.len) {
-            const ScrStr *value = args->v.arr.items[++i]->v.str;
-            if (strict && value->len > 1 && value->data[0] == '-') {
+          } else if (i + 1 < args->v.arr.len &&
+                     args->v.arr.items[i + 1]->kind != SCR_DYN_NULL &&
+                     args->v.arr.items[i + 1]->kind != SCR_DYN_UNDEF) {
+            const ScrDyn *value = args->v.arr.items[++i];
+            if (strict && value->kind != SCR_DYN_STR) {
+              pa_missing_value(desc, name);
+              scr_str_release(raw);
+              scr_str_release(name);
+              scr_str_release(short_name);
+              goto fail;
+            }
+            if (strict && value->kind == SCR_DYN_STR &&
+                value->v.str->len > 1 && value->v.str->data[0] == '-') {
               pa_ambiguous(raw, name, true);
               scr_str_release(raw);
               scr_str_release(name);
@@ -517,20 +627,22 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
             }
             pa_store(values, tokens, desc, name, raw, i - 1, value, true, 0);
           } else if (strict) {
-            pa_missing_short(raw, name);
+            pa_missing_value(desc, name);
             scr_str_release(raw);
             scr_str_release(name);
             scr_str_release(short_name);
             goto fail;
           } else {
-            pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+            pa_store_flag(values, tokens, options, desc, name, raw, i,
+                          allow_negative);
           }
           scr_str_release(raw);
           scr_str_release(name);
           scr_str_release(short_name);
           break;
         }
-        pa_store(values, tokens, desc, name, raw, i, NULL, true, -1);
+        pa_store_flag(values, tokens, options, desc, name, raw, i,
+                      allow_negative);
         scr_str_release(raw);
         scr_str_release(name);
         scr_str_release(short_name);
@@ -538,16 +650,18 @@ ScrDyn *scr_util_parse_args(const ScrDyn *config) {
       continue;
     }
 
-    if (strict && !allow_positionals) {
+    if (!allow_positionals) {
       pa_unexpected(arg);
       goto fail;
     }
-    pa_positional(positionals, tokens, arg, i);
+    pa_positional(positionals, tokens, arg_value, i);
   }
 
   if (options) {
     for (size_t i = 0; i < options->v.obj.len; i++) {
       const ScrDynEntry *entry = &options->v.obj.entries[i];
+      if (entry->key_len == 9 &&
+          memcmp(entry->key, "__proto__", 9) == 0) continue;
       if (scr_dyn_obj_get(values, entry->key, entry->key_len)) continue;
       const ScrDyn *def = pa_member(entry->value, "default");
       if (def) {

--- a/packages/runtime/src/scr_util.c
+++ b/packages/runtime/src/scr_util.c
@@ -200,6 +200,8 @@ static bool pa_default_value_ok(const ScrDyn *v, int type) {
   return type == 1 ? v->kind == SCR_DYN_STR : v->kind == SCR_DYN_BOOL;
 }
 
+static ScrDyn *pa_materialize_js_array(const ScrDyn *value);
+
 static bool pa_validate_option(const ScrStr *name, const ScrDyn *desc) {
   char *base = pa_path("options.", name->data, name->len, "");
   if (desc->kind != SCR_DYN_OBJ) {
@@ -246,26 +248,37 @@ static bool pa_validate_option(const ScrStr *name, const ScrDyn *desc) {
   if (def) {
     char *path = pa_path(base, "", 0, ".default");
     if (pa_desc_multiple(desc)) {
-      if (def->kind != SCR_DYN_ARR) {
-        scr_dyn_prop_type_fail(path, "an instance of Array", def);
+      /* A live typed/island array stays in the descriptor so phase 3 can
+       * return that exact reference. Validate against a temporary snapshot. */
+      ScrDyn *items = pa_materialize_js_array(def);
+      if (!items) {
         free(path);
         free(base);
         return false;
       }
-      for (size_t j = 0; j < def->v.arr.len; j++) {
-        if (!pa_default_value_ok(def->v.arr.items[j], type)) {
+      if (items->kind != SCR_DYN_ARR) {
+        scr_dyn_prop_type_fail(path, "an instance of Array", def);
+        scr_dyn_release(items);
+        free(path);
+        free(base);
+        return false;
+      }
+      for (size_t j = 0; j < items->v.arr.len; j++) {
+        if (!pa_default_value_ok(items->v.arr.items[j], type)) {
           char suffix[48];
           snprintf(suffix, sizeof suffix, "[%zu]", j);
           char *item_path = pa_path(path, "", 0, suffix);
           scr_dyn_prop_type_fail(item_path,
                                  type ? "of type string" : "of type boolean",
-                                 def->v.arr.items[j]);
+                                 items->v.arr.items[j]);
           free(item_path);
+          scr_dyn_release(items);
           free(path);
           free(base);
           return false;
         }
       }
+      scr_dyn_release(items);
     } else if (!pa_default_value_ok(def, type)) {
       scr_dyn_prop_type_fail(path,
                              type ? "of type string" : "of type boolean", def);
@@ -349,7 +362,10 @@ static const ScrDyn *pa_find_short(const ScrDyn *options,
   }
   scr_dyn_release(entries);
   *long_name = pa_str_bytes(short_name->data, short_name->len);
-  return NULL;
+  /* Node falls back to the short spelling itself as the long option name.
+   * Thus `{ x: { type: "boolean" } }` accepts both `--x` and `-x` even
+   * without an explicit `short: "x"` descriptor. */
+  return pa_find_long(options, short_name);
 }
 
 static ScrDyn *pa_option_token(const ScrStr *name, const ScrStr *raw,
@@ -446,6 +462,9 @@ static ScrDyn *pa_default_args(void) {
  * so indexed Gets (including holes -> undefined) and the live length are
  * the relevant semantics; an overridden Symbol.iterator is not. */
 static ScrDyn *pa_materialize_js_array(const ScrDyn *value) {
+  if (value->kind == SCR_DYN_TYPED_REF) {
+    return scr_dyn_typed_ref_materialize(value);
+  }
   if (value->kind != SCR_DYN_JSVAL ||
       !scr_dyn_jsval_ops()->is_array(value->v.jsval.cell)) {
     return scr_dyn_retain((ScrDyn *)value);
@@ -499,6 +518,12 @@ static ScrDyn *pa_owned_member(const ScrDyn *obj, const char *key) {
 }
 
 static ScrDyn *pa_materialize_descriptor(const ScrDyn *desc) {
+  if (desc->kind == SCR_DYN_TYPED_REF) {
+    ScrDyn *view = scr_dyn_typed_ref_materialize(desc);
+    ScrDyn *out = pa_materialize_descriptor(view);
+    scr_dyn_release(view);
+    return out;
+  }
   if (desc->kind == SCR_DYN_JSVAL &&
       scr_dyn_jsval_ops()->is_array(desc->v.jsval.cell)) {
     return pa_materialize_js_array(desc);
@@ -518,7 +543,13 @@ static ScrDyn *pa_materialize_descriptor(const ScrDyn *desc) {
       if (scr_exc_pending()) { scr_dyn_release(out); return NULL; }
       continue;
     }
-    ScrDyn *native = pa_materialize_js_array(value);
+    /* Node assigns a descriptor default directly into result.values. Keep
+     * typed array defaults as their original static reference; island arrays
+     * still need the ordinary native snapshot so dynCheck can consume them. */
+    ScrDyn *native = strcmp(fields[i], "default") == 0 &&
+                             value->kind == SCR_DYN_TYPED_REF
+                         ? scr_dyn_retain(value)
+                         : pa_materialize_js_array(value);
     scr_dyn_release(value);
     if (!native) { scr_dyn_release(out); return NULL; }
     scr_dyn_obj_set(out, fields[i], strlen(fields[i]), native);
@@ -527,6 +558,12 @@ static ScrDyn *pa_materialize_descriptor(const ScrDyn *desc) {
 }
 
 static ScrDyn *pa_materialize_options(const ScrDyn *options) {
+  if (options->kind == SCR_DYN_TYPED_REF) {
+    ScrDyn *view = scr_dyn_typed_ref_materialize(options);
+    ScrDyn *out = pa_materialize_options(view);
+    scr_dyn_release(view);
+    return out;
+  }
   if (options->kind == SCR_DYN_JSVAL &&
       scr_dyn_jsval_ops()->is_array(options->v.jsval.cell)) {
     return pa_materialize_js_array(options);
@@ -560,6 +597,12 @@ static ScrDyn *pa_materialize_options(const ScrDyn *options) {
  * snapshot, matching parseArgs's synchronous reads, while preserving own
  * property presence (including explicit undefined) across the island. */
 static ScrDyn *pa_materialize_config(const ScrDyn *config) {
+  if (config->kind == SCR_DYN_TYPED_REF) {
+    ScrDyn *view = scr_dyn_typed_ref_materialize(config);
+    ScrDyn *out = pa_materialize_config(view);
+    scr_dyn_release(view);
+    return out;
+  }
   if (config->kind != SCR_DYN_OBJ && config->kind != SCR_DYN_JSVAL) {
     return scr_dyn_retain((ScrDyn *)config);
   }

--- a/tests/corpus/2678-util-parseargs.ts
+++ b/tests/corpus/2678-util-parseargs.ts
@@ -1,0 +1,72 @@
+// Static node:util.parseArgs — Node is the oracle for grammar, defaults,
+// negative booleans, tokens, and coded error paths.
+import { parseArgs } from "node:util";
+
+const full = parseArgs({
+  args: ["-v", "--output=result.txt", "--tag", "a", "--tag=b", "file", "--", "--literal"],
+  options: {
+    verbose: { type: "boolean", short: "v" },
+    output: { type: "string", short: "o" },
+    tag: { type: "string", short: "t", multiple: true },
+    color: { type: "boolean", default: true },
+  },
+  allowPositionals: true,
+  tokens: true,
+});
+console.log("full", JSON.stringify(full));
+const { values: fullValues, positionals: fullPositionals } = full;
+console.log("destructured", fullValues.verbose, fullPositionals.length);
+const { values: { output: nestedOutput } } = full;
+console.log("nested", nestedOutput);
+if (full.tokens !== undefined) {
+  const firstToken = full.tokens[0];
+  if (firstToken !== undefined && firstToken.kind === "option") {
+    console.log("first-token", firstToken.name, firstToken.rawName);
+    const { name: tokenName, rawName: tokenRawName } = firstToken;
+    console.log("token-pattern", tokenName, tokenRawName);
+  }
+}
+
+const clustered = parseArgs({
+  args: ["-abVALUE", "--color", "--no-color", "tail"],
+  options: {
+    all: { type: "boolean", short: "a" },
+    build: { type: "string", short: "b" },
+    color: { type: "boolean", multiple: true },
+  },
+  allowNegative: true,
+  allowPositionals: true,
+  tokens: true,
+});
+console.log("cluster", JSON.stringify(clustered));
+
+const loose = parseArgs({
+  args: ["--mystery=x", "-qz", "--=odd", "pos"],
+  strict: false,
+  tokens: true,
+});
+console.log("loose", JSON.stringify(loose));
+
+const typedConfig: import("node:util").ParseArgsConfig = {
+  args: ["--mode", "fast"],
+  options: { mode: { type: "string" } },
+  tokens: true,
+};
+console.log("typed", JSON.stringify(parseArgs(typedConfig)));
+console.log("undefined", JSON.stringify(parseArgs(undefined)));
+
+for (const run of [
+  (): void => { parseArgs({ args: ["--name"], options: { name: { type: "string" } } }); },
+  (): void => { parseArgs({ args: ["--wat"] }); },
+  (): void => { parseArgs({ args: ["position"] }); },
+  (): void => { parseArgs({ args: ["--name", "--next"], options: { name: { type: "string" } } }); },
+  (): void => { parseArgs({ args: ["-n", "-1"], options: { name: { type: "string", short: "n" } } }); },
+]) {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof TypeError) {
+      console.log("error", `${(error as NodeJS.ErrnoException).code}`, error.message);
+    }
+  }
+}

--- a/tests/corpus/2678-util-parseargs.ts
+++ b/tests/corpus/2678-util-parseargs.ts
@@ -40,6 +40,14 @@ const clustered = parseArgs({
 });
 console.log("cluster", JSON.stringify(clustered));
 
+const explicitNegative = parseArgs({
+  args: ["--no-x"],
+  options: { "no-x": { type: "boolean" } },
+  allowNegative: true,
+  tokens: true,
+});
+console.log("explicit-negative", JSON.stringify(explicitNegative));
+
 const loose = parseArgs({
   args: ["--mystery=x", "-qz", "--=odd", "pos"],
   strict: false,
@@ -61,6 +69,11 @@ for (const run of [
   (): void => { parseArgs({ args: ["position"] }); },
   (): void => { parseArgs({ args: ["--name", "--next"], options: { name: { type: "string" } } }); },
   (): void => { parseArgs({ args: ["-n", "-1"], options: { name: { type: "string", short: "n" } } }); },
+  (): void => { parseArgs({ args: ["tail"], strict: false, allowPositionals: false }); },
+  (): void => { parseArgs({ args: ["--", "tail"] }); },
+  (): void => { parseArgs({ args: ["--wat"], allowPositionals: true }); },
+  (): void => { parseArgs({ args: ["--name"], options: { name: { type: "string", short: "n" } } }); },
+  (): void => { parseArgs({ args: ["--force=yes"], options: { force: { type: "boolean", short: "f" } } }); },
 ]) {
   try {
     run();

--- a/tests/corpus/2678-util-parseargs.ts
+++ b/tests/corpus/2678-util-parseargs.ts
@@ -18,12 +18,20 @@ const { values: fullValues, positionals: fullPositionals } = full;
 console.log("destructured", fullValues.verbose, fullPositionals.length);
 const { values: { output: nestedOutput } } = full;
 console.log("nested", nestedOutput);
+function printParsed({ values }: ReturnType<typeof parseArgs>): void {
+  console.log("param-pattern", values["output"]);
+}
+printParsed(full);
 if (full.tokens !== undefined) {
   const firstToken = full.tokens[0];
   if (firstToken !== undefined && firstToken.kind === "option") {
     console.log("first-token", firstToken.name, firstToken.rawName);
     const { name: tokenName, rawName: tokenRawName } = firstToken;
     console.log("token-pattern", tokenName, tokenRawName);
+  }
+  for (const { kind } of full.tokens) {
+    console.log("loop-pattern", kind);
+    break;
   }
 }
 
@@ -54,6 +62,28 @@ const loose = parseArgs({
   tokens: true,
 });
 console.log("loose", JSON.stringify(loose));
+console.log("equals-1", JSON.stringify(parseArgs({
+  args: ["--==x"],
+  strict: false,
+  tokens: true,
+})));
+console.log("equals-2", JSON.stringify(parseArgs({
+  args: ["--=x=y"],
+  strict: false,
+  tokens: true,
+})));
+console.log("empty-negative-loose", JSON.stringify(parseArgs({
+  args: ["--no-"],
+  strict: false,
+  allowNegative: true,
+  tokens: true,
+})));
+console.log("empty-negative-strict", JSON.stringify(parseArgs({
+  args: ["--no-"],
+  options: { "": { type: "boolean" } },
+  allowNegative: true,
+  tokens: true,
+})));
 
 const typedConfig: import("node:util").ParseArgsConfig = {
   args: ["--mode", "fast"],
@@ -74,6 +104,7 @@ for (const run of [
   (): void => { parseArgs({ args: ["--wat"], allowPositionals: true }); },
   (): void => { parseArgs({ args: ["--name"], options: { name: { type: "string", short: "n" } } }); },
   (): void => { parseArgs({ args: ["--force=yes"], options: { force: { type: "boolean", short: "f" } } }); },
+  (): void => { parseArgs({ args: ["--no-color=yes"], options: { color: { type: "boolean" } }, allowNegative: true }); },
 ]) {
   try {
     run();
@@ -83,3 +114,9 @@ for (const run of [
     }
   }
 }
+
+process.argv.push("--live-flag");
+console.log("live-argv", JSON.stringify(parseArgs({
+  options: { "live-flag": { type: "boolean" } },
+})));
+process.argv.pop();

--- a/tests/corpus/2678-util-parseargs.ts
+++ b/tests/corpus/2678-util-parseargs.ts
@@ -93,6 +93,28 @@ const typedConfig: import("node:util").ParseArgsConfig = {
 console.log("typed", JSON.stringify(parseArgs(typedConfig)));
 console.log("undefined", JSON.stringify(parseArgs(undefined)));
 
+// A one-character long name is also its implicit short spelling. Node only
+// consults an explicit `short` alias first, then falls back to the name.
+console.log("implicit-short", JSON.stringify(parseArgs({
+  args: ["-x"],
+  options: { x: { type: "boolean" } },
+  tokens: true,
+})));
+
+// Defaults are assigned, not cloned: result.values keeps the exact array
+// reference and observes later mutations through either alias.
+const defaultTags = ["fallback"];
+const withArrayDefault = parseArgs({
+  args: [],
+  options: {
+    tag: { type: "string", multiple: true, default: defaultTags },
+  },
+} as const);
+const returnedTags = withArrayDefault.values.tag as string[];
+console.log("default-array-identity", returnedTags === defaultTags);
+defaultTags.push("later");
+console.log("default-array-live", JSON.stringify(returnedTags));
+
 for (const run of [
   (): void => { parseArgs({ args: ["--name"], options: { name: { type: "string" } } }); },
   (): void => { parseArgs({ args: ["--wat"] }); },

--- a/tests/corpus/2679-util-parseargs-cjs.cjs
+++ b/tests/corpus/2679-util-parseargs-cjs.cjs
@@ -21,6 +21,23 @@ console.log("proto-token", JSON.stringify(parse(JSON.parse(
 console.log("proto-default", JSON.stringify(parse(JSON.parse(
   '{"args":[],"options":{"__proto__":{"type":"boolean","default":true}},"tokens":true}',
 ))));
+console.log("proto-negative", JSON.stringify(parse(JSON.parse(
+  '{"args":["--no-__proto__"],"options":{"__proto__":{"type":"boolean"}},"allowNegative":true,"tokens":true}',
+))));
+console.log("numeric-short-order", JSON.stringify(parse(JSON.parse(
+  '{"args":["-x"],"options":{"2":{"type":"boolean","short":"x"},"1":{"type":"boolean","short":"x"}},"tokens":true}',
+))));
+
+try {
+  parse(JSON.parse('{"args":["--unknown",null]}'));
+} catch (error) {
+  console.log("tokenize-error", `${error.code}`, error.message);
+}
+try {
+  parse(JSON.parse('{"args":[],"options":{"2":{},"1":{}}}'));
+} catch (error) {
+  console.log("numeric-validation-order", `${error.code}`, error.message);
+}
 
 for (const config of [
   null,

--- a/tests/corpus/2679-util-parseargs-cjs.cjs
+++ b/tests/corpus/2679-util-parseargs-cjs.cjs
@@ -8,6 +8,19 @@ console.log(JSON.stringify(util.parseArgs({
   allowPositionals: true,
 })));
 console.log(JSON.stringify(parse({ args: ["--x=1"], strict: false, tokens: true })));
+console.log("null-strict", JSON.stringify(parse({ args: [], strict: null })));
+console.log("null-positionals", JSON.stringify(parse({ args: [], allowPositionals: null })));
+console.log("null-negative", JSON.stringify(parse({ args: [], allowNegative: null })));
+console.log("null-tokens", JSON.stringify(parse({ args: [], tokens: null })));
+console.log("non-string-arg", JSON.stringify(parse(JSON.parse(
+  '{"args":[1],"strict":false,"tokens":true}',
+))));
+console.log("proto-token", JSON.stringify(parse(JSON.parse(
+  '{"args":["--__proto__"],"options":{"__proto__":{"type":"boolean"}},"tokens":true}',
+))));
+console.log("proto-default", JSON.stringify(parse(JSON.parse(
+  '{"args":[],"options":{"__proto__":{"type":"boolean","default":true}},"tokens":true}',
+))));
 
 for (const config of [
   null,
@@ -15,10 +28,21 @@ for (const config of [
   { args: [], options: { x: {} } },
   { args: [], options: { x: { type: "boolean", short: "xx" } } },
   { args: [], options: { x: { type: "string", default: false } } },
+  { args: 1, strict: 1, options: 1 },
+  { args: [], options: { x: { type: "boolean", short: undefined } } },
+  { args: [], options: { x: { type: "boolean", multiple: undefined } } },
 ]) {
   try {
     parse(config);
   } catch (error) {
     console.log("config-error", `${error.code}`, error.message);
   }
+}
+
+try {
+  parse(JSON.parse(
+    '{"args":[],"options":{"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa":{}}}',
+  ));
+} catch (error) {
+  console.log("long-config-error", `${error.code}`, error.message.length);
 }

--- a/tests/corpus/2679-util-parseargs-cjs.cjs
+++ b/tests/corpus/2679-util-parseargs-cjs.cjs
@@ -27,11 +27,28 @@ console.log("proto-negative", JSON.stringify(parse(JSON.parse(
 console.log("numeric-short-order", JSON.stringify(parse(JSON.parse(
   '{"args":["-x"],"options":{"2":{"type":"boolean","short":"x"},"1":{"type":"boolean","short":"x"}},"tokens":true}',
 ))));
+console.log("numeric-values-order", JSON.stringify(parse({
+  args: ["--9", "--2", "--100", "--a"],
+  options: {
+    "9": { type: "boolean" },
+    "2": { type: "boolean" },
+    "100": { type: "boolean" },
+    a: { type: "boolean" },
+  },
+  tokens: true,
+})));
 
 try {
   parse(JSON.parse('{"args":["--unknown",null]}'));
 } catch (error) {
   console.log("tokenize-error", `${error.code}`, error.message);
+}
+try {
+  parse(JSON.parse(
+    '{"args":["--name","--",null],"options":{"name":{"type":"string"}}}',
+  ));
+} catch (error) {
+  console.log("consumed-terminator-tokenize-error", `${error.code}`, error.message);
 }
 try {
   parse(JSON.parse('{"args":[],"options":{"2":{},"1":{}}}'));

--- a/tests/corpus/2679-util-parseargs-cjs.cjs
+++ b/tests/corpus/2679-util-parseargs-cjs.cjs
@@ -1,0 +1,24 @@
+// CommonJS namespace/member plumbing reaches the same static parseArgs spoke.
+const util = require("node:util");
+const parse = require("util").parseArgs;
+
+console.log(JSON.stringify(util.parseArgs({
+  args: ["-f", "one", "two"],
+  options: { force: { type: "boolean", short: "f" } },
+  allowPositionals: true,
+})));
+console.log(JSON.stringify(parse({ args: ["--x=1"], strict: false, tokens: true })));
+
+for (const config of [
+  null,
+  { args: [], strict: 1 },
+  { args: [], options: { x: {} } },
+  { args: [], options: { x: { type: "boolean", short: "xx" } } },
+  { args: [], options: { x: { type: "string", default: false } } },
+]) {
+  try {
+    parse(config);
+  } catch (error) {
+    console.log("config-error", `${error.code}`, error.message);
+  }
+}

--- a/tests/corpus/2680-util-parseargs-default.ts
+++ b/tests/corpus/2680-util-parseargs-default.ts
@@ -1,0 +1,5 @@
+// Omitted args reads process.argv.slice(2); the corpus run pins the empty
+// case, while focused CLI validation invokes the compiled binary with args.
+import { parseArgs } from "node:util";
+
+console.log(JSON.stringify(parseArgs({ strict: false, tokens: true })));

--- a/tests/corpus/2681-util-parseargs-dynamic.js
+++ b/tests/corpus/2681-util-parseargs-dynamic.js
@@ -1,0 +1,13 @@
+// @dynamic
+// An any-typed config is engine-backed in the dynamic tier. The static
+// util.parseArgs spoke must snapshot its documented members before parsing.
+import { parseArgs } from "node:util";
+
+const config = /** @type {any} */ ({
+  args: ["--name=codex", "tail"],
+  options: { name: { type: "string" } },
+  allowPositionals: true,
+  tokens: true,
+});
+
+console.log(JSON.stringify(parseArgs(config)));


### PR DESCRIPTION
- Lower typed util.parseArgs calls through the C and LLVM backends.
- Add a link-gated native parser with Node-compatible options, tokens, defaults, and errors.
- Cover ESM, CommonJS, default argv, sanitizer, and TS7 behavior.