### PR TITLE
feat(fs): support three-argument writeFile

### DIFF
--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -1130,7 +1130,12 @@ declare module "fs/promises" {
   export function open(path: string, flags?: string, mode?: number): Promise<FileHandle>;
   export function readFile(path: string, encoding: "utf8" | "utf-8"): Promise<string>;
   export function readFile(path: string): Promise<Buffer>;
-  export function writeFile(path: string, data: string): Promise<void>;
+  export function writeFile(
+    path: string,
+    data: string,
+    options?: { mode?: number; encoding?: "utf8" | "utf-8"; flag?: string; [option: string]: unknown },
+  ): Promise<void>;
+  export function writeFile(path: string, data: string, encoding: "utf8" | "utf-8"): Promise<void>;
   export function mkdir(path: string, options?: { recursive?: boolean; mode?: number }): Promise<void>;
   export function readdir(path: string): Promise<string[]>;
   export function rm(path: string): Promise<void>;

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -5519,6 +5519,8 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             return finish(`scr_fsp_read_file(${arg(0)})`);
           case "fsp.writeFile":
             return finish(`scr_fsp_write_file(${arg(0)}, ${arg(1)})`);
+          case "fsp.writeFileMode":
+            return finish(`scr_fsp_write_file_mode(${arg(0)}, ${arg(1)}, ${arg(2)})`);
           case "fsp.mkdir":
             return finish(`scr_fsp_mkdir(${arg(0)})`);
           case "fsp.mkdirMode":

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -496,6 +496,7 @@ const LIB_FN_SYMS: Record<string, string> = {
   // so it is special-cased in emitLibCall (the fs.readFileSync pattern).
   "fsp.readFileBytes": "scr_fsp_read_file_bytes",
   "fsp.writeFile": "scr_fsp_write_file",
+  "fsp.writeFileMode": "scr_fsp_write_file_mode",
   "fsp.mkdir": "scr_fsp_mkdir",
   "fsp.mkdirMode": "scr_fsp_mkdir_mode",
   "fsp.mkdirRecursive": "scr_fsp_mkdir_recursive",

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -1543,14 +1543,21 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         return { kind: "libCall", fn: "fs.writeFileSyncBytes", args: [path, data], type: VOID, loc };
       }
     }
-    // writeFileSync(p, data, options): the lowered options are a literal
+    // writeFileSync(p, data, options) / fs.promises.writeFile(p, data,
+    // options): the lowered options are a literal
     // `{ mode?: <number>, encoding?: "utf8" }` — the mode is open(2)'s
     // O_CREAT argument (creation only; an existing file keeps its
     // permissions, exactly Node), and the encoding may only spell the
-    // utf8 the runtime writes anyway. String data only — the Buffer form
-    // never carries options in the supported corpus.
-    if (bi.module === "fs" && bi.member === "writeFileSync" && expr.arguments.length === 3) {
+    // utf8 the runtime writes anyway. String data only — Buffer options
+    // remain outside the static surface.
+    const syncWriteOptions = bi.module === "fs" && bi.member === "writeFileSync";
+    const promiseWriteOptions = bi.module === "fs/promises" && bi.member === "writeFile";
+    if ((syncWriteOptions || promiseWriteOptions) && expr.arguments.length === 3) {
       const optsNode = expr.arguments[2]!;
+      const operation = promiseWriteOptions ? "fs.promises.writeFile" : "writeFileSync";
+      const plainFn: IrLibFn = promiseWriteOptions ? "fsp.writeFile" : "fs.writeFileSync";
+      const modeFn: IrLibFn = promiseWriteOptions ? "fsp.writeFileMode" : "fs.writeFileModeSync";
+      const resultType: IrType = promiseWriteOptions ? { kind: "promise", inner: VOID } : VOID;
       // The bare-encoding spelling — writeFileSync(p, data, "utf-8") — is
       // the options record's encoding key alone: utf8 is what the runtime
       // writes anyway, so string data takes the plain write. Any OTHER
@@ -1563,7 +1570,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         ) {
           const path = L.lowerExprExpecting(expr.arguments[0]!, STRING);
           const data = L.lowerExprExpecting(expr.arguments[1]!, STRING);
-          return { kind: "libCall", fn: "fs.writeFileSync", args: [path, data], type: VOID, loc };
+          return { kind: "libCall", fn: plainFn, args: [path, data], type: resultType, loc };
         }
       }
       let modeNode: ts.Expression | null = null;
