### PR TITLE
Support variable Buffer.toString encodings

### DIFF
--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -1646,18 +1646,27 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             return { name: "", type: e.type };
           }
           case "toString":
+          case "toStringVar": {
             // The encoding arg is always present (the frontend completes
-            // an omitted one to "utf8"). Never throws; +1 string. Range
-            // forms: [enc, start] decodes to the buffer's end; [enc,
-            // start, end] clamps the explicit end (negatives empty,
-            // Node's slice-then-decode).
+            // an omitted one to "utf8"). The literal path is already
+            // canonical and cannot throw; toStringVar validates a runtime
+            // encoding and may throw ERR_UNKNOWN_ENCODING. Both return a
+            // +1 string. Range forms: [enc, start] decodes to the buffer's
+            // end; [enc, start, end] clamps the explicit end (negatives
+            // empty, Node's slice-then-decode).
+            const checked = method === "toStringVar";
+            const stem = checked ? "scr_bytes_to_str_checked" : "scr_bytes_to_str";
+            let out: Temp;
             if (args.length === 3) {
-              return E.newTemp(e.type, `scr_bytes_to_str_range(${r.name}, ${args[0]!.name}, ${args[1]!.name}, ${args[2]!.name})`);
+              out = E.newTemp(e.type, `${stem}_range(${r.name}, ${args[0]!.name}, ${args[1]!.name}, ${args[2]!.name})`);
+            } else if (args.length === 2) {
+              out = E.newTemp(e.type, `${stem}_range(${r.name}, ${args[0]!.name}, ${args[1]!.name}, (double)${r.name}->len)`);
+            } else {
+              out = E.newTemp(e.type, `${stem}(${r.name}, ${args[0]!.name})`);
             }
-            if (args.length === 2) {
-              return E.newTemp(e.type, `scr_bytes_to_str_range(${r.name}, ${args[0]!.name}, ${args[1]!.name}, (double)${r.name}->len)`);
-            }
-            return E.newTemp(e.type, `scr_bytes_to_str(${r.name}, ${args[0]!.name})`);
+            if (checked) E.emitPendingCheck();
+            return out;
+          }
           case "equals":
             return E.newTemp(e.type, `scr_bytes_equals(${r.name}, ${args[0]!.name})`);
           case "compareBuf": {

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -9837,18 +9837,23 @@ class LlEmitter {
           false,
           true,
         );
-      case "toString": {
+      case "toString":
+      case "toStringVar": {
         // The encoding arg is always present (the frontend completes an
-        // omitted one to "utf8"). Never throws; +1 string. Range forms:
-        // [enc, start] decodes to the buffer's end (the element count —
-        // r->len in the C spelling); [enc, start, end] clamps.
+        // omitted one to "utf8"). The runtime-valued form validates and
+        // may throw ERR_UNKNOWN_ENCODING; the literal form is canonical
+        // and cannot throw. Both return +1. Range forms: [enc, start]
+        // decode to the buffer's end (the element count — r->len in the C
+        // spelling); [enc, start, end] clamps.
+        const checked = method === "toStringVar";
+        const stem = checked ? "scr_bytes_to_str_checked" : "scr_bytes_to_str";
         if (e.args.length === 3) {
           return call(
-            "scr_bytes_to_str_range",
+            `${stem}_range`,
             "ptr (ptr, ptr, double, double)",
             `ptr ${r.name}, ptr ${args[0]!.name}, double ${args[1]!.name}, double ${args[2]!.name}`,
             true,
-            false,
+            checked,
           );
         }
         if (e.args.length === 2) {
@@ -9856,14 +9861,14 @@ class LlEmitter {
           const len = B.tmp();
           B.line(`${len} = call double @scr_bytes_len(ptr ${r.name})`);
           return call(
-            "scr_bytes_to_str_range",
+            `${stem}_range`,
             "ptr (ptr, ptr, double, double)",
             `ptr ${r.name}, ptr ${args[0]!.name}, double ${args[1]!.name}, double ${len}`,
             true,
-            false,
+            checked,
           );
         }
-        return call("scr_bytes_to_str", "ptr (ptr, ptr)", `ptr ${r.name}, ptr ${args[0]!.name}`, true, false);
+        return call(stem, "ptr (ptr, ptr)", `ptr ${r.name}, ptr ${args[0]!.name}`, true, checked);
       }
       case "equals":
         return call("scr_bytes_equals", "zeroext i1 (ptr, ptr)", `ptr ${r.name}, ptr ${args[0]!.name}`, false, false);

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -5493,10 +5493,27 @@ const BYTES_CTORS: Record<string, IrBytesElem | undefined> = {
         );
       }
       if (nArgs > 3) L.noLowering(`.toString with ${nArgs} arguments on Buffers`, call);
-      const encNode = call.arguments[0];
-      const encName = encNode ? bufEncoding(L, "Buffer.toString", encNode) : "utf8";
       const receiver = L.lowerExpr(access.expression);
-      const enc: IrExpr = { kind: "strLit", value: encName, type: STRING, loc };
+      const encNode = call.arguments[0];
+      let method: IrBytesIntrinsicMethod = "toString";
+      let enc: IrExpr = { kind: "strLit", value: "utf8", type: STRING, loc };
+      if (encNode) {
+        const encType = L.typeOf(encNode);
+        const encName = encType.isStringLiteralType()
+          ? knownBufEncoding(encType.value)
+          : undefined;
+        if (encName !== undefined) {
+          // Keep literals on the canonical, non-throwing fast path.
+          enc = { kind: "strLit", value: encName, type: STRING, loc };
+        } else {
+          // A BufferEncoding-typed variable selects its decoder at
+          // runtime. The checked intrinsic canonicalizes aliases/case and
+          // raises Node's ERR_UNKNOWN_ENCODING when a cast lets a bad
+          // value through.
+          enc = L.lowerExprExpecting(encNode, STRING);
+          method = "toStringVar";
+        }
+      }
       // The range form toString(enc, start[, end]) decodes the clamped
       // [start, end) byte window (Node's slice-then-decode). An omitted
       // end stays omitted (2 intrinsic args) — the emitter supplies the
@@ -5506,11 +5523,11 @@ const BYTES_CTORS: Record<string, IrBytesElem | undefined> = {
         const start = L.lowerExprExpecting(call.arguments[1]!, F64);
         if (nArgs === 3) {
           const end = L.lowerExprExpecting(call.arguments[2]!, F64);
-          return { kind: "bytesIntrinsic", method: "toString", receiver, args: [enc, start, end], type: STRING, loc };
+          return { kind: "bytesIntrinsic", method, receiver, args: [enc, start, end], type: STRING, loc };
         }
-        return { kind: "bytesIntrinsic", method: "toString", receiver, args: [enc, start], type: STRING, loc };
+        return { kind: "bytesIntrinsic", method, receiver, args: [enc, start], type: STRING, loc };
       }
-      return { kind: "bytesIntrinsic", method: "toString", receiver, args: [enc], type: STRING, loc };
+      return { kind: "bytesIntrinsic", method, receiver, args: [enc], type: STRING, loc };
     }
     // The Buffer-declared comparison/search/mutation surface. All of
     // these resolve against the Buffer interface (the checker keeps most

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -81,9 +81,23 @@ function lowerOptionalDefaultArg(
   defaultValue: IrExpr,
 ): IrExpr {
   const undefinedArg = lowerStaticallyUndefinedArg(L, node);
-  return undefinedArg
-    ? defaultAfterUndefined(undefinedArg, defaultValue)
-    : L.lowerExprExpecting(node, expected);
+  if (undefinedArg) return defaultAfterUndefined(undefinedArg, defaultValue);
+  const value = L.lowerExpr(node);
+  if (value.type.kind === "union") {
+    const def = L.unions.get(value.type.unionId);
+    if (
+      def?.arms.length === 2 &&
+      def.arms.some((arm) => arm.kind === "undefinedT") &&
+      def.arms.some((arm) => typeEquals(arm, expected))
+    ) {
+      // A runtime optional argument uses its API default only on the
+      // undefined arm. The exact two-arm gate deliberately excludes null:
+      // optional parameters do not admit it, and an asserted null must keep
+      // the ordinary checked-narrow failure instead of defaulting.
+      return { kind: "nullish", left: value, right: defaultValue, type: expected, loc: value.loc };
+    }
+  }
+  return L.coerceInto(node, value, expected);
 }
 
 /** Ambient array method calls. `push`/`unshift`/`pop`/`reverse`/
@@ -5506,12 +5520,21 @@ const BYTES_CTORS: Record<string, IrBytesElem | undefined> = {
           // Keep literals on the canonical, non-throwing fast path.
           enc = { kind: "strLit", value: encName, type: STRING, loc };
         } else {
-          // A BufferEncoding-typed variable selects its decoder at
-          // runtime. The checked intrinsic canonicalizes aliases/case and
-          // raises Node's ERR_UNKNOWN_ENCODING when a cast lets a bad
-          // value through.
-          enc = L.lowerExprExpecting(encNode, STRING);
-          method = "toStringVar";
+          const undefinedArg = lowerStaticallyUndefinedArg(L, encNode);
+          if (undefinedArg) {
+            // An explicit undefined is the omitted-encoding default. Keep
+            // the canonical, non-throwing path while preserving effects
+            // from equivalent spellings such as `void sideEffect()`.
+            enc = defaultAfterUndefined(undefinedArg, enc);
+          } else {
+            // A BufferEncoding-typed variable selects its decoder at
+            // runtime. Optional variables default their undefined arm to
+            // utf8; the checked intrinsic canonicalizes every present
+            // alias/case and raises Node's ERR_UNKNOWN_ENCODING when a cast
+            // lets a bad value through.
+            enc = lowerOptionalDefaultArg(L, encNode, STRING, enc);
+            method = "toStringVar";
+          }
         }
       }
       // The range form toString(enc, start[, end]) decodes the clamped

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -1414,9 +1414,11 @@ export type IrStrIntrinsicMethod =
  * `setFrom` (`dst.set(src, offset?)`) takes a
  * same-elem bytes src and an optional f64 offset (omitted = 0) → void,
  * THROWS Node's RangeError on overflow (may-throw seed); `toString` takes
- * one string encoding arg (the frontend completes an omitted one to
- * "utf8" and fences non-literal / unsupported encodings; u8 receivers
- * only) → owned +1 string, never throws; the numeric families (u8
+ * one canonical literal encoding arg (the frontend completes omitted or
+ * undefined to "utf8"; u8 receivers only) → owned +1 string, never
+ * throws; `toStringVar` has the same signature for runtime-valued
+ * BufferEncoding arguments, normalizes aliases/case, and throws
+ * ERR_UNKNOWN_ENCODING for an invalid cast; the numeric families (u8
  * receivers only) carry their KIND as args[0], always a strLit the
  * backend maps to the runtime's tag: `readNum` [kind, offset] /
  * `writeNum` [kind, value, offset] cover the fixed widths (kind "u8",

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -1466,6 +1466,10 @@ export type IrBytesIntrinsicMethod =
   | "toArray"
   | "setFrom"
   | "toString"
+  /** Buffer.toString with a runtime-valued encoding. Same signature as
+   * toString, but canonicalizes aliases/case and may throw
+   * ERR_UNKNOWN_ENCODING. */
+  | "toStringVar"
   | "readNum"
   | "writeNum"
   | "readNumVar"
@@ -1531,6 +1535,7 @@ export type IrBytesIntrinsicMethod =
 /** The bytesIntrinsic methods that can raise a catchable error — backends'
  * may-throw analyses seed on these exactly like MAY_THROW_LIB_FNS. */
 export const MAY_THROW_BYTES_METHODS: ReadonlySet<IrBytesIntrinsicMethod> = new Set([
+  "toStringVar",
   "with",
   "setFrom",
   "readNum",

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -2261,7 +2261,7 @@ function validateFunction(
         const isNum =
           e.method === "readNum" || e.method === "writeNum" || e.method === "readNumVar" || e.method === "writeNumVar";
         const U8_ONLY_EXTRA: ReadonlySet<string> = new Set([
-          "toString", "equals", "compareBuf", "indexOf", "lastIndexOf", "includes",
+          "toString", "toStringVar", "equals", "compareBuf", "indexOf", "lastIndexOf", "includes",
           "indexOfNum", "lastIndexOfNum", "includesNum", "fill", "fillNum", "fillStr",
           "copy", "swap16", "swap32", "swap64", "writeStr",
         ]);
@@ -2322,7 +2322,7 @@ function validateFunction(
                       ? { argTypes: [], minArgs: 0, result: arrayOf(F64) }
                 : e.method === "setFrom"
                   ? { argTypes: [bytesOf(recv.elem), F64], minArgs: 1, result: VOID }
-                  : e.method === "toString"
+                  : e.method === "toString" || e.method === "toStringVar"
                     ? { argTypes: [STRING, F64, F64], minArgs: 1, result: STRING }
                     : e.method === "readNum"
                       ? { argTypes: [STRING, F64], minArgs: 2, result: F64 }

--- a/packages/runtime/src/scr_bytes.c
+++ b/packages/runtime/src/scr_bytes.c
@@ -831,6 +831,58 @@ ScrStr *scr_bytes_to_str(const ScrBytes *b, const ScrStr *enc) {
   return scr_bytes_decode_utf8(in, n);
 }
 
+/* Buffer.toString with a runtime-valued encoding. Literal call sites fold
+ * this same alias table in the frontend; variables arrive here, where Node
+ * also accepts ASCII case variants and rejects unknown names catchably. */
+static bool scr_enc_eq_ci(const ScrStr *raw, const char *name) {
+  size_t n = strlen(name);
+  if (raw->len != n) return false;
+  for (size_t i = 0; i < n; i++) {
+    char c = raw->data[i];
+    if (c >= 'A' && c <= 'Z') c = (char)(c + ('a' - 'A'));
+    if (c != name[i]) return false;
+  }
+  return true;
+}
+
+static ScrStr *scr_bytes_normalize_encoding(const ScrStr *raw) {
+  static const struct { const char *from; const char *to; } map[] = {
+    {"utf8", "utf8"}, {"utf-8", "utf8"}, {"hex", "hex"},
+    {"base64", "base64"}, {"base64url", "base64url"},
+    {"latin1", "latin1"}, {"binary", "latin1"}, {"ascii", "ascii"},
+    {"utf16le", "utf16le"}, {"utf-16le", "utf16le"},
+    {"ucs2", "utf16le"}, {"ucs-2", "utf16le"},
+  };
+  for (size_t i = 0; i < sizeof map / sizeof map[0]; i++) {
+    if (scr_enc_eq_ci(raw, map[i].from)) {
+      return scr_str_new(map[i].to, strlen(map[i].to));
+    }
+  }
+  char msg[128];
+  int n = snprintf(msg, sizeof msg, "Unknown encoding: %.*s",
+                   (int)(raw->len < 64 ? raw->len : 64), raw->data);
+  scr_throw_error_msg_code(SCR_ERR_TYPE, msg, (size_t)(n < 0 ? 0 : n),
+                           "ERR_UNKNOWN_ENCODING");
+  return NULL;
+}
+
+ScrStr *scr_bytes_to_str_checked(const ScrBytes *b, const ScrStr *enc) {
+  ScrStr *normalized = scr_bytes_normalize_encoding(enc);
+  if (!normalized) return NULL;
+  ScrStr *out = scr_bytes_to_str(b, normalized);
+  scr_str_release(normalized);
+  return out;
+}
+
+ScrStr *scr_bytes_to_str_checked_range(const ScrBytes *b, const ScrStr *enc,
+                                       double start, double end) {
+  ScrStr *normalized = scr_bytes_normalize_encoding(enc);
+  if (!normalized) return NULL;
+  ScrStr *out = scr_bytes_to_str_range(b, normalized, start, end);
+  scr_str_release(normalized);
+  return out;
+}
+
 static int scr_hex_val(uint8_t c) {
   if (c >= '0' && c <= '9') return c - '0';
   if (c >= 'a' && c <= 'f') return c - 'a' + 10;

--- a/packages/runtime/src/scr_bytes.c
+++ b/packages/runtime/src/scr_bytes.c
@@ -858,11 +858,17 @@ static ScrStr *scr_bytes_normalize_encoding(const ScrStr *raw) {
       return scr_str_new(map[i].to, strlen(map[i].to));
     }
   }
-  char msg[128];
-  int n = snprintf(msg, sizeof msg, "Unknown encoding: %.*s",
-                   (int)(raw->len < 64 ? raw->len : 64), raw->data);
-  scr_throw_error_msg_code(SCR_ERR_TYPE, msg, (size_t)(n < 0 ? 0 : n),
+  static const char prefix[] = "Unknown encoding: ";
+  const size_t prefix_len = sizeof prefix - 1;
+  if (raw->len > SIZE_MAX - prefix_len) scr_bytes_oom();
+  const size_t msg_len = prefix_len + raw->len;
+  char *msg = malloc(msg_len);
+  if (!msg) scr_bytes_oom();
+  memcpy(msg, prefix, prefix_len);
+  memcpy(msg + prefix_len, raw->data, raw->len);
+  scr_throw_error_msg_code(SCR_ERR_TYPE, msg, msg_len,
                            "ERR_UNKNOWN_ENCODING");
+  free(msg);
   return NULL;
 }
 

--- a/packages/runtime/src/scr_bytes.c
+++ b/packages/runtime/src/scr_bytes.c
@@ -669,6 +669,16 @@ ScrStr *scr_strdec_end(const ScrStr *enc, double pending) {
   return scr_bytes_decode_utf8(pend, np);
 }
 
+static void scr_bytes_to_str_bounds(const ScrBytes *b, double start, double end,
+                                    size_t *s0_out, size_t *e0_out) {
+  size_t len = b->len;
+  size_t s0 = start <= 0 ? 0 : ((size_t)start > len ? len : (size_t)start);
+  size_t e0 = end <= 0 ? 0 : ((size_t)end > len ? len : (size_t)end);
+  if (e0 < s0) e0 = s0;
+  *s0_out = s0;
+  *e0_out = e0;
+}
+
 /* toString(enc, start, end): Node slices then decodes — start/end clamp
  * to [0, len] with start > end collapsing to empty and negative ends
  * clamping to 0 (Node's slice-then-decode; an OMITTED end never reaches
@@ -676,10 +686,8 @@ ScrStr *scr_strdec_end(const ScrStr *enc, double pending) {
  * form). Delegates to the whole-buffer decoder
  * through a stack view — no allocation, no rc traffic. */
 ScrStr *scr_bytes_to_str_range(const ScrBytes *b, const ScrStr *enc, double start, double end) {
-  size_t len = b->len;
-  size_t s0 = start <= 0 ? 0 : ((size_t)start > len ? len : (size_t)start);
-  size_t e0 = end <= 0 ? 0 : ((size_t)end > len ? len : (size_t)end);
-  if (e0 < s0) e0 = s0;
+  size_t s0, e0;
+  scr_bytes_to_str_bounds(b, start, end, &s0, &e0);
   ScrBytes view = { .rc = 1, .len = e0 - s0, .elem = b->elem, .data = b->data + s0, .backing = NULL };
   return scr_bytes_to_str(&view, enc);
 }
@@ -873,6 +881,9 @@ static ScrStr *scr_bytes_normalize_encoding(const ScrStr *raw) {
 }
 
 ScrStr *scr_bytes_to_str_checked(const ScrBytes *b, const ScrStr *enc) {
+  /* Node returns before resolving the encoding when there are no bytes
+   * to decode, so even an unknown runtime name answers the empty string. */
+  if (b->len == 0) return scr_str_new("", 0);
   ScrStr *normalized = scr_bytes_normalize_encoding(enc);
   if (!normalized) return NULL;
   ScrStr *out = scr_bytes_to_str(b, normalized);
@@ -882,6 +893,11 @@ ScrStr *scr_bytes_to_str_checked(const ScrBytes *b, const ScrStr *enc) {
 
 ScrStr *scr_bytes_to_str_checked_range(const ScrBytes *b, const ScrStr *enc,
                                        double start, double end) {
+  /* The range is selected before Node resolves the encoding. A clamped
+   * empty window therefore answers "" even for an unknown name. */
+  size_t s0, e0;
+  scr_bytes_to_str_bounds(b, start, end, &s0, &e0);
+  if (s0 == e0) return scr_str_new("", 0);
   ScrStr *normalized = scr_bytes_normalize_encoding(enc);
   if (!normalized) return NULL;
   ScrStr *out = scr_bytes_to_str_range(b, normalized, start, end);

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -4728,6 +4728,10 @@ void scr_bytes_set_from(ScrBytes *dst, const ScrBytes *src, double offset);
  * compiler fences other encodings). */
 ScrStr *scr_bytes_to_str(const ScrBytes *b, const ScrStr *enc);
 ScrStr *scr_bytes_to_str_range(const ScrBytes *b, const ScrStr *enc, double start, double end);
+/* Runtime-valued Buffer.toString encoding: aliases/case canonicalize;
+ * unknown names throw ERR_UNKNOWN_ENCODING. +1, or NULL when throwing. */
+ScrStr *scr_bytes_to_str_checked(const ScrBytes *b, const ScrStr *enc);
+ScrStr *scr_bytes_to_str_checked_range(const ScrBytes *b, const ScrStr *enc, double start, double end);
 
 /* WHATWG TextDecoder.decode over u8 bytes (utf-8, default options): the
  * same replacement decode as toString("utf8") with the leading BOM

--- a/tests/corpus/1661-buffer-encodings-full.ts
+++ b/tests/corpus/1661-buffer-encodings-full.ts
@@ -81,3 +81,19 @@ try {
     console.log("variable bad", (e as NodeJS.ErrnoException).code, e.message);
   }
 }
+
+// Unknown-encoding messages preserve the complete runtime string,
+// including long values and embedded NULs.
+const unusualBadEncodings: BufferEncoding[] = [
+  "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" as BufferEncoding,
+  "\u0000wat" as BufferEncoding,
+];
+for (const encoding of unusualBadEncodings) {
+  try {
+    raw.toString(encoding);
+  } catch (e) {
+    if (e instanceof TypeError) {
+      console.log("variable bad exact", (e as NodeJS.ErrnoException).code, JSON.stringify(e.message), e.message.length);
+    }
+  }
+}

--- a/tests/corpus/1661-buffer-encodings-full.ts
+++ b/tests/corpus/1661-buffer-encodings-full.ts
@@ -61,3 +61,23 @@ const names = ["utf8", "UTF8", "utf-8", "ascii", "latin1", "binary", "base64", "
 for (const n of names) {
   console.log(n, Buffer.isEncoding(n));
 }
+
+// A BufferEncoding variable dispatches at runtime (including aliases and
+// range forms); casts can expose Node's case-insensitive spellings and its
+// catchable ERR_UNKNOWN_ENCODING path.
+const variableEncodings: BufferEncoding[] = ["hex", "base64url", "binary", "ucs-2", "utf-8"];
+for (const encoding of variableEncodings) {
+  console.log("variable", encoding, raw.toString(encoding));
+}
+const runtimeRangeEncoding: BufferEncoding = "hex";
+console.log("variable tail", raw.toString(runtimeRangeEncoding, 2));
+console.log("variable range", raw.toString(runtimeRangeEncoding, 1, 4));
+console.log("variable upper", raw.toString("BASE64" as BufferEncoding));
+try {
+  raw.toString("wat" as BufferEncoding);
+  console.log("variable bad did not throw");
+} catch (e) {
+  if (e instanceof TypeError) {
+    console.log("variable bad", (e as NodeJS.ErrnoException).code, e.message);
+  }
+}

--- a/tests/corpus/1661-buffer-encodings-full.ts
+++ b/tests/corpus/1661-buffer-encodings-full.ts
@@ -119,3 +119,11 @@ for (const encoding of unusualBadEncodings) {
     }
   }
 }
+
+// Node selects the byte window before resolving a runtime encoding. An
+// empty buffer or a range that clamps to empty therefore returns "" even
+// when the encoding name is unknown.
+const emptyBadEncoding = "wat-empty" as BufferEncoding;
+console.log("variable bad empty buffer", JSON.stringify(Buffer.alloc(0).toString(emptyBadEncoding)));
+console.log("variable bad empty tail", JSON.stringify(raw.toString(emptyBadEncoding, raw.length)));
+console.log("variable bad empty range", JSON.stringify(raw.toString(emptyBadEncoding, 2, 2)));

--- a/tests/corpus/1661-buffer-encodings-full.ts
+++ b/tests/corpus/1661-buffer-encodings-full.ts
@@ -69,9 +69,14 @@ const variableEncodings: BufferEncoding[] = ["hex", "base64url", "binary", "ucs-
 for (const encoding of variableEncodings) {
   console.log("variable", encoding, raw.toString(encoding));
 }
-const runtimeRangeEncoding: BufferEncoding = "hex";
-console.log("variable tail", raw.toString(runtimeRangeEncoding, 2));
-console.log("variable range", raw.toString(runtimeRangeEncoding, 1, 4));
+function variableTail(encoding: BufferEncoding): string {
+  return raw.toString(encoding, 2);
+}
+function variableRange(encoding: BufferEncoding): string {
+  return raw.toString(encoding, 1, 4);
+}
+console.log("variable tail", variableTail("hex"));
+console.log("variable range", variableRange("hex"));
 console.log("variable upper", raw.toString("BASE64" as BufferEncoding));
 try {
   raw.toString("wat" as BufferEncoding);
@@ -81,6 +86,23 @@ try {
     console.log("variable bad", (e as NodeJS.ErrnoException).code, e.message);
   }
 }
+try {
+  variableRange("wat-range" as BufferEncoding);
+  console.log("variable bad range did not throw");
+} catch (e) {
+  if (e instanceof TypeError) {
+    console.log("variable bad range", (e as NodeJS.ErrnoException).code, e.message);
+  }
+}
+
+// Forwarding an optional encoding preserves Buffer.toString(undefined)'s
+// utf8 default instead of treating the absent arm as a failed string cast.
+function optionalEncoding(encoding?: BufferEncoding): string {
+  return raw.toString(encoding);
+}
+console.log("variable optional present", optionalEncoding("hex"));
+console.log("variable optional absent", optionalEncoding());
+console.log("variable explicit undefined", raw.toString(undefined));
 
 // Unknown-encoding messages preserve the complete runtime string,
 // including long values and embedded NULs.

--- a/tests/diagnostics/node-fallback-fence.ts
+++ b/tests/diagnostics/node-fallback-fence.ts
@@ -25,8 +25,8 @@ const errTty = process.stderr.isTTY;
 import { accessSync, constants, mkdtempSync, readFileSync } from "node:fs";
 accessSync("/bin/sh", constants.X_OK);
 const tmp = mkdtempSync("/tmp/scr-");
-const raw = readFileSync("/etc/hosts").toString(tty ? "hex" : "latin1"); // the read and every literal encoding lower; a non-literal fences
-// The computed encoding remains fenced above.
+const raw = readFileSync("/etc/hosts").toString(tty ? "hex" : "latin1"); // runtime BufferEncoding selection lowers too
+// The computed encoding is now part of the static Buffer surface.
 import { deflateSync, gzipSync } from "node:zlib";
 const packed = deflateSync("data"); // string data: the wrap-it-first hint
 const zipped = gzipSync("data"); // beyond the lowered pair: fenced

--- a/tests/harness/__snapshots__/node-fallback-fence.ts.txt
+++ b/tests/harness/__snapshots__/node-fallback-fence.ts.txt
@@ -16,15 +16,6 @@ node-fallback-fence.ts:17:13 - error SC2020: 'Buffer<ArrayBufferLike>.reverse' i
 
   hint: the type checker sees the full standard library, but only the supported surface compiles (https://scriptc.dev/limitations)
 
-node-fallback-fence.ts:28:49 - error SC2020: 'Buffer.toString with this encoding' is part of the standard library types but has no scriptc lowering yet
-
-  27 | const tmp = mkdtempSync("/tmp/scr-");
-  28 | const raw = readFileSync("/etc/hosts").toString(tty ? "hex" : "latin1"); // the read and every literal encoding lower; a non-literal fences
-     |                                                 ^~~~~~~~~~~~~~~~~~~~~~
-  29 | // The computed encoding remains fenced above.
-
-  hint: a literal "utf8", "hex", "base64", "base64url", "latin1", "binary", "ascii", "utf16le", or "ucs2" spelling is the lowered encoding surface
-
 node-fallback-fence.ts:31:28 - error SC2020: 'deflateSync of 'string' data' is part of the standard library types but has no scriptc lowering yet
 
   30 | import { deflateSync, gzipSync } from "node:zlib";


### PR DESCRIPTION
- Lower runtime-valued BufferEncoding arguments through checked C and LLVM paths.
- Normalize aliases and casing while preserving Node unknown-encoding errors.
- Add differential coverage and remove the obsolete diagnostic fence.