### PR TITLE
feat(string): support static split limits

### DIFF
--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -1178,7 +1178,10 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           case "trimEnd":
             return E.newTemp(e.type, `scr_str_trim_end(${r.name})`);
           case "split":
-            return E.newTemp(e.type, `scr_str_split(${r.name}, ${args[0]!.name})`);
+            return E.newTemp(
+              e.type,
+              `scr_str_split_limit(${r.name}, ${args[0]!.name}, ${args[1]!.name})`,
+            );
           case "padStart":
             return E.newTemp(
               e.type,
@@ -1294,7 +1297,10 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
               `scr_regex_replace_all(${r.name}, ${args[0]!.name}, ${args[1]!.name})`,
             );
           case "split":
-            return E.fallibleTemp(e.type, `scr_regex_split(${r.name}, ${args[0]!.name})`);
+            return E.fallibleTemp(
+              e.type,
+              `scr_regex_split_limit(${r.name}, ${args[0]!.name}, ${args[1]!.name})`,
+            );
           default: {
             const _exhaustive: never = method;
             void _exhaustive;

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -8875,7 +8875,13 @@ class LlEmitter {
       case "trimEnd":
         return call("scr_str_trim_end", "ptr (ptr)", `ptr ${r.name}`, "ptr", true);
       case "split":
-        return call("scr_str_split", "ptr (ptr, ptr)", `ptr ${r.name}, ptr ${args[0]!.name}`, "ptr", true);
+        return call(
+          "scr_str_split_limit",
+          "ptr (ptr, ptr, double)",
+          `ptr ${r.name}, ptr ${args[0]!.name}, double ${args[1]!.name}`,
+          "ptr",
+          true,
+        );
       case "padStart":
         return call(
           "scr_str_pad_start",
@@ -10059,7 +10065,16 @@ class LlEmitter {
       case "replaceAll":
         return fallible("scr_regex_replace_all", `ptr ${r.name}, ptr ${args[0]!.name}, ptr ${args[1]!.name}`);
       case "split":
-        return fallible("scr_regex_split", `ptr ${r.name}, ptr ${args[0]!.name}`);
+        this.declare(`declare ptr @scr_regex_split_limit(ptr, ptr, double)`);
+        {
+          const t = B.tmp();
+          B.line(
+            `${t} = call ptr @scr_regex_split_limit(ptr ${r.name}, ptr ${args[0]!.name}, double ${args[1]!.name})`,
+          );
+          const out = this.own({ name: t, type: e.type });
+          this.emitPendingCheck();
+          return out;
+        }
       case "test": {
         this.declare(`declare zeroext i1 @scr_regex_test(ptr, ptr)`);
         const t = B.tmp();

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -81,9 +81,24 @@ function lowerOptionalDefaultArg(
   defaultValue: IrExpr,
 ): IrExpr {
   const undefinedArg = lowerStaticallyUndefinedArg(L, node);
-  return undefinedArg
-    ? defaultAfterUndefined(undefinedArg, defaultValue)
-    : L.lowerExprExpecting(node, expected);
+  if (undefinedArg) return defaultAfterUndefined(undefinedArg, defaultValue);
+  const value = L.lowerExpr(node);
+  if (value.type.kind === "union") {
+    const def = L.unions.get(value.type.unionId);
+    if (
+      def?.arms.length === 2 &&
+      def.arms.some((arm) => arm.kind === "undefinedT") &&
+      def.arms.some((arm) => typeEquals(arm, expected))
+    ) {
+      return { kind: "nullish", left: value, right: defaultValue, type: expected, loc: value.loc };
+    }
+  }
+  return L.coerceInto(node, value, expected);
+}
+
+function lowerSplitLimitArg(L: Lowerer, node: ts.Expression | undefined, loc: SrcLoc): IrExpr {
+  const defaultValue: IrExpr = { kind: "numLit", value: 4294967295, type: F64, loc };
+  return node ? lowerOptionalDefaultArg(L, node, F64, defaultValue) : defaultValue;
 }
 
 /** Ambient array method calls. `push`/`unshift`/`pop`/`reverse`/
@@ -4998,12 +5013,12 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       const arg0 = call.arguments[0];
       if (!arg0 || L.mapTypeOf(L.typeOf(arg0))?.kind !== "regex") return null;
       const receiver = lowerReceiver();
-      const args = call.arguments.map((a) => L.lowerExpr(a));
-      // Split's omitted limit is 2^32-1. Complete it here so both IR
-      // backends and the runtime have one required (regex, limit) shape.
-      if (name === "split" && args.length === 1) {
-        args.push({ kind: "numLit", value: 4294967295, type: F64, loc });
-      }
+      // Split's omitted or undefined limit is 2^32-1. Complete it here so
+      // both IR backends and the runtime have one required (regex, limit)
+      // shape; an optional-number value selects the default at runtime.
+      const args = name === "split"
+        ? [L.lowerExpr(arg0), lowerSplitLimitArg(L, call.arguments[1], loc)]
+        : call.arguments.map((a) => L.lowerExpr(a));
       if (name !== "split" && args[1]?.type.kind !== "string") {
         L.unsupported(
           "SC1120",
@@ -5060,7 +5075,9 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       );
     }
     const receiver = dynReceiver ? dynReceiver() : L.lowerExpr(access.expression);
-    const args = call.arguments.map((a) => L.lowerExpr(a));
+    const args = entry.method === "split"
+      ? [L.lowerExpr(call.arguments[0]!), lowerSplitLimitArg(L, call.arguments[1], locOf(call))]
+      : call.arguments.map((a) => L.lowerExpr(a));
     // split's separator must BE a string here (a regex argument was
     // claimed by lowerRegexMethodCall before this path) — the lib's
     // `string | RegExp` union has no lowering as a VALUE.
@@ -5070,11 +5087,6 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
         call.arguments[0]!,
         `'.split()' on a '${L.fmt(args[0]!.type)}' separator (pass a string, or a regex literal)`,
       );
-    }
-    // Split's omitted limit is 2^32-1 (the default after ToUint32).
-    // Complete it just like pad's default fill so the IR has one shape.
-    if (entry.method === "split" && args.length === 1) {
-      args.push({ kind: "numLit", value: 4294967295, type: F64, loc: locOf(call) });
     }
     // padStart/padEnd with the fill omitted: Node pads with " " — the
     // same call with the default made explicit.

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -4997,14 +4997,13 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     ) {
       const arg0 = call.arguments[0];
       if (!arg0 || L.mapTypeOf(L.typeOf(arg0))?.kind !== "regex") return null;
-      // The lib declares forms beyond the lowered slice: split's limit
-      // parameter and function replacement values both typecheck now —
-      // fenced with the regex-surface code (its hint lists what works).
-      if (name === "split" && call.arguments.length !== 1) {
-        L.unsupported("SC1120", call, "'.split()' with a limit argument");
-      }
       const receiver = lowerReceiver();
       const args = call.arguments.map((a) => L.lowerExpr(a));
+      // Split's omitted limit is 2^32-1. Complete it here so both IR
+      // backends and the runtime have one required (regex, limit) shape.
+      if (name === "split" && args.length === 1) {
+        args.push({ kind: "numLit", value: 4294967295, type: F64, loc });
+      }
       if (name !== "split" && args[1]?.type.kind !== "string") {
         L.unsupported(
           "SC1120",
@@ -5071,6 +5070,11 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
         call.arguments[0]!,
         `'.split()' on a '${L.fmt(args[0]!.type)}' separator (pass a string, or a regex literal)`,
       );
+    }
+    // Split's omitted limit is 2^32-1 (the default after ToUint32).
+    // Complete it just like pad's default fill so the IR has one shape.
+    if (entry.method === "split" && args.length === 1) {
+      args.push({ kind: "numLit", value: 4294967295, type: F64, loc: locOf(call) });
     }
     // padStart/padEnd with the fill omitted: Node pads with " " — the
     // same call with the default made explicit.

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -366,12 +366,13 @@ export const STR_METHODS: Record<
   // deprecated twins — same behavior, per spec).
   trimLeft: { method: "trimStart", result: STRING, minArgs: 0, maxArgs: 0 },
   trimRight: { method: "trimEnd", result: STRING, minArgs: 0, maxArgs: 0 },
-  // The STRING-separator split, no limit (the lib's limit parameter
-  // fences by arity here; regex separators lowered earlier as
-  // regexIntrinsic). Empty separator splits per UTF-16 code unit —
+  // The STRING-separator split (regex separators lower earlier as a
+  // regexIntrinsic). The optional limit is completed to 2^32-1 by the
+  // lowering so the IR/runtime always see the spec's effective value.
+  // Empty separator splits per UTF-16 code unit —
   // astral halves become U+FFFD (SEMANTICS.md divergence 2, the same
   // substitution the island's boundary marshal applied).
-  split: { method: "split", result: arrayOf(STRING), minArgs: 1, maxArgs: 1 },
+  split: { method: "split", result: arrayOf(STRING), minArgs: 1, maxArgs: 2 },
   // padStart/padEnd with the fill omitted: Node pads with " " — the
   // lowering completes the default (lowerStringMethodCall).
   padStart: { method: "padStart", result: STRING, minArgs: 1, maxArgs: 2 },

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -1367,7 +1367,8 @@ export type IrSetIntrinsicMethod =
  * Conversion via libunicode's tables — scr_regex.c): their presence sets
  * the regex LINK flag like a regex literal does (moduleUsesRegex).
  * `split` is the STRING-separator form (regex separators are
- * regexIntrinsic), no limit: args[0] the separator, result a fresh +1
+ * regexIntrinsic): args[0] is the separator and args[1] the numeric limit
+ * (an omitted source limit is completed to 2^32-1), result a fresh +1
  * string[] — the empty separator splits per UTF-16 code unit (astral
  * halves become U+FFFD, divergence 2). `padStart`/`padEnd` take (target
  * length, fill) — the frontend completes an omitted fill to " ", Node's
@@ -1574,7 +1575,8 @@ export const MAY_THROW_BYTES_METHODS: ReadonlySet<IrBytesIntrinsicMethod> = new 
  * regex and (for the replaces) args[1] the replacement template — string
  * replacements only, function replacements are checker-rejected (the
  * ambient overloads accept only strings). `replaceAll` THROWS Node's
- * TypeError when the regex lacks /g and `split` THROWS on a pattern with
+ * TypeError when the regex lacks /g. For `split`, args[1] is the numeric
+ * limit (an omitted source limit is completed to 2^32-1); it THROWS on a pattern with
  * capture groups (JS would splice the captured values into the result) —
  * both catchable: backends' may-throw analyses must seed on these two
  * methods like a `throw`. */

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -42,7 +42,7 @@ export const STR_INTRINSIC_SIGS: Record<
   trim: { argTypes: [], minArgs: 0, result: STRING },
   trimStart: { argTypes: [], minArgs: 0, result: STRING },
   trimEnd: { argTypes: [], minArgs: 0, result: STRING },
-  split: { argTypes: [STRING], minArgs: 1, result: arrayOf(STRING) },
+  split: { argTypes: [STRING, F64], minArgs: 2, result: arrayOf(STRING) },
   padStart: { argTypes: [F64, STRING], minArgs: 2, result: STRING },
   padEnd: { argTypes: [F64, STRING], minArgs: 2, result: STRING },
   toLowerCase: { argTypes: [], minArgs: 0, result: STRING },
@@ -72,7 +72,7 @@ export const REGEX_INTRINSIC_SIGS: Record<
   flags: { receiver: REGEX, argTypes: [], result: STRING },
   replace: { receiver: STRING, argTypes: [REGEX, STRING], result: STRING },
   replaceAll: { receiver: STRING, argTypes: [REGEX, STRING], result: STRING },
-  split: { receiver: STRING, argTypes: [REGEX], result: arrayOf(STRING) },
+  split: { receiver: STRING, argTypes: [REGEX, F64], result: arrayOf(STRING) },
 };
 
 /** Closed-union signature table for `libCall` (mirrors ambient/scriptc.d.ts).

--- a/packages/compiler/surface-manifest.json
+++ b/packages/compiler/surface-manifest.json
@@ -3459,7 +3459,7 @@
       "kind": "stdlib",
       "name": "string.prototype.split",
       "status": "static",
-      "note": "the lowered call form takes exactly 1 argument"
+      "note": "the lowered call form takes 1 to 2 arguments"
     },
     {
       "id": "stdlib.string.startsWith",

--- a/packages/runtime/src/scr_lib.c
+++ b/packages/runtime/src/scr_lib.c
@@ -3590,10 +3590,6 @@ ScrStr *scr_crypto_x509_valid_to_str(ScrStr *pem) {
 
 /* ── String surface (fromCharCode / lastIndexOf) ─────────────────────── */
 
-/* Forward declaration — scr_to_uint32 lives with the bitwise operators
- * below (ToUint16 is its low 16 bits, per spec). */
-static uint32_t scr_to_uint32(double d);
-
 /* String.fromCharCode core over n UTF-16 code units read through
  * `unit(src, i)` (already ToUint16'd): combine adjacent surrogate pairs,
  * substitute U+FFFD for lone surrogates (divergence 1's storage policy —
@@ -4406,14 +4402,6 @@ bool scr_num_is_safe_integer(double x) {
  * as two's complement, spelled portably (no implementation-defined
  * narrowing casts, no UB shifts of signed values).
  */
-
-static uint32_t scr_to_uint32(double d) {
-  if (!isfinite(d)) return 0; /* NaN, +Infinity, -Infinity */
-  double t = trunc(d);
-  t = fmod(t, 4294967296.0); /* exact for doubles; result in (-2^32, 2^32) */
-  if (t < 0) t += 4294967296.0;
-  return (uint32_t)t;
-}
 
 /* The 32 bits as a SIGNED (Int32) JS number. */
 static double scr_bits_as_int32(uint32_t u) {

--- a/packages/runtime/src/scr_number.c
+++ b/packages/runtime/src/scr_number.c
@@ -24,6 +24,15 @@
  * unchanged. Provides d2d(), d2d_small_int(), decimalLength17(), div10(). */
 #include "../vendor/ryu/d2s.c"
 
+/* ECMA ToUint32, shared by bitwise operators and split's limit: non-finite
+ * values become zero, finite values truncate toward zero and wrap mod 2^32. */
+uint32_t scr_to_uint32(double d) {
+  if (!isfinite(d)) return 0;
+  double t = fmod(trunc(d), 4294967296.0);
+  if (t < 0) t += 4294967296.0;
+  return (uint32_t)t;
+}
+
 /* The Ryū digit core, shared by the ECMA placement below and the Intl
  * en-US number formatter (scr_lib.c): the shortest round-tripping digit
  * string for a positive finite double — value = 0.digits × 10^n with no

--- a/packages/runtime/src/scr_regex.c
+++ b/packages/runtime/src/scr_regex.c
@@ -624,8 +624,10 @@ ScrStr *scr_regex_replace_all(ScrStr *s, ScrRegex *re, ScrStr *rep) {
 
 /* ── split ────────────────────────────────────────────────────────────── */
 
-ScrArr *scr_regex_split(ScrStr *s, ScrRegex *re) {
+ScrArr *scr_regex_split_limit(ScrStr *s, ScrRegex *re, double limit_num) {
   uint8_t *bc = scr_regex_bc(re);
+  uint32_t limit = scr_to_uint32(limit_num);
+  if (limit == 0) return scr_arr_new(SCR_ELEM_STR, 0);
   if (lre_get_capture_count(bc) > 1) {
     /* JS splices every capture group's value into the result between the
      * pieces, changing the array's SHAPE per match — not modeled this
@@ -675,6 +677,11 @@ ScrArr *scr_regex_split(ScrStr *s, ScrRegex *re) {
       q = scr_advance(u, len, start, unicode);
     } else {
       scr_arr_push_ref(out, scr_str_from_utf16(u, p, start));
+      if (out->len == limit) {
+        free(capture);
+        free(u);
+        return out;
+      }
       p = end;
       q = p;
     }
@@ -683,6 +690,10 @@ ScrArr *scr_regex_split(ScrStr *s, ScrRegex *re) {
   free(capture);
   free(u);
   return out;
+}
+
+ScrArr *scr_regex_split(ScrStr *s, ScrRegex *re) {
+  return scr_regex_split_limit(s, re, 4294967295.0);
 }
 
 /* ── String.prototype.toLowerCase / toUpperCase (the static path) ──────

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -612,12 +612,14 @@ ScrStr *scr_str_cp_at(ScrStr *s, double i);
 ScrStr *scr_str_trim_start(ScrStr *s);
 ScrStr *scr_str_trim_end(ScrStr *s);
 
-/* split(separator) with a STRING separator, no limit: empty separator
+/* split(separator[, limit]) with a STRING separator: limit uses ToUint32;
+ * the no-limit wrapper supplies 2^32-1. Empty separator
  * splits into single UTF-16 code units (each half of an astral char is
  * U+FFFD — divergence, see above); otherwise splits on every occurrence,
  * empty pieces kept. Borrows both; returns a +1 string[] (SCR_ELEM_STR). */
 struct ScrArr;
 struct ScrArr *scr_str_split(ScrStr *s, ScrStr *sep);
+struct ScrArr *scr_str_split_limit(ScrStr *s, ScrStr *sep, double limit);
 
 /* padStart(maxLength, fill)/padEnd — ECMA StringPad, UTF-16 unit counts.
  * Target at or below the length (or empty fill) returns the receiver
@@ -998,8 +1000,10 @@ ScrStr *scr_regex_flags(ScrRegex *re);        /* +1 */
 ScrStr *scr_regex_replace(ScrStr *s, ScrRegex *re, ScrStr *rep);
 /* replaceAll: throws Node's TypeError when /g is missing (may-throw). */
 ScrStr *scr_regex_replace_all(ScrStr *s, ScrRegex *re, ScrStr *rep);
-/* split: capture-free patterns only — capture groups throw (may-throw). */
+/* split: capture-free patterns only — capture groups throw (may-throw).
+ * limit uses ToUint32; the no-limit wrapper supplies 2^32-1. */
 ScrArr *scr_regex_split(ScrStr *s, ScrRegex *re);
+ScrArr *scr_regex_split_limit(ScrStr *s, ScrRegex *re, double limit);
 /* matchAll drained eagerly: +1 string[][] of honest match slices; throws
  * Node's TypeError on a non-global regex (catchable). */
 ScrArr *scr_regex_match_all(ScrStr *s, ScrRegex *re);
@@ -4533,12 +4537,14 @@ double scr_date_get_minutes_utc(double ms);
 double scr_date_get_seconds_local(double ms);
 double scr_date_get_seconds_utc(double ms);
 
-/* ── bitwise operators (scr_lib.c) ────────────────────────────────────
+/* ── numeric coercion + bitwise operators ─────────────────────────────
  * JS-exact ToInt32/ToUint32 semantics: NaN/±Infinity → 0, truncation
  * toward zero, modular wrap into 32 bits; the operation runs in 32-bit
  * space (shift counts mask to 5 bits, `>>` is an arithmetic shift spelled
  * portably — no C UB/implementation-defined shifts) and the result
- * returns to f64: `>>>` as Uint32, everything else as Int32. */
+ * returns to f64: `>>>` as Uint32, everything else as Int32.
+ * scr_to_uint32 lives in scr_number.c; the bitwise operations in scr_lib.c. */
+uint32_t scr_to_uint32(double d);
 double scr_bit_and(double a, double b);
 double scr_bit_or(double a, double b);
 double scr_bit_xor(double a, double b);

--- a/packages/runtime/src/scr_string.c
+++ b/packages/runtime/src/scr_string.c
@@ -678,7 +678,9 @@ ScrStr *scr_str_trim_end(ScrStr *s) {
 static const struct { size_t rc; size_t len; size_t cap; char data[4]; }
     scr_lit_fffd = {SIZE_MAX, 3, 3, "\xEF\xBF\xBD"};
 
-/* split(separator) with a STRING separator, no limit (ECMA-262 22.1.3.23):
+/* split(separator, limit) with a STRING separator (ECMA-262 22.1.3.23):
+ * limit is ToUint32'd; zero returns [] and reaching the limit stops before
+ * any later separator probes. The no-limit wrapper supplies 2^32-1.
  * an empty separator splits into single UTF-16 code units ("".split("") is
  * [] — no probe matches nothing); a non-empty separator splits on every
  * byte-level occurrence (well-formed UTF-8 is self-synchronizing, so byte
@@ -688,8 +690,10 @@ static const struct { size_t rc; size_t len; size_t cap; char data[4]; }
  * yield the two lone surrogate halves, each half is U+FFFD here
  * (divergence 2 — the same substitution the island's boundary marshal
  * applied). Borrows both; returns a +1 string[]. */
-ScrArr *scr_str_split(ScrStr *s, ScrStr *sep) {
+ScrArr *scr_str_split_limit(ScrStr *s, ScrStr *sep, double limit_num) {
   ScrArr *out = scr_arr_new(SCR_ELEM_STR, 0);
+  uint32_t limit = scr_to_uint32(limit_num);
+  if (limit == 0) return out;
   if (sep->len == 0) {
     size_t i = 0;
     while (i < s->len) {
@@ -697,10 +701,12 @@ ScrArr *scr_str_split(ScrStr *s, ScrStr *sep) {
       uint32_t cp = scr_utf8_decode(s->data + i, &adv);
       if (cp >= 0x10000) { /* two units in JS: both halves become U+FFFD */
         scr_arr_push_ref(out, scr_str_retain((ScrStr *)&scr_lit_fffd));
+        if (out->len == limit) return out;
         scr_arr_push_ref(out, scr_str_retain((ScrStr *)&scr_lit_fffd));
       } else {
         scr_arr_push_ref(out, scr_str_from_span(s->data + i, adv));
       }
+      if (out->len == limit) return out;
       i += adv;
     }
     return out;
@@ -712,10 +718,15 @@ ScrArr *scr_str_split(ScrStr *s, ScrStr *sep) {
     if (!found) break;
     size_t at = (size_t)(found - s->data);
     scr_arr_push_ref(out, scr_str_from_span(s->data + start, at - start));
+    if (out->len == limit) return out;
     start = at + sep->len;
   }
   scr_arr_push_ref(out, scr_str_from_span(s->data + start, s->len - start));
   return out;
+}
+
+ScrArr *scr_str_split(ScrStr *s, ScrStr *sep) {
+  return scr_str_split_limit(s, sep, 4294967295.0);
 }
 
 /* StringPad (ECMA-262 22.1.3.16/17): target length in UTF-16 units, the

--- a/tests/corpus/1203-regex-split.ts
+++ b/tests/corpus/1203-regex-split.ts
@@ -39,3 +39,9 @@ console.log(show("a1b2c3".split(/\d/, 1)), show("a1b2c3".split(/\d/, 3)));
 console.log(show("abc".split(/(?:)/, 2)));
 console.log(show("a1b2c3".split(/\d/, 4294967298)));
 console.log(show("a1b2c3".split(/\d/, -1)));
+
+function optionalLimit(limit?: number): string {
+  return show("a1b2c3".split(/\d/, limit));
+}
+console.log(show("a1b2c3".split(/\d/, undefined)));
+console.log(optionalLimit(), optionalLimit(undefined), optionalLimit(2));

--- a/tests/corpus/1203-regex-split.ts
+++ b/tests/corpus/1203-regex-split.ts
@@ -32,3 +32,10 @@ console.log(show("a1b2c".split(/\d/g)));
 const csv = "name;age;city";
 const cols = csv.split(/;/);
 console.log(show(cols), cols[1].replace(/a/, "A"));
+
+// The optional limit shares split's ToUint32 rules with string separators.
+console.log(show("a1b2c3".split(/\d/, 0)));
+console.log(show("a1b2c3".split(/\d/, 1)), show("a1b2c3".split(/\d/, 3)));
+console.log(show("abc".split(/(?:)/, 2)));
+console.log(show("a1b2c3".split(/\d/, 4294967298)));
+console.log(show("a1b2c3".split(/\d/, -1)));

--- a/tests/corpus/1520-string-split-static.ts
+++ b/tests/corpus/1520-string-split-static.ts
@@ -32,3 +32,16 @@ console.log(limited("a,b,,c,", ",", 99), limited("a,b,,c,", ",", -1));
 console.log(limited("a,b,,c,", ",", 2.9), limited("a,b,,c,", ",", 4294967298));
 console.log(limited("a,b,,c,", ",", 4294967296), limited("a,b,,c,", ",", NaN));
 console.log(limited("abcd", "", 2), limited("", ",", 1));
+
+// Explicit and forwarded undefined are omission, with effects preserved.
+let limitEffects = 0;
+function undefinedLimit(): undefined {
+  limitEffects++;
+  return undefined;
+}
+function optionalLimit(limit?: number): string {
+  return JSON.stringify("a,b,c".split(",", limit));
+}
+console.log(JSON.stringify("a,b,c".split(",", undefined)));
+console.log(JSON.stringify("a,b,c".split(",", undefinedLimit())), limitEffects);
+console.log(optionalLimit(), optionalLimit(undefined), optionalLimit(2));

--- a/tests/corpus/1520-string-split-static.ts
+++ b/tests/corpus/1520-string-split-static.ts
@@ -21,3 +21,14 @@ const words = "one two  three".split(" ");
 console.log(words.length, words.indexOf("three"), words.includes("two"));
 const nums = "1,2,3,4".split(",").map((s) => parseInt(s, 10) * 2);
 console.log(nums.join(","));
+
+// The optional limit is ToUint32'd, and truncation happens before wrap.
+function limited(text: string, separator: string, limit: number): string {
+  return JSON.stringify(text.split(separator, limit));
+}
+console.log(limited("a,b,,c,", ",", 0));
+console.log(limited("a,b,,c,", ",", 1), limited("a,b,,c,", ",", 3));
+console.log(limited("a,b,,c,", ",", 99), limited("a,b,,c,", ",", -1));
+console.log(limited("a,b,,c,", ",", 2.9), limited("a,b,,c,", ",", 4294967298));
+console.log(limited("a,b,,c,", ",", 4294967296), limited("a,b,,c,", ",", NaN));
+console.log(limited("abcd", "", 2), limited("", ",", 1));

--- a/tests/diagnostics/stdlib-fence.ts
+++ b/tests/diagnostics/stdlib-fence.ts
@@ -41,7 +41,7 @@ const clamped = Math.min(1, ...[2, 3]);
 const entries = [1, 2].entries();
 const arrAt = [1, 2].at(0);
 const norm = "abc".normalize();
-const limited = "a,b,c".split(",", 2); // the string-separator split lowers; the limit form stays fenced
+const limited = "a,b,c".split(Math.random() ? "," : /,/, 2); // union separators stay fenced; limits lower
 const fixed = (1.5).toFixed(); // digit-free toFixed lowers now (the static ties-up integer)
 const localized = (1234.5).toLocaleString();
 // Unlowered call FORMS of lowered members. (push is fully variadic now —

--- a/tests/harness/__snapshots__/stdlib-fence.ts.txt
+++ b/tests/harness/__snapshots__/stdlib-fence.ts.txt
@@ -204,18 +204,16 @@ stdlib-fence.ts:43:14 - error SC2020: 'string.normalize' is part of the standard
   42 | const arrAt = [1, 2].at(0);
   43 | const norm = "abc".normalize();
      |              ^~~~~~~~~~~~~~~
-  44 | const limited = "a,b,c".split(",", 2); // the string-separator split lowers; the limit form stays fenced
+  44 | const limited = "a,b,c".split(Math.random() ? "," : /,/, 2); // union separators stay fenced; limits lower
 
   hint: the type checker sees the full standard library, but only the supported surface compiles (https://scriptc.dev/limitations)
 
-stdlib-fence.ts:44:17 - error SC2020: '.split with 2 arguments on strings' is part of the standard library types but has no scriptc lowering yet
+stdlib-fence.ts:44:31 - error SC1090: '.split()' on a 'RegExp | string' separator (pass a string, or a regex literal) is not supported yet
 
   43 | const norm = "abc".normalize();
-  44 | const limited = "a,b,c".split(",", 2); // the string-separator split lowers; the limit form stays fenced
-     |                 ^~~~~~~~~~~~~~~~~~~~~
+  44 | const limited = "a,b,c".split(Math.random() ? "," : /,/, 2); // union separators stay fenced; limits lower
+     |                               ^~~~~~~~~~~~~~~~~~~~~~~~~
   45 | const fixed = (1.5).toFixed(); // digit-free toFixed lowers now (the static ties-up integer)
-
-  hint: the type checker sees the full standard library, but only the supported surface compiles (https://scriptc.dev/limitations)
 
 stdlib-fence.ts:46:19 - error SC2020: 'Number.prototype.toLocaleString without a locale' is part of the standard library types but has no scriptc lowering yet
 


### PR DESCRIPTION
- Lower split limits for string and literal RegExp separators across C and LLVM.
- Match JavaScript ToUint32 limit semantics in the runtime.
- Add differential coverage and refresh diagnostics and surface metadata.