@@ -1581,15 +1588,15 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
             // Documented, behavior-changing (open(2)'s disposition — 'a'
             // IS appendFileSync), no lowering: fence by name.
             L.noLowering(
-              "writeFileSync with the flag option",
+              `${operation} with the flag option`,
               p,
-              "the write truncates-or-creates (Node's default 'w') — appendFileSync is the lowered append; other flags have no lowering",
+              "the write truncates-or-creates (Node's default 'w'); other flags have no lowering",
             );
           } else {
             // The options-record stance: documented keys with no lowering
             // fence by name; undocumented keys drop like Node.
             fenceOrDropOptionKey(
-              L, p, m.name, "writeFileSync", FS_WRITE_FILE_DOCUMENTED_OPTIONS,
+              L, p, m.name, operation, FS_WRITE_FILE_DOCUMENTED_OPTIONS,
               'the supported options are { mode: <number>, encoding: "utf8" }',
             );
           }
@@ -1597,7 +1604,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
       }
       if (!ok || L.mapTypeOf(L.typeOf(expr.arguments[1]!))?.kind !== "string") {
         L.noLowering(
-          "fs.writeFileSync with 3 arguments",
+          `${operation} with 3 arguments`,
           optsNode,
           'the supported options are { mode: <number>, encoding: "utf8" } over string data',
         );
@@ -1606,10 +1613,10 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
       const data = L.lowerExprExpecting(expr.arguments[1]!, STRING);
       if (modeNode === null) {
         // encoding-only options change nothing: the plain write.
-        return { kind: "libCall", fn: "fs.writeFileSync", args: [path, data], type: VOID, loc };
+        return { kind: "libCall", fn: plainFn, args: [path, data], type: resultType, loc };
       }
       const mode = L.lowerExprExpecting(modeNode, F64);
-      return { kind: "libCall", fn: "fs.writeFileModeSync", args: [path, data, mode], type: VOID, loc };
+      return { kind: "libCall", fn: modeFn, args: [path, data, mode], type: resultType, loc };
     }
     // zlib takes Buffers; a string argument (the lib admits it) gets the
     // wrap-it-first hint instead of a generic type mismatch.

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -1558,6 +1558,40 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
       const plainFn: IrLibFn = promiseWriteOptions ? "fsp.writeFile" : "fs.writeFileSync";
       const modeFn: IrLibFn = promiseWriteOptions ? "fsp.writeFileMode" : "fs.writeFileModeSync";
       const resultType: IrType = promiseWriteOptions ? { kind: "promise", inner: VOID } : VOID;
+      type WriteOptionValue = { kind: "effect" | "mode"; value: IrExpr };
+      // The runtime needs only `mode`, but every source option value is an
+      // ordinary JS expression. Stage path/data and then evaluate the option
+      // values in object-literal order before issuing the write; otherwise a
+      // call/getter statically typed as the accepted utf8 literal can vanish.
+      const finishWrite = (optionValues: WriteOptionValue[]): IrExpr => {
+        const path = L.lowerExprExpecting(expr.arguments[0]!, STRING);
+        const data = L.lowerExprExpecting(expr.arguments[1]!, STRING);
+        const pathLocal = L.declareHiddenLocal("%writePath", STRING);
+        const dataLocal = L.declareHiddenLocal("%writeData", STRING);
+        const ref = (local: IrLocal): IrExpr => ({ kind: "varRef", localId: local.id, type: local.type, loc });
+        const stmts: IrStmt[] = [
+          { kind: "varDecl", localId: pathLocal.id, init: path, loc: path.loc },
+          { kind: "varDecl", localId: dataLocal.id, init: data, loc: data.loc },
+        ];
+        let mode: IrExpr | null = null;
+        for (const option of optionValues) {
+          if (option.kind === "effect") {
+            stmts.push({ kind: "exprStmt", expr: option.value, loc: option.value.loc });
+            continue;
+          }
+          const modeLocal = L.declareHiddenLocal("%writeMode", F64);
+          stmts.push({ kind: "varDecl", localId: modeLocal.id, init: option.value, loc: option.value.loc });
+          mode = ref(modeLocal);
+        }
+        const result: IrExpr = {
+          kind: "libCall",
+          fn: mode ? modeFn : plainFn,
+          args: mode ? [ref(pathLocal), ref(dataLocal), mode] : [ref(pathLocal), ref(dataLocal)],
+          type: resultType,
+          loc,
+        };
+        return { kind: "seqExpr", stmts, result, type: resultType, loc };
+      };
       // The bare-encoding spelling — writeFileSync(p, data, "utf-8") — is
       // the options record's encoding key alone: utf8 is what the runtime
       // writes anyway, so string data takes the plain write. Any OTHER
@@ -1568,22 +1602,21 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
           t.isStringLiteralType() && (t.value === "utf8" || t.value === "utf-8") &&
           L.mapTypeOf(L.typeOf(expr.arguments[1]!))?.kind === "string"
         ) {
-          const path = L.lowerExprExpecting(expr.arguments[0]!, STRING);
-          const data = L.lowerExprExpecting(expr.arguments[1]!, STRING);
-          return { kind: "libCall", fn: plainFn, args: [path, data], type: resultType, loc };
+          return finishWrite([{ kind: "effect", value: L.lowerExprExpecting(optsNode, STRING) }]);
         }
       }
-      let modeNode: ts.Expression | null = null;
+      const optionValues: WriteOptionValue[] = [];
       let ok = ts.isObjectLiteralExpression(optsNode);
       if (ok) {
         for (const p of (optsNode as ts.ObjectLiteralExpression).properties) {
           const m = optionMember(p);
           if (!m) { ok = false; break; }
           if (m.name === "mode") {
-            modeNode = m.value;
+            optionValues.push({ kind: "mode", value: L.lowerExprExpecting(m.value, F64) });
           } else if (m.name === "encoding") {
             const t = L.typeOf(m.value);
             if (!t.isStringLiteralType() || (t.value !== "utf8" && t.value !== "utf-8")) { ok = false; break; }
+            optionValues.push({ kind: "effect", value: L.lowerExprExpecting(m.value, STRING) });
           } else if (m.name === "flag") {
             // Documented, behavior-changing (open(2)'s disposition — 'a'
             // IS appendFileSync), no lowering: fence by name.
@@ -1599,6 +1632,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
               L, p, m.name, operation, FS_WRITE_FILE_DOCUMENTED_OPTIONS,
               'the supported options are { mode: <number>, encoding: "utf8" }',
             );
+            optionValues.push({ kind: "effect", value: L.lowerExpr(m.value) });
           }
         }
       }
@@ -1609,14 +1643,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
           'the supported options are { mode: <number>, encoding: "utf8" } over string data',
         );
       }
-      const path = L.lowerExprExpecting(expr.arguments[0]!, STRING);
-      const data = L.lowerExprExpecting(expr.arguments[1]!, STRING);
-      if (modeNode === null) {
-        // encoding-only options change nothing: the plain write.
-        return { kind: "libCall", fn: plainFn, args: [path, data], type: resultType, loc };
-      }
-      const mode = L.lowerExprExpecting(modeNode, F64);
-      return { kind: "libCall", fn: modeFn, args: [path, data, mode], type: resultType, loc };
+      return finishWrite(optionValues);
     }
     // zlib takes Buffers; a string argument (the lib admits it) gets the
     // wrap-it-first hint instead of a generic type mismatch.

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -1632,7 +1632,6 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
               L, p, m.name, operation, FS_WRITE_FILE_DOCUMENTED_OPTIONS,
               'the supported options are { mode: <number>, encoding: "utf8" }',
             );
