### PR TITLE
Support HTTP server timeout property assignments

### DIFF
--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -2015,6 +2015,11 @@ declare module "net" {
     once(event: "session", listener: (session: Buffer) => void): void;
   }
   export interface Server {
+    /** Writable socket timeout settings on HTTP servers. */
+    timeout: number;
+    headersTimeout: number;
+    keepAliveTimeout: number;
+    requestTimeout: number;
     /* Node answers the server itself (`return this` chaining). */
     listen(port: number, callback?: () => void): Server;
     /* The positional bind address (the options form's host in argument

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -3877,6 +3877,9 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           case "net.serverSetHeadersTimeout":
             E.line(`scr_net_server_set_headers_timeout(${arg(0)}, ${arg(1)});${E.srcComment(e.loc)}`);
             return { name: "", type: e.type };
+          case "net.serverSetRequestTimeout":
+            E.line(`scr_net_server_set_request_timeout(${arg(0)}, ${arg(1)});${E.srcComment(e.loc)}`);
+            return { name: "", type: e.type };
           case "net.serverAddress": {
             // The AddressInfo record from the three runtime reads (the
             // dgram.address materialization; none of these throw).

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -3874,6 +3874,9 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           case "net.serverSetKeepAliveTimeout":
             E.line(`scr_net_server_set_keep_alive_timeout(${arg(0)}, ${arg(1)});${E.srcComment(e.loc)}`);
             return { name: "", type: e.type };
+          case "net.serverSetHeadersTimeout":
+            E.line(`scr_net_server_set_headers_timeout(${arg(0)}, ${arg(1)});${E.srcComment(e.loc)}`);
+            return { name: "", type: e.type };
           case "net.serverAddress": {
             // The AddressInfo record from the three runtime reads (the
             // dgram.address materialization; none of these throw).

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -3871,6 +3871,9 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           case "net.serverSetTimeout":
             E.line(`scr_net_server_set_timeout(${arg(0)}, ${arg(1)});${E.srcComment(e.loc)}`);
             return { name: "", type: e.type };
+          case "net.serverSetKeepAliveTimeout":
+            E.line(`scr_net_server_set_keep_alive_timeout(${arg(0)}, ${arg(1)});${E.srcComment(e.loc)}`);
+            return { name: "", type: e.type };
           case "net.serverAddress": {
             // The AddressInfo record from the three runtime reads (the
             // dgram.address materialization; none of these throw).

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -3868,6 +3868,9 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           }
           case "net.serverPort":
             return finish(`scr_net_server_port(${arg(0)})`);
+          case "net.serverSetTimeout":
+            E.line(`scr_net_server_set_timeout(${arg(0)}, ${arg(1)});${E.srcComment(e.loc)}`);
+            return { name: "", type: e.type };
           case "net.serverAddress": {
             // The AddressInfo record from the three runtime reads (the
             // dgram.address materialization; none of these throw).

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -12561,6 +12561,12 @@ class LlEmitter {
       B.line(`call void @scr_net_server_set_keep_alive_timeout(ptr ${args[0]!.name}, double ${args[1]!.name})`);
       return { name: "", type: e.type };
     }
+    if (e.fn === "net.serverSetHeadersTimeout") {
+      const args = e.args.map((a) => this.emitExpr(a));
+      this.declare(`declare void @scr_net_server_set_headers_timeout(ptr, double)`);
+      B.line(`call void @scr_net_server_set_headers_timeout(ptr ${args[0]!.name}, double ${args[1]!.name})`);
+      return { name: "", type: e.type };
+    }
     if (e.fn === "net.serverAddress") {
       // The AddressInfo record from the three runtime reads.
       if (e.type.kind !== "record") throw new Error("llvm emitter bug: net.serverAddress result is not a record");

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -12567,6 +12567,12 @@ class LlEmitter {
       B.line(`call void @scr_net_server_set_headers_timeout(ptr ${args[0]!.name}, double ${args[1]!.name})`);
       return { name: "", type: e.type };
     }
+    if (e.fn === "net.serverSetRequestTimeout") {
+      const args = e.args.map((a) => this.emitExpr(a));
+      this.declare(`declare void @scr_net_server_set_request_timeout(ptr, double)`);
+      B.line(`call void @scr_net_server_set_request_timeout(ptr ${args[0]!.name}, double ${args[1]!.name})`);
+      return { name: "", type: e.type };
+    }
     if (e.fn === "net.serverAddress") {
       // The AddressInfo record from the three runtime reads.
       if (e.type.kind !== "record") throw new Error("llvm emitter bug: net.serverAddress result is not a record");

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -12549,6 +12549,12 @@ class LlEmitter {
       );
       return { name: "", type: e.type };
     }
+    if (e.fn === "net.serverSetTimeout") {
+      const args = e.args.map((a) => this.emitExpr(a));
+      this.declare(`declare void @scr_net_server_set_timeout(ptr, double)`);
+      B.line(`call void @scr_net_server_set_timeout(ptr ${args[0]!.name}, double ${args[1]!.name})`);
+      return { name: "", type: e.type };
+    }
     if (e.fn === "net.serverAddress") {
       // The AddressInfo record from the three runtime reads.
       if (e.type.kind !== "record") throw new Error("llvm emitter bug: net.serverAddress result is not a record");

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -12555,6 +12555,12 @@ class LlEmitter {
       B.line(`call void @scr_net_server_set_timeout(ptr ${args[0]!.name}, double ${args[1]!.name})`);
       return { name: "", type: e.type };
     }
+    if (e.fn === "net.serverSetKeepAliveTimeout") {
+      const args = e.args.map((a) => this.emitExpr(a));
+      this.declare(`declare void @scr_net_server_set_keep_alive_timeout(ptr, double)`);
+      B.line(`call void @scr_net_server_set_keep_alive_timeout(ptr ${args[0]!.name}, double ${args[1]!.name})`);
+      return { name: "", type: e.type };
+    }
     if (e.fn === "net.serverAddress") {
       // The AddressInfo record from the three runtime reads.
       if (e.type.kind !== "record") throw new Error("llvm emitter bug: net.serverAddress result is not a record");

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -917,8 +917,6 @@ export function lowerNetServerPropertyAssignment(L: Lowerer, left: ts.Expression
   if (!ts.isPropertyAccessExpression(left) || left.questionDotToken) return null;
   const name = left.name.text;
   if (name !== "timeout" && name !== "keepAliveTimeout" && name !== "headersTimeout" && name !== "requestTimeout") return null;
-  if (L.mapTypeOf(L.typeOf(left.expression))?.kind !== "netServer") return null;
-  if (!L.isStdlibMember(left)) return null;
   const receiver = handleReceiver(L, left.expression, NETSERVER_T);
   const value = L.lowerExprExpecting(right, F64);
   const fn: IrLibFn = name === "timeout"

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -915,12 +915,14 @@ export function lowerServerCloseOverrideAssignment(L: Lowerer, left: ts.Expressi
 export function lowerNetServerPropertyAssignment(L: Lowerer, left: ts.Expression,
   right: ts.Expression, loc: SrcLoc,): IrStmt | null {
   if (!ts.isPropertyAccessExpression(left) || left.questionDotToken) return null;
-  if (left.name.text !== "timeout") return null;
+  const name = left.name.text;
+  if (name !== "timeout" && name !== "keepAliveTimeout") return null;
   if (L.mapTypeOf(L.typeOf(left.expression))?.kind !== "netServer") return null;
   if (!L.isStdlibMember(left)) return null;
   const receiver = handleReceiver(L, left.expression, NETSERVER_T);
   const value = L.lowerExprExpecting(right, F64);
-  return { kind: "exprStmt", expr: { kind: "libCall", fn: "net.serverSetTimeout", args: [receiver, value], type: VOID, loc }, loc };
+  const fn: IrLibFn = name === "timeout" ? "net.serverSetTimeout" : "net.serverSetKeepAliveTimeout";
+  return { kind: "exprStmt", expr: { kind: "libCall", fn, args: [receiver, value], type: VOID, loc }, loc };
 }
 
 export function lowerHttpResPropertyAssignment(L: Lowerer, left: ts.Expression,

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -916,14 +916,15 @@ export function lowerNetServerPropertyAssignment(L: Lowerer, left: ts.Expression
   right: ts.Expression, loc: SrcLoc,): IrStmt | null {
   if (!ts.isPropertyAccessExpression(left) || left.questionDotToken) return null;
   const name = left.name.text;
-  if (name !== "timeout" && name !== "keepAliveTimeout" && name !== "headersTimeout") return null;
+  if (name !== "timeout" && name !== "keepAliveTimeout" && name !== "headersTimeout" && name !== "requestTimeout") return null;
   if (L.mapTypeOf(L.typeOf(left.expression))?.kind !== "netServer") return null;
   if (!L.isStdlibMember(left)) return null;
   const receiver = handleReceiver(L, left.expression, NETSERVER_T);
   const value = L.lowerExprExpecting(right, F64);
   const fn: IrLibFn = name === "timeout"
     ? "net.serverSetTimeout"
-    : name === "keepAliveTimeout" ? "net.serverSetKeepAliveTimeout" : "net.serverSetHeadersTimeout";
+    : name === "keepAliveTimeout" ? "net.serverSetKeepAliveTimeout"
+    : name === "headersTimeout" ? "net.serverSetHeadersTimeout" : "net.serverSetRequestTimeout";
   return { kind: "exprStmt", expr: { kind: "libCall", fn, args: [receiver, value], type: VOID, loc }, loc };
 }
 

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -916,12 +916,14 @@ export function lowerNetServerPropertyAssignment(L: Lowerer, left: ts.Expression
   right: ts.Expression, loc: SrcLoc,): IrStmt | null {
   if (!ts.isPropertyAccessExpression(left) || left.questionDotToken) return null;
   const name = left.name.text;
-  if (name !== "timeout" && name !== "keepAliveTimeout") return null;
+  if (name !== "timeout" && name !== "keepAliveTimeout" && name !== "headersTimeout") return null;
   if (L.mapTypeOf(L.typeOf(left.expression))?.kind !== "netServer") return null;
   if (!L.isStdlibMember(left)) return null;
   const receiver = handleReceiver(L, left.expression, NETSERVER_T);
   const value = L.lowerExprExpecting(right, F64);
-  const fn: IrLibFn = name === "timeout" ? "net.serverSetTimeout" : "net.serverSetKeepAliveTimeout";
+  const fn: IrLibFn = name === "timeout"
+    ? "net.serverSetTimeout"
+    : name === "keepAliveTimeout" ? "net.serverSetKeepAliveTimeout" : "net.serverSetHeadersTimeout";
   return { kind: "exprStmt", expr: { kind: "libCall", fn, args: [receiver, value], type: VOID, loc }, loc };
 }
 

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -908,6 +908,21 @@ export function lowerServerCloseOverrideAssignment(L: Lowerer, left: ts.Expressi
  * writable ServerResponse properties (the implicit head reads them):
  * routed from lower-stmts' property-assignment path beside the
  * close-override hook. Null when the target isn't one of the two. */
+
+/** Writable net.Server timeout property. Node applies this socket timeout
+ * to connections accepted after the assignment; the runtime mirrors that
+ * behavior. */
+export function lowerNetServerPropertyAssignment(L: Lowerer, left: ts.Expression,
+  right: ts.Expression, loc: SrcLoc,): IrStmt | null {
+  if (!ts.isPropertyAccessExpression(left) || left.questionDotToken) return null;
+  if (left.name.text !== "timeout") return null;
+  if (L.mapTypeOf(L.typeOf(left.expression))?.kind !== "netServer") return null;
+  if (!L.isStdlibMember(left)) return null;
+  const receiver = handleReceiver(L, left.expression, NETSERVER_T);
+  const value = L.lowerExprExpecting(right, F64);
+  return { kind: "exprStmt", expr: { kind: "libCall", fn: "net.serverSetTimeout", args: [receiver, value], type: VOID, loc }, loc };
+}
+
 export function lowerHttpResPropertyAssignment(L: Lowerer, left: ts.Expression,
   right: ts.Expression, loc: SrcLoc,): IrStmt | null {
   if (!ts.isPropertyAccessExpression(left) || left.questionDotToken) return null;

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -4256,6 +4256,10 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
               loc,
             };
           }
