### PR TITLE
fix: prevent socket reads from starving timers

### DIFF
--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -987,15 +987,21 @@ static bool scr_net_sock_deliver(ScrNetSocket *s, const char *buf, size_t n) {
   return true;
 }
 
-/* One readable wake: read until EAGAIN/EOF, one 'data' emit per read(2)
- * chunk (Node's chunking is arrival-driven too — only the reassembled
- * bytes are contractual, the stdin stance). Peeked/unshifted bytes in
- * the receive buffer deliver first — they precede the kernel's in the
- * stream. A TLS socket drains those through the engine's bio instead. */
+/* One readable wake: read until EAGAIN/EOF OR a bounded batch, one 'data'
+ * emit per read(2) chunk (Node's chunking is arrival-driven too — only the
+ * reassembled bytes are contractual, the stdin stance). The batch bound is
+ * the loop's fairness fence: a continuously writing peer can otherwise keep
+ * every nonblocking read successful forever and strand timers plus every
+ * other fd inside this function. All poller arms are level-triggered, so
+ * unread kernel bytes make the socket ready again on the next loop turn.
+ * Peeked/unshifted bytes in the receive buffer deliver first — they precede
+ * the kernel's in the stream. A TLS socket drains those through the engine's
+ * bio instead. */
 static void scr_net_sock_append_rbuf(ScrNetSocket *s, const char *data, size_t len);
 static void scr_net_sock_transport_pump(ScrNetSocket *s);
 
 static void scr_net_sock_read(ScrNetSocket *s) {
+  size_t reads_left = 32; /* at most 2 MiB with the 64 KiB read buffer */
   if (s->tops && !s->t_est) return; /* readiness feeds the handshake pump instead */
   for (;;) {
     if (s->fd < 0 || s->user_paused) return;
@@ -1061,6 +1067,7 @@ static void scr_net_sock_read(ScrNetSocket *s) {
       }
     }
     scr_net_sock_update_read(s); /* a once-listener may have been the last consumer */
+    if (--reads_left == 0) return;
   }
 }
 

--- a/tests/fixtures/server/cases/upgrade-read-fairness/driver.mjs
+++ b/tests/fixtures/server/cases/upgrade-read-fairness/driver.mjs
@@ -1,0 +1,42 @@
+import net from "node:net";
+
+const CLIENTS = 8;
+const payload = Buffer.alloc(1024 * 1024, 0x61);
+const port = Number(process.argv[2]);
+const sockets = [];
+let closed = 0;
+
+function flood(socket) {
+  if (socket.destroyed) return;
+  if (socket.write(payload)) setImmediate(() => flood(socket));
+  else socket.once("drain", () => flood(socket));
+}
+
+for (let i = 0; i < CLIENTS; i++) {
+  const socket = net.connect(port, "127.0.0.1");
+  let handshake = "";
+  socket.on("connect", () => {
+    socket.write(
+      `GET /${i} HTTP/1.1\r\nHost: localhost\r\nConnection: Upgrade\r\nUpgrade: websocket\r\n\r\n`,
+    );
+  });
+  socket.on("data", (chunk) => {
+    if (handshake.endsWith("\r\n\r\n")) return;
+    handshake += chunk.toString("latin1");
+    if (!handshake.includes("\r\n\r\n")) return;
+    flood(socket);
+  });
+  socket.on("error", () => {});
+  socket.on("close", () => {
+    closed++;
+    if (closed === CLIENTS) {
+      clearTimeout(watchdog);
+      console.log(`driver closed ${closed} sockets`);
+    }
+  });
+  sockets.push(socket);
+}
+
+const watchdog = setTimeout(() => {
+  for (const socket of sockets) socket.destroy();
+}, 1_000);

--- a/tests/fixtures/server/cases/upgrade-read-fairness/main.ts
+++ b/tests/fixtures/server/cases/upgrade-read-fairness/main.ts
@@ -1,0 +1,56 @@
+/* A continuously writing upgraded peer must not monopolize the native
+ * socket-read loop. The driver starts a backpressure-aware flood after each
+ * HTTP upgrade. Once all clients connect, the timer must still run and tear
+ * the server down while every socket remains readable. */
+import * as http from "node:http";
+
+const CLIENTS = 8;
+const TICKS = 50;
+const destroyers: (() => void)[] = [];
+let connected = 0;
+let bytes = 0;
+let ticks = 0;
+let peerClosed = false;
+
+const server = http.createServer((_req, res) => {
+  res.writeHead(426);
+  res.end();
+});
+
+function tick(): void {
+  ticks++;
+  if (ticks < TICKS) {
+    setTimeout(() => tick(), 10);
+    return;
+  }
+  console.log(
+    `timers stayed live with ${connected} upgraded sockets`,
+    bytes > 0,
+    peerClosed,
+  );
+  for (const destroy of destroyers) destroy();
+  server.close();
+}
+
+server.on("upgrade", (_req, socket, _head) => {
+  socket.write(
+    "HTTP/1.1 101 Switching Protocols\r\nUpgrade: websocket\r\nConnection: Upgrade\r\n\r\n",
+  );
+  socket.on("error", () => socket.destroy());
+  socket.on("close", () => {
+    peerClosed = true;
+  });
+  destroyers.push(() => socket.destroy());
+  connected++;
+
+  socket.on("data", (chunk: Buffer) => {
+    bytes += chunk.length;
+  });
+  if (connected === CLIENTS) {
+    setTimeout(() => tick(), 10);
+  }
+});
+
+server.listen(0, () => {
+  process.stderr.write(`PORT ${server.address().port}\n`);
+});


### PR DESCRIPTION
- Bound each readable wake so busy sockets yield to timers and other descriptors.
- Add differential coverage for continuously flooded upgraded connections.