-            optionValues.push({ kind: "effect", value: L.lowerExpr(m.value) });
           }
         }
       }

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -86,9 +86,9 @@ export const NARROW_FIRST =
  *   - undocumented keys DROP exactly as Node drops them, provided the
  *     value expression is side-effect-free (an effectful initializer
  *     fences: Node would have evaluated it, so skipping it would be
- *     observable). A bare `__proto__: value` assignment is never a
- *     droppable key: it changes the record's prototype, and Node may read
- *     documented options inherited from that value.
+ *     observable). A bare `__proto__: value` assignment with an
+ *     object-capable value is not droppable: it may change the record's
+ *     prototype, and Node may read documented options inherited from it.
  * fenceOrDropOptionKey is that split's tail — option walks call it for
  * every key outside their lowered set. */
 
@@ -123,6 +123,25 @@ export function sideEffectFreeOptionValue(node: ts.Expression): boolean {
   return false;
 }
 
+/** True when an object-literal `__proto__: value` entry is provably a
+ * no-op. The special prototype setter accepts only objects or null; every
+ * primitive value is ignored. Unknown/object-capable types stay fenced. */
+function primitiveProtoValueIsIgnored(L: Lowerer, node: ts.Expression): boolean {
+  const primitive =
+    ts.TypeFlags.StringLike |
+    ts.TypeFlags.NumberLike |
+    ts.TypeFlags.BooleanLike |
+    ts.TypeFlags.BigIntLike |
+    ts.TypeFlags.ESSymbolLike |
+    ts.TypeFlags.EnumLike |
+    ts.TypeFlags.Undefined |
+    ts.TypeFlags.Void |
+    ts.TypeFlags.Never;
+  const t = L.typeOf(node);
+  const parts = t.isUnionType() ? t.getTypes() : [t];
+  return parts.every((p) => (p.flags & primitive) !== 0);
+}
+
 /** The stance's tail: `key` is outside the walk's lowered set. Documented
  * keys of the API fence by name (pointed per-key hints first, the walk's
  * supported-options hint otherwise); undocumented keys drop like Node
@@ -143,7 +162,8 @@ export function fenceOrDropOptionKey(
   if (
     key === "__proto__" &&
     ts.isPropertyAssignment(prop) &&
-    !ts.isComputedPropertyName(prop.name)
+    !ts.isComputedPropertyName(prop.name) &&
+    !primitiveProtoValueIsIgnored(L, prop.initializer)
   ) {
     L.noLowering(
       `${api} option '__proto__'`,

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -871,6 +871,8 @@ export const BUILTIN_MODULE_FN_ALIASES: Record<string, Record<string, readonly I
   "fs/promises": {
     // The Buffer form (no encoding).
     readFile: ["fsp.readFileBytes"],
+    // The string-data { mode } options form.
+    writeFile: ["fsp.writeFileMode"],
   },
   crypto: {
     // The composed randomBytes(n).toString(enc) chain keeps its one-libCall

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -86,7 +86,9 @@ export const NARROW_FIRST =
  *   - undocumented keys DROP exactly as Node drops them, provided the
  *     value expression is side-effect-free (an effectful initializer
  *     fences: Node would have evaluated it, so skipping it would be
- *     observable).
+ *     observable). A bare `__proto__: value` assignment is never a
+ *     droppable key: it changes the record's prototype, and Node may read
+ *     documented options inherited from that value.
  * fenceOrDropOptionKey is that split's tail — option walks call it for
  * every key outside their lowered set. */
 
