### PR TITLE
Support static HTTP server timeout properties

### DIFF
--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -2118,17 +2118,22 @@ declare module "node:net" {
  * connection per call (no agent pooling) with Node's exact wire head. */
 declare module "http" {
   import { Server as NetServer, Socket } from "net";
-  export type Server = NetServer;
+  export interface Server extends NetServer {
+    timeout: number;
+    keepAliveTimeout: number;
+    headersTimeout: number;
+    requestTimeout: number;
+  }
   export type RequestListener =
     (req: IncomingMessage, res: ServerResponse) => void;
   /* The Server VALUE — Node's constructor works with and without `new`
    * (test/parallel's http.Server(fn) spelling); both route to the
    * createServer lowering. */
   export const Server: {
-    new (requestListener?: (req: IncomingMessage, res: ServerResponse) => void): NetServer;
-    new (options: ServerOptions, requestListener?: (req: IncomingMessage, res: ServerResponse) => void): NetServer;
-    (requestListener?: (req: IncomingMessage, res: ServerResponse) => void): NetServer;
-    (options: ServerOptions, requestListener?: (req: IncomingMessage, res: ServerResponse) => void): NetServer;
+    new (requestListener?: (req: IncomingMessage, res: ServerResponse) => void): Server;
+    new (options: ServerOptions, requestListener?: (req: IncomingMessage, res: ServerResponse) => void): Server;
+    (requestListener?: (req: IncomingMessage, res: ServerResponse) => void): Server;
+    (options: ServerOptions, requestListener?: (req: IncomingMessage, res: ServerResponse) => void): Server;
   };
   /* The options-record stance (the RequestOptions precedent): every
    * documented key typechecks; the lowering's option walk decides per
@@ -2392,7 +2397,7 @@ declare module "node:tls" {
  * self-signed probe shape). With neither, /etc/ssl/cert.pem stands in
  * for Node's bundled roots. */
 declare module "https" {
-  import { Server } from "net";
+  import { Server } from "http";
   import { Agent, ClientRequest, IncomingMessage, ServerResponse } from "http";
   export { Agent, Server };
   export interface ServerOptions {

--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -2121,6 +2121,7 @@ declare module "http" {
   export interface Server extends NetServer {
     timeout: number;
     keepAliveTimeout: number;
+    keepAliveTimeoutBuffer: number;
     headersTimeout: number;
     requestTimeout: number;
   }

--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -2138,11 +2138,13 @@ declare module "http" {
   };
   /* The options-record stance (the RequestOptions precedent): every
    * documented key typechecks; the lowering's option walk decides per
-   * key — requireHostHeader: false and joinDuplicateHeaders lower,
+   * key — requireHostHeader: false, joinDuplicateHeaders, and
+   * keepAliveTimeoutBuffer lower,
    * documented-but-unlowered keys fence by name, unknown keys drop. */
   export interface ServerOptions {
     requireHostHeader?: boolean;
     joinDuplicateHeaders?: boolean;
+    keepAliveTimeoutBuffer?: number;
     [option: string]: unknown;
   }
   /* The outgoing-header shape, @types/node's matrix: numbers format via

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -4469,6 +4469,8 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           case "http.serverTimeoutSet":
             E.line(`scr_net_server_timeout_set(${arg(0)}, ${arg(1)}, ${arg(2)});${E.srcComment(e.loc)}`);
             return { name: "", type: e.type };
+          case "http.serverTimeoutOptionSet":
+            return finish(`scr_net_server_timeout_option_set(${arg(0)}, ${arg(1)}, ${arg(2)})`);
           case "net.serverOnListening": {
             const cb = args[1]!;
             E.moveTemp(cb);

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -4464,6 +4464,11 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           case "http.serverJoinDupHeaders":
             E.line(`scr_http_server_join_duplicate_headers(${arg(0)});${E.srcComment(e.loc)}`);
             return { name: "", type: e.type };
+          case "http.serverTimeoutGet":
+            return finish(`scr_net_server_timeout_get(${arg(0)}, ${arg(1)})`);
+          case "http.serverTimeoutSet":
+            E.line(`scr_net_server_timeout_set(${arg(0)}, ${arg(1)}, ${arg(2)});${E.srcComment(e.loc)}`);
+            return { name: "", type: e.type };
           case "net.serverOnListening": {
             const cb = args[1]!;
             E.moveTemp(cb);

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -686,6 +686,8 @@ const LIB_FN_SYMS: Record<string, string> = {
   "http.resWriteHeadPairs": "scr_http_res_write_head_pairs",
   "http.resWriteHeadDyn": "scr_http_res_write_head_dyn",
   "http.serverJoinDupHeaders": "scr_http_server_join_duplicate_headers",
+  "http.serverTimeoutGet": "scr_net_server_timeout_get",
+  "http.serverTimeoutSet": "scr_net_server_timeout_set",
   "http.clientWrite": "scr_http_client_write_str",
   "http.clientWriteBytes": "scr_http_client_write_bytes",
   "http.clientEnd": "scr_http_client_end",

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -688,6 +688,7 @@ const LIB_FN_SYMS: Record<string, string> = {
   "http.serverJoinDupHeaders": "scr_http_server_join_duplicate_headers",
   "http.serverTimeoutGet": "scr_net_server_timeout_get",
   "http.serverTimeoutSet": "scr_net_server_timeout_set",
+  "http.serverTimeoutOptionSet": "scr_net_server_timeout_option_set",
   "http.clientWrite": "scr_http_client_write_str",
   "http.clientWriteBytes": "scr_http_client_write_bytes",
   "http.clientEnd": "scr_http_client_end",

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -2348,10 +2348,23 @@ function lowerHttpServerOptions(L: Lowerer, node: ts.Expression, what: string): 
           "write keepAliveTimeoutBuffer once in the options literal",
         );
       }
-      const value = initializer !== null
+      const raw = initializer !== null
         ? L.lowerExpr(initializer)
         : L.lowerShorthandValue(prop as ts.ShorthandPropertyAssignment);
-      keepAliveTimeoutBuffer = L.coerceToExpected(value, F64);
+      const value = L.coerceToExpected(raw, DYN);
+      if (value.type.kind !== "dyn") {
+        L.noLowering(
+          `${what} with a keepAliveTimeoutBuffer value that cannot cross the runtime option boundary`,
+          prop,
+          "keepAliveTimeoutBuffer is a number or undefined",
+        );
+      }
+      // Preserve the optional field's undefined arm until runtime: Node
+      // treats it as absent, while numbers take the constructor-only
+      // integer/range ladder and dynamic non-numbers get its named type
+      // error. Coercing eagerly to F64 would reject the valid explicit-
+      // undefined spelling before the option helper sees it.
+      keepAliveTimeoutBuffer = value;
       continue;
     }
     fenceOrDropOptionKey(
@@ -2405,14 +2418,14 @@ function lowerHttpCreateServerForms(L: Lowerer, expr: ts.CallExpression | ts.New
   if (!existing) {
     L.arrHofHelpers.set(key, name);
     const params = [
-      ...(hasBuffer ? [{ localId: "b.0", name: "buffer", type: F64 }] : []),
+      ...(hasBuffer ? [{ localId: "b.0", name: "buffer", type: DYN }] : []),
       { localId: "s.0", name: "s", type: NETSERVER_T },
     ];
     const ref: IrExpr = { kind: "varRef", localId: "s.0", type: NETSERVER_T, loc };
     const body: IrStmt[] = [];
     if (hasBuffer) {
       const selector: IrExpr = { kind: "numLit", value: 4, type: F64, loc };
-      const value: IrExpr = { kind: "varRef", localId: "b.0", type: F64, loc };
+      const value: IrExpr = { kind: "varRef", localId: "b.0", type: DYN, loc };
       body.push({
         kind: "exprStmt",
         expr: { kind: "libCall", fn: "http.serverTimeoutOptionSet", args: [ref, selector, value], type: VOID, loc },

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -2001,7 +2001,7 @@ function lowerH2StreamMethodCall(L: Lowerer, call: ts.CallExpression,
  * the two reads never materializes; the runtime answers the bound port
  * directly. Null for every other property shape. */
 export function lowerServerProperty(L: Lowerer, expr: ts.PropertyAccessExpression): IrExpr | null {
-  if (expr.questionDotToken) return null;
+  if (expr.questionDotToken && !L.chainHandled.has(expr)) return null;
   const loc = locOf(expr);
   // req.url / req.method — always-present strings on server requests;
   // req.headers.NAME — the `string | undefined` union (envGet's type).
@@ -2277,13 +2277,15 @@ function lowerRequestHandlerArg(L: Lowerer, node: ts.Expression): IrExpr {
 }
 
 /** The http.createServer / http.Server options object — { requireHostHeader?,
- * joinDuplicateHeaders?, ... }: the two lowered keys are exactly the
- * parser behaviors this runtime has (requireHostHeader: false IS the
- * parser's stance — it never answers 400 for a missing Host;
- * joinDuplicateHeaders: true joins repeated request-header reads with
- * ", "). Other documented keys fence by name; unknown keys drop like
- * Node drops them. Answers whether joinDuplicateHeaders was requested. */
-function lowerHttpServerOptions(L: Lowerer, node: ts.Expression, what: string): { joinDup: boolean } {
+ * joinDuplicateHeaders?, keepAliveTimeoutBuffer?, ... }. The first two
+ * select parser behavior; keepAliveTimeoutBuffer initializes the matching
+ * writable server field after Node's non-negative-safe-integer validation.
+ * Other documented keys fence by name; unknown keys drop like Node drops
+ * them. */
+function lowerHttpServerOptions(L: Lowerer, node: ts.Expression, what: string): {
+  joinDup: boolean;
+  keepAliveTimeoutBuffer: IrExpr | null;
+} {
   if (!ts.isObjectLiteralExpression(node)) {
     L.noLowering(
       `${what} with a non-literal options argument`,
@@ -2292,6 +2294,7 @@ function lowerHttpServerOptions(L: Lowerer, node: ts.Expression, what: string): 
     );
   }
   let joinDup = false;
+  let keepAliveTimeoutBuffer: IrExpr | null = null;
   for (const prop of node.properties) {
     let initializer: ts.Expression | null;
     if (ts.isPropertyAssignment(prop) &&
@@ -2337,20 +2340,34 @@ function lowerHttpServerOptions(L: Lowerer, node: ts.Expression, what: string): 
         "the lowered forms are the literals joinDuplicateHeaders: true (repeats join \", \") and false (the keep-first default)",
       );
     }
+    if (key === "keepAliveTimeoutBuffer") {
+      if (keepAliveTimeoutBuffer !== null) {
+        L.noLowering(
+          `${what} with duplicate keepAliveTimeoutBuffer options`,
+          prop,
+          "write keepAliveTimeoutBuffer once in the options literal",
+        );
+      }
+      const value = initializer !== null
+        ? L.lowerExpr(initializer)
+        : L.lowerShorthandValue(prop as ts.ShorthandPropertyAssignment);
+      keepAliveTimeoutBuffer = L.coerceToExpected(value, F64);
+      continue;
+    }
     fenceOrDropOptionKey(
       L, prop, key, what, HTTP_SERVER_DOCUMENTED_OPTIONS,
-      "requireHostHeader: false and joinDuplicateHeaders are the supported options",
+      "requireHostHeader: false, joinDuplicateHeaders, and keepAliveTimeoutBuffer are the supported options",
     );
     // An undocumented key, dropped like Node drops it.
   }
-  return { joinDup };
+  return { joinDup, keepAliveTimeoutBuffer };
 }
 
 /** The shared createServer([options][, handler]) shapes behind
  * http.createServer, http.Server, and `new http.Server`: no arguments
  * (the on("request") route), a lone handler, a lone options object, and
- * (options, handler). joinDuplicateHeaders wraps the construction in the
- * flag-setting helper. */
+ * (options, handler). Modeled option values wrap the construction in an
+ * interned option-setting helper. */
 function lowerHttpCreateServerForms(L: Lowerer, expr: ts.CallExpression | ts.NewExpression,
   what: string, loc: SrcLoc,): IrExpr {
   const args = expr.arguments ?? ([] as unknown as ts.NodeArray<ts.Expression>);
@@ -2370,36 +2387,62 @@ function lowerHttpCreateServerForms(L: Lowerer, expr: ts.CallExpression | ts.New
     if (ts.isObjectLiteralExpression(args[0]!)) optsNode = args[0]!;
     else handlerNode = args[0]!;
   }
-  const joinDup = optsNode !== null && lowerHttpServerOptions(L, optsNode, what).joinDup;
+  const opts = optsNode !== null
+    ? lowerHttpServerOptions(L, optsNode, what)
+    : { joinDup: false, keepAliveTimeoutBuffer: null };
   const server: IrExpr = handlerNode !== null
     ? { kind: "libCall", fn: "http.createServer", args: [lowerRequestHandlerArg(L, handlerNode)], type: NETSERVER_T, loc }
     : { kind: "libCall", fn: "http.createServerEmpty", args: [], type: NETSERVER_T, loc };
-  if (!joinDup) return server;
-  // The flag-setting composition: an interned helper takes the fresh
-  // server, sets the parser flag, and answers it — one expression.
-  const key = `server.joindup`;
+  if (!opts.joinDup && opts.keepAliveTimeoutBuffer === null) return server;
+  // The option-setting composition: an interned helper takes the option
+  // values first (preserving Node's options-before-handler evaluation
+  // order), then the fresh server, applies the modeled fields, and answers
+  // the server as the constructor/factory result.
+  const hasBuffer = opts.keepAliveTimeoutBuffer !== null;
+  const key = `server.opts:${opts.joinDup ? 1 : 0}:${hasBuffer ? 1 : 0}`;
   const existing = L.arrHofHelpers.get(key);
-  const name = existing ?? `%server.joindup.${L.arrHofHelpers.size}`;
+  const name = existing ?? `%server.opts.${L.arrHofHelpers.size}`;
   if (!existing) {
     L.arrHofHelpers.set(key, name);
+    const params = [
+      ...(hasBuffer ? [{ localId: "b.0", name: "buffer", type: F64 }] : []),
+      { localId: "s.0", name: "s", type: NETSERVER_T },
+    ];
     const ref: IrExpr = { kind: "varRef", localId: "s.0", type: NETSERVER_T, loc };
+    const body: IrStmt[] = [];
+    if (hasBuffer) {
+      const selector: IrExpr = { kind: "numLit", value: 4, type: F64, loc };
+      const value: IrExpr = { kind: "varRef", localId: "b.0", type: F64, loc };
+      body.push({
+        kind: "exprStmt",
+        expr: { kind: "libCall", fn: "http.serverTimeoutOptionSet", args: [ref, selector, value], type: VOID, loc },
+        loc,
+      });
+    }
+    if (opts.joinDup) {
+      body.push({
+        kind: "exprStmt",
+        expr: { kind: "libCall", fn: "http.serverJoinDupHeaders", args: [ref], type: VOID, loc },
+        loc,
+      });
+    }
+    body.push({ kind: "return", value: ref, loc });
     L.liftedFns.push({
       name,
-      params: [{ localId: "s.0", name: "s", type: NETSERVER_T }],
+      params,
       returnType: NETSERVER_T,
-      locals: [{ id: "s.0", name: "s", type: NETSERVER_T, mutable: false }],
-      body: [
-        {
-          kind: "exprStmt",
-          expr: { kind: "libCall", fn: "http.serverJoinDupHeaders", args: [ref], type: VOID, loc },
-          loc,
-        },
-        { kind: "return", value: ref, loc },
-      ],
+      locals: params.map((p) => ({ id: p.localId, name: p.name, type: p.type, mutable: false })),
+      body,
       loc,
     });
   }
-  return { kind: "call", callee: name, args: [server], type: NETSERVER_T, loc };
+  return {
+    kind: "call",
+    callee: name,
+    args: [...(opts.keepAliveTimeoutBuffer !== null ? [opts.keepAliveTimeoutBuffer] : []), server],
+    type: NETSERVER_T,
+    loc,
+  };
 }
 
 /** `new http.Server([options][, handler])` — the constructor spelling of

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -39,6 +39,19 @@ export const NET_MODULE_FNS: ReadonlySet<string> = new Set([
 const NARROW_DATA_HINT =
   'write/end take one string or one Uint8Array/Buffer value (narrow unions first)';
 
+/** The writable numeric http.Server timeout fields. The selector is an
+ * internal runtime ABI shared by the get/set libCalls (kept here beside
+ * the only two construction/lowering paths that can mint the accesses). */
+function httpServerTimeoutField(name: string): number | null {
+  switch (name) {
+    case "timeout": return 0;
+    case "keepAliveTimeout": return 1;
+    case "headersTimeout": return 2;
+    case "requestTimeout": return 3;
+    default: return null;
+  }
+}
+
 /** VOID-result server/socket calls are usable as statements and as concise
  * arrow bodies (`socket.on("error", () => socket.destroy())` — the shape
  * portless is made of); anything that would CONSUME the result (Node
@@ -923,6 +936,27 @@ export function lowerHttpResPropertyAssignment(L: Lowerer, left: ts.Expression,
   return {
     kind: "exprStmt",
     expr: { kind: "libCall", fn, args: [receiver, value], type: VOID, loc },
+    loc,
+  };
+}
+
+/** `server.timeout = n` and the three HTTP parser/keep-alive timeout
+ * siblings. These are ordinary writable number properties in Node: the
+ * runtime stores their exact value per server; active timeout behavior is
+ * a separate protocol concern. */
+export function lowerHttpServerTimeoutAssignment(L: Lowerer, left: ts.Expression,
+  right: ts.Expression, loc: SrcLoc,): IrStmt | null {
+  if (!ts.isPropertyAccessExpression(left) || left.questionDotToken) return null;
+  const field = httpServerTimeoutField(left.name.text);
+  if (field === null) return null;
+  if (L.mapTypeOf(L.typeOf(left.expression))?.kind !== "netServer") return null;
+  if (!L.isStdlibMember(left)) return null;
+  const receiver = handleReceiver(L, left.expression, NETSERVER_T);
+  const selector: IrExpr = { kind: "numLit", value: field, type: F64, loc };
+  const value = L.lowerExprExpecting(right, F64);
+  return {
+    kind: "exprStmt",
+    expr: { kind: "libCall", fn: "http.serverTimeoutSet", args: [receiver, selector, value], type: VOID, loc },
     loc,
   };
 }
@@ -1971,6 +2005,14 @@ export function lowerServerProperty(L: Lowerer, expr: ts.PropertyAccessExpressio
   // req.url / req.method — always-present strings on server requests;
   // req.headers.NAME — the `string | undefined` union (envGet's type).
   const recvKind = L.mapTypeOf(L.typeOf(expr.expression))?.kind;
+  if (recvKind === "netServer" && L.isStdlibMember(expr)) {
+    const field = httpServerTimeoutField(expr.name.text);
+    if (field !== null) {
+      const receiver = handleReceiver(L, expr.expression, NETSERVER_T);
+      const selector: IrExpr = { kind: "numLit", value: field, type: F64, loc };
+      return { kind: "libCall", fn: "http.serverTimeoutGet", args: [receiver, selector], type: F64, loc };
+    }
+  }
   if (recvKind === "httpReq" && L.isStdlibMember(expr)) {
     const name = expr.name.text;
     if (name === "url" || name === "method") {

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -48,6 +48,7 @@ function httpServerTimeoutField(name: string): number | null {
     case "keepAliveTimeout": return 1;
     case "headersTimeout": return 2;
     case "requestTimeout": return 3;
+    case "keepAliveTimeoutBuffer": return 4;
     default: return null;
   }
 }
@@ -940,7 +941,7 @@ export function lowerHttpResPropertyAssignment(L: Lowerer, left: ts.Expression,
   };
 }
 
-/** `server.timeout = n` and the three HTTP parser/keep-alive timeout
+/** `server.timeout = n` and the four HTTP parser/keep-alive timeout
  * siblings. These are ordinary writable number properties in Node: the
  * runtime stores their exact value per server; active timeout behavior is
  * a separate protocol concern. */

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -2719,21 +2719,26 @@ const TLS_VALIDATED_OPTIONS: ReadonlySet<string> = new Set([
   "sessionTimeout", "ticketKeys",
 ]);
 
-/** True when a literal options bag carries a runtime-validated key (and
- * the source is JS — TypeScript keeps its compile fences). */
-function tlsLiteralNeedsRuntimeWalk(node: ts.ObjectLiteralExpression): boolean {
-  if (!isJsSourceFile(node.getSourceFile())) return false;
+/** True when a literal options bag must ride the runtime walker: JS uses
+ * it for the typed TLS validation ladders, and HTTPS uses it for
+ * keepAliveTimeoutBuffer so the HTTP option is consumed without losing
+ * the literal's evaluation order. */
+function tlsLiteralNeedsRuntimeWalk(node: ts.ObjectLiteralExpression,
+  includeHttpTimeoutOptions = false,): boolean {
+  const jsSource = isJsSourceFile(node.getSourceFile());
   return node.properties.some((p) =>
     (ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p)) &&
     (ts.isIdentifier(p.name) || ts.isStringLiteral(p.name)) &&
-    TLS_VALIDATED_OPTIONS.has(p.name.text),
+    ((includeHttpTimeoutOptions && p.name.text === "keepAliveTimeoutBuffer") ||
+      (jsSource && TLS_VALIDATED_OPTIONS.has(p.name.text))),
   );
 }
 
 function lowerTlsServerOptionsOrDyn(
-  L: Lowerer, node: ts.Expression, what: string,
+  L: Lowerer, node: ts.Expression, what: string, includeHttpTimeoutOptions = false,
 ): { cert: IrExpr; key: IrExpr; dyn?: undefined } | { dyn: IrExpr } {
-  if (ts.isObjectLiteralExpression(node) && !tlsLiteralNeedsRuntimeWalk(node)) {
+  if (ts.isObjectLiteralExpression(node) &&
+      !tlsLiteralNeedsRuntimeWalk(node, includeHttpTimeoutOptions)) {
     return lowerTlsServerOptions(L, node, what);
   }
   const v = L.lowerExpr(node);
@@ -3128,7 +3133,7 @@ function lowerHttpsModuleCall(L: Lowerer, expr: ts.CallExpression,
         "the supported form is createServer({ cert, key }, (req, res) => ...)",
       );
     }
-    const opts = lowerTlsServerOptionsOrDyn(L, args[0]!, "https.createServer");
+    const opts = lowerTlsServerOptionsOrDyn(L, args[0]!, "https.createServer", true);
     if (args.length === 1) {
       // The handler-less form: 'request' listeners arrive later via
       // server.on("request", ...) — the createSecureServer emission's

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -19,7 +19,7 @@ import { isMixinFnBinding, mixinResultBindingClassOf } from "./lower-mixins.js";
 import type { ClassInfo, ClassIteratorInfo } from "./lower-classes.js";
 import { genericIfaceBindingKeepsClass } from "./lower-classes.js";
 import { lowerStreamUnderscoreAssign, streamClassAliasDecl, streamSidesOf } from "./lower-stream.js";
-import { lowerHttpResPropertyAssignment, lowerServerCloseOverrideAssignment } from "./lower-server.js";
+import { lowerHttpResPropertyAssignment, lowerHttpServerTimeoutAssignment, lowerServerCloseOverrideAssignment } from "./lower-server.js";
 import { builtinMemberRequireDecl, builtinNamespaceDestructureModuleOf, createRequireBindingDecl, createRequireCalleeFileOf, createRequireNamespaceDecl, textCodecBindingDecl } from "./lower-builtins.js";
 import { lowerEnumDeclaration } from "./lower-enums.js";
 import { abstractPropertyDeclOf, aliasTypeofNarrows, isMatchSliceType, lowerGroupsProjection, matchResultNamedGroupsOf, probeLower, pureReemittable, symbolFieldInfo } from "./lower-exprs.js";
@@ -4302,6 +4302,12 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
           {
             const resProp = lowerHttpResPropertyAssignment(L, expr.left, expr.right, locOf(expr));
             if (resProp) return resProp;
+          }
+          // server.timeout / keepAliveTimeout / headersTimeout /
+          // requestTimeout — the writable numeric http.Server fields.
+          {
+            const timeoutProp = lowerHttpServerTimeoutAssignment(L, expr.left, expr.right, locOf(expr));
+            if (timeoutProp) return timeoutProp;
           }
           // `N.x = v` — a namespace-qualified write: exported `let`
           // members are module globals, so the qualified spelling assigns

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -195,12 +195,13 @@ export const HTTP_CLIENT_DOCUMENTED_OPTIONS: ReadonlySet<string> = new Set([
 
 /** http.createServer / http.Server's documented option keys (Node v24 —
  * http.createServer options + the net.Server knobs it forwards). The
- * lowered pair is requireHostHeader/joinDuplicateHeaders; the rest fence
- * by name here, and unknown keys drop like Node drops them. */
+ * lowered set is requireHostHeader/joinDuplicateHeaders plus
+ * keepAliveTimeoutBuffer storage; the rest fence by name here, and
+ * unknown keys drop like Node drops them. */
 export const HTTP_SERVER_DOCUMENTED_OPTIONS: ReadonlySet<string> = new Set([
   "IncomingMessage", "ServerResponse", "allowHalfOpen", "connectionsCheckingInterval",
   "headersTimeout", "highWaterMark", "insecureHTTPParser", "joinDuplicateHeaders",
-  "keepAlive", "keepAliveInitialDelay", "keepAliveTimeout", "maxHeaderSize",
+  "keepAlive", "keepAliveInitialDelay", "keepAliveTimeout", "keepAliveTimeoutBuffer", "maxHeaderSize",
   "noDelay", "pauseOnConnect", "rejectNonStandardBodyWrites", "requestTimeout",
   "requireHostHeader", "uniqueHeaders",
 ]);

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2335,10 +2335,10 @@ export type IrLibFn =
    * joinDuplicateHeaders joins repeated request-header reads ", "). */
   | "http.createServerEmpty"
   | "http.serverJoinDupHeaders"
-  /** The four writable numeric http.Server timeout fields use one
+  /** The five writable numeric http.Server timeout fields use one
    * selector ABI: 0 timeout, 1 keepAliveTimeout, 2 headersTimeout,
-   * 3 requestTimeout. These calls store/read the property values; timer
-   * enforcement remains outside this surface. */
+   * 3 requestTimeout, 4 keepAliveTimeoutBuffer. These calls store/read
+   * the property values; timer enforcement remains outside this surface. */
   | "http.serverTimeoutGet"
   | "http.serverTimeoutSet"
   /** server.on("listening", cb) — the deferred listen-callback list. */

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2338,7 +2338,9 @@ export type IrLibFn =
   /** The five writable numeric http.Server timeout fields use one
    * selector ABI: 0 timeout, 1 keepAliveTimeout, 2 headersTimeout,
    * 3 requestTimeout, 4 keepAliveTimeoutBuffer. These calls store/read
-   * the property values; timer enforcement remains outside this surface. */
+   * the property values; timer enforcement remains outside this surface.
+   * The constructor-option setter takes dyn so explicit undefined remains
+   * distinguishable from a numeric value until its Node validation ladder. */
   | "http.serverTimeoutGet"
   | "http.serverTimeoutSet"
   | "http.serverTimeoutOptionSet"
@@ -6759,6 +6761,7 @@ export const MAY_THROW_LIB_FNS: ReadonlySet<IrLibFn> = new Set([
   "dc.chanBindStore",
   "dc.chanRunStores",
   "http.resWriteHeadDyn",
+  "http.serverTimeoutGet",
   "http.serverTimeoutOptionSet",
   "net.sockSetEncoding",
   "http.reqSetEncoding",

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2335,6 +2335,12 @@ export type IrLibFn =
    * joinDuplicateHeaders joins repeated request-header reads ", "). */
   | "http.createServerEmpty"
   | "http.serverJoinDupHeaders"
+  /** The four writable numeric http.Server timeout fields use one
+   * selector ABI: 0 timeout, 1 keepAliveTimeout, 2 headersTimeout,
+   * 3 requestTimeout. These calls store/read the property values; timer
+   * enforcement remains outside this surface. */
+  | "http.serverTimeoutGet"
+  | "http.serverTimeoutSet"
   /** server.on("listening", cb) — the deferred listen-callback list. */
   | "net.serverOnListening"
   /** The ServerResponse member surface: statusCode/statusMessage reads

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -2341,6 +2341,7 @@ export type IrLibFn =
    * the property values; timer enforcement remains outside this surface. */
   | "http.serverTimeoutGet"
   | "http.serverTimeoutSet"
+  | "http.serverTimeoutOptionSet"
   /** server.on("listening", cb) — the deferred listen-callback list. */
   | "net.serverOnListening"
   /** The ServerResponse member surface: statusCode/statusMessage reads
@@ -6758,6 +6759,7 @@ export const MAY_THROW_LIB_FNS: ReadonlySet<IrLibFn> = new Set([
   "dc.chanBindStore",
   "dc.chanRunStores",
   "http.resWriteHeadDyn",
+  "http.serverTimeoutOptionSet",
   "net.sockSetEncoding",
   "http.reqSetEncoding",
   "fs.readFileSyncBuf",

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -425,6 +425,8 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "http.createServer": { argTypes: [null], result: NETSERVER_T },
   "http.createServerEmpty": { argTypes: [], result: NETSERVER_T },
   "http.serverJoinDupHeaders": { argTypes: [NETSERVER_T], result: VOID },
+  "http.serverTimeoutGet": { argTypes: [NETSERVER_T, F64], result: F64 },
+  "http.serverTimeoutSet": { argTypes: [NETSERVER_T, F64, F64], result: VOID },
   "net.serverOnListening": { argTypes: [NETSERVER_T, { kind: "func", params: [], ret: VOID }, BOOL], result: VOID },
   "http.resStatusGet": { argTypes: [HTTPRES_T], result: F64 },
   "http.resStatusSet": { argTypes: [HTTPRES_T, F64], result: VOID },

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -427,7 +427,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "http.serverJoinDupHeaders": { argTypes: [NETSERVER_T], result: VOID },
   "http.serverTimeoutGet": { argTypes: [NETSERVER_T, F64], result: F64 },
   "http.serverTimeoutSet": { argTypes: [NETSERVER_T, F64, F64], result: VOID },
-  "http.serverTimeoutOptionSet": { argTypes: [NETSERVER_T, F64, F64], result: VOID },
+  "http.serverTimeoutOptionSet": { argTypes: [NETSERVER_T, F64, DYN], result: VOID },
   "net.serverOnListening": { argTypes: [NETSERVER_T, { kind: "func", params: [], ret: VOID }, BOOL], result: VOID },
   "http.resStatusGet": { argTypes: [HTTPRES_T], result: F64 },
   "http.resStatusSet": { argTypes: [HTTPRES_T, F64], result: VOID },

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -427,6 +427,7 @@ export const LIB_FN_SIGS: Record<IrLibFn, { argTypes: (IrType | null)[]; result:
   "http.serverJoinDupHeaders": { argTypes: [NETSERVER_T], result: VOID },
   "http.serverTimeoutGet": { argTypes: [NETSERVER_T, F64], result: F64 },
   "http.serverTimeoutSet": { argTypes: [NETSERVER_T, F64, F64], result: VOID },
+  "http.serverTimeoutOptionSet": { argTypes: [NETSERVER_T, F64, F64], result: VOID },
   "net.serverOnListening": { argTypes: [NETSERVER_T, { kind: "func", params: [], ret: VOID }, BOOL], result: VOID },
   "http.resStatusGet": { argTypes: [HTTPRES_T], result: F64 },
   "http.resStatusSet": { argTypes: [HTTPRES_T, F64], result: VOID },

--- a/packages/runtime/src/scr_http.c
+++ b/packages/runtime/src/scr_http.c
@@ -2009,6 +2009,7 @@ void scr_http2_stream_undef_call(ScrStr *member) {
 ScrNetServer *scr_http_create_server(ScrClosure *handler /*moves, nullable*/, ScrHttpReqFn fn) {
   scr_http_install();
   ScrNetServer *s = scr_net_create_server(NULL, NULL);
+  scr_net_server_enable_http_timeout_surface(s);
   ScrHttpSrvCtx *ctx = calloc(1, sizeof *ctx);
   if (!ctx) scr_http_oom();
   ctx->proto = SCR_NET_PROTO_HTTP1;

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -389,6 +389,11 @@ struct ScrNetServer {
   bool closing;       /* close() called; 'close' fires when conns drain */
   bool close_emitted; /* settled: off the registry, listeners dropped */
   bool emit_listening;
+  /* The writable http.Server timeout property values. Kept on the shared
+   * server handle because http/https servers retain that handle identity;
+   * plain net servers never expose these fields through the static type
+   * surface. Indices match lower-server.ts's selector ABI. */
+  double http_timeouts[4];
   bool defer_conn; /* TLS: 'connection' fires post-handshake, not at accept */
   bool bound_v6;       /* the bound family (address()'s 'IPv6'/'IPv4' split) */
   ScrStr *bound_host;  /* the explicit bind host (NULL = the host-less any:
@@ -1200,6 +1205,10 @@ static ScrNetServer *scr_net_server_new(void) {
   s->kind = SCR_NET_K_SERVER;
   s->rc = 1;
   s->fd = -1;
+  s->http_timeouts[0] = 0;      /* timeout */
+  s->http_timeouts[1] = 5000;   /* keepAliveTimeout */
+  s->http_timeouts[2] = 60000;  /* headersTimeout */
+  s->http_timeouts[3] = 300000; /* requestTimeout */
 #ifdef SCR_RC_AUDIT
   scr_net_live++;
 #endif
@@ -1377,6 +1386,18 @@ void scr_net_listen_opts(ScrNetServer *s, double port, ScrStr *host /*borrowed*/
 }
 
 double scr_net_server_port(ScrNetServer *s) { return (double)s->port; }
+
+double scr_net_server_timeout_get(ScrNetServer *s, double field) {
+  int i = (int)field;
+  if (i < 0 || i >= 4) abort(); /* compiler/runtime ABI violation */
+  return s->http_timeouts[i];
+}
+
+void scr_net_server_timeout_set(ScrNetServer *s, double field, double value) {
+  int i = (int)field;
+  if (i < 0 || i >= 4) abort(); /* compiler/runtime ABI violation */
+  s->http_timeouts[i] = value;
+}
 
 /* address()'s other two fields — the bound host ('::'/'0.0.0.0' for the
  * host-less any, the normalized explicit host otherwise) and the family

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -394,6 +394,10 @@ struct ScrNetServer {
    * plain net servers never expose these fields through the static type
    * surface. Indices match lower-server.ts's selector ABI. */
   double http_timeouts[5];
+  /* A dynamic write may store any JS value on these ordinary writable
+   * properties. Numeric writes stay in http_timeouts; every other value
+   * is retained here so dynamic reads preserve kind and identity. */
+  ScrDyn *http_timeout_dyn[5];
   bool http_timeout_surface; /* true only for HTTP/1 and HTTPS servers */
   bool defer_conn; /* TLS: 'connection' fires post-handshake, not at accept */
   bool bound_v6;       /* the bound family (address()'s 'IPv6'/'IPv4' split) */
@@ -562,6 +566,7 @@ void scr_net_server_release(ScrNetServer *s) {
     scr_net_ls_drop(&s->close_ls);
     scr_net_ls_drop(&s->listening_cbs);
     scr_closure_release(s->close_override);
+    for (size_t i = 0; i < 5; i++) scr_dyn_release(s->http_timeout_dyn[i]);
     scr_str_release(s->bound_host);
     scr_str_release(s->pending_err);
     if (s->fd >= 0) scr_net_close_fd_raw(s->fd);
@@ -1390,14 +1395,24 @@ void scr_net_listen_opts(ScrNetServer *s, double port, ScrStr *host /*borrowed*/
 double scr_net_server_port(ScrNetServer *s) { return (double)s->port; }
 
 double scr_net_server_timeout_get(ScrNetServer *s, double field) {
+  static const char *const names[] = {
+    "timeout", "keepAliveTimeout", "headersTimeout", "requestTimeout",
+    "keepAliveTimeoutBuffer",
+  };
   int i = (int)field;
   if (i < 0 || i >= 5) abort(); /* compiler/runtime ABI violation */
+  if (s->http_timeout_dyn[i] != NULL) {
+    scr_dyn_arg_type_fail(names[i], "of type number", s->http_timeout_dyn[i]);
+    return 0; /* pending exception; typed reads validate an any-written value */
+  }
   return s->http_timeouts[i];
 }
 
 void scr_net_server_timeout_set(ScrNetServer *s, double field, double value) {
   int i = (int)field;
   if (i < 0 || i >= 5) abort(); /* compiler/runtime ABI violation */
+  scr_dyn_release(s->http_timeout_dyn[i]);
+  s->http_timeout_dyn[i] = NULL;
   s->http_timeouts[i] = value;
 }
 
@@ -1436,10 +1451,20 @@ bool scr_net_server_timeout_option_check(double field, double value) {
   return true;
 }
 
-void scr_net_server_timeout_option_set(ScrNetServer *s, double field, double value) {
-  if (!scr_net_server_timeout_option_check(field, value)) return;
+void scr_net_server_timeout_option_set(ScrNetServer *s, double field, const ScrDyn *value) {
   int i = (int)field;
-  s->http_timeouts[i] = value;
+  if (i < 0 || i >= 5) abort(); /* compiler/runtime ABI violation */
+  if (value->kind == SCR_DYN_UNDEF) return; /* optional field is absent */
+  if (value->kind != SCR_DYN_NUM) {
+    static const char *const names[] = {
+      "timeout", "keepAliveTimeout", "headersTimeout", "requestTimeout",
+      "keepAliveTimeoutBuffer",
+    };
+    scr_dyn_arg_type_fail(names[i], "of type number", value);
+    return;
+  }
+  if (!scr_net_server_timeout_option_check(field, value->v.num)) return;
+  scr_net_server_timeout_set(s, field, value->v.num);
 }
 
 /* address()'s other two fields — the bound host ('::'/'0.0.0.0' for the
@@ -3378,6 +3403,9 @@ static ScrDyn *scr_net_dynh_srv_get(void *h, const char *key, size_t key_len) {
   if (strcmp(key, "listening") == 0) return scr_dyn_new_bool(s->listening);
   int timeout_field = scr_net_dynh_srv_timeout_field(key);
   if (timeout_field >= 0 && s->http_timeout_surface) {
+    if (s->http_timeout_dyn[timeout_field] != NULL) {
+      return scr_dyn_retain(s->http_timeout_dyn[timeout_field]);
+    }
     return scr_dyn_new_num(scr_net_server_timeout_get(s, (double)timeout_field));
   }
   {
@@ -3397,11 +3425,12 @@ static bool scr_net_dynh_srv_set(void *h, const char *key, size_t key_len, const
   (void)key_len;
   int timeout_field = scr_net_dynh_srv_timeout_field(key);
   if (timeout_field >= 0 && s->http_timeout_surface) {
-    if (value->kind != SCR_DYN_NUM) {
-      scr_dyn_arg_type_fail(key, "of type number", value);
-      return true; /* handled: the exception is pending */
+    if (value->kind == SCR_DYN_NUM) {
+      scr_net_server_timeout_set(s, (double)timeout_field, value->v.num);
+    } else {
+      scr_dyn_release(s->http_timeout_dyn[timeout_field]);
+      s->http_timeout_dyn[timeout_field] = scr_dyn_retain((ScrDyn *)value);
     }
-    scr_net_server_timeout_set(s, (double)timeout_field, value->v.num);
     return true;
   }
   return false;

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -393,7 +393,7 @@ struct ScrNetServer {
    * server handle because http/https servers retain that handle identity;
    * plain net servers never expose these fields through the static type
    * surface. Indices match lower-server.ts's selector ABI. */
-  double http_timeouts[4];
+  double http_timeouts[5];
   bool defer_conn; /* TLS: 'connection' fires post-handshake, not at accept */
   bool bound_v6;       /* the bound family (address()'s 'IPv6'/'IPv4' split) */
   ScrStr *bound_host;  /* the explicit bind host (NULL = the host-less any:
@@ -1209,6 +1209,7 @@ static ScrNetServer *scr_net_server_new(void) {
   s->http_timeouts[1] = 5000;   /* keepAliveTimeout */
   s->http_timeouts[2] = 60000;  /* headersTimeout */
   s->http_timeouts[3] = 300000; /* requestTimeout */
+  s->http_timeouts[4] = 1000;   /* keepAliveTimeoutBuffer */
 #ifdef SCR_RC_AUDIT
   scr_net_live++;
 #endif
@@ -1389,13 +1390,13 @@ double scr_net_server_port(ScrNetServer *s) { return (double)s->port; }
 
 double scr_net_server_timeout_get(ScrNetServer *s, double field) {
   int i = (int)field;
-  if (i < 0 || i >= 4) abort(); /* compiler/runtime ABI violation */
+  if (i < 0 || i >= 5) abort(); /* compiler/runtime ABI violation */
   return s->http_timeouts[i];
 }
 
 void scr_net_server_timeout_set(ScrNetServer *s, double field, double value) {
   int i = (int)field;
-  if (i < 0 || i >= 4) abort(); /* compiler/runtime ABI violation */
+  if (i < 0 || i >= 5) abort(); /* compiler/runtime ABI violation */
   s->http_timeouts[i] = value;
 }
 

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -1400,6 +1400,37 @@ void scr_net_server_timeout_set(ScrNetServer *s, double field, double value) {
   s->http_timeouts[i] = value;
 }
 
+/* Constructor-option validation is intentionally separate from the plain
+ * writable-property setter above. Node validates these option values as
+ * non-negative safe integers, while later property assignments store the
+ * number directly. */
+void scr_net_server_timeout_option_set(ScrNetServer *s, double field, double value) {
+  static const char *const names[] = {
+    "timeout", "keepAliveTimeout", "headersTimeout", "requestTimeout",
+    "keepAliveTimeoutBuffer",
+  };
+  int i = (int)field;
+  if (i < 0 || i >= 5) abort(); /* compiler/runtime ABI violation */
+  char recv[48], msg[224];
+  if (!(isfinite(value) && trunc(value) == value)) {
+    scr_num_received(value, recv);
+    int len = snprintf(msg, sizeof msg,
+                       "The value of \"%s\" is out of range. It must be an integer. Received %s",
+                       names[i], recv);
+    scr_throw_error_msg_code(SCR_ERR_RANGE, msg, (size_t)len, "ERR_OUT_OF_RANGE");
+    return;
+  }
+  if (value < 0 || value > 9007199254740991.0) {
+    scr_num_received(value, recv);
+    int len = snprintf(msg, sizeof msg,
+                       "The value of \"%s\" is out of range. It must be >= 0 && <= 9007199254740991. Received %s",
+                       names[i], recv);
+    scr_throw_error_msg_code(SCR_ERR_RANGE, msg, (size_t)len, "ERR_OUT_OF_RANGE");
+    return;
+  }
+  s->http_timeouts[i] = value;
+}
+
 /* address()'s other two fields — the bound host ('::'/'0.0.0.0' for the
  * host-less any, the normalized explicit host otherwise) and the family
  * string. Answer the any-form defaults before listen (Node answers null
@@ -3321,13 +3352,25 @@ static ScrDyn *scr_net_dynh_srv_invoke(void *h, ScrDyn *self, const char *method
   return NULL;
 }
 
+static int scr_net_dynh_srv_timeout_field(const char *key) {
+  if (strcmp(key, "timeout") == 0) return 0;
+  if (strcmp(key, "keepAliveTimeout") == 0) return 1;
+  if (strcmp(key, "headersTimeout") == 0) return 2;
+  if (strcmp(key, "requestTimeout") == 0) return 3;
+  if (strcmp(key, "keepAliveTimeoutBuffer") == 0) return 4;
+  return -1;
+}
+
 static ScrDyn *scr_net_dynh_srv_get(void *h, const char *key, size_t key_len) {
   ScrNetServer *s = (ScrNetServer *)h;
   (void)key_len;
   if (strcmp(key, "listening") == 0) return scr_dyn_new_bool(s->listening);
+  int timeout_field = scr_net_dynh_srv_timeout_field(key);
+  if (timeout_field >= 0) {
+    return scr_dyn_new_num(scr_net_server_timeout_get(s, (double)timeout_field));
+  }
   {
-    static const char *const known[] = { "maxConnections", "connections", "maxHeadersCount",
-      "timeout", "keepAliveTimeout", "headersTimeout", "requestTimeout", NULL };
+    static const char *const known[] = { "maxConnections", "connections", "maxHeadersCount", NULL };
     for (size_t i = 0; known[i]; i++) {
       if (strcmp(key, known[i]) == 0) {
         scr_net_dynh_srv_unsupported(key, NULL);
@@ -3339,7 +3382,17 @@ static ScrDyn *scr_net_dynh_srv_get(void *h, const char *key, size_t key_len) {
 }
 
 static bool scr_net_dynh_srv_set(void *h, const char *key, size_t key_len, const ScrDyn *value) {
-  (void)h; (void)key; (void)key_len; (void)value;
+  ScrNetServer *s = (ScrNetServer *)h;
+  (void)key_len;
+  int timeout_field = scr_net_dynh_srv_timeout_field(key);
+  if (timeout_field >= 0) {
+    if (value->kind != SCR_DYN_NUM) {
+      scr_dyn_arg_type_fail(key, "of type number", value);
+      return true; /* handled: the exception is pending */
+    }
+    scr_net_server_timeout_set(s, (double)timeout_field, value->v.num);
+    return true;
+  }
   return false;
 }
 

--- a/packages/runtime/src/scr_net.c
+++ b/packages/runtime/src/scr_net.c
@@ -394,6 +394,7 @@ struct ScrNetServer {
    * plain net servers never expose these fields through the static type
    * surface. Indices match lower-server.ts's selector ABI. */
   double http_timeouts[5];
+  bool http_timeout_surface; /* true only for HTTP/1 and HTTPS servers */
   bool defer_conn; /* TLS: 'connection' fires post-handshake, not at accept */
   bool bound_v6;       /* the bound family (address()'s 'IPv6'/'IPv4' split) */
   ScrStr *bound_host;  /* the explicit bind host (NULL = the host-less any:
@@ -1400,11 +1401,15 @@ void scr_net_server_timeout_set(ScrNetServer *s, double field, double value) {
   s->http_timeouts[i] = value;
 }
 
+void scr_net_server_enable_http_timeout_surface(ScrNetServer *s) {
+  s->http_timeout_surface = true;
+}
+
 /* Constructor-option validation is intentionally separate from the plain
  * writable-property setter above. Node validates these option values as
  * non-negative safe integers, while later property assignments store the
  * number directly. */
-void scr_net_server_timeout_option_set(ScrNetServer *s, double field, double value) {
+bool scr_net_server_timeout_option_check(double field, double value) {
   static const char *const names[] = {
     "timeout", "keepAliveTimeout", "headersTimeout", "requestTimeout",
     "keepAliveTimeoutBuffer",
@@ -1418,7 +1423,7 @@ void scr_net_server_timeout_option_set(ScrNetServer *s, double field, double val
                        "The value of \"%s\" is out of range. It must be an integer. Received %s",
                        names[i], recv);
     scr_throw_error_msg_code(SCR_ERR_RANGE, msg, (size_t)len, "ERR_OUT_OF_RANGE");
-    return;
+    return false;
   }
   if (value < 0 || value > 9007199254740991.0) {
     scr_num_received(value, recv);
@@ -1426,8 +1431,14 @@ void scr_net_server_timeout_option_set(ScrNetServer *s, double field, double val
                        "The value of \"%s\" is out of range. It must be >= 0 && <= 9007199254740991. Received %s",
                        names[i], recv);
     scr_throw_error_msg_code(SCR_ERR_RANGE, msg, (size_t)len, "ERR_OUT_OF_RANGE");
-    return;
+    return false;
   }
+  return true;
+}
+
+void scr_net_server_timeout_option_set(ScrNetServer *s, double field, double value) {
+  if (!scr_net_server_timeout_option_check(field, value)) return;
+  int i = (int)field;
   s->http_timeouts[i] = value;
 }
 
@@ -3366,7 +3377,7 @@ static ScrDyn *scr_net_dynh_srv_get(void *h, const char *key, size_t key_len) {
   (void)key_len;
   if (strcmp(key, "listening") == 0) return scr_dyn_new_bool(s->listening);
   int timeout_field = scr_net_dynh_srv_timeout_field(key);
-  if (timeout_field >= 0) {
+  if (timeout_field >= 0 && s->http_timeout_surface) {
     return scr_dyn_new_num(scr_net_server_timeout_get(s, (double)timeout_field));
   }
   {
@@ -3385,7 +3396,7 @@ static bool scr_net_dynh_srv_set(void *h, const char *key, size_t key_len, const
   ScrNetServer *s = (ScrNetServer *)h;
   (void)key_len;
   int timeout_field = scr_net_dynh_srv_timeout_field(key);
-  if (timeout_field >= 0) {
+  if (timeout_field >= 0 && s->http_timeout_surface) {
     if (value->kind != SCR_DYN_NUM) {
       scr_dyn_arg_type_fail(key, "of type number", value);
       return true; /* handled: the exception is pending */

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5113,6 +5113,10 @@ void scr_net_listen(ScrNetServer *s, double port, ScrClosure *cb /*moves, nullab
 void scr_net_listen_opts(ScrNetServer *s, double port, ScrStr *host /*borrowed*/,
                           bool ipv6_only, ScrClosure *cb /*moves, nullable*/);
 double scr_net_server_port(ScrNetServer *s); /* address().port */
+/* Writable http.Server timeout property storage. `field` is the compiler
+ * ABI selector: timeout, keepAliveTimeout, headersTimeout, requestTimeout. */
+double scr_net_server_timeout_get(ScrNetServer *s, double field);
+void scr_net_server_timeout_set(ScrNetServer *s, double field, double value);
 ScrStr *scr_net_server_addr_ip(ScrNetServer *s);     /* +1 — address().address */
 ScrStr *scr_net_server_addr_family(ScrNetServer *s); /* +1 — address().family */
 void scr_net_server_close(ScrNetServer *s, ScrClosure *cb /*moves, nullable*/);

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5114,7 +5114,8 @@ void scr_net_listen_opts(ScrNetServer *s, double port, ScrStr *host /*borrowed*/
                           bool ipv6_only, ScrClosure *cb /*moves, nullable*/);
 double scr_net_server_port(ScrNetServer *s); /* address().port */
 /* Writable http.Server timeout property storage. `field` is the compiler
- * ABI selector: timeout, keepAliveTimeout, headersTimeout, requestTimeout. */
+ * ABI selector: timeout, keepAliveTimeout, headersTimeout, requestTimeout,
+ * keepAliveTimeoutBuffer. */
 double scr_net_server_timeout_get(ScrNetServer *s, double field);
 void scr_net_server_timeout_set(ScrNetServer *s, double field, double value);
 ScrStr *scr_net_server_addr_ip(ScrNetServer *s);     /* +1 — address().address */

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5118,8 +5118,12 @@ double scr_net_server_port(ScrNetServer *s); /* address().port */
  * keepAliveTimeoutBuffer. */
 double scr_net_server_timeout_get(ScrNetServer *s, double field);
 void scr_net_server_timeout_set(ScrNetServer *s, double field, double value);
+/* Marks the shared net-server handle as an HTTP/1 or HTTPS server. The
+ * dynamic handle uses this to keep HTTP-only fields off net/TLS/H2. */
+void scr_net_server_enable_http_timeout_surface(ScrNetServer *s);
 /* Constructor-option twin: validates a non-negative safe integer before
  * storing, matching Node's option ladder (plain property writes do not). */
+bool scr_net_server_timeout_option_check(double field, double value);
 void scr_net_server_timeout_option_set(ScrNetServer *s, double field, double value);
 ScrStr *scr_net_server_addr_ip(ScrNetServer *s);     /* +1 — address().address */
 ScrStr *scr_net_server_addr_family(ScrNetServer *s); /* +1 — address().family */

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5118,6 +5118,9 @@ double scr_net_server_port(ScrNetServer *s); /* address().port */
  * keepAliveTimeoutBuffer. */
 double scr_net_server_timeout_get(ScrNetServer *s, double field);
 void scr_net_server_timeout_set(ScrNetServer *s, double field, double value);
+/* Constructor-option twin: validates a non-negative safe integer before
+ * storing, matching Node's option ladder (plain property writes do not). */
+void scr_net_server_timeout_option_set(ScrNetServer *s, double field, double value);
 ScrStr *scr_net_server_addr_ip(ScrNetServer *s);     /* +1 — address().address */
 ScrStr *scr_net_server_addr_family(ScrNetServer *s); /* +1 — address().family */
 void scr_net_server_close(ScrNetServer *s, ScrClosure *cb /*moves, nullable*/);

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5115,16 +5115,18 @@ void scr_net_listen_opts(ScrNetServer *s, double port, ScrStr *host /*borrowed*/
 double scr_net_server_port(ScrNetServer *s); /* address().port */
 /* Writable http.Server timeout property storage. `field` is the compiler
  * ABI selector: timeout, keepAliveTimeout, headersTimeout, requestTimeout,
- * keepAliveTimeoutBuffer. */
+ * keepAliveTimeoutBuffer. Typed reads validate that no dynamic write left
+ * a non-number in the ordinary JS property slot. */
 double scr_net_server_timeout_get(ScrNetServer *s, double field);
 void scr_net_server_timeout_set(ScrNetServer *s, double field, double value);
 /* Marks the shared net-server handle as an HTTP/1 or HTTPS server. The
  * dynamic handle uses this to keep HTTP-only fields off net/TLS/H2. */
 void scr_net_server_enable_http_timeout_surface(ScrNetServer *s);
-/* Constructor-option twin: validates a non-negative safe integer before
- * storing, matching Node's option ladder (plain property writes do not). */
+/* Constructor-option twin: undefined is absent; otherwise validates type
+ * and a non-negative safe integer before storing, matching Node's option
+ * ladder (plain property writes do not validate). */
 bool scr_net_server_timeout_option_check(double field, double value);
-void scr_net_server_timeout_option_set(ScrNetServer *s, double field, double value);
+void scr_net_server_timeout_option_set(ScrNetServer *s, double field, const struct ScrDyn *value);
 ScrStr *scr_net_server_addr_ip(ScrNetServer *s);     /* +1 — address().address */
 ScrStr *scr_net_server_addr_family(ScrNetServer *s); /* +1 — address().family */
 void scr_net_server_close(ScrNetServer *s, ScrClosure *cb /*moves, nullable*/);

--- a/packages/runtime/src/scr_tls.c
+++ b/packages/runtime/src/scr_tls.c
@@ -1415,6 +1415,27 @@ ScrNetServer *scr_tls_create_server_dyn(const ScrDyn *opts /*borrowed*/,
 ScrNetServer *scr_https_create_server_dyn(const ScrDyn *opts /*borrowed*/,
                                            ScrClosure *handler /*moves, nullable*/,
                                            ScrHttpReqFn fn) {
+  /* HTTPS ServerOptions extends http.ServerOptions. Consume the one HTTP
+   * constructor field this runtime models before the shared TLS walker;
+   * that walker deliberately owns only the TLS-side option surface. */
+  bool has_timeout_buffer = false;
+  double timeout_buffer = 0;
+  if (opts != NULL && opts->kind == SCR_DYN_OBJ) {
+    const ScrDyn *v = scr_dyn_obj_get(opts, "keepAliveTimeoutBuffer", 22);
+    if (v != NULL && v->kind != SCR_DYN_UNDEF) {
+      if (v->kind != SCR_DYN_NUM) {
+        scr_dyn_arg_type_fail("keepAliveTimeoutBuffer", "of type number", v);
+        scr_closure_release(handler);
+        return NULL;
+      }
+      timeout_buffer = v->v.num;
+      if (!scr_net_server_timeout_option_check(4, timeout_buffer)) {
+        scr_closure_release(handler);
+        return NULL;
+      }
+      has_timeout_buffer = true;
+    }
+  }
   ScrBytes *cert, *key;
   if (!scr_tls_srv_opts_walk(opts, "https.createServer", &cert, &key)) {
     scr_closure_release(handler);
@@ -1422,6 +1443,7 @@ ScrNetServer *scr_https_create_server_dyn(const ScrDyn *opts /*borrowed*/,
   }
   ScrNetServer *s = scr_https_create_server((const char *)cert->data, cert->len,
                                              (const char *)key->data, key->len, handler, fn);
+  if (has_timeout_buffer) scr_net_server_timeout_set(s, 4, timeout_buffer);
   scr_bytes_release(cert);
   scr_bytes_release(key);
   return s;

--- a/tests/corpus/2689-http-server-timeout-properties.ts
+++ b/tests/corpus/2689-http-server-timeout-properties.ts
@@ -3,6 +3,7 @@
 // dynamic access, and static reads/writes through a typed helper. Timer
 // enforcement is a separate server behavior surface.
 import { createServer, Server } from "node:http";
+import { createServer as createNetServer } from "node:net";
 
 function configure(server: Server): void {
   server.timeout = 125;
@@ -52,6 +53,9 @@ const dynamic: any = fromOption;
 console.log("dynamic", dynamic.keepAliveTimeoutBuffer);
 dynamic.keepAliveTimeoutBuffer = 8765;
 console.log("dynamic-set", dynamic.keepAliveTimeoutBuffer, fromOption.keepAliveTimeoutBuffer);
+
+const plainNetDynamic: any = createNetServer();
+console.log("plain-net-dynamic", plainNetDynamic.timeout, plainNetDynamic.keepAliveTimeoutBuffer);
 
 try {
   createServer({ keepAliveTimeoutBuffer: -1 });

--- a/tests/corpus/2689-http-server-timeout-properties.ts
+++ b/tests/corpus/2689-http-server-timeout-properties.ts
@@ -16,6 +16,13 @@ function configure(server: Server): void {
 const configured = createServer();
 const untouched = new Server();
 const fromOption = createServer({ keepAliveTimeoutBuffer: 4321 });
+const fromUndefined = createServer({ keepAliveTimeoutBuffer: undefined });
+
+function serverFromMaybeBuffer(value: number | undefined): Server {
+  return createServer({ keepAliveTimeoutBuffer: value });
+}
+const fromMaybeUndefined = serverFromMaybeBuffer(undefined);
+const fromMaybeNumber = serverFromMaybeBuffer(2468);
 
 console.log(
   configured.timeout,
@@ -42,6 +49,12 @@ console.log(
 );
 
 console.log("option", fromOption.keepAliveTimeoutBuffer);
+console.log(
+  "optional-options",
+  fromUndefined.keepAliveTimeoutBuffer,
+  fromMaybeUndefined.keepAliveTimeoutBuffer,
+  fromMaybeNumber.keepAliveTimeoutBuffer,
+);
 
 function logOptional(server: Server | undefined): void {
   console.log("optional", server?.keepAliveTimeoutBuffer);
@@ -53,6 +66,12 @@ const dynamic: any = fromOption;
 console.log("dynamic", dynamic.keepAliveTimeoutBuffer);
 dynamic.keepAliveTimeoutBuffer = 8765;
 console.log("dynamic-set", dynamic.keepAliveTimeoutBuffer, fromOption.keepAliveTimeoutBuffer);
+dynamic.timeout = "disabled";
+console.log("dynamic-string", typeof dynamic.timeout, dynamic.timeout);
+dynamic.timeout = undefined;
+console.log("dynamic-undefined", typeof dynamic.timeout, dynamic.timeout);
+dynamic.timeout = 2468;
+console.log("dynamic-number", dynamic.timeout, fromOption.timeout);
 
 const plainNetDynamic: any = createNetServer();
 console.log("plain-net-dynamic", plainNetDynamic.timeout, plainNetDynamic.keepAliveTimeoutBuffer);

--- a/tests/corpus/2689-http-server-timeout-properties.ts
+++ b/tests/corpus/2689-http-server-timeout-properties.ts
@@ -1,6 +1,7 @@
 // The five writable numeric http.Server timeout fields: Node 24 defaults,
-// independent per-server storage, and static reads/writes through a typed
-// helper. Timer enforcement is a separate server behavior surface.
+// independent per-server storage, constructor initialization, optional and
+// dynamic access, and static reads/writes through a typed helper. Timer
+// enforcement is a separate server behavior surface.
 import { createServer, Server } from "node:http";
 
 function configure(server: Server): void {
@@ -13,6 +14,7 @@ function configure(server: Server): void {
 
 const configured = createServer();
 const untouched = new Server();
+const fromOption = createServer({ keepAliveTimeoutBuffer: 4321 });
 
 console.log(
   configured.timeout,
@@ -37,3 +39,25 @@ console.log(
   untouched.headersTimeout,
   untouched.requestTimeout,
 );
+
+console.log("option", fromOption.keepAliveTimeoutBuffer);
+
+function logOptional(server: Server | undefined): void {
+  console.log("optional", server?.keepAliveTimeoutBuffer);
+}
+logOptional(fromOption);
+logOptional(undefined);
+
+const dynamic: any = fromOption;
+console.log("dynamic", dynamic.keepAliveTimeoutBuffer);
+dynamic.keepAliveTimeoutBuffer = 8765;
+console.log("dynamic-set", dynamic.keepAliveTimeoutBuffer, fromOption.keepAliveTimeoutBuffer);
+
+try {
+  createServer({ keepAliveTimeoutBuffer: -1 });
+} catch (err) {
+  if (err instanceof Error) {
+    const code = (err as NodeJS.ErrnoException).code;
+    console.log(err.name, code, err.message);
+  }
+}

--- a/tests/corpus/2689-http-server-timeout-properties.ts
+++ b/tests/corpus/2689-http-server-timeout-properties.ts
@@ -1,4 +1,4 @@
-// The four writable numeric http.Server timeout fields: Node 24 defaults,
+// The five writable numeric http.Server timeout fields: Node 24 defaults,
 // independent per-server storage, and static reads/writes through a typed
 // helper. Timer enforcement is a separate server behavior surface.
 import { createServer, Server } from "node:http";
@@ -6,6 +6,7 @@ import { createServer, Server } from "node:http";
 function configure(server: Server): void {
   server.timeout = 125;
   server.keepAliveTimeout = 250;
+  server.keepAliveTimeoutBuffer = 300;
   server.headersTimeout = 375;
   server.requestTimeout = 500;
 }
@@ -16,6 +17,7 @@ const untouched = new Server();
 console.log(
   configured.timeout,
   configured.keepAliveTimeout,
+  configured.keepAliveTimeoutBuffer,
   configured.headersTimeout,
   configured.requestTimeout,
 );
@@ -24,12 +26,14 @@ configure(configured);
 console.log(
   configured.timeout,
   configured.keepAliveTimeout,
+  configured.keepAliveTimeoutBuffer,
   configured.headersTimeout,
   configured.requestTimeout,
 );
 console.log(
   untouched.timeout,
   untouched.keepAliveTimeout,
+  untouched.keepAliveTimeoutBuffer,
   untouched.headersTimeout,
   untouched.requestTimeout,
 );

--- a/tests/corpus/2689-http-server-timeout-properties.ts
+++ b/tests/corpus/2689-http-server-timeout-properties.ts
@@ -1,0 +1,35 @@
+// The four writable numeric http.Server timeout fields: Node 24 defaults,
+// independent per-server storage, and static reads/writes through a typed
+// helper. Timer enforcement is a separate server behavior surface.
+import { createServer, Server } from "node:http";
+
+function configure(server: Server): void {
+  server.timeout = 125;
+  server.keepAliveTimeout = 250;
+  server.headersTimeout = 375;
+  server.requestTimeout = 500;
+}
+
+const configured = createServer();
+const untouched = new Server();
+
+console.log(
+  configured.timeout,
+  configured.keepAliveTimeout,
+  configured.headersTimeout,
+  configured.requestTimeout,
+);
+
+configure(configured);
+console.log(
+  configured.timeout,
+  configured.keepAliveTimeout,
+  configured.headersTimeout,
+  configured.requestTimeout,
+);
+console.log(
+  untouched.timeout,
+  untouched.keepAliveTimeout,
+  untouched.headersTimeout,
+  untouched.requestTimeout,
+);

--- a/tests/corpus/2690-https-server-timeout-option.ts
+++ b/tests/corpus/2690-https-server-timeout-option.ts
@@ -1,0 +1,23 @@
+// HTTPS ServerOptions extends the HTTP option surface: literal and bound
+// option records initialize keepAliveTimeoutBuffer with the same validation
+// as http.createServer. No listen is needed to observe the server property.
+import { readFileSync } from "node:fs";
+import { createServer } from "node:https";
+
+const cert = readFileSync("tests/fixtures/server/certs/localhost.pem");
+const key = readFileSync("tests/fixtures/server/certs/localhost-key.pem");
+
+const literal = createServer({ cert, key, keepAliveTimeoutBuffer: 4321 }, () => {});
+console.log("literal", literal.keepAliveTimeoutBuffer);
+
+const options = { cert, key, keepAliveTimeoutBuffer: 5432 };
+const bound = createServer(options, () => {});
+console.log("bound", bound.keepAliveTimeoutBuffer);
+
+try {
+  createServer({ cert, key, keepAliveTimeoutBuffer: -1 }, () => {});
+} catch (err) {
+  if (err instanceof Error) {
+    console.log(err.name, (err as NodeJS.ErrnoException).code, err.message);
+  }
+}


### PR DESCRIPTION
- Lower typed timeout property reads and writes through both native backends.
- Store Node-compatible defaults independently on each HTTP/HTTPS server.
- Cover defaults and assignments with differential corpus tests.