### PR TITLE
Fix dynamic promise runtime gating

### DIFF
--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -6074,6 +6074,14 @@ export function moduleUsesDynAsync(mod: IrModule): boolean {
       found = true;
       return;
     }
+    // Promise values crossing the checked-dynamic boundary are boxed by
+    // emit-walkers through scr_dyn_new_promise_adapting(). That constructor
+    // lives in scr_async_dyn.c, so promise-typed IR must pull that TU in even
+    // when the program never awaits a dyn value.
+    if (node.type !== undefined && node.type.kind === "promise") {
+      found = true;
+      return;
+    }
     for (const key of Object.keys(v)) visit((v as Record<string, unknown>)[key]);
   };
   visit(mod);

--- a/tests/harness/island.test.ts
+++ b/tests/harness/island.test.ts
@@ -338,6 +338,16 @@ console.log(__island_eval("Promise.reject(new TypeError('island second')); 'arme
     expect(r.stderr).toBe("Unhandled promise rejection: RangeError: static first\n");
   });
 
+  test("links the dynamic promise adapter for typed promises crossing a dynamic callback", async () => {
+    await build(
+      "typed-promise-dynamic-boundary",
+      `async function typed(): Promise<number> { return 1; }
+function invoke(fn: () => unknown): unknown { return fn(); }
+console.log(invoke(typed));
+`,
+    );
+  });
+
   test("--dynamic does not change emitted C for island-free programs", async () => {
     const source = `function greet(who: string): string {
   return "hello " + who;


### PR DESCRIPTION
## Summary

When a typed Promise crossed the checked-dynamic boundary, the compiler emitted `scr_dyn_new_promise_adapting` but did not always link the runtime translation unit defining it.

This caused a linker failure for valid programs using typed promises through dynamic callbacks.

## Fix

`moduleUsesDynAsync()` now detects Promise-typed IR values and enables the dynamic Promise runtime support when required.

## Validation

- Focused regression test passed:
  `npx pnpm exec vitest run tests/harness/island.test.ts -t "links the dynamic promise adapter"`
- Result: 1 passed, 25 skipped.
- Full suite was attempted but was not green within the available run.
- The reported static-size failures reproduce on `main` with the same 418664-byte result, so they are not introduced by this patch.

Commit: `27537e0`