@@ -137,6 +139,17 @@ export function fenceOrDropOptionKey(
 ): void {
   if (documented.has(key)) {
     L.noLowering(`${api} option '${key}'`, prop, pointedHints?.[key] ?? supportedHint);
+  }
+  if (
+    key === "__proto__" &&
+    ts.isPropertyAssignment(prop) &&
+    !ts.isComputedPropertyName(prop.name)
+  ) {
+    L.noLowering(
+      `${api} option '__proto__'`,
+      prop,
+      "a bare __proto__: value entry changes the options object's prototype, so inherited options cannot be lowered",
+    );
   }
   const value = ts.isPropertyAssignment(prop) ? prop.initializer : null;
   if (value !== null && !sideEffectFreeOptionValue(value)) {

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2887,6 +2887,9 @@ export type IrLibFn =
   | "process.stderrWriteBytes"
   | "fsp.readFile"
   | "fsp.writeFile"
+  /** fs.promises.writeFile(path, data, { mode }): the settled-promise
+   * twin of fs.writeFileModeSync. */
+  | "fsp.writeFileMode"
   | "fsp.mkdir"
   /** The fs/promises option/member tail the certs pipeline uses: mkdir's
    * literal { recursive?, mode? } options (the mkdirSync matrix behind

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -755,6 +755,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "process.stderrWriteBytes": { argTypes: [BYTES_U8], result: BOOL },
   "fsp.readFile": { argTypes: [STRING, STRING], result: { kind: "promise", inner: STRING } },
   "fsp.writeFile": { argTypes: [STRING, STRING], result: { kind: "promise", inner: VOID } },
+  "fsp.writeFileMode": { argTypes: [STRING, STRING, F64], result: { kind: "promise", inner: VOID } },
   "fsp.mkdir": { argTypes: [STRING], result: { kind: "promise", inner: VOID } },
   "fsp.mkdirMode": { argTypes: [STRING, F64], result: { kind: "promise", inner: VOID } },
   "fsp.mkdirRecursive": { argTypes: [STRING], result: { kind: "promise", inner: VOID } },

--- a/packages/runtime/src/scr_async.c
+++ b/packages/runtime/src/scr_async.c
@@ -1442,6 +1442,11 @@ ScrPromise *scr_fsp_write_file(ScrStr *path, ScrStr *data) {
   return scr_promise_settled_void();
 }
 
+ScrPromise *scr_fsp_write_file_mode(ScrStr *path, ScrStr *data, double mode) {
+  scr_fs_write_file_mode(path, data, mode);
+  return scr_promise_settled_void();
+}
+
 ScrPromise *scr_fsp_mkdir(ScrStr *path) {
   scr_fs_mkdir(path);
   return scr_promise_settled_void();

--- a/packages/runtime/src/scr_lib.c
+++ b/packages/runtime/src/scr_lib.c
@@ -1567,6 +1567,22 @@ void scr_fs_write_file(ScrStr *path, ScrStr *data) {
  * existing file keeps its permissions, exactly Node (which never chmods
  * here). Same error shapes as the plain form. */
 void scr_fs_write_file_mode(ScrStr *path, ScrStr *data, double mode) {
+  char recv[48], msg[176];
+  scr_num_received(mode, recv);
+  if (!(isfinite(mode) && trunc(mode) == mode)) {
+    int len = snprintf(msg, sizeof msg,
+                       "The value of \"mode\" is out of range. It must be an integer. Received %s",
+                       recv);
+    scr_throw_error_msg_code(SCR_ERR_RANGE, msg, (size_t)len, "ERR_OUT_OF_RANGE");
+    return;
+  }
+  if (mode < 0 || mode > 4294967295.0) {
+    int len = snprintf(msg, sizeof msg,
+                       "The value of \"mode\" is out of range. It must be >= 0 && <= 4294967295. Received %s",
+                       recv);
+    scr_throw_error_msg_code(SCR_ERR_RANGE, msg, (size_t)len, "ERR_OUT_OF_RANGE");
+    return;
+  }
   /* O_BINARY: zero on POSIX; on Windows it keeps the CRT from translating
    * \n in these byte-exact writes (fopen's "wb" path already does). */
   int fd = open(path->data, O_WRONLY | O_CREAT | O_TRUNC | O_BINARY, (mode_t)mode);

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -2126,6 +2126,7 @@ double scr_stats_mtime_ms(ScrStats *s); /* ms with the ns fraction */
  * scr_lib.c without the fiber slice). */
 ScrPromise *scr_fsp_read_file(ScrStr *path);
 ScrPromise *scr_fsp_write_file(ScrStr *path, ScrStr *data);
+ScrPromise *scr_fsp_write_file_mode(ScrStr *path, ScrStr *data, double mode);
 ScrPromise *scr_fsp_mkdir(ScrStr *path);
 ScrPromise *scr_fsp_mkdir_mode(ScrStr *path, double mode);
 ScrPromise *scr_fsp_mkdir_recursive(ScrStr *path);

--- a/tests/corpus/2687-fsp-write-file-options.ts
+++ b/tests/corpus/2687-fsp-write-file-options.ts
@@ -1,0 +1,35 @@
+// Static three-argument fs/promises.writeFile: utf8's string and object
+// spellings, creation mode (which does not re-apply to existing files),
+// and syscall failures delivered as promise rejections.
+import { accessSync, constants, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "scr-fsp-write-"));
+const encoded = join(dir, "encoded.txt");
+const modeFile = join(dir, "mode.txt");
+
+await writeFile(encoded, "first", "utf-8");
+await writeFile(encoded, "second", { encoding: "utf8" });
+console.log("encoded:", readFileSync(encoded, "utf8"));
+
+await writeFile(modeFile, "created", { mode: 0o600, encoding: "utf-8" });
+accessSync(modeFile, constants.W_OK);
+await writeFile(modeFile, "rewritten", { mode: 0o400 });
+accessSync(modeFile, constants.W_OK);
+console.log("mode:", readFileSync(modeFile, "utf8"));
+
+try {
+  const rejected = writeFile(join(dir, "missing", "file.txt"), "x", { mode: 0o600 });
+  console.log("promise returned");
+  await rejected;
+  console.log("no rejection");
+} catch (e) {
+  if (e instanceof Error) {
+    console.log("rejected:", `${(e as NodeJS.ErrnoException).code}`, e.message.includes("open"));
+  }
+}
+
+rmSync(dir, { recursive: true, force: true });
+console.log("done:", !existsSync(dir));

--- a/tests/corpus/2687-fsp-write-file-options.ts
+++ b/tests/corpus/2687-fsp-write-file-options.ts
@@ -10,9 +10,32 @@ const dir = mkdtempSync(join(tmpdir(), "scr-fsp-write-"));
 const encoded = join(dir, "encoded.txt");
 const modeFile = join(dir, "mode.txt");
 
+let evaluations: string[] = [];
+function encoding(label: string): "utf8" {
+  evaluations.push(label);
+  return "utf8";
+}
+function mode(label: string): number {
+  evaluations.push(label);
+  return 0o600;
+}
+function writePath(label: string): string {
+  evaluations.push(label);
+  return encoded;
+}
+function writeData(label: string, value: string): string {
+  evaluations.push(label);
+  return value;
+}
+
 await writeFile(encoded, "first", "utf-8");
 await writeFile(encoded, "second", { encoding: "utf8" });
 console.log("encoded:", readFileSync(encoded, "utf8"));
+
+await writeFile(writePath("path"), writeData("data", "bare effect"), encoding("bare"));
+await writeFile(encoded, "encoding first", { encoding: encoding("encoding"), mode: mode("mode") });
+await writeFile(encoded, "mode first", { mode: mode("mode"), encoding: encoding("encoding") });
+console.log("evaluated:", evaluations.join(","), readFileSync(encoded, "utf8"));
 
 await writeFile(modeFile, "created", { mode: 0o600, encoding: "utf-8" });
 accessSync(modeFile, constants.W_OK);
@@ -30,6 +53,24 @@ try {
     console.log("rejected:", `${(e as NodeJS.ErrnoException).code}`, e.message.includes("open"));
   }
 }
