### PR TITLE
perf: use integer induction for byte loops

### DIFF
--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -554,6 +554,8 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
         // tag-only); one reaching the generic dispatch escaped its wrap.
         throw new Error(`emitter bug: bare unitLit '${e.unit}'`);
       case "varRef": {
+        const integerLoopIndex = E.integerLoopIndex(e);
+        if (integerLoopIndex !== null) return E.newTemp(e.type, `(double)${integerLoopIndex}`);
         const local = E.currentLocals.get(e.localId);
         if (!local && E.globalsById.has(e.localId)) {
           const gname = mangleGlobal(e.localId);
@@ -1590,7 +1592,8 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
         const r = directElementAccess
           ? emitBytesReceiver(E, e.receiver, e.args)
           : E.emitExpr(e.receiver);
-        const args = e.args.map((a) => E.emitExpr(a));
+        const integerIndex = method === "get" ? E.integerLoopIndex(e.args[0]!) : null;
+        const args = integerIndex === null ? e.args.map((a) => E.emitExpr(a)) : [];
         switch (method) {
           case "length":
             return E.newTemp(e.type, `(double)${r.name}->len`);
@@ -1609,7 +1612,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             }
             return E.newTemp(
               e.type,
-              `${E.bytesElementHelper("get", e.receiver.type.elem)}(${r.name}, ${args[0]!.name})`,
+              `${E.bytesElementHelper("get", e.receiver.type.elem, integerIndex !== null)}(${r.name}, ${integerIndex ?? args[0]!.name})`,
             );
           case "slice":
             // Omitted relative indices default like string slice: start 0,

--- a/packages/compiler/src/backend/emission/emit-stmts.ts
+++ b/packages/compiler/src/backend/emission/emit-stmts.ts
@@ -9,6 +9,7 @@ import { BOOL, CAUGHT, IrExpr, IrStmt, RUNTIME_ERROR_CLASSES, isRefCounted } fro
 import { boxAccess, cDecl, cStringLiteral, elemAccess, vAdapters } from "./emit-types.js";
 import { OVERFLOW_MEMBER } from "./emit-shapes.js";
 import { emitBytesReceiver } from "./emit-exprs.js";
+import { matchIntegerBytesForLoop } from "../../ir/integer-loops.js";
 
 
 
@@ -27,6 +28,7 @@ export function emitFunction(E: CEmitter, fn: IrFunction): void {
     E.labelCounter = 0;
     E.currentLocals = new Map(fn.locals.map((l) => [l.id, l]));
     E.captureIds = new Set((fn.captures ?? []).map((c) => c.localId));
+    E.integerLoopBindings.clear();
 
     E.line(`${E.signature(fn)} {${E.srcComment(fn.loc)}`);
     E.indent++;
@@ -307,13 +309,24 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
       case "for": {
         // Desugared in place; the init's scope wraps the whole loop, so
         // break/continue must NOT release it (scopeDepth captured after).
+        const integerLoop = matchIntegerBytesForLoop(s, E.currentLocals);
         E.line(`{${E.srcComment(s.loc)}`);
         E.indent++;
         E.scopes.push([]);
-        if (s.init) E.emitStmt(s.init);
+        let integerShadow: string | null = null;
+        if (integerLoop) {
+          integerShadow = `sc_i${E.tempCounter++}`;
+          E.line(`uint64_t ${integerShadow} = 0; /* integer induction ${E.currentLocals.get(integerLoop.localId)!.name} */`);
+          E.integerLoopBindings.set(integerLoop.localId, integerShadow);
+        } else if (s.init) {
+          E.emitStmt(s.init);
+        }
         E.line(`for (;;) {`);
         E.indent++;
-        if (s.cond) {
+        if (integerLoop && integerShadow) {
+          const receiver = emitBytesReceiver(E, integerLoop.limitReceiver, []);
+          E.line(`if (!(${integerShadow} < ${receiver.name}->len)) break;`);
+        } else if (s.cond) {
           const cond = E.emitCondition(s.cond);
           E.line(`if (!(${cond})) break;`);
         }
@@ -341,7 +354,8 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
             // loop exit — which is now the freshest binding. Nothing to fix.
           }
         }
-        if (s.update) E.emitStmt(s.update);
+        if (integerLoop && integerShadow) E.line(`${integerShadow}++;`);
+        else if (s.update) E.emitStmt(s.update);
         E.indent--;
         E.line(`}`);
         // A labeled break lands exactly where C break does: BEFORE the
@@ -349,6 +363,7 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
         // as the fall-through path).
         if (loop.usedEnd) E.line(`${loop.endLabel}:;`);
         E.releaseFrame(E.scopes.pop()!);
+        if (integerLoop) E.integerLoopBindings.delete(integerLoop.localId);
         E.indent--;
         E.line(`}`);
         break;
@@ -373,11 +388,12 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
         // append. The IR carries the element kind; do not rediscover it in
         // the generic runtime accessor on every loop iteration.
         const arr = emitBytesReceiver(E, s.arr, [s.index, s.value]);
-        const idx = E.emitExpr(s.index);
+        const integerIndex = E.integerLoopIndex(s.index);
+        const idx = integerIndex === null ? E.emitExpr(s.index).name : integerIndex;
         const v = E.emitExpr(s.value);
         if (s.arr.type.kind !== "bytes") throw new Error("emitter bug: bytesSet on non-bytes");
         E.line(
-          `${E.bytesElementHelper("set", s.arr.type.elem)}(${arr.name}, ${idx.name}, ${v.name});${E.srcComment(s.loc)}`,
+          `${E.bytesElementHelper("set", s.arr.type.elem, integerIndex !== null)}(${arr.name}, ${idx}, ${v.name});${E.srcComment(s.loc)}`,
         );
         break;
       }

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -87,7 +87,7 @@ export class CEmitter {
   /** Kind-specialized typed-array access helpers actually used by this
    * program. Keeping these in the generated TU means unrelated binaries do
    * not pay even debug/link metadata for byte-loop fast paths. */
-  readonly bytesElementHelpers = new Set<`${"get" | "set"}:${IrBytesElem}`>();
+  readonly bytesElementHelpers = new Set<`${"get" | "set"}:${IrBytesElem}:${"f64" | "u64"}`>();
   /** Interned unit-armed union instances: "unionId:tag" → static symbol.
    * A unit arm (undefined/null) has no payload, so every instance of one
    * (union, tag) pair is identical — ONE immortal (rc == SIZE_MAX) static
@@ -122,6 +122,10 @@ export class CEmitter {
    * borrowed — never declared, never released here). */
   currentLocals = new Map<string, IrLocal>();
   captureIds = new Set<string>();
+  /** Canonical byte-loop induction locals currently represented by an
+   * unsigned integer shadow. Ordinary number reads widen the shadow back to
+   * f64; direct byte indices consume it without a conversion round trip. */
+  integerLoopBindings = new Map<string, string>();
   /** Declared functions referenced as values: each needs an env-signature
    * wrapper + an interned immortal closure (so `f === f` holds). */
   readonly fnValues = new Set<string>();
@@ -1308,23 +1312,40 @@ export class CEmitter {
 
   /* ── plumbing ─────────────────────────────────────────────────────── */
 
-  bytesElementHelper(op: "get" | "set", elem: IrBytesElem): string {
-    this.bytesElementHelpers.add(`${op}:${elem}`);
-    return `sc_bytes_${op}_${elem}`;
+  integerLoopIndex(expr: IrExpr): string | null {
+    return expr.kind === "varRef" ? this.integerLoopBindings.get(expr.localId) ?? null : null;
+  }
+
+  bytesElementHelper(op: "get" | "set", elem: IrBytesElem, integerIndex = false): string {
+    const mode = integerIndex ? "u64" : "f64";
+    this.bytesElementHelpers.add(`${op}:${elem}:${mode}`);
+    return `sc_bytes_${op}_${elem}${integerIndex ? "_u64" : ""}`;
   }
 
   private emitBytesElementHelpers(): string[] {
     if (this.bytesElementHelpers.size === 0) return [];
-    const out = [
-      `/* Typed-array hot paths specialized from the IR element kind. */`,
-      `static inline size_t sc_bytes_index_checked(const ScrBytes *b, double i) {`,
-      `  if (!(i >= 0.0 && i < (double)b->len)) { (void)scr_bytes_get(b, i); return 0; }`,
-      `  size_t idx = (size_t)i;`,
-      `  if ((double)idx != i) { (void)scr_bytes_get(b, i); return 0; }`,
-      `  return idx;`,
-      `}`,
-    ];
-    if ([...this.bytesElementHelpers].some((key) => key.startsWith("set:") && key !== "set:f32")) {
+    const hasF64 = [...this.bytesElementHelpers].some((key) => key.endsWith(":f64"));
+    const hasU64 = [...this.bytesElementHelpers].some((key) => key.endsWith(":u64"));
+    const out = [`/* Typed-array hot paths specialized from the IR element kind. */`];
+    if (hasF64) {
+      out.push(
+        `static inline size_t sc_bytes_index_checked(const ScrBytes *b, double i) {`,
+        `  if (!(i >= 0.0 && i < (double)b->len)) { (void)scr_bytes_get(b, i); return 0; }`,
+        `  size_t idx = (size_t)i;`,
+        `  if ((double)idx != i) { (void)scr_bytes_get(b, i); return 0; }`,
+        `  return idx;`,
+        `}`,
+      );
+    }
+    if (hasU64) {
+      out.push(
+        `static inline size_t sc_bytes_index_u64_checked(const ScrBytes *b, uint64_t i) {`,
+        `  if (i >= b->len) { (void)scr_bytes_get(b, (double)i); return 0; }`,
+        `  return (size_t)i;`,
+        `}`,
+      );
+    }
+    if ([...this.bytesElementHelpers].some((key) => key.startsWith("set:") && key.split(":")[1] !== "f32")) {
       out.push(
         `static inline uint32_t sc_bytes_coerce_u32(double v) {`,
         `  if (v >= -9007199254740992.0 && v <= 9007199254740992.0) return (uint32_t)(int64_t)v;`,
@@ -1336,41 +1357,46 @@ export class CEmitter {
       );
     }
     for (const elem of ["u8", "u32", "i32", "f32"] as const) {
-      if (this.bytesElementHelpers.has(`get:${elem}`)) {
-        if (elem === "u8") {
-          out.push(
-            `static inline double sc_bytes_get_u8(const ScrBytes *b, double i) {`,
-            `  return (double)b->data[sc_bytes_index_checked(b, i)];`,
-            `}`,
-          );
-        } else {
-          const valueType = elem === "f32" ? "float" : elem === "i32" ? "int32_t" : "uint32_t";
-          out.push(
-            `static inline double sc_bytes_get_${elem}(const ScrBytes *b, double i) {`,
-            `  ${valueType} v;`,
-            `  memcpy(&v, b->data + sc_bytes_index_checked(b, i) * 4, 4);`,
-            `  return (double)v;`,
-            `}`,
-          );
+      for (const mode of ["f64", "u64"] as const) {
+        const suffix = mode === "u64" ? "_u64" : "";
+        const indexType = mode === "u64" ? "uint64_t" : "double";
+        const checked = mode === "u64" ? "sc_bytes_index_u64_checked" : "sc_bytes_index_checked";
+        if (this.bytesElementHelpers.has(`get:${elem}:${mode}`)) {
+          if (elem === "u8") {
+            out.push(
+              `static inline double sc_bytes_get_u8${suffix}(const ScrBytes *b, ${indexType} i) {`,
+              `  return (double)b->data[${checked}(b, i)];`,
+              `}`,
+            );
+          } else {
+            const valueType = elem === "f32" ? "float" : elem === "i32" ? "int32_t" : "uint32_t";
+            out.push(
+              `static inline double sc_bytes_get_${elem}${suffix}(const ScrBytes *b, ${indexType} i) {`,
+              `  ${valueType} v;`,
+              `  memcpy(&v, b->data + ${checked}(b, i) * 4, 4);`,
+              `  return (double)v;`,
+              `}`,
+            );
+          }
         }
-      }
-      if (this.bytesElementHelpers.has(`set:${elem}`)) {
-        if (elem === "u8") {
-          out.push(
-            `static inline void sc_bytes_set_u8(ScrBytes *b, double i, double v) {`,
-            `  b->data[sc_bytes_index_checked(b, i)] = (uint8_t)sc_bytes_coerce_u32(v);`,
-            `}`,
-          );
-        } else {
-          const valueType = elem === "f32" ? "float" : "uint32_t";
-          const init = elem === "f32" ? `(float)v` : `sc_bytes_coerce_u32(v)`;
-          out.push(
-            `static inline void sc_bytes_set_${elem}(ScrBytes *b, double i, double v) {`,
-            `  size_t idx = sc_bytes_index_checked(b, i);`,
-            `  ${valueType} stored = ${init};`,
-            `  memcpy(b->data + idx * 4, &stored, 4);`,
-            `}`,
-          );
+        if (this.bytesElementHelpers.has(`set:${elem}:${mode}`)) {
+          if (elem === "u8") {
+            out.push(
+              `static inline void sc_bytes_set_u8${suffix}(ScrBytes *b, ${indexType} i, double v) {`,
+              `  b->data[${checked}(b, i)] = (uint8_t)sc_bytes_coerce_u32(v);`,
+              `}`,
+            );
+          } else {
+            const valueType = elem === "f32" ? "float" : "uint32_t";
+            const init = elem === "f32" ? `(float)v` : `sc_bytes_coerce_u32(v)`;
+            out.push(
+              `static inline void sc_bytes_set_${elem}${suffix}(ScrBytes *b, ${indexType} i, double v) {`,
+              `  size_t idx = ${checked}(b, i);`,
+              `  ${valueType} stored = ${init};`,
+              `  memcpy(b->data + idx * 4, &stored, 4);`,
+              `}`,
+            );
+          }
         }
       }
     }

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -75,6 +75,7 @@ import type {
   SrcLoc,
 } from "../../ir/nodes.js";
 import { canMarshalFuncIntoIsland, CAUGHT, DYN, F64, islandCallbackRet, islandPromisePayloadTag, isRefCounted, isUnitType, MAY_THROW_LIB_FNS, moduleUsesDynInvoke, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttpServer, moduleUsesNet, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, typeEquals, typeKey, VOID } from "../../ir/nodes.js";
+import { matchIntegerBytesForLoop } from "../../ir/integer-loops.js";
 import { computeMayThrow } from "../emission/may-throw.js";
 import { mangleArgPack, mangleAsyncSpawn, mangleClassNew, mangleClassObj, mangleClassRetain, mangleFnClosure, mangleFunction, mangleGenDrop, mangleGenResThunk, mangleGenSpawn, mangleGlobal, mangleLocal, mangleRecordNew, mangleRecordStruct, mangleResolveThunk, mangleTrampoline, mangleVtStruct, mangleWrapper } from "../mangle.js";
 import { BlockBuilder } from "./blocks.js";
@@ -1025,6 +1026,8 @@ class LlEmitter {
   }[] = [];
   private currentLocals = new Map<string, IrLocal>();
   private captureIds = new Set<string>();
+  /** Active canonical byte-loop induction bindings: local id → i64 slot. */
+  private integerLoopBindings = new Map<string, string>();
   /** Enclosing try-with-FINALLY regions, innermost last: a `return`
    * inside one runs every crossed finally (innermost first) before the
    * actual ret — the C emitter's pending-return path, with the finally
@@ -3044,6 +3047,7 @@ class LlEmitter {
     this.jumpTargets = [];
     this.currentLocals = new Map(fn.locals.map((l) => [l.id, l]));
     this.captureIds = new Set((fn.captures ?? []).map((c) => c.localId));
+    this.integerLoopBindings.clear();
     this.chainSlots.clear();
     this.finallyStack = [];
     this.tryStack = [];
@@ -3242,10 +3246,11 @@ class LlEmitter {
         // append. IrBytesElem is static, so never rediscover it through the
         // generic runtime switch in a hot loop.
         const arr = this.emitBytesReceiver(s.arr, [s.index, s.value]);
-        const idx = this.emitExpr(s.index);
+        const integerIndex = this.emitIntegerLoopIndex(s.index);
+        const idx = integerIndex ?? this.emitExpr(s.index).name;
         const v = this.emitExpr(s.value);
         if (s.arr.type.kind !== "bytes") throw new Error("llvm emitter bug: bytesSet on non-bytes");
-        this.emitBytesSet(s.arr.type.elem, arr.name, idx.name, v.name);
+        this.emitBytesSet(s.arr.type.elem, arr.name, idx, v.name, integerIndex !== null);
         break;
       }
       case "fieldSet":
@@ -3496,8 +3501,17 @@ class LlEmitter {
       case "for": {
         // The init's scope wraps the whole loop (break/continue must NOT
         // release it — scopeDepth captured after the push, C parity).
+        const integerLoop = matchIntegerBytesForLoop(s, this.currentLocals);
         this.scopes.push([]);
-        if (s.init) this.emitStmt(s.init);
+        let integerSlot: string | null = null;
+        if (integerLoop) {
+          integerSlot = B.slot();
+          B.entryAllocas.push(`${integerSlot} = alloca i64 ; integer induction ${this.currentLocals.get(integerLoop.localId)!.name}`);
+          B.line(`store i64 0, ptr ${integerSlot}`);
+          this.integerLoopBindings.set(integerLoop.localId, integerSlot);
+        } else if (s.init) {
+          this.emitStmt(s.init);
+        }
         const lc = B.newLabel("loop.c");
         const lb = B.newLabel("loop.b");
         const le = B.newLabel("loop.e");
@@ -3511,7 +3525,18 @@ class LlEmitter {
         const lu = s.update || freshens ? B.newLabel("loop.u") : lc;
         B.br(lc);
         B.startBlock(lc);
-        if (s.cond) B.condBr(this.emitCondition(s.cond), lb, le);
+        if (integerLoop && integerSlot) {
+          const receiver = this.emitBytesReceiver(integerLoop.limitReceiver, []);
+          const lenPtr = B.tmp();
+          const len = B.tmp();
+          const index = B.tmp();
+          const inBounds = B.tmp();
+          B.line(`${lenPtr} = getelementptr inbounds %ScrBytes, ptr ${receiver.name}, i64 0, i32 1`);
+          B.line(`${len} = load i64, ptr ${lenPtr}`);
+          B.line(`${index} = load i64, ptr ${integerSlot}`);
+          B.line(`${inBounds} = icmp ult i64 ${index}, ${len}`);
+          B.condBr(inBounds, lb, le);
+        } else if (s.cond) B.condBr(this.emitCondition(s.cond), lb, le);
         else B.br(lb);
         B.startBlock(lb);
         this.jumpTargets.push({
@@ -3541,11 +3566,18 @@ class LlEmitter {
             // The wrapper scope's entry releases whatever the slot points
             // to at loop exit — now the freshest binding. Nothing to fix.
           }
-          if (s.update) this.emitStmt(s.update);
+          if (integerLoop && integerSlot) {
+            const old = B.tmp();
+            const next = B.tmp();
+            B.line(`${old} = load i64, ptr ${integerSlot}`);
+            B.line(`${next} = add nuw i64 ${old}, 1`);
+            B.line(`store i64 ${next}, ptr ${integerSlot}`);
+          } else if (s.update) this.emitStmt(s.update);
           B.br(lc);
         }
         B.startBlock(le);
         this.releaseScope(this.scopes.pop()!);
+        if (integerLoop) this.integerLoopBindings.delete(integerLoop.localId);
         break;
       }
       case "forOf": {
@@ -4016,6 +4048,14 @@ class LlEmitter {
         // tag-only); one reaching the generic dispatch escaped its wrap.
         throw new Error(`llvm emitter bug: bare unitLit '${e.unit}'`);
       case "varRef": {
+        const integerSlot = this.integerLoopBindings.get(e.localId);
+        if (integerSlot !== undefined) {
+          const integer = B.tmp();
+          const number = B.tmp();
+          B.line(`${integer} = load i64, ptr ${integerSlot}`);
+          B.line(`${number} = uitofp i64 ${integer} to double`);
+          return { name: number, type: e.type };
+        }
         const b = this.binding(e.localId);
         if (b.kind === "boxed") {
           // Reads go through the shared binding; ref kinds come out +1.
@@ -9536,20 +9576,46 @@ class LlEmitter {
     return this.emitExpr(receiver);
   }
 
+  /** Load a canonical integer-loop induction value for a direct index use.
+   * Other expression shapes retain ordinary f64 evaluation. */
+  private emitIntegerLoopIndex(expr: IrExpr): string | null {
+    if (expr.kind !== "varRef") return null;
+    const slot = this.integerLoopBindings.get(expr.localId);
+    if (slot === undefined) return null;
+    const index = this.B.tmp();
+    this.B.line(`${index} = load i64, ptr ${slot}`);
+    return index;
+  }
+
   /** Bounds-check a typed-array element index without an out-of-line call
    * on the valid path. The range test rejects NaN/infinity before fptoui;
    * the integer round trip then rejects fractions. The error block retains
    * the runtime's exact trap text. Leaves the builder in the valid block. */
-  private emitBytesIndex(receiver: string, index: string): string {
+  private emitBytesIndex(receiver: string, index: string, integerIndex = false): string {
     const B = this.B;
     const lenPtr = B.tmp();
     const len = B.tmp();
+    B.line(`${lenPtr} = getelementptr inbounds %ScrBytes, ptr ${receiver}, i64 0, i32 1`);
+    B.line(`${len} = load i64, ptr ${lenPtr}`);
+    if (integerIndex) {
+      const inRange = B.tmp();
+      B.line(`${inRange} = icmp ult i64 ${index}, ${len}`);
+      const invalid = B.newLabel("bytes.index.invalid");
+      const valid = B.newLabel("bytes.index.valid");
+      B.condBr(inRange, valid, invalid);
+      B.startBlock(invalid);
+      const indexF64 = B.tmp();
+      B.line(`${indexF64} = uitofp i64 ${index} to double`);
+      this.declare(`declare double @scr_bytes_get(ptr, double)`);
+      B.line(`call double @scr_bytes_get(ptr ${receiver}, double ${indexF64})`);
+      B.terminate("unreachable");
+      B.startBlock(valid);
+      return index;
+    }
     const lenF64 = B.tmp();
     const nonnegative = B.tmp();
     const belowLen = B.tmp();
     const inRange = B.tmp();
-    B.line(`${lenPtr} = getelementptr inbounds %ScrBytes, ptr ${receiver}, i64 0, i32 1`);
-    B.line(`${len} = load i64, ptr ${lenPtr}`);
     B.line(`${lenF64} = uitofp i64 ${len} to double`);
     B.line(`${nonnegative} = fcmp oge double ${index}, ${f64Lit(0)}`);
     B.line(`${belowLen} = fcmp olt double ${index}, ${lenF64}`);
@@ -9602,9 +9668,9 @@ class LlEmitter {
   }
 
   /** Kind-specialized typed-array load. */
-  private emitBytesGet(elem: IrBytesElem, receiver: string, index: string): LlValue {
+  private emitBytesGet(elem: IrBytesElem, receiver: string, index: string, integerIndex = false): LlValue {
     const B = this.B;
-    const idx = this.emitBytesIndex(receiver, index);
+    const idx = this.emitBytesIndex(receiver, index, integerIndex);
     const data = this.emitBytesData(receiver);
     const p = B.tmp();
     if (elem === "u8") {
@@ -9705,9 +9771,9 @@ class LlEmitter {
   }
 
   /** Kind-specialized typed-array store. */
-  private emitBytesSet(elem: IrBytesElem, receiver: string, index: string, value: string): void {
+  private emitBytesSet(elem: IrBytesElem, receiver: string, index: string, value: string, integerIndex = false): void {
     const B = this.B;
-    const idx = this.emitBytesIndex(receiver, index);
+    const idx = this.emitBytesIndex(receiver, index, integerIndex);
     const stored = elem === "f32" ? null : this.emitBytesU32(value);
     const data = this.emitBytesData(receiver);
     const p = B.tmp();
@@ -9779,7 +9845,8 @@ class LlEmitter {
     const r = directElementAccess
       ? this.emitBytesReceiver(e.receiver, e.args)
       : this.emitExpr(e.receiver);
-    const args = e.args.map((a) => this.emitExpr(a));
+    const integerIndex = method === "get" ? this.emitIntegerLoopIndex(e.args[0]!) : null;
+    const args = integerIndex === null ? e.args.map((a) => this.emitExpr(a)) : [];
     const NAN = f64Lit(NaN);
     switch (method) {
       case "length":
@@ -9797,7 +9864,12 @@ class LlEmitter {
         if (e.receiver.type.kind !== "bytes") {
           throw new Error("llvm emitter bug: bytesIntrinsic get on non-bytes");
         }
-        return this.emitBytesGet(e.receiver.type.elem, r.name, args[0]!.name);
+        return this.emitBytesGet(
+          e.receiver.type.elem,
+          r.name,
+          integerIndex ?? args[0]!.name,
+          integerIndex !== null,
+        );
       case "slice":
         return call(
           "scr_bytes_slice",

--- a/packages/compiler/src/ir/integer-loops.ts
+++ b/packages/compiler/src/ir/integer-loops.ts
@@ -1,0 +1,102 @@
+import type { IrExpr, IrLocal, IrStmt } from "./nodes.js";
+
+/** A canonical byte loop whose induction variable is mathematically an
+ * unsigned integer for every body entry. Backends may keep this binding in
+ * integer storage while the loop runs, converting to f64 at ordinary JS
+ * number uses and using the integer directly for typed-array indices. */
+export interface IntegerBytesForLoop {
+  localId: string;
+  limitReceiver: IrExpr;
+}
+
+/** True when a lowered subtree writes `localId`. Local ids are unique per
+ * function, so a generic structured walk is sufficient and includes writes
+ * nested in expressions, branches, nested loops, and try/finally bodies. */
+function writesLocal(value: unknown, localId: string): boolean {
+  if (Array.isArray(value)) return value.some((item) => writesLocal(item, localId));
+  if (value === null || typeof value !== "object") return false;
+  const node = value as { kind?: unknown; localId?: unknown };
+  if (
+    (node.kind === "assign" || node.kind === "assignExpr" || node.kind === "incDec") &&
+    node.localId === localId
+  ) {
+    return true;
+  }
+  for (const [key, child] of Object.entries(value)) {
+    if (key === "type" || key === "loc") continue;
+    if (writesLocal(child, localId)) return true;
+  }
+  return false;
+}
+
+function isUnitIncrement(update: IrStmt | null, localId: string): boolean {
+  // The frontend normally lowers `i++` to `i = i + 1` before backend
+  // emission. Accept the incDec form too so this analysis remains valid for
+  // hand-built IR and if normalization is moved later in the pipeline.
+  if (update?.kind === "exprStmt") {
+    return (
+      update.expr.kind === "incDec" &&
+      update.expr.localId === localId &&
+      update.expr.op === "+"
+    );
+  }
+  return (
+    update?.kind === "assign" &&
+    update.localId === localId &&
+    update.value.kind === "bin" &&
+    update.value.op === "+" &&
+    update.value.left.kind === "varRef" &&
+    update.value.left.localId === localId &&
+    update.value.right.kind === "numLit" &&
+    update.value.right.value === 1
+  );
+}
+
+/** Recognize the deliberately small, semantics-transparent first tier of
+ * integer induction:
+ *
+ *   for (let i = 0; i < bytes.length; i++) { ... }
+ *
+ * The binding must be an unboxed mutable f64 local and the body must not
+ * write it. The exact zero start plus unit increment and ScrBytes' fixed,
+ * safe-integer length prove every body value is an exactly representable
+ * non-negative integer. A captured loop binding is boxed and therefore
+ * refused (per-iteration binding identity remains on the generic path).
+ */
+export function matchIntegerBytesForLoop(
+  stmt: IrStmt & { kind: "for" },
+  locals: ReadonlyMap<string, IrLocal>,
+): IntegerBytesForLoop | null {
+  const init = stmt.init;
+  if (
+    init?.kind !== "varDecl" ||
+    init.init?.kind !== "numLit" ||
+    init.init.value !== 0 ||
+    Object.is(init.init.value, -0)
+  ) {
+    return null;
+  }
+  const local = locals.get(init.localId);
+  if (local?.type.kind !== "f64" || !local.mutable || local.boxed === true) return null;
+
+  const cond = stmt.cond;
+  if (
+    cond?.kind !== "bin" ||
+    cond.op !== "<" ||
+    cond.left.kind !== "varRef" ||
+    cond.left.localId !== init.localId ||
+    cond.right.kind !== "bytesIntrinsic" ||
+    cond.right.method !== "length" ||
+    cond.right.receiver.kind !== "varRef" ||
+    cond.right.receiver.type.kind !== "bytes"
+  ) {
+    return null;
+  }
+  const receiverLocal = locals.get(cond.right.receiver.localId);
+  if (receiverLocal?.boxed === true) return null;
+
+  if (!isUnitIncrement(stmt.update, init.localId)) return null;
+  if (writesLocal(stmt.body, init.localId)) return null;
+
+  return { localId: init.localId, limitReceiver: cond.right.receiver };
+}

--- a/packages/compiler/test/bytes-element-emission.test.ts
+++ b/packages/compiler/test/bytes-element-emission.test.ts
@@ -168,6 +168,80 @@ function sideEffectFixture(): IrModule {
   return mod;
 }
 
+function integerLoopFixture(mutatesIndex = false): IrModule {
+  const bytes = bytesOf("u8");
+  const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+  const ref = (localId: string, type = F64): IrExpr => ({ kind: "varRef", localId, type, loc });
+  const bytesRef = (): IrExpr => ref("bytes", bytes);
+  const indexRef = (): IrExpr => ref("index");
+  const get: IrExpr = {
+    kind: "bytesIntrinsic",
+    method: "get",
+    receiver: bytesRef(),
+    args: [indexRef()],
+    type: F64,
+    loc,
+  };
+  const loopBody: IrStmt[] = [];
+  if (mutatesIndex) {
+    loopBody.push({
+      kind: "assign",
+      localId: "index",
+      value: { kind: "bin", op: "+", left: indexRef(), right: num(1), type: F64, loc },
+      loc,
+    });
+  }
+  loopBody.push(
+    {
+      kind: "assign",
+      localId: "sum",
+      value: { kind: "bin", op: "+", left: ref("sum"), right: get, type: F64, loc },
+      loc,
+    },
+    { kind: "bytesSet", arr: bytesRef(), index: indexRef(), value: ref("sum"), loc },
+  );
+  return {
+    irVersion: 3,
+    sourceFile: loc.file,
+    entry: "__main",
+    functions: [{
+      name: "__main",
+      params: [],
+      returnType: VOID,
+      locals: [
+        { id: "bytes", name: "bytes", type: bytes, mutable: false },
+        { id: "sum", name: "sum", type: F64, mutable: true },
+        { id: "index", name: "index", type: F64, mutable: true },
+      ],
+      body: [
+        { kind: "varDecl", localId: "bytes", init: { kind: "bytesNew", source: num(4), type: bytes, loc }, loc },
+        { kind: "varDecl", localId: "sum", init: num(0), loc },
+        {
+          kind: "for",
+          init: { kind: "varDecl", localId: "index", init: num(0), loc },
+          cond: {
+            kind: "bin",
+            op: "<",
+            left: indexRef(),
+            right: { kind: "bytesIntrinsic", method: "length", receiver: bytesRef(), args: [], type: F64, loc },
+            type: BOOL,
+            loc,
+          },
+          update: {
+            kind: "assign",
+            localId: "index",
+            value: { kind: "bin", op: "+", left: indexRef(), right: num(1), type: F64, loc },
+            loc,
+          },
+          body: loopBody,
+          loc,
+        },
+      ],
+      loc,
+    }],
+  };
+}
+
 test("C emission specializes typed-array element access by static element kind", () => {
   const mod = fixture();
   expect(validateModule(mod)).toEqual([]);
@@ -218,4 +292,33 @@ test("receiver assignments nested in numeric operands retain the receiver snapsh
   // Two receiver snapshots plus two retains per yielded bytes assignment
   // (one for the RHS temp and one for the binding's stored reference).
   expect(ll.match(/call ptr @scr_bytes_retain_v/g)).toHaveLength(6);
+});
+
+test("canonical byte loops keep their induction variable and indices integral", () => {
+  const mod = integerLoopFixture();
+  expect(validateModule(mod)).toEqual([]);
+  const c = emitModule(mod);
+  const ll = emitLlvmModule(mod);
+
+  expect(c).toContain("uint64_t sc_i");
+  expect(c).toContain("sc_bytes_get_u8_u64(");
+  expect(c).toContain("sc_bytes_set_u8_u64(");
+  expect(c).not.toContain("sc_bytes_index_checked(");
+
+  expect(ll).toContain("alloca i64 ; integer induction index");
+  expect(ll).toContain("icmp ult i64");
+  expect(ll).not.toContain("bytes.index.range");
+});
+
+test("a body mutation keeps the byte loop on the general f64 path", () => {
+  const mod = integerLoopFixture(true);
+  expect(validateModule(mod)).toEqual([]);
+  const c = emitModule(mod);
+  const ll = emitLlvmModule(mod);
+
+  expect(c).not.toContain("integer induction index");
+  expect(c).not.toContain("_u64(");
+  expect(ll).not.toContain("integer induction index");
+  expect(ll).toContain("bytes.index.range");
+  expect(ll).toContain("fptoui double");
 });

--- a/tests/corpus/1409-typedarray-integer-loops.ts
+++ b/tests/corpus/1409-typedarray-integer-loops.ts
@@ -1,0 +1,49 @@
+// Canonical byte loops use integer induction internally while every ordinary
+// observation of the index remains a JavaScript number. Body mutation falls
+// back to the general f64 path; changing the fixed-length receiver binding is
+// safe because the loop condition and accesses read the current receiver.
+function byteSum(buf: Uint8Array): number {
+  let sum = 0;
+  for (let i = 0; i < buf.length; i++) sum += buf[i];
+  return sum;
+}
+
+function byteFill(buf: Uint8Array, value: number): void {
+  for (let i = 0; i < buf.length; i++) buf[i] = value;
+}
+
+function weighted(buf: Uint8Array): number {
+  let sum = 0;
+  for (let i = 0; i < buf.length; i++) {
+    if (i === 2) continue;
+    sum += i * buf[i];
+  }
+  return sum;
+}
+
+function bodyMutation(buf: Uint8Array): number {
+  let digits = 0;
+  for (let i = 0; i < buf.length; i++) {
+    if (i === 1) i++;
+    digits = digits * 10 + buf[i];
+  }
+  return digits;
+}
+
+function receiverChange(first: Uint8Array, replacement: Uint8Array): number {
+  let current = first;
+  let sum = 0;
+  for (let i = 0; i < current.length; i++) {
+    if (i === 1) current = replacement;
+    sum += current[i];
+  }
+  return sum;
+}
+
+const bytes = new Uint8Array([1, 2, 3, 4]);
+console.log("sum", byteSum(bytes));
+console.log("weighted", weighted(bytes));
+console.log("mutated", bodyMutation(bytes));
+console.log("receiver", receiverChange(new Uint8Array([5, 6]), new Uint8Array([10, 20, 30, 40])));
+byteFill(bytes, 9);
+console.log("filled", bytes.join(","), byteSum(bytes));


### PR DESCRIPTION
- Recognize canonical typed-array loops with semantics-safe fallbacks.
- Emit integer induction and direct integer byte indices in C and LLVM.
- Add backend and differential regression coverage.