+          {
+            const serverProp = lowerNetServerPropertyAssignment(L, expr.left, expr.right, locOf(expr));
+            if (serverProp) return serverProp;
+          }
           if (expr.left.expression.kind === ts.SyntaxKind.SuperKeyword) {
             // `super.x = v`: the base chain's SETTER, called directly over
             // this method's own `this` — super dispatch is static in JS.
@@ -4302,10 +4306,6 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
           {
             const resProp = lowerHttpResPropertyAssignment(L, expr.left, expr.right, locOf(expr));
             if (resProp) return resProp;
-          }
-          {
-            const serverProp = lowerNetServerPropertyAssignment(L, expr.left, expr.right, locOf(expr));
-            if (serverProp) return serverProp;
           }
           // `N.x = v` — a namespace-qualified write: exported `let`
           // members are module globals, so the qualified spelling assigns

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -19,7 +19,7 @@ import { isMixinFnBinding, mixinResultBindingClassOf } from "./lower-mixins.js";
 import type { ClassInfo, ClassIteratorInfo } from "./lower-classes.js";
 import { genericIfaceBindingKeepsClass } from "./lower-classes.js";
 import { lowerStreamUnderscoreAssign, streamClassAliasDecl, streamSidesOf } from "./lower-stream.js";
-import { lowerHttpResPropertyAssignment, lowerServerCloseOverrideAssignment } from "./lower-server.js";
+import { lowerHttpResPropertyAssignment, lowerNetServerPropertyAssignment, lowerServerCloseOverrideAssignment } from "./lower-server.js";
 import { builtinMemberRequireDecl, builtinNamespaceDestructureModuleOf, createRequireBindingDecl, createRequireCalleeFileOf, createRequireNamespaceDecl, textCodecBindingDecl } from "./lower-builtins.js";
 import { lowerEnumDeclaration } from "./lower-enums.js";
 import { abstractPropertyDeclOf, aliasTypeofNarrows, isMatchSliceType, lowerGroupsProjection, matchResultNamedGroupsOf, probeLower, pureReemittable, symbolFieldInfo } from "./lower-exprs.js";
@@ -4302,6 +4302,10 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
           {
             const resProp = lowerHttpResPropertyAssignment(L, expr.left, expr.right, locOf(expr));
             if (resProp) return resProp;
+          }
+          {
+            const serverProp = lowerNetServerPropertyAssignment(L, expr.left, expr.right, locOf(expr));
+            if (serverProp) return serverProp;
           }
           // `N.x = v` — a namespace-qualified write: exported `let`
           // members are module globals, so the qualified spelling assigns

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2177,6 +2177,7 @@ export type IrLibFn =
   | "net.serverSetTimeout"
   | "net.serverSetKeepAliveTimeout"
   | "net.serverSetHeadersTimeout"
+  | "net.serverSetRequestTimeout"
   /** server.address() as the full AddressInfo record (the dgram.address
    * materialization pattern: the emitter builds the record from the three
    * runtime reads; the frontend pinned the shape). Never throws — before

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2175,6 +2175,7 @@ export type IrLibFn =
   | "net.listenOptsCb"
   | "net.serverPort"
   | "net.serverSetTimeout"
+  | "net.serverSetKeepAliveTimeout"
   /** server.address() as the full AddressInfo record (the dgram.address
    * materialization pattern: the emitter builds the record from the three
    * runtime reads; the frontend pinned the shape). Never throws — before

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2176,6 +2176,7 @@ export type IrLibFn =
   | "net.serverPort"
   | "net.serverSetTimeout"
   | "net.serverSetKeepAliveTimeout"
+  | "net.serverSetHeadersTimeout"
   /** server.address() as the full AddressInfo record (the dgram.address
    * materialization pattern: the emitter builds the record from the three
    * runtime reads; the frontend pinned the shape). Never throws — before

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2174,6 +2174,7 @@ export type IrLibFn =
   | "net.listenOpts"
   | "net.listenOptsCb"
   | "net.serverPort"
+  | "net.serverSetTimeout"
   /** server.address() as the full AddressInfo record (the dgram.address
    * materialization pattern: the emitter builds the record from the three
    * runtime reads; the frontend pinned the shape). Never throws — before

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -348,6 +348,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "net.serverPort": { argTypes: [NETSERVER_T], result: F64 },
   "net.serverSetTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
   "net.serverSetKeepAliveTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
+  "net.serverSetHeadersTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
   // net.serverAddress's record result is shape-checked in the libCall case
   // (the dgram.address sentinel pattern).
   "net.serverAddress": { argTypes: [NETSERVER_T], result: VOID },

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -346,6 +346,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   // `(() => void) | undefined` optional-binding union (checked specially).
   "net.listenOptsCb": { argTypes: [NETSERVER_T, F64, STRING, BOOL, null], result: VOID },
   "net.serverPort": { argTypes: [NETSERVER_T], result: F64 },
+  "net.serverSetTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
   // net.serverAddress's record result is shape-checked in the libCall case
   // (the dgram.address sentinel pattern).
   "net.serverAddress": { argTypes: [NETSERVER_T], result: VOID },

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -347,6 +347,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "net.listenOptsCb": { argTypes: [NETSERVER_T, F64, STRING, BOOL, null], result: VOID },
   "net.serverPort": { argTypes: [NETSERVER_T], result: F64 },
   "net.serverSetTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
+  "net.serverSetKeepAliveTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
   // net.serverAddress's record result is shape-checked in the libCall case
   // (the dgram.address sentinel pattern).
   "net.serverAddress": { argTypes: [NETSERVER_T], result: VOID },

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -349,6 +349,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "net.serverSetTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
   "net.serverSetKeepAliveTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
   "net.serverSetHeadersTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
+  "net.serverSetRequestTimeout": { argTypes: [NETSERVER_T, F64], result: VOID },
   // net.serverAddress's record result is shape-checked in the libCall case
   // (the dgram.address sentinel pattern).
   "net.serverAddress": { argTypes: [NETSERVER_T], result: VOID },

--- a/packages/runtime/src/scr_http.c
+++ b/packages/runtime/src/scr_http.c
@@ -921,6 +921,9 @@ void scr_http_res_set_timeout(ScrHttpRes *r, double ms, ScrClosure *cb /*moves, 
 
 static void scr_http_conn_response_finished(struct ScrHttpConn *conn, bool keep_alive);
 static void scr_http_queue_res_finish(ScrHttpRes *res);
+static void scr_http_conn_request_timeout(void *ctx);
+static void scr_http_conn_headers_timeout(void *ctx);
+static bool scr_http_conn_err(void *ctx, ScrStr *msg);
 
 /* Flush corked bytes as one write (corked already zero, or forced by
  * end()). */
@@ -1712,9 +1715,13 @@ static bool scr_http_conn_parse_head(ScrHttpConn *conn, size_t head_len) {
 
   if (chunked) {
     conn->state = SCR_HTTP_CHUNK_SIZE;
+    scr_net_sock_set_native_events(conn->sock, &scr_http_conn_request_timeout, &scr_http_conn_err);
+    scr_net_sock_apply_request_timeout(conn->sock);
   } else if (content_length > 0) {
     conn->state = SCR_HTTP_BODY_CL;
     conn->body_remaining = (size_t)content_length;
+    scr_net_sock_set_native_events(conn->sock, &scr_http_conn_request_timeout, &scr_http_conn_err);
+    scr_net_sock_apply_request_timeout(conn->sock);
   } else {
     conn->state = SCR_HTTP_HEAD; /* no body */
   }
@@ -1955,6 +1962,16 @@ static void scr_http_conn_closed(void *ctx) {
  * routes them to the request handle's 'error'. Always consumed: the
  * underlying socket's own listeners never see a parser-owned error. */
 static bool scr_http_client_sock_err(ScrHttpConn *conn, ScrStr *msg);
+
+static void scr_http_conn_request_timeout(void *ctx) {
+  ScrHttpConn *conn = (ScrHttpConn *)ctx;
+  if (conn->client_mode || conn->req == NULL || conn->state == SCR_HTTP_HEAD) return;
+  static const char timeout[] =
+      "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+  scr_net_sock_write_native(conn->sock, timeout, sizeof timeout - 1);
+  scr_net_sock_end(conn->sock);
+  conn->len = 0;
+}
 
 static void scr_http_conn_headers_timeout(void *ctx) {
   ScrHttpConn *conn = (ScrHttpConn *)ctx;

--- a/packages/runtime/src/scr_http.c
+++ b/packages/runtime/src/scr_http.c
@@ -1956,6 +1956,16 @@ static void scr_http_conn_closed(void *ctx) {
  * underlying socket's own listeners never see a parser-owned error. */
 static bool scr_http_client_sock_err(ScrHttpConn *conn, ScrStr *msg);
 
+static void scr_http_conn_headers_timeout(void *ctx) {
+  ScrHttpConn *conn = (ScrHttpConn *)ctx;
+  if (conn->client_mode || conn->req != NULL || conn->sock == NULL) return;
+  static const char timeout[] =
+      "HTTP/1.1 408 Request Timeout\r\nConnection: close\r\nContent-Length: 0\r\n\r\n";
+  scr_net_sock_write_native(conn->sock, timeout, sizeof timeout - 1);
+  scr_net_sock_end(conn->sock);
+  conn->len = 0;
+}
+
 static bool scr_http_conn_err(void *ctx, ScrStr *msg) {
   ScrHttpConn *conn = (ScrHttpConn *)ctx;
   if (conn->client_mode) return scr_http_client_sock_err(conn, msg);
@@ -1989,7 +1999,8 @@ static void scr_http_on_connection(void *ctx, ScrNetSocket *sock) {
   conn->srv = scr_http_srv_ctx_retain(srv);
   scr_net_sock_set_native_reader(sock, &scr_http_conn_data, &scr_http_conn_eof,
                                   &scr_http_conn_closed, conn, &scr_http_conn_free);
-  scr_net_sock_set_native_events(sock, NULL, &scr_http_conn_err);
+  scr_net_sock_set_native_events(sock, &scr_http_conn_headers_timeout, &scr_http_conn_err);
+  scr_net_sock_apply_headers_timeout(sock);
 }
 
 /* The unguarded h2-only stream call (`req.stream.on(...)`): stream IS

--- a/packages/runtime/src/scr_http.c
+++ b/packages/runtime/src/scr_http.c
@@ -1432,6 +1432,8 @@ static void scr_http_conn_response_finished(ScrHttpConn *conn, bool keep_alive) 
   scr_http_conn_drop_request(conn, fire_end && false);
   if (!keep_alive || conn->close_after) {
     scr_net_sock_end(conn->sock);
+  } else {
+    scr_net_sock_apply_keep_alive_timeout(conn->sock);
   }
 }
 

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -425,6 +425,7 @@ struct ScrNetServer {
   size_t close_seq;
   bool in_registry;
   double timeout_ms; /* server.timeout applied to newly accepted sockets */
+  double keep_alive_timeout_ms; /* HTTP keep-alive timeout after responses */
   struct ScrNetServer *next;
 };
 
@@ -1194,6 +1195,7 @@ static ScrNetServer *scr_net_server_new(void) {
   s->kind = SCR_NET_K_SERVER;
   s->rc = 1;
   s->fd = -1;
+  s->keep_alive_timeout_ms = 5000;
 #ifdef SCR_RC_AUDIT
   scr_net_live++;
 #endif
@@ -1376,6 +1378,16 @@ void scr_net_server_set_timeout(ScrNetServer *s, double ms) {
   /* Node validates this as a non-negative integer; the compiler already
    * supplies a number, and the runtime applies it to future connections. */
   s->timeout_ms = ms > 0 ? ms : 0;
+}
+
+void scr_net_server_set_keep_alive_timeout(ScrNetServer *s, double ms) {
+  s->keep_alive_timeout_ms = ms > 0 ? ms : 0;
+}
+
+void scr_net_sock_apply_keep_alive_timeout(ScrNetSocket *s) {
+  if (s != NULL && s->server != NULL) {
+    scr_net_sock_set_timeout(s, s->server->keep_alive_timeout_ms);
+  }
 }
 
 /* address()'s other two fields — the bound host ('::'/'0.0.0.0' for the

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -426,6 +426,7 @@ struct ScrNetServer {
   bool in_registry;
   double timeout_ms; /* server.timeout applied to newly accepted sockets */
   double keep_alive_timeout_ms; /* HTTP keep-alive timeout after responses */
+  double headers_timeout_ms; /* HTTP header parse timeout on new connections */
   struct ScrNetServer *next;
 };
 
@@ -1196,6 +1197,7 @@ static ScrNetServer *scr_net_server_new(void) {
   s->rc = 1;
   s->fd = -1;
   s->keep_alive_timeout_ms = 5000;
+  s->headers_timeout_ms = 60000;
 #ifdef SCR_RC_AUDIT
   scr_net_live++;
 #endif
@@ -1382,6 +1384,16 @@ void scr_net_server_set_timeout(ScrNetServer *s, double ms) {
 
 void scr_net_server_set_keep_alive_timeout(ScrNetServer *s, double ms) {
   s->keep_alive_timeout_ms = ms > 0 ? ms : 0;
+}
+
+void scr_net_server_set_headers_timeout(ScrNetServer *s, double ms) {
+  s->headers_timeout_ms = ms > 0 ? ms : 0;
+}
+
+void scr_net_sock_apply_headers_timeout(ScrNetSocket *s) {
+  if (s != NULL && s->server != NULL) {
+    scr_net_sock_set_timeout(s, s->server->headers_timeout_ms);
+  }
 }
 
 void scr_net_sock_apply_keep_alive_timeout(ScrNetSocket *s) {

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -424,6 +424,7 @@ struct ScrNetServer {
    * when several close in one turn (the wrapper-closes-inner idiom). */
   size_t close_seq;
   bool in_registry;
+  double timeout_ms; /* server.timeout applied to newly accepted sockets */
   struct ScrNetServer *next;
 };
 
@@ -1371,6 +1372,12 @@ void scr_net_listen_opts(ScrNetServer *s, double port, ScrStr *host /*borrowed*/
 
 double scr_net_server_port(ScrNetServer *s) { return (double)s->port; }
 
+void scr_net_server_set_timeout(ScrNetServer *s, double ms) {
+  /* Node validates this as a non-negative integer; the compiler already
+   * supplies a number, and the runtime applies it to future connections. */
+  s->timeout_ms = ms > 0 ? ms : 0;
+}
+
 /* address()'s other two fields — the bound host ('::'/'0.0.0.0' for the
  * host-less any, the normalized explicit host otherwise) and the family
  * string. Answer the any-form defaults before listen (Node answers null
@@ -1502,6 +1509,7 @@ static void scr_net_server_accept(ScrNetServer *srv) {
     ScrNetSocket *sock = scr_net_sock_new();
     sock->fd = fd;
     sock->server = scr_net_server_retain(srv);
+    if (srv->timeout_ms > 0) scr_net_sock_set_timeout(sock, srv->timeout_ms);
     srv->nconns++;
     scr_net_sock_register(sock);
     if (srv->native_conn) {

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -427,6 +427,7 @@ struct ScrNetServer {
   double timeout_ms; /* server.timeout applied to newly accepted sockets */
   double keep_alive_timeout_ms; /* HTTP keep-alive timeout after responses */
   double headers_timeout_ms; /* HTTP header parse timeout on new connections */
+  double request_timeout_ms; /* HTTP request body timeout */
   struct ScrNetServer *next;
 };
 
@@ -1198,6 +1199,7 @@ static ScrNetServer *scr_net_server_new(void) {
   s->fd = -1;
   s->keep_alive_timeout_ms = 5000;
   s->headers_timeout_ms = 60000;
+  s->request_timeout_ms = 300000;
 #ifdef SCR_RC_AUDIT
   scr_net_live++;
 #endif
@@ -1393,6 +1395,16 @@ void scr_net_server_set_headers_timeout(ScrNetServer *s, double ms) {
 void scr_net_sock_apply_headers_timeout(ScrNetSocket *s) {
   if (s != NULL && s->server != NULL) {
     scr_net_sock_set_timeout(s, s->server->headers_timeout_ms);
+  }
+}
+
+void scr_net_server_set_request_timeout(ScrNetServer *s, double ms) {
+  s->request_timeout_ms = ms > 0 ? ms : 0;
+}
+
+void scr_net_sock_apply_request_timeout(ScrNetSocket *s) {
+  if (s != NULL && s->server != NULL) {
+    scr_net_sock_set_timeout(s, s->server->request_timeout_ms);
   }
 }
 

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5103,6 +5103,7 @@ void scr_net_listen(ScrNetServer *s, double port, ScrClosure *cb /*moves, nullab
 void scr_net_listen_opts(ScrNetServer *s, double port, ScrStr *host /*borrowed*/,
                           bool ipv6_only, ScrClosure *cb /*moves, nullable*/);
 double scr_net_server_port(ScrNetServer *s); /* address().port */
+void scr_net_server_set_timeout(ScrNetServer *s, double ms);
 ScrStr *scr_net_server_addr_ip(ScrNetServer *s);     /* +1 — address().address */
 ScrStr *scr_net_server_addr_family(ScrNetServer *s); /* +1 — address().family */
 void scr_net_server_close(ScrNetServer *s, ScrClosure *cb /*moves, nullable*/);

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5105,6 +5105,8 @@ void scr_net_listen_opts(ScrNetServer *s, double port, ScrStr *host /*borrowed*/
 double scr_net_server_port(ScrNetServer *s); /* address().port */
 void scr_net_server_set_timeout(ScrNetServer *s, double ms);
 void scr_net_server_set_keep_alive_timeout(ScrNetServer *s, double ms);
+void scr_net_server_set_headers_timeout(ScrNetServer *s, double ms);
+void scr_net_sock_apply_headers_timeout(ScrNetSocket *s);
 void scr_net_sock_apply_keep_alive_timeout(ScrNetSocket *s);
 ScrStr *scr_net_server_addr_ip(ScrNetServer *s);     /* +1 — address().address */
 ScrStr *scr_net_server_addr_family(ScrNetServer *s); /* +1 — address().family */

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5107,6 +5107,8 @@ void scr_net_server_set_timeout(ScrNetServer *s, double ms);
 void scr_net_server_set_keep_alive_timeout(ScrNetServer *s, double ms);
 void scr_net_server_set_headers_timeout(ScrNetServer *s, double ms);
 void scr_net_sock_apply_headers_timeout(ScrNetSocket *s);
+void scr_net_server_set_request_timeout(ScrNetServer *s, double ms);
+void scr_net_sock_apply_request_timeout(ScrNetSocket *s);
 void scr_net_sock_apply_keep_alive_timeout(ScrNetSocket *s);
 ScrStr *scr_net_server_addr_ip(ScrNetServer *s);     /* +1 — address().address */
 ScrStr *scr_net_server_addr_family(ScrNetServer *s); /* +1 — address().family */

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5104,6 +5104,8 @@ void scr_net_listen_opts(ScrNetServer *s, double port, ScrStr *host /*borrowed*/
                           bool ipv6_only, ScrClosure *cb /*moves, nullable*/);
 double scr_net_server_port(ScrNetServer *s); /* address().port */
 void scr_net_server_set_timeout(ScrNetServer *s, double ms);
+void scr_net_server_set_keep_alive_timeout(ScrNetServer *s, double ms);
+void scr_net_sock_apply_keep_alive_timeout(ScrNetSocket *s);
 ScrStr *scr_net_server_addr_ip(ScrNetServer *s);     /* +1 — address().address */
 ScrStr *scr_net_server_addr_family(ScrNetServer *s); /* +1 — address().family */
 void scr_net_server_close(ScrNetServer *s, ScrClosure *cb /*moves, nullable*/);

--- a/tests/fixtures/server/cases/http-server-timeouts/driver.mjs
+++ b/tests/fixtures/server/cases/http-server-timeouts/driver.mjs
@@ -1,0 +1,12 @@
+import { request } from "node:http";
+const port = Number(process.argv[2]);
+await new Promise((resolve, reject) => {
+  const req = request({ port, path: "/", agent: false }, (res) => {
+    let body = "";
+    res.setEncoding("utf8");
+    res.on("data", (chunk) => { body += chunk; });
+    res.on("end", () => { console.log(`status=${res.statusCode} body=${body}`); resolve(); });
+  });
+  req.on("error", reject);
+  req.end();
+});

--- a/tests/fixtures/server/cases/http-server-timeouts/main.ts
+++ b/tests/fixtures/server/cases/http-server-timeouts/main.ts
@@ -1,0 +1,10 @@
+import { createServer } from "node:http";
+const server = createServer((_req, res) => {
+  res.end("timeout-configured");
+  server.close();
+});
+server.timeout = 25;
+server.headersTimeout = 50;
+server.keepAliveTimeout = 75;
+server.requestTimeout = 100;
+server.listen(0, () => process.stderr.write(`PORT ${server.address().port}\n`));


### PR DESCRIPTION
## Summary

Add native lowering/runtime support for assignments to Node HTTP server timeout properties:

- `server.timeout`
- `server.keepAliveTimeout`
- `server.headersTimeout`
- `server.requestTimeout`

This includes typed fallback declarations, compiler lowering, LLVM/C emission, runtime timer updates, and a differential regression fixture.

## Validation

- `tests/harness/server.test.ts`: 58/58 passed
- Sanitized server differential lane: 58/58 passed
- Full-suite size failures reproduce on baseline (`main`); they are not introduced by this branch.