+
+async function invalidMode(label: string, value: number): Promise<void> {
+  const path = join(dir, `${label}.txt`);
+  try {
+    const rejected = writeFile(path, "x", { mode: value });
+    console.log(label, "promise returned");
+    await rejected;
+    console.log(label, "resolved", existsSync(path));
+  } catch (e) {
+    if (e instanceof Error) {
+      console.log(label, e.name, `${(e as NodeJS.ErrnoException).code}`, existsSync(path));
+    }
+  }
+}
+
+await invalidMode("negative", -1);
+await invalidMode("fractional", 1.5);
+await invalidMode("nan", NaN);
 
 rmSync(dir, { recursive: true, force: true });
 console.log("done:", !existsSync(dir));

--- a/tests/corpus/2687-fsp-write-file-options.ts
+++ b/tests/corpus/2687-fsp-write-file-options.ts
@@ -1,7 +1,8 @@
 // Static three-argument fs/promises.writeFile: utf8's string and object
 // spellings, creation mode (which does not re-apply to existing files),
-// and syscall failures delivered as promise rejections.
-import { accessSync, constants, existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+// safely ignored option values, and syscall failures delivered as promise
+// rejections.
+import { accessSync, constants, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -36,6 +37,20 @@ await writeFile(writePath("path"), writeData("data", "bare effect"), encoding("b
 await writeFile(encoded, "encoding first", { encoding: encoding("encoding"), mode: mode("mode") });
 await writeFile(encoded, "mode first", { mode: mode("mode"), encoding: encoding("encoding") });
 console.log("evaluated:", evaluations.join(","), readFileSync(encoded, "utf8"));
+
+// Undocumented values that cannot have effects stay dropped rather than
+// being lowered themselves. Primitive __proto__ values are also ignored by
+// JavaScript's special object-literal setter, so they do not need the
+// prototype-backed-options fence.
+writeFileSync(encoded, "sync ignored", {
+  ignored: <T>(value: T): T => value,
+  __proto__: 1,
+});
+await writeFile(encoded, "promise ignored", {
+  ignored: <T>(value: T): T => value,
+  __proto__: "primitive",
+});
+console.log("ignored:", readFileSync(encoded, "utf8"));
 
 await writeFile(modeFile, "created", { mode: 0o600, encoding: "utf-8" });
 accessSync(modeFile, constants.W_OK);

--- a/tests/diagnostics/options-record.ts
+++ b/tests/diagnostics/options-record.ts
@@ -50,3 +50,10 @@ dns.lookup("localhost", { family: 4, all: true }, () => {});
 // needs an interactive terminal.
 readline.createInterface({ input: process.stdin, output: process.stdout, crlfDelay: 100 });
 readline.createInterface({ input: process.stdin, output: process.stdout, completer: (l: string) => [[l], l] });
+
+// A bare __proto__: value entry is not an ordinary undocumented key: it
+// changes the options record's prototype, and Node reads inherited options.
+// These must fence instead of silently dropping an inherited flag or mode.
+fs.writeFileSync("/tmp/proto-sync", "x", { __proto__: { flag: "a" } });
+void fs.promises.writeFile("/tmp/proto-promise", "x", { __proto__: { mode: 0o600 } });
+// Both calls must terminate in the explicit prototype-options fence.

--- a/tests/harness/__snapshots__/options-record.ts.txt
+++ b/tests/harness/__snapshots__/options-record.ts.txt
@@ -123,3 +123,21 @@ options-record.ts:52:74 - error SC2020: 'createInterface with a completer' is pa
   53 | 
 
   hint: tab completion needs an interactive terminal — the lowered interface reads piped lines (terminal: false)
+
+options-record.ts:57:44 - error SC2020: 'writeFileSync option '__proto__'' is part of the standard library types but has no scriptc lowering yet
+
+  56 | // These must fence instead of silently dropping an inherited flag or mode.
+  57 | fs.writeFileSync("/tmp/proto-sync", "x", { __proto__: { flag: "a" } });
+     |                                            ^~~~~~~~~~~~~~~~~~~~~~~~
+  58 | void fs.promises.writeFile("/tmp/proto-promise", "x", { __proto__: { mode: 0o600 } });
+
+  hint: a bare __proto__: value entry changes the options object's prototype, so inherited options cannot be lowered
+
+options-record.ts:58:57 - error SC2020: 'fs.promises.writeFile option '__proto__'' is part of the standard library types but has no scriptc lowering yet
+
+  57 | fs.writeFileSync("/tmp/proto-sync", "x", { __proto__: { flag: "a" } });
+  58 | void fs.promises.writeFile("/tmp/proto-promise", "x", { __proto__: { mode: 0o600 } });
+     |                                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~
+  59 | // Both calls must terminate in the explicit prototype-options fence.
+
+  hint: a bare __proto__: value entry changes the options object's prototype, so inherited options cannot be lowered


### PR DESCRIPTION
- Lower static UTF-8 encoding and mode options for fs/promises.writeFile.
- Add mode-aware runtime and backend support with promise rejection behavior.
- Cover supported options and failures in the differential corpus.