### PR TITLE
feat(ffi): support call-scoped native callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to scriptc will be documented in this file.
 
 <!-- release:start -->
 
+### Features
+
+- **Native FFI accepts C function-pointer callbacks.** Format 2 describes callback pointers and opaque contexts as independently positioned ABI entries, adapts ordinary capturing TypeScript closures through both backends, and preserves scalar C conversion and catchable callback throws. Raw callbacks without userdata use a binding-specific same-thread trampoline. The initial lifetime policy is explicit and bounded: callbacks are valid only during the native call; retained and foreign-thread callbacks remain rejected by contract.
+
 ## 0.0.25
 
 ### Fixes

--- a/docs/src/app/ffi/page.mdx
+++ b/docs/src/app/ffi/page.mdx
@@ -124,18 +124,80 @@ The manifest is the native ABI authority. TypeScript has only `number`, so its d
   </tbody>
 </table>
 
-String and byte pointers are borrowed only for the duration of the call. Native code must not mutate, free, or retain them. Strings may contain embedded NUL bytes, so always use the supplied length; an empty span may have a null pointer. Format 1 deliberately has no pointer, string, or byte return because those need an explicit ownership and allocator contract.
+String and byte pointers are borrowed only for the duration of the call. Native code must not mutate, free, or retain them. Strings may contain embedded NUL bytes, so always use the supplied length; an empty span may have a null pointer. The current formats deliberately have no pointer, string, or byte return because those need an explicit ownership and allocator contract.
 
 For C++, export the symbol with `extern "C"` so it keeps the manifest's unmangled C name.
+
+## Callbacks and context pointers
+
+Format 2 adds call-scoped C function-pointer parameters. It describes the function pointer and opaque context as independent ABI entries, in their actual positions—matching the model used by C, Rust's `extern "C" fn` plus `*mut c_void`, and Zig's `*const fn (...) callconv(.c)` plus `*anyopaque`.
+
+For example, this C function takes a callback first, a value second, and its context last. The callback itself receives the context last:
+
+```c:native.c
+typedef double (*map_callback)(double value, void *context);
+
+double native_map(map_callback callback, double value, void *context) {
+  return callback(value, context);
+}
+```
+
+The TypeScript declaration contains only source values. Context entries are supplied by the compiler, so there is no context parameter in TypeScript:
+
+```ts:main.ts
+declare function nativeMap(
+  callback: (value: number) => number,
+  value: number,
+): number;
+
+const offset = 7;
+console.log(nativeMap((value) => value + offset, 5));
+```
+
+The callback id connects the two independently positioned context entries. Both positions are explicit; no adjacency or conventional argument order is assumed.
+
+```json:ffi.json
+{
+  "ffi_format": 2,
+  "functions": [
+    {
+      "name": "nativeMap",
+      "symbol": "native_map",
+      "params": [
+        {
+          "callback": {
+            "id": "map",
+            "params": ["f64", { "context": "map" }],
+            "returns": "f64",
+            "lifetime": "call"
+          }
+        },
+        "f64",
+        { "context": "map" }
+      ],
+      "returns": "f64"
+    }
+  ],
+  "libraries": ["./libnative.a"]
+}
+```
+
+A callback descriptor consumes one TypeScript function parameter and one native function-pointer slot. A context entry consumes no TypeScript parameter and one native `void *` slot. Callback parameter lists currently accept `f64`, `bool`, `u8`, `u32`, and `i32`, plus at most one context entry; callback returns accept those scalar classes or `void`.
+
+For a raw C callback type with no userdata, omit the context entry from both parameter lists. scriptc installs that closure in a binding-specific thread-local slot around the native call, so captures and nested calls still work. This remains call-scoped: the native function must invoke it synchronously on the thread that entered the native call.
+
+`lifetime` must currently be `"call"`. Native code must not retain a callback or context, invoke it after the outer function returns, or invoke it from another thread. As with a bad native pointer or mismatched signature, violating that contract is outside scriptc's memory-safety guarantees. Retained callbacks will require an explicit registration/unregistration ownership model; foreign-thread callbacks will additionally require runtime scheduling and synchronization.
+
+If a callback throws, the adapter returns zero (or `void`) to native code and suppresses further script callback execution while the exception is pending. When the outer native function returns, the original exception resumes through scriptc's ordinary catchable unwind path. Native work performed between the callback's return and the outer function's return is not rolled back.
 
 ## Manifest fields
 
 <dl>
   <dt><code>ffi_format</code></dt>
-  <dd>Required. Must be <code>1</code>.</dd>
+  <dd>Required. Format <code>1</code> supports value parameters; format <code>2</code> preserves them and adds callback/context entries.</dd>
 
   <dt><code>functions</code></dt>
-  <dd>Required array. Every entry has exactly <code>name</code>, <code>symbol</code>, <code>params</code>, and <code>returns</code>. Binding names and symbols must be unique.</dd>
+  <dd>Required array. Every entry has exactly <code>name</code>, <code>symbol</code>, <code>params</code>, and <code>returns</code>. Binding names and symbols must be unique. In format 2, callback ids must be unique within a function and every context must match exactly one callback.</dd>
 
   <dt><code>libraries</code></dt>
   <dd>Optional array of archive or object paths. Relative paths are resolved from the manifest directory and appended after the generated program at link time.</dd>
@@ -150,6 +212,7 @@ Unknown fields, invalid ABI classes, duplicate names, and signature mismatches f
 
 - Native calls are synchronous and must return normally. Do not unwind C++ exceptions or `longjmp` across the boundary.
 - Native code is outside scriptc's exception, reference-counting, and sanitizer contracts. A bad pointer or mismatched C signature can still corrupt the process.
-- There are no callbacks, variadic calls, struct-by-value arguments, owned pointer returns, or runtime `dlopen`/`dlsym` handles yet.
+- Callbacks are synchronous, call-scoped, and same-thread only. Retained callbacks and foreign-thread invocation are not supported yet.
+- There are no variadic calls, struct-by-value arguments, owned pointer returns, or runtime `dlopen`/`dlsym` handles yet.
 - The archive or object must match the build target. Cross-compilation does not translate native inputs.
 - Outbound FFI is currently available for executable builds, not `scriptc build --lib`.

--- a/docs/src/app/limitations/page.mdx
+++ b/docs/src/app/limitations/page.mdx
@@ -87,6 +87,6 @@ const who = process.argv.length > 2 ? process.argv[2] : "world";
 ## Tooling gaps
 
 - `scriptc run` does not forward extra CLI arguments to the program — `build` and invoke the binary directly.
-- Native FFI is a direct, manifest-declared C ABI link surface. It does not yet support callbacks, variadic calls, structs by value, owned pointer/string/byte returns, runtime dynamic-library loading, or library-mode builds. See [Native FFI](/ffi).
+- Native FFI is a direct, manifest-declared C ABI link surface. Callback parameters are synchronous, call-scoped, and same-thread; retained or foreign-thread callbacks are not supported yet. Variadic calls, structs by value, owned pointer/string/byte returns, runtime dynamic-library loading, and library-mode builds also remain unsupported. See [Native FFI](/ffi).
 - Numbers are JS-exact f64 everywhere. Integer inference and ownership analysis — the systems-language performance ceiling — are roadmap, not shipped.
 - No Windows servers or `child_process` yet — see [Platform Support](/platforms).

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -2,7 +2,7 @@
  * expression lands in a fresh C temp, with RC ownership tracked on the
  * emitter's frames (see the discipline comment in emitter core). */
 import type { CEmitter, Temp } from "./emitter.js";
-import { arrayOf, BOOL, BYTES_U8, bytesOf, canMarshalFuncIntoIsland, CHILDSTREAM_T, DYN, F64, IrExpr, IrRecordShape, IrType, islandPromisePayloadTag, isRefCounted, isUnitType, MAY_THROW_LIB_FNS, RUNTIME_ERROR_CLASSES, STRING, typeEquals, typeKey } from "../../ir/nodes.js";
+import { arrayOf, BOOL, BYTES_U8, bytesOf, canMarshalFuncIntoIsland, CHILDSTREAM_T, DYN, F64, IrExpr, IrRecordShape, IrType, islandPromisePayloadTag, isFfiCallbackParam, isFfiContextParam, isRefCounted, isUnitType, MAY_THROW_LIB_FNS, RUNTIME_ERROR_CLASSES, STRING, typeEquals, typeKey } from "../../ir/nodes.js";
 import { boxAccess, BYTES_NUM_KIND_C, BYTES_NUM_VAR_C, bytesElemKindC, cDecl, cFnPtrCast, cNumberLiteral, cStringLiteral, cType, DV_GET_KIND_C, DV_SET_KIND_C, elemAccess, mapKeyAccess, mapKeyKindC, mapValKindC, releaseCallC, retainCallC, vAdapters } from "./emit-types.js";
 import { mangleClassNew, mangleClassRetain, mangleClassStruct, mangleField, mangleFnClosure, mangleFunction, mangleGlobal, mangleLocal, mangleRecordNew, mangleRecordStruct, mangleVtStruct } from "../mangle.js";
 import { OVERFLOW_MEMBER } from "./emit-shapes.js";
@@ -2057,10 +2057,45 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
         const entry = E.ffiByName.get(e.import);
         if (!entry) throw new Error(`emitter bug: unknown FFI import ${e.import}`);
         const args = e.args.map((arg) => E.emitExpr(arg));
+        const sourceArgs = new Map<number, Temp>();
+        const callbackArgs = new Map<string, Temp>();
+        let sourceIndex = 0;
+        entry.params.forEach((param, abiIndex) => {
+          if (isFfiContextParam(param)) return;
+          const arg = args[sourceIndex++]!;
+          sourceArgs.set(abiIndex, arg);
+          if (isFfiCallbackParam(param)) callbackArgs.set(param.callback.id, arg);
+        });
+
+        // Raw C callback pointers carry no userdata. For the documented
+        // call-scoped/same-thread policy, lend each one a distinct TLS
+        // slot for the dynamic extent of this native call. Save/restore
+        // makes nested and reentrant calls stack correctly.
+        const rawContexts: { tls: string; previous: Temp }[] = [];
+        for (const param of entry.params) {
+          if (!isFfiCallbackParam(param)) continue;
+          const adapter = E.ffiCallbackAdapter(entry.name, param.callback.id);
+          if (adapter.tls === null) continue;
+          const callback = callbackArgs.get(param.callback.id)!;
+          const previous = E.newBorrowedTemp(callback.type, adapter.tls);
+          E.line(`${adapter.tls} = ${callback.name};`);
+          rawContexts.push({ tls: adapter.tls, previous });
+        }
         const nativeArgs: string[] = [];
-        entry.params.forEach((cls, i) => {
-          const arg = args[i]!;
-          switch (cls) {
+        entry.params.forEach((param, i) => {
+          if (isFfiCallbackParam(param)) {
+            const adapter = E.ffiCallbackAdapter(entry.name, param.callback.id);
+            nativeArgs.push(`&${adapter.symbol}`);
+            return;
+          }
+          if (isFfiContextParam(param)) {
+            const callback = callbackArgs.get(param.context);
+            if (!callback) throw new Error(`emitter bug: FFI context '${param.context}' has no callback arg`);
+            nativeArgs.push(`(void *)${callback.name}`);
+            return;
+          }
+          const arg = sourceArgs.get(i)!;
+          switch (param) {
             case "f64":
               nativeArgs.push(arg.name);
               break;
@@ -2085,18 +2120,39 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           }
         });
         const call = `${entry.symbol}(${nativeArgs.join(", ")})`;
+        const restoreRawContexts = (): void => {
+          for (let i = rawContexts.length - 1; i >= 0; i--) {
+            const saved = rawContexts[i]!;
+            E.line(`${saved.tls} = ${saved.previous.name};`);
+          }
+        };
+        const callbacksMayThrow = callbackArgs.size > 0;
         switch (entry.returns) {
           case "void":
             E.line(`${call};${E.srcComment(e.loc)}`);
+            restoreRawContexts();
+            if (callbacksMayThrow) E.emitPendingCheck();
             return { name: "", type: e.type };
-          case "f64":
-            return E.newTemp(e.type, call);
-          case "bool":
-            return E.newTemp(e.type, `(${call} != 0)`);
+          case "f64": {
+            const result = E.newTemp(e.type, call);
+            restoreRawContexts();
+            if (callbacksMayThrow) E.emitPendingCheck();
+            return result;
+          }
+          case "bool": {
+            const result = E.newTemp(e.type, `(${call} != 0)`);
+            restoreRawContexts();
+            if (callbacksMayThrow) E.emitPendingCheck();
+            return result;
+          }
           case "u8":
           case "u32":
-          case "i32":
-            return E.newTemp(e.type, `(double)${call}`);
+          case "i32": {
+            const result = E.newTemp(e.type, `(double)${call}`);
+            restoreRawContexts();
+            if (callbacksMayThrow) E.emitPendingCheck();
+            return result;
+          }
         }
       }
       case "closure": {

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -39,6 +39,7 @@ import type {
   SrcLoc,
 } from "../../ir/nodes.js";
 import { ffiCallbackType, funcOf, isFfiCallbackParam, isFfiContextParam, isRefCounted, isUnitType, mapOf, moduleEmbedsCompressedNpm, moduleUsesDgram, moduleUsesDynInvoke, moduleEmbedsBuiltin, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, RUNTIME_EMITTER_CLASS, STRING, VOID } from "../../ir/nodes.js";
+import { allocateFfiCallbackAdapters, type FfiCallbackAdapter } from "../ffi-callbacks.js";
 import {
   mangleAsyncSpawn,
   mangleGenSpawn,
@@ -80,13 +81,6 @@ export interface Temp {
  * capture box (boxed locals release their BOX; the box frees its contents). */
 export interface ScopeEntry extends Temp {
   boxed?: boolean;
-}
-
-export interface CCallbackAdapter {
-  symbol: string;
-  /** Raw callbacks have no ABI context parameter and borrow this TLS slot. */
-  tls: string | null;
-  callback: IrFfiCallbackParam["callback"];
 }
 
 export function ffiNativeTypeC(
@@ -234,7 +228,7 @@ export class CEmitter {
   /** One C-ABI trampoline per manifest callback entry. Raw function
    * pointers additionally get a distinct TLS context slot, so two
    * callbacks with the same signature never alias each other's closure. */
-  readonly ffiCallbackAdapters = new Map<string, CCallbackAdapter>();
+  readonly ffiCallbackAdapters: Map<string, FfiCallbackAdapter>;
   readonly globalsById = new Map<string, IrGlobal>();
   readonly unionsById = new Map<string, IrUnionDef>();
   /** Active optional-chain bind temps, by chain id (chainRecv reads). */
@@ -399,22 +393,13 @@ export class CEmitter {
     readonly mod: IrModule,
     sourceText?: string,
   ) {
+    this.ffiCallbackAdapters = allocateFfiCallbackAdapters(mod.ffiImports ?? []);
     for (const fn of mod.functions) {
       this.returnTypeByFn.set(fn.name, fn.returnType);
       this.fnByName.set(fn.name, fn);
     }
     for (const entry of mod.ffiImports ?? []) {
       this.ffiByName.set(entry.name, entry);
-      for (const param of entry.params) {
-        if (!isFfiCallbackParam(param)) continue;
-        const index = this.ffiCallbackAdapters.size;
-        const hasContext = param.callback.params.some(isFfiContextParam);
-        this.ffiCallbackAdapters.set(`${entry.name}:${param.callback.id}`, {
-          symbol: `sc_ffi_cb_${index}`,
-          tls: hasContext ? null : `sc_ffi_cb_ctx_${index}`,
-          callback: param.callback,
-        });
-      }
     }
     const mt = computeMayThrow(mod);
     this.mayThrow = mt.fns;
@@ -1706,7 +1691,7 @@ export class CEmitter {
 
   /* ── functions ────────────────────────────────────────────────────── */
 
-  ffiCallbackAdapter(binding: string, id: string): CCallbackAdapter {
+  ffiCallbackAdapter(binding: string, id: string): FfiCallbackAdapter {
     const adapter = this.ffiCallbackAdapters.get(`${binding}:${id}`);
     if (!adapter) throw new Error(`emitter bug: no callback adapter for ${binding}:${id}`);
     return adapter;

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -25,7 +25,11 @@ import type {
   IrGlobal,
   IrRecordShape,
   IrExpr,
+  IrFfiCallbackParamClass,
+  IrFfiCallbackParam,
   IrFfiImport,
+  IrFfiReturnClass,
+  IrFfiValueParamClass,
   IrFunction,
   IrLocal,
   IrModule,
@@ -34,7 +38,7 @@ import type {
   IrUnionDef,
   SrcLoc,
 } from "../../ir/nodes.js";
-import { funcOf, isRefCounted, isUnitType, mapOf, moduleEmbedsCompressedNpm, moduleUsesDgram, moduleUsesDynInvoke, moduleEmbedsBuiltin, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, RUNTIME_EMITTER_CLASS, STRING, VOID } from "../../ir/nodes.js";
+import { ffiCallbackType, funcOf, isFfiCallbackParam, isFfiContextParam, isRefCounted, isUnitType, mapOf, moduleEmbedsCompressedNpm, moduleUsesDgram, moduleUsesDynInvoke, moduleEmbedsBuiltin, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, RUNTIME_EMITTER_CLASS, STRING, VOID } from "../../ir/nodes.js";
 import {
   mangleAsyncSpawn,
   mangleGenSpawn,
@@ -48,7 +52,7 @@ import {
   mangleVtSlot,
   mangleWrapper,
 } from "../mangle.js";
-import { cType, releaseCallC, cStringLiteral, cDecl } from "./emit-types.js";
+import { cFnPtrCast, cType, releaseCallC, cStringLiteral, cDecl } from "./emit-types.js";
 import { computeMayThrow } from "./may-throw.js";
 import { dynDesc, unionTruthyHelper, unionEqHelper, unionToStrHelper, unionJoinHelper, jsonWriteHelper, jsonIndentHelper, dynMatchHelper, dynCheckHelper, dynFuncBoxHelper, dynToStrHelper, caughtToDynHelper, toDynHelper, recordKeyGetHelper, recordKeySetHelper } from "./emit-walkers.js";
 import { VtSlot, ClassMeta, emitStructDefs, vtEntriesFor, vtSlotParams, emitVtableDecls, emitVtableInstances, emitVtAdapterDefs, emitHierarchyClassHelpers, emitClassObjs, emitCtorThunkDefs, errorVtStampLines, emitterVtStampLines, streamVtStampLines, traceAdapterC, traceArgC, boxNewC, arrNewC } from "./emit-shapes.js";
@@ -76,6 +80,52 @@ export interface Temp {
  * capture box (boxed locals release their BOX; the box frees its contents). */
 export interface ScopeEntry extends Temp {
   boxed?: boolean;
+}
+
+export interface CCallbackAdapter {
+  symbol: string;
+  /** Raw callbacks have no ABI context parameter and borrow this TLS slot. */
+  tls: string | null;
+  callback: IrFfiCallbackParam["callback"];
+}
+
+export function ffiNativeTypeC(
+  cls: IrFfiCallbackParamClass | IrFfiValueParamClass | IrFfiReturnClass,
+): string {
+  switch (cls) {
+    case "f64":
+      return "double";
+    case "bool":
+    case "u8":
+      return "uint8_t";
+    case "u32":
+      return "uint32_t";
+    case "i32":
+      return "int32_t";
+    case "string":
+    case "bytes":
+      throw new Error(`emitter bug: span class '${cls}' has no scalar C type`);
+    case "void":
+      return "void";
+  }
+}
+
+function ffiCallbackNativeParamsC(callback: IrFfiCallbackParam["callback"], named: boolean): string[] {
+  return callback.params.map((param, i) =>
+    isFfiContextParam(param)
+      ? `void *${named ? "sc_ctx" : ""}`.trim()
+      : `${ffiNativeTypeC(param)}${named ? ` sc_a${i}` : ""}`,
+  );
+}
+
+function ffiCallbackPointerTypeC(callback: IrFfiCallbackParam["callback"]): string {
+  const ret = ffiNativeTypeC(callback.returns);
+  const params = ffiCallbackNativeParamsC(callback, false);
+  return `${ret} (*)(${params.length > 0 ? params.join(", ") : "void"})`;
+}
+
+function ffiCallbackDummyC(callback: IrFfiCallbackParam["callback"]): string {
+  return callback.returns === "void" ? "" : "0";
 }
 
 export class CEmitter {
@@ -181,6 +231,10 @@ export class CEmitter {
   readonly fnByName = new Map<string, IrFunction>();
   /** Manifest-bound native imports, used by ffiCall emission. */
   readonly ffiByName = new Map<string, IrFfiImport>();
+  /** One C-ABI trampoline per manifest callback entry. Raw function
+   * pointers additionally get a distinct TLS context slot, so two
+   * callbacks with the same signature never alias each other's closure. */
+  readonly ffiCallbackAdapters = new Map<string, CCallbackAdapter>();
   readonly globalsById = new Map<string, IrGlobal>();
   readonly unionsById = new Map<string, IrUnionDef>();
   /** Active optional-chain bind temps, by chain id (chainRecv reads). */
@@ -349,7 +403,19 @@ export class CEmitter {
       this.returnTypeByFn.set(fn.name, fn.returnType);
       this.fnByName.set(fn.name, fn);
     }
-    for (const entry of mod.ffiImports ?? []) this.ffiByName.set(entry.name, entry);
+    for (const entry of mod.ffiImports ?? []) {
+      this.ffiByName.set(entry.name, entry);
+      for (const param of entry.params) {
+        if (!isFfiCallbackParam(param)) continue;
+        const index = this.ffiCallbackAdapters.size;
+        const hasContext = param.callback.params.some(isFfiContextParam);
+        this.ffiCallbackAdapters.set(`${entry.name}:${param.callback.id}`, {
+          symbol: `sc_ffi_cb_${index}`,
+          tls: hasContext ? null : `sc_ffi_cb_ctx_${index}`,
+          callback: param.callback,
+        });
+      }
+    }
     const mt = computeMayThrow(mod);
     this.mayThrow = mt.fns;
     this.indirectMayThrow = mt.indirect;
@@ -641,10 +707,13 @@ export class CEmitter {
     }
     if (globals.length > 0) out.push("");
     // Outbound native FFI declarations. string/bytes each expand from one
-    // scriptc value to a borrowed pointer+length pair at the C boundary.
+    // scriptc value to a borrowed pointer+length pair. Format-2 callbacks
+    // and their independently positioned contexts are exact pointer slots.
     for (const entry of this.mod.ffiImports ?? []) {
-      const params = entry.params.flatMap((cls): string[] => {
-        switch (cls) {
+      const params = entry.params.flatMap((param): string[] => {
+        if (isFfiCallbackParam(param)) return [ffiCallbackPointerTypeC(param.callback)];
+        if (isFfiContextParam(param)) return ["void *"];
+        switch (param) {
           case "f64":
             return ["double"];
           case "bool":
@@ -659,16 +728,12 @@ export class CEmitter {
             return ["const uint8_t *", "size_t"];
         }
       });
-      const ret =
-        entry.returns === "f64" ? "double"
-        : entry.returns === "bool" || entry.returns === "u8" ? "uint8_t"
-        : entry.returns === "u32" ? "uint32_t"
-        : entry.returns === "i32" ? "int32_t"
-        : "void";
+      const ret = ffiNativeTypeC(entry.returns);
       out.push(`extern ${ret} ${entry.symbol}(${params.length > 0 ? params.join(", ") : "void"});`);
     }
     if ((this.mod.ffiImports?.length ?? 0) > 0) out.push("");
     for (const fn of this.mod.functions) out.push(this.signature(fn) + ";");
+    this.emitFfiCallbackDefs(out);
     // Class objects (classes as values): construct-thunk prototypes plus
     // the immortal statics that take their addresses — after the function
     // signatures (the thunks call sc_new_*/the constructors), before
@@ -1640,6 +1705,75 @@ export class CEmitter {
   }
 
   /* ── functions ────────────────────────────────────────────────────── */
+
+  ffiCallbackAdapter(binding: string, id: string): CCallbackAdapter {
+    const adapter = this.ffiCallbackAdapters.get(`${binding}:${id}`);
+    if (!adapter) throw new Error(`emitter bug: no callback adapter for ${binding}:${id}`);
+    return adapter;
+  }
+
+  /** C-callable trampolines for format-2 callbacks. The external callback
+   * ABI is scalar C plus an optional exact-position context pointer; the
+   * internal side is scriptc's (ScrClosure *env, params...) convention.
+   * A raw callback borrows its closure through a distinct TLS slot for the
+   * dynamic extent of the outer call. */
+  emitFfiCallbackDefs(out: string[]): void {
+    if (this.ffiCallbackAdapters.size === 0) return;
+    for (const adapter of this.ffiCallbackAdapters.values()) {
+      const cb = adapter.callback;
+      if (adapter.tls !== null) {
+        out.push(`static _Thread_local ScrClosure *${adapter.tls};`);
+      }
+      const nativeParams = ffiCallbackNativeParamsC(cb, true);
+      const ret = ffiNativeTypeC(cb.returns);
+      const contextParam = cb.params.findIndex(isFfiContextParam);
+      out.push(
+        `static ${ret} ${adapter.symbol}(${nativeParams.length > 0 ? nativeParams.join(", ") : "void"}) {`,
+        `  ScrClosure *sc_cb = ${contextParam >= 0 ? `(ScrClosure *)sc_ctx` : adapter.tls};`,
+        `  if (sc_cb == NULL) scr_trap("scriptc: native callback invoked outside its call-scoped lifetime\\n");`,
+      );
+      const dummy = ffiCallbackDummyC(cb);
+      out.push(`  if (scr_exc_pending()) ${cb.returns === "void" ? "return;" : `return ${dummy};`}`);
+      const ft = ffiCallbackType(cb);
+      const scriptArgs = cb.params.flatMap((param, i): string[] => {
+        if (isFfiContextParam(param)) return [];
+        switch (param) {
+          case "f64":
+            return [`sc_a${i}`];
+          case "bool":
+            return [`(sc_a${i} != 0)`];
+          case "u8":
+          case "u32":
+          case "i32":
+            return [`(double)sc_a${i}`];
+        }
+      });
+      const call = `(${cFnPtrCast(ft)}sc_cb->fn)(sc_cb${scriptArgs.length ? `, ${scriptArgs.join(", ")}` : ""})`;
+      if (cb.returns === "void") {
+        out.push(`  ${call};`, `  return;`, `}`, ``);
+        continue;
+      }
+      out.push(`  ${cDecl(ft.ret, "sc_result")} = ${call};`);
+      switch (cb.returns) {
+        case "f64":
+          out.push(`  return sc_result;`);
+          break;
+        case "bool":
+          out.push(`  return (uint8_t)(sc_result ? 1 : 0);`);
+          break;
+        case "u8":
+          out.push(`  return (uint8_t)(uint32_t)scr_bit_ushr(sc_result, 0.0);`);
+          break;
+        case "u32":
+          out.push(`  return (uint32_t)scr_bit_ushr(sc_result, 0.0);`);
+          break;
+        case "i32":
+          out.push(`  return (int32_t)scr_bit_or(sc_result, 0.0);`);
+          break;
+      }
+      out.push(`}`, ``);
+    }
+  }
 
   signature(fn: IrFunction): string {
     const boxedIds = new Set(fn.locals.filter((l) => l.boxed).map((l) => l.id));

--- a/packages/compiler/src/backend/emission/may-throw.ts
+++ b/packages/compiler/src/backend/emission/may-throw.ts
@@ -1,7 +1,7 @@
 /* Cheap whole-module may-throw analysis (see computeMayThrow). Pure function
  * of the IR module; the emitter consults the result to place unwind checks. */
 import type { IrArrIntrinsicMethod, IrBytesIntrinsicMethod, IrLibFn, IrModule } from "../../ir/nodes.js";
-import { MAY_THROW_ARR_METHODS, MAY_THROW_BYTES_METHODS, MAY_THROW_LIB_FNS } from "../../ir/nodes.js";
+import { isFfiCallbackParam, MAY_THROW_ARR_METHODS, MAY_THROW_BYTES_METHODS, MAY_THROW_LIB_FNS } from "../../ir/nodes.js";
 
 /** Cheap may-throw analysis (cost discipline: functions that transitively
  * CANNOT throw pay for no pending-exception checks). A function may throw
@@ -29,6 +29,11 @@ export function computeMayThrow(mod: IrModule): { fns: Set<string>; indirect: bo
   // allocates the suspended fiber (nothing runs, nothing can throw) — a
   // body throw surfaces at genResume, which seeds unconditionally below.
   const genFns = new Set(mod.functions.filter((fn) => fn.generator).map((fn) => fn.name));
+  const callbackFfiImports = new Set(
+    (mod.ffiImports ?? [])
+      .filter((entry) => entry.params.some(isFfiCallbackParam))
+      .map((entry) => entry.name),
+  );
   // Method name → every class's implementation of it (virtualCall callees).
   const methodImpls = new Map<string, string[]>();
   for (const cls of mod.classes ?? []) {
@@ -162,6 +167,12 @@ export function computeMayThrow(mod: IrModule): { fns: Set<string>; indirect: bo
           // The may-throw seed hook: throwing library calls (fs.*,
           // json.parse) count exactly like a `throw` statement.
           if (MAY_THROW_LIB_FNS.has(rec["fn"] as IrLibFn)) f.throws = true;
+          break;
+        case "ffiCall":
+          // A call-scoped native callback may run arbitrary scriptc code.
+          // Its exception stays pending until the outer native call
+          // returns, where the emitter checks and unwinds normally.
+          if (callbackFfiImports.has(rec["import"] as string)) f.throws = true;
           break;
         case "bytesNew": {
           // The size form (`new Uint8Array(n)`) throws Node's "Invalid

--- a/packages/compiler/src/backend/ffi-callbacks.ts
+++ b/packages/compiler/src/backend/ffi-callbacks.ts
@@ -1,0 +1,43 @@
+import type { IrFfiCallbackParam, IrFfiImport } from "../ir/nodes.js";
+import { isFfiCallbackParam, isFfiContextParam } from "../ir/nodes.js";
+
+export interface FfiCallbackAdapter {
+  symbol: string;
+  /** Raw callbacks have no ABI context parameter and borrow this TLS slot. */
+  tls: string | null;
+  callback: IrFfiCallbackParam["callback"];
+}
+
+/** Allocate internal callback symbols outside the manifest's external
+ * symbol set. C and LLVM share this table so a valid native symbol can
+ * never collide with a generated trampoline or raw-callback TLS slot. */
+export function allocateFfiCallbackAdapters(
+  imports: readonly IrFfiImport[],
+): Map<string, FfiCallbackAdapter> {
+  const reserved = new Set(imports.map((entry) => entry.symbol));
+  const adapters = new Map<string, FfiCallbackAdapter>();
+  let suffix = 0;
+
+  for (const entry of imports) {
+    for (const param of entry.params) {
+      if (!isFfiCallbackParam(param)) continue;
+      const hasContext = param.callback.params.some(isFfiContextParam);
+      let symbol: string;
+      let tls: string | null;
+      do {
+        const index = suffix++;
+        symbol = `sc_ffi_cb_${index}`;
+        tls = hasContext ? null : `sc_ffi_cb_ctx_${index}`;
+      } while (reserved.has(symbol) || (tls !== null && reserved.has(tls)));
+      reserved.add(symbol);
+      if (tls !== null) reserved.add(tls);
+      adapters.set(`${entry.name}:${param.callback.id}`, {
+        symbol,
+        tls,
+        callback: param.callback,
+      });
+    }
+  }
+
+  return adapters;
+}

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -80,6 +80,7 @@ import type {
 } from "../../ir/nodes.js";
 import { canMarshalFuncIntoIsland, CAUGHT, DYN, F64, ffiCallbackType, islandCallbackRet, islandPromisePayloadTag, isFfiCallbackParam, isFfiContextParam, isRefCounted, isUnitType, MAY_THROW_LIB_FNS, moduleUsesDynInvoke, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttpServer, moduleUsesNet, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, typeEquals, typeKey, VOID } from "../../ir/nodes.js";
 import { matchIntegerBytesForLoop } from "../../ir/integer-loops.js";
+import { allocateFfiCallbackAdapters, type FfiCallbackAdapter } from "../ffi-callbacks.js";
 import { computeMayThrow } from "../emission/may-throw.js";
 import { mangleArgPack, mangleAsyncSpawn, mangleClassNew, mangleClassObj, mangleClassRetain, mangleFnClosure, mangleFunction, mangleGenDrop, mangleGenResThunk, mangleGenSpawn, mangleGlobal, mangleLocal, mangleRecordNew, mangleRecordStruct, mangleResolveThunk, mangleTrampoline, mangleVtStruct, mangleWrapper } from "../mangle.js";
 import { BlockBuilder } from "./blocks.js";
@@ -103,12 +104,6 @@ interface LlStreamTypedRefAdapter {
 interface LlStreamTypedRefContext {
   prefix: string;
   adapters: Map<string, LlStreamTypedRefAdapter>;
-}
-
-interface LlFfiCallbackAdapter {
-  symbol: string;
-  tls: string | null;
-  callback: IrFfiCallbackParam["callback"];
 }
 
 function ffiNativeTypeLl(
@@ -1003,7 +998,7 @@ class LlEmitter {
   private readonly ffiByName = new Map<string, IrFfiImport>();
   /** C-ABI callback trampolines and (for raw/no-userdata callbacks) their
    * distinct call-scoped TLS closure slots. */
-  private readonly ffiCallbackAdapters = new Map<string, LlFfiCallbackAdapter>();
+  private readonly ffiCallbackAdapters: Map<string, FfiCallbackAdapter>;
   private readonly globalTypes = new Map<string, IrType>();
   /** May-throw analysis (the C emitter's computeMayThrow, shared): pending
    * checks are emitted only after calls that can actually raise. */
@@ -1107,19 +1102,10 @@ class LlEmitter {
   private logArgSlots = 0;
 
   constructor(private readonly mod: IrModule) {
+    this.ffiCallbackAdapters = allocateFfiCallbackAdapters(mod.ffiImports ?? []);
     for (const fn of mod.functions) this.fnByName.set(fn.name, fn);
     for (const entry of mod.ffiImports ?? []) {
       this.ffiByName.set(entry.name, entry);
-      for (const param of entry.params) {
-        if (!isFfiCallbackParam(param)) continue;
-        const index = this.ffiCallbackAdapters.size;
-        const hasContext = param.callback.params.some(isFfiContextParam);
-        this.ffiCallbackAdapters.set(`${entry.name}:${param.callback.id}`, {
-          symbol: `sc_ffi_cb_${index}`,
-          tls: hasContext ? null : `sc_ffi_cb_ctx_${index}`,
-          callback: param.callback,
-        });
-      }
     }
     const mt = computeMayThrow(mod);
     this.mayThrow = mt.fns;
@@ -1249,7 +1235,7 @@ class LlEmitter {
 
   // ── module assembly ─────────────────────────────────────────────────────
 
-  private ffiCallbackAdapter(binding: string, id: string): LlFfiCallbackAdapter {
+  private ffiCallbackAdapter(binding: string, id: string): FfiCallbackAdapter {
     const adapter = this.ffiCallbackAdapters.get(`${binding}:${id}`);
     if (!adapter) throw new Error(`llvm emitter bug: no callback adapter for ${binding}:${id}`);
     return adapter;

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -63,7 +63,11 @@
 import type {
   IrBytesElem,
   IrExpr,
+  IrFfiCallbackParam,
+  IrFfiCallbackParamClass,
   IrFfiImport,
+  IrFfiReturnClass,
+  IrFfiValueParamClass,
   IrFunction,
   IrGlobal,
   IrLocal,
@@ -74,7 +78,7 @@ import type {
   IrUnionDef,
   SrcLoc,
 } from "../../ir/nodes.js";
-import { canMarshalFuncIntoIsland, CAUGHT, DYN, F64, islandCallbackRet, islandPromisePayloadTag, isRefCounted, isUnitType, MAY_THROW_LIB_FNS, moduleUsesDynInvoke, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttpServer, moduleUsesNet, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, typeEquals, typeKey, VOID } from "../../ir/nodes.js";
+import { canMarshalFuncIntoIsland, CAUGHT, DYN, F64, ffiCallbackType, islandCallbackRet, islandPromisePayloadTag, isFfiCallbackParam, isFfiContextParam, isRefCounted, isUnitType, MAY_THROW_LIB_FNS, moduleUsesDynInvoke, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttpServer, moduleUsesNet, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, typeEquals, typeKey, VOID } from "../../ir/nodes.js";
 import { matchIntegerBytesForLoop } from "../../ir/integer-loops.js";
 import { computeMayThrow } from "../emission/may-throw.js";
 import { mangleArgPack, mangleAsyncSpawn, mangleClassNew, mangleClassObj, mangleClassRetain, mangleFnClosure, mangleFunction, mangleGenDrop, mangleGenResThunk, mangleGenSpawn, mangleGlobal, mangleLocal, mangleRecordNew, mangleRecordStruct, mangleResolveThunk, mangleTrampoline, mangleVtStruct, mangleWrapper } from "../mangle.js";
@@ -99,6 +103,47 @@ interface LlStreamTypedRefAdapter {
 interface LlStreamTypedRefContext {
   prefix: string;
   adapters: Map<string, LlStreamTypedRefAdapter>;
+}
+
+interface LlFfiCallbackAdapter {
+  symbol: string;
+  tls: string | null;
+  callback: IrFfiCallbackParam["callback"];
+}
+
+function ffiNativeTypeLl(
+  cls: IrFfiCallbackParamClass | IrFfiValueParamClass | IrFfiReturnClass,
+): string {
+  switch (cls) {
+    case "f64":
+      return "double";
+    case "bool":
+    case "u8":
+      return "i8";
+    case "u32":
+    case "i32":
+      return "i32";
+    case "string":
+    case "bytes":
+      throw new Error(`llvm emitter bug: span class '${cls}' has no scalar LLVM type`);
+    case "void":
+      return "void";
+  }
+}
+
+function ffiCallbackDummyLl(callback: IrFfiCallbackParam["callback"]): string {
+  switch (callback.returns) {
+    case "void":
+      return "void";
+    case "f64":
+      return "double 0.0";
+    case "bool":
+    case "u8":
+      return "i8 0";
+    case "u32":
+    case "i32":
+      return "i32 0";
+  }
 }
 import {
   arrNewCall,
@@ -956,6 +1001,9 @@ class LlEmitter {
   private readonly fnByName = new Map<string, IrFunction>();
   /** Manifest-bound native imports, used by ffiCall emission. */
   private readonly ffiByName = new Map<string, IrFfiImport>();
+  /** C-ABI callback trampolines and (for raw/no-userdata callbacks) their
+   * distinct call-scoped TLS closure slots. */
+  private readonly ffiCallbackAdapters = new Map<string, LlFfiCallbackAdapter>();
   private readonly globalTypes = new Map<string, IrType>();
   /** May-throw analysis (the C emitter's computeMayThrow, shared): pending
    * checks are emitted only after calls that can actually raise. */
@@ -1060,7 +1108,19 @@ class LlEmitter {
 
   constructor(private readonly mod: IrModule) {
     for (const fn of mod.functions) this.fnByName.set(fn.name, fn);
-    for (const entry of mod.ffiImports ?? []) this.ffiByName.set(entry.name, entry);
+    for (const entry of mod.ffiImports ?? []) {
+      this.ffiByName.set(entry.name, entry);
+      for (const param of entry.params) {
+        if (!isFfiCallbackParam(param)) continue;
+        const index = this.ffiCallbackAdapters.size;
+        const hasContext = param.callback.params.some(isFfiContextParam);
+        this.ffiCallbackAdapters.set(`${entry.name}:${param.callback.id}`, {
+          symbol: `sc_ffi_cb_${index}`,
+          tls: hasContext ? null : `sc_ffi_cb_ctx_${index}`,
+          callback: param.callback,
+        });
+      }
+    }
     const mt = computeMayThrow(mod);
     this.mayThrow = mt.fns;
     this.indirectMayThrow = mt.indirect;
@@ -1189,6 +1249,116 @@ class LlEmitter {
 
   // ── module assembly ─────────────────────────────────────────────────────
 
+  private ffiCallbackAdapter(binding: string, id: string): LlFfiCallbackAdapter {
+    const adapter = this.ffiCallbackAdapters.get(`${binding}:${id}`);
+    if (!adapter) throw new Error(`llvm emitter bug: no callback adapter for ${binding}:${id}`);
+    return adapter;
+  }
+
+  /** C-callable scalar callback trampolines. A callback with an explicit
+   * context entry receives the closure at that exact ABI position. A raw
+   * callback loads it from a call-scoped TLS slot installed around the
+   * outer native call. */
+  private emitFfiCallbackDefs(): { globals: string[]; defs: string[] } {
+    const globals: string[] = [];
+    const defs: string[] = [];
+    if (this.ffiCallbackAdapters.size === 0) return { globals, defs };
+    this.declare(`declare zeroext i1 @scr_exc_pending()`);
+    this.declare(`declare void @scr_trap(ptr)`);
+    const expired = this.cstr("scriptc: native callback invoked outside its call-scoped lifetime\n");
+    for (const adapter of this.ffiCallbackAdapters.values()) {
+      const cb = adapter.callback;
+      if (adapter.tls !== null) globals.push(`@${adapter.tls} = internal thread_local global ptr null`);
+      const params = cb.params.map((param, i) =>
+        isFfiContextParam(param) ? `ptr %ctx` : `${ffiNativeTypeLl(param)} %a${i}`,
+      );
+      const ret = ffiNativeTypeLl(cb.returns);
+      defs.push(
+        `define internal ${ret} @${adapter.symbol}(${params.join(", ")}) ${FN_ATTRS} {`,
+        `entry:`,
+        adapter.tls === null ? `  %cb = getelementptr inbounds i8, ptr %ctx, i64 0` : `  %cb = load ptr, ptr @${adapter.tls}`,
+        `  %missing = icmp eq ptr %cb, null`,
+        `  br i1 %missing, label %expired, label %ready`,
+        `expired:`,
+        `  call void @scr_trap(ptr ${expired})`,
+        `  unreachable`,
+        `ready:`,
+        `  %pending = call zeroext i1 @scr_exc_pending()`,
+        `  br i1 %pending, label %skip, label %invoke`,
+        `skip:`,
+        `  ret ${ffiCallbackDummyLl(cb)}`,
+        `invoke:`,
+        `  %fnp = getelementptr inbounds %ScrClosure, ptr %cb, i64 0, i32 1`,
+        `  %fn = load ptr, ptr %fnp`,
+      );
+      const scriptArgs: string[] = [];
+      for (let i = 0; i < cb.params.length; i++) {
+        const param = cb.params[i]!;
+        if (isFfiContextParam(param)) continue;
+        switch (param) {
+          case "f64":
+            scriptArgs.push(`double %a${i}`);
+            break;
+          case "bool":
+            defs.push(`  %s${i} = icmp ne i8 %a${i}, 0`);
+            scriptArgs.push(`i1 %s${i}`);
+            break;
+          case "u8":
+            defs.push(`  %s${i} = uitofp i8 %a${i} to double`);
+            scriptArgs.push(`double %s${i}`);
+            break;
+          case "u32":
+            defs.push(`  %s${i} = uitofp i32 %a${i} to double`);
+            scriptArgs.push(`double %s${i}`);
+            break;
+          case "i32":
+            defs.push(`  %s${i} = sitofp i32 %a${i} to double`);
+            scriptArgs.push(`double %s${i}`);
+            break;
+        }
+      }
+      const ft = ffiCallbackType(cb);
+      const internalRet = this.llType(ft.ret);
+      const callArgs = [`ptr %cb`, ...scriptArgs].join(", ");
+      if (cb.returns === "void") {
+        defs.push(`  call void %fn(${callArgs})`, `  ret void`, `}`, ``);
+        continue;
+      }
+      defs.push(`  %result = call ${internalRet} %fn(${callArgs})`);
+      switch (cb.returns) {
+        case "f64":
+          defs.push(`  ret double %result`);
+          break;
+        case "bool":
+          defs.push(`  %out = zext i1 %result to i8`, `  ret i8 %out`);
+          break;
+        case "u8":
+        case "u32":
+          this.declare(`declare double @scr_bit_ushr(double, double)`);
+          defs.push(
+            `  %coerced = call double @scr_bit_ushr(double %result, double ${f64Lit(0)})`,
+            `  %wide = fptoui double %coerced to i32`,
+          );
+          if (cb.returns === "u8") {
+            defs.push(`  %out = trunc i32 %wide to i8`, `  ret i8 %out`);
+          } else {
+            defs.push(`  ret i32 %wide`);
+          }
+          break;
+        case "i32":
+          this.declare(`declare double @scr_bit_or(double, double)`);
+          defs.push(
+            `  %coerced = call double @scr_bit_or(double %result, double ${f64Lit(0)})`,
+            `  %out = fptosi double %coerced to i32`,
+            `  ret i32 %out`,
+          );
+          break;
+      }
+      defs.push(`}`, ``);
+    }
+    return { globals, defs };
+  }
+
   emit(): string {
     // Function bodies first (the literal/unit/fn-value tables fill as they
     // emit), then the file assembles around them — the C emitter's order.
@@ -1199,6 +1369,7 @@ class LlEmitter {
     const classObjDefs = emitClassObjDefs(this, this.classMeta, this.classObjs, this.fnByName, (t) => this.llType(t));
     const wrappers = this.emitFnValueDefs();
     const asyncDefs = this.emitAsyncScaffolding();
+    const ffiCallbacks = this.emitFfiCallbackDefs();
 
     // Module globals, FIRST OCCURRENCE per id: a class-expression static
     // instantiated through several mixin applications registers one global
@@ -1464,6 +1635,8 @@ class LlEmitter {
       );
     }
     if (this.cstrs.size > 0) out.push(``);
+    out.push(...ffiCallbacks.globals);
+    if (ffiCallbacks.globals.length > 0) out.push(``);
     for (const g of globals) {
       const ty = this.llType(g.type);
       const zero = ty === "double" ? f64Lit(0) : ty === "ptr" ? "null" : "false";
@@ -1471,6 +1644,7 @@ class LlEmitter {
     }
     if (globals.length > 0) out.push(``);
     out.push(...helpers);
+    out.push(...ffiCallbacks.defs);
     out.push(...shapes.defs);
     out.push(...classShapes.defs);
     out.push(...classObjDefs);
@@ -5222,11 +5396,45 @@ class LlEmitter {
         const entry = this.ffiByName.get(e.import);
         if (!entry) throw new Error(`llvm emitter bug: unknown FFI import ${e.import}`);
         const args = e.args.map((arg) => this.emitExpr(arg));
+        const sourceArgs = new Map<number, LlValue>();
+        const callbackArgs = new Map<string, LlValue>();
+        let sourceIndex = 0;
+        entry.params.forEach((param, abiIndex) => {
+          if (isFfiContextParam(param)) return;
+          const arg = args[sourceIndex++]!;
+          sourceArgs.set(abiIndex, arg);
+          if (isFfiCallbackParam(param)) callbackArgs.set(param.callback.id, arg);
+        });
+
+        const rawContexts: { tls: string; previous: string }[] = [];
+        for (const param of entry.params) {
+          if (!isFfiCallbackParam(param)) continue;
+          const adapter = this.ffiCallbackAdapter(entry.name, param.callback.id);
+          if (adapter.tls === null) continue;
+          const callback = callbackArgs.get(param.callback.id)!;
+          const previous = B.tmp();
+          B.line(`${previous} = load ptr, ptr @${adapter.tls}`);
+          B.line(`store ptr ${callback.name}, ptr @${adapter.tls}`);
+          rawContexts.push({ tls: adapter.tls, previous });
+        }
         const nativeArgs: string[] = [];
         const nativeParamTypes: string[] = [];
-        entry.params.forEach((cls, i) => {
-          const arg = args[i]!;
-          switch (cls) {
+        entry.params.forEach((param, i) => {
+          if (isFfiCallbackParam(param)) {
+            const adapter = this.ffiCallbackAdapter(entry.name, param.callback.id);
+            nativeParamTypes.push("ptr");
+            nativeArgs.push(`ptr @${adapter.symbol}`);
+            return;
+          }
+          if (isFfiContextParam(param)) {
+            const callback = callbackArgs.get(param.context);
+            if (!callback) throw new Error(`llvm emitter bug: FFI context '${param.context}' has no callback arg`);
+            nativeParamTypes.push("ptr");
+            nativeArgs.push(`ptr ${callback.name}`);
+            return;
+          }
+          const arg = sourceArgs.get(i)!;
+          switch (param) {
             case "f64":
               nativeParamTypes.push("double");
               nativeArgs.push(`double ${arg.name}`);
@@ -5245,7 +5453,7 @@ class LlEmitter {
               const asU32 = B.tmp();
               B.line(`${asDouble} = call double @scr_bit_ushr(double ${arg.name}, double ${f64Lit(0)})`);
               B.line(`${asU32} = fptoui double ${asDouble} to i32`);
-              if (cls === "u8") {
+              if (param === "u8") {
                 const asU8 = B.tmp();
                 B.line(`${asU8} = trunc i32 ${asU32} to i8`);
                 nativeParamTypes.push("i8");
@@ -5292,31 +5500,45 @@ class LlEmitter {
             }
           }
         });
-        const retTy =
-          entry.returns === "f64" ? "double"
-          : entry.returns === "bool" || entry.returns === "u8" ? "i8"
-          : entry.returns === "u32" || entry.returns === "i32" ? "i32"
-          : "void";
+        const retTy = ffiNativeTypeLl(entry.returns);
         this.declare(
           `declare ${retTy} @${entry.symbol}(${nativeParamTypes.join(", ")})`,
         );
         const call = `call ${retTy} @${entry.symbol}(${nativeArgs.join(", ")})`;
+        const restoreRawContexts = (): void => {
+          for (let i = rawContexts.length - 1; i >= 0; i--) {
+            const saved = rawContexts[i]!;
+            B.line(`store ptr ${saved.previous}, ptr @${saved.tls}`);
+          }
+        };
+        const callbacksMayThrow = callbackArgs.size > 0;
         if (entry.returns === "void") {
           B.line(call);
+          restoreRawContexts();
+          if (callbacksMayThrow) this.emitPendingCheck();
           return { name: "", type: e.type };
         }
         const raw = B.tmp();
         B.line(`${raw} = ${call}`);
-        if (entry.returns === "f64") return { name: raw, type: e.type };
+        restoreRawContexts();
+        if (entry.returns === "f64") {
+          const result = { name: raw, type: e.type };
+          if (callbacksMayThrow) this.emitPendingCheck();
+          return result;
+        }
         if (entry.returns === "bool") {
           const value = B.tmp();
           B.line(`${value} = icmp ne i8 ${raw}, 0`);
-          return { name: value, type: e.type };
+          const result = { name: value, type: e.type };
+          if (callbacksMayThrow) this.emitPendingCheck();
+          return result;
         }
         const value = B.tmp();
         const op = entry.returns === "i32" ? "sitofp" : "uitofp";
         B.line(`${value} = ${op} ${retTy} ${raw} to double`);
-        return { name: value, type: e.type };
+        const result = { name: value, type: e.type };
+        if (callbacksMayThrow) this.emitPendingCheck();
+        return result;
       }
       case "new": {
         // Allocate (fields zeroed, vt stamped), then run the ctor. The

--- a/packages/compiler/src/diagnostics/diagnostic.ts
+++ b/packages/compiler/src/diagnostics/diagnostic.ts
@@ -100,7 +100,8 @@ export function ffiSignatureDiag(name: string, detail: string, loc: SrcLoc): Scr
     loc,
     hint:
       "FFI parameter classes: f64/u8/u32/i32 (TypeScript number), bool, string, and bytes " +
-      "(Uint8Array/Buffer); return classes: f64/u8/u32/i32, bool, and void",
+      "(Uint8Array/Buffer); format 2 also accepts call-scoped callback descriptors with explicit context slots; " +
+      "return classes: f64/u8/u32/i32, bool, and void",
   };
 }
 

--- a/packages/compiler/src/ffi/profile.ts
+++ b/packages/compiler/src/ffi/profile.ts
@@ -17,7 +17,24 @@
  * string and bytes parameters expand to the length-delimited C pair
  * `(const uint8_t *, size_t)`. Their storage is borrowed for the duration
  * of the call only. Return values deliberately stay scalar in format 1:
- * pointer ownership needs an allocator/free contract, not a guess. */
+ * pointer ownership needs an allocator/free contract, not a guess.
+ *
+ * Format 2 preserves those value classes and adds exact-position callback
+ * ABI entries. A callback and its optional opaque context carry the same
+ * manifest-local id; context entries appear independently in BOTH the
+ * native function's params and the callback's params, so their C positions
+ * are described rather than guessed:
+ *
+ *   "params": [
+ *     { "callback": { "id": "visit", "params": ["f64", { "context": "visit" }],
+ *                     "returns": "f64", "lifetime": "call" } },
+ *     { "context": "visit" }
+ *   ]
+ *
+ * Context entries are compiler-supplied and consume no TypeScript
+ * parameter. `lifetime: "call"` is deliberately the only policy today:
+ * native code may invoke the callback synchronously on the calling thread
+ * and must not retain either pointer after the outer call returns. */
 import { readFileSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { ffiProfileDiag, type ScrDiagnostic } from "../diagnostics/diagnostic.js";
@@ -33,9 +50,30 @@ export const FFI_PARAM_CLASSES = [
 ] as const;
 
 export const FFI_RETURN_CLASSES = ["f64", "bool", "u8", "u32", "i32", "void"] as const;
+export const FFI_CALLBACK_PARAM_CLASSES = ["f64", "bool", "u8", "u32", "i32"] as const;
 
-export type FfiParamClass = (typeof FFI_PARAM_CLASSES)[number];
+export type FfiValueParamClass = (typeof FFI_PARAM_CLASSES)[number];
 export type FfiReturnClass = (typeof FFI_RETURN_CLASSES)[number];
+export type FfiCallbackParamClass = (typeof FFI_CALLBACK_PARAM_CLASSES)[number];
+
+export interface FfiContextParam {
+  /** Manifest-local callback id whose closure pointer occupies this slot. */
+  context: string;
+}
+
+export interface FfiCallbackParam {
+  callback: {
+    /** Unique within the containing native function. */
+    id: string;
+    /** Exact native callback ABI; a context entry consumes no TS argument. */
+    params: (FfiCallbackParamClass | FfiContextParam)[];
+    returns: FfiReturnClass;
+    /** Callbacks are valid only for the dynamic extent of the outer call. */
+    lifetime: "call";
+  };
+}
+
+export type FfiParamClass = FfiValueParamClass | FfiCallbackParam | FfiContextParam;
 
 export interface FfiFunction {
   /** The signature-only TypeScript function declaration's binding name. */
@@ -47,7 +85,7 @@ export interface FfiFunction {
 }
 
 export interface FfiProfile {
-  ffiFormat: 1;
+  ffiFormat: 1 | 2;
   functions: FfiFunction[];
   /** Absolute paths, resolved relative to the manifest. */
   libraries: string[];
@@ -91,6 +129,65 @@ function stringArray(value: unknown, path: string): string[] {
   return value.map((entry, i) => stringField(entry, `${path}[${i}]`));
 }
 
+function contextParam(value: unknown, path: string): FfiContextParam | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const rec = value as Record<string, unknown>;
+  if (!("context" in rec)) return null;
+  rejectUnknownKeys(rec, path, ["context"]);
+  return { context: stringField(rec["context"], `${path}.context`) };
+}
+
+function callbackParam(value: unknown, path: string): FfiCallbackParam | null {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
+  const rec = value as Record<string, unknown>;
+  if (!("callback" in rec)) return null;
+  rejectUnknownKeys(rec, path, ["callback"]);
+  const raw = rec["callback"];
+  if (raw === null || typeof raw !== "object" || Array.isArray(raw)) {
+    throw new FfiProfileError(`'${path}.callback' must be an object`);
+  }
+  const callback = raw as Record<string, unknown>;
+  rejectUnknownKeys(callback, `${path}.callback`, ["id", "params", "returns", "lifetime"]);
+  const id = stringField(callback["id"], `${path}.callback.id`);
+  if (!TS_IDENT.test(id)) {
+    throw new FfiProfileError(`'${path}.callback.id' is not a plain identifier: '${id}'`);
+  }
+  if (!Array.isArray(callback["params"])) {
+    throw new FfiProfileError(`'${path}.callback.params' must be an array`);
+  }
+  const params = callback["params"].map((entry, i): FfiCallbackParamClass | FfiContextParam => {
+    const entryPath = `${path}.callback.params[${i}]`;
+    if (
+      typeof entry === "string" &&
+      (FFI_CALLBACK_PARAM_CLASSES as readonly string[]).includes(entry)
+    ) {
+      return entry as FfiCallbackParamClass;
+    }
+    const context = contextParam(entry, entryPath);
+    if (context !== null) return context;
+    throw new FfiProfileError(
+      `'${entryPath}' must be one of ${FFI_CALLBACK_PARAM_CLASSES.join("/")} or a context entry`,
+    );
+  });
+  const returns = stringField(callback["returns"], `${path}.callback.returns`);
+  if (!(FFI_RETURN_CLASSES as readonly string[]).includes(returns)) {
+    throw new FfiProfileError(
+      `'${path}.callback.returns' must be one of ${FFI_RETURN_CLASSES.join("/")}, got '${returns}'`,
+    );
+  }
+  if (callback["lifetime"] !== "call") {
+    throw new FfiProfileError(`'${path}.callback.lifetime' must be 'call'`);
+  }
+  return {
+    callback: {
+      id,
+      params,
+      returns: returns as FfiReturnClass,
+      lifetime: "call",
+    },
+  };
+}
+
 /** Parse and strictly validate one outbound native-FFI manifest. */
 export function loadFfiProfile(
   profilePath: string,
@@ -117,11 +214,11 @@ export function loadFfiProfile(
     }
     const root = raw as Record<string, unknown>;
     const format = root["ffi_format"];
-    if (format !== 1) {
+    if (format !== 1 && format !== 2) {
       throw new FfiProfileError(
         typeof format === "number"
-          ? `unsupported ffi_format ${format} (this scriptc reads format 1)`
-          : "'ffi_format' must be the number 1",
+          ? `unsupported ffi_format ${format} (this scriptc reads formats 1 and 2)`
+          : "'ffi_format' must be the number 1 or 2",
       );
     }
     rejectUnknownKeys(root, "", [
@@ -165,17 +262,72 @@ export function loadFfiProfile(
       if (!Array.isArray(row["params"])) {
         throw new FfiProfileError(`'${path}.params' must be an array`);
       }
-      const params = row["params"].map((value, j) => {
+      const params = row["params"].map((value, j): FfiParamClass => {
+        const paramPath = `${path}.params[${j}]`;
         if (
           typeof value !== "string" ||
           !(FFI_PARAM_CLASSES as readonly string[]).includes(value)
         ) {
+          if (format === 2) {
+            const callback = callbackParam(value, paramPath);
+            if (callback !== null) return callback;
+            const context = contextParam(value, paramPath);
+            if (context !== null) return context;
+          }
           throw new FfiProfileError(
-            `'${path}.params[${j}]' must be one of ${FFI_PARAM_CLASSES.join("/")}, got ${JSON.stringify(value)}`,
+            format === 1
+              ? `'${paramPath}' must be one of ${FFI_PARAM_CLASSES.join("/")}, got ${JSON.stringify(value)}`
+              : `'${paramPath}' must be one of ${FFI_PARAM_CLASSES.join("/")}, a callback, or a context entry`,
           );
         }
-        return value as FfiParamClass;
+        return value as FfiValueParamClass;
       });
+      if (format === 2) {
+        const callbacks = new Map<string, FfiCallbackParam["callback"]>();
+        const outerContexts = new Map<string, number>();
+        for (const param of params) {
+          if (typeof param === "object" && "callback" in param) {
+            const cb = param.callback;
+            if (callbacks.has(cb.id)) {
+              throw new FfiProfileError(`callback id '${cb.id}' is declared twice in '${path}.params'`);
+            }
+            callbacks.set(cb.id, cb);
+          } else if (typeof param === "object") {
+            outerContexts.set(param.context, (outerContexts.get(param.context) ?? 0) + 1);
+          }
+        }
+        for (const [id, count] of outerContexts) {
+          if (!callbacks.has(id)) {
+            throw new FfiProfileError(`context '${id}' in '${path}.params' has no matching callback`);
+          }
+          if (count !== 1) {
+            throw new FfiProfileError(`context '${id}' appears ${count} times in '${path}.params'; exactly one is required`);
+          }
+        }
+        for (const [id, cb] of callbacks) {
+          const callbackContexts = cb.params.filter(
+            (param): param is FfiContextParam => typeof param === "object",
+          );
+          for (const context of callbackContexts) {
+            if (context.context !== id) {
+              throw new FfiProfileError(
+                `callback '${id}' contains context '${context.context}'; callback contexts must reference their own id`,
+              );
+            }
+          }
+          if (callbackContexts.length > 1) {
+            throw new FfiProfileError(
+              `callback '${id}' contains ${callbackContexts.length} context parameters; at most one is supported`,
+            );
+          }
+          const outerCount = outerContexts.get(id) ?? 0;
+          if ((callbackContexts.length === 1) !== (outerCount === 1)) {
+            throw new FfiProfileError(
+              `callback '${id}' must declare its context exactly once in both the native function and callback parameter lists, or in neither`,
+            );
+          }
+        }
+      }
       const returns = stringField(row["returns"], `${path}.returns`);
       if (!(FFI_RETURN_CLASSES as readonly string[]).includes(returns)) {
         throw new FfiProfileError(
@@ -222,7 +374,7 @@ export function loadFfiProfile(
     return {
       ok: true,
       profile: {
-        ffiFormat: 1,
+        ffiFormat: format,
         functions,
         libraries,
         systemLibraries,

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -6,7 +6,7 @@ import * as ts from "../ts7/adapter.js";
 import type { Lowerer } from "./lowerer.js";
 import { lowerGenMethodCall } from "./lower-generators.js";
 import { BOOL, CAUGHT, DYN, F64, IrExpr, IrFunction, IrLocal, IrParam, IrStmt, IrType, JSVAL, STRING, SYMBOL_T, SrcLoc, UNDEFINED_T, VOID, arrayOf, canBoxFuncIntoDyn, canConvertToDyn, canDynCheckTo, canMarshalTypedFuncIntoIsland, ffiClassType, ffiSourceParamTypes, funcOf, isFfiCallbackParam, isFfiContextParam, isUnitType, shapeHasAccessorSlots, typeEquals } from "../../ir/nodes.js";
-import type { IrFfiImport } from "../../ir/nodes.js";
+import type { IrFfiCallbackParam, IrFfiCallbackParamClass, IrFfiImport } from "../../ir/nodes.js";
 import { isJsSourceFile, locOf } from "../program.js";
 import { isGenericCallableMemberType, typeKey } from "../types.js";
 import { PoisonError, dynFallbackType, dynUndefinedExpr, importCallHandleType, jsFuncNameOf, newFnCtx, nodeThrowExpr } from "./lowerer.js";
@@ -2482,6 +2482,54 @@ function ffiParamDisplay(param: ReturnType<typeof ffiSourceParams>[number]): str
   return isFfiCallbackParam(param) ? `callback '${param.callback.id}'` : `class '${param}'`;
 }
 
+/** Callback arguments flow from native code into TypeScript. Their source
+ * declarations therefore need to cover the whole scalar domain represented
+ * by the manifest class: IR widening alone cannot distinguish `0`, a numeric
+ * enum, or `never` from an unrestricted `number`. */
+function ffiCallbackInputDiagnostic(
+  L: Lowerer,
+  descriptor: IrFfiCallbackParam,
+  callbackType: ts.Type,
+): string | null {
+  const signatures = L.checker.getCallSignatures(callbackType);
+  if (signatures.length !== 1) return null;
+
+  const nativeParams = descriptor.callback.params.filter(
+    (param): param is IrFfiCallbackParamClass => !isFfiContextParam(param),
+  );
+  let nativeIndex = 0;
+  const params = signatures[0]!.getParameters();
+  for (let i = 0; i < params.length; i++) {
+    const paramType = L.checker.getTypeOfSymbol(params[i]!);
+    const mapped = L.mapTypeOf(paramType);
+    // Function mapping drops a `void` parameter because it consumes no
+    // argument. Mirror that alignment before comparing manifest slots.
+    if (mapped?.kind === "void") continue;
+
+    const nativeClass = nativeParams[nativeIndex++];
+    if (
+      nativeClass === undefined ||
+      mapped === null ||
+      !typeEquals(mapped, ffiClassType(nativeClass))
+    ) {
+      continue;
+    }
+
+    const domain = nativeClass === "bool" ? "boolean" : "number";
+    const coversDomain = nativeClass === "bool"
+      ? (paramType.flags & ts.TypeFlags.Boolean) !== 0
+      : (paramType.flags & ts.TypeFlags.Number) !== 0;
+    if (!coversDomain) {
+      return (
+        `callback '${descriptor.callback.id}' parameter ${i + 1} is '${L.checker.typeToString(paramType)}', ` +
+        `but native class '${nativeClass}' may supply any ${domain}; declare it as '${domain}'`
+      );
+    }
+  }
+
+  return null;
+}
+
 /** The declaration half of an outbound FFI binding. Kept independent of
  * call-site argument checks so the whole manifest can be validated even
  * when a configured function is never called. */
@@ -2533,6 +2581,7 @@ function ffiDeclarationDiagnostic(
   const expectedParams = ffiSourceParamTypes(binding.params);
   for (let i = 0; i < params.length; i++) {
     const paramType = L.checker.getTypeOfSymbol(params[i]!);
+    const sourceParam = sourceParams[i]!;
     // `mapType` deliberately gives uninhabited value positions a cheap f64
     // slot because no TypeScript value can ever reach them. An FFI
     // declaration is different: it is a callable external contract, so a
@@ -2544,13 +2593,19 @@ function ffiDeclarationDiagnostic(
         loc,
       );
     }
+    if (isFfiCallbackParam(sourceParam)) {
+      const callbackDiagnostic = ffiCallbackInputDiagnostic(L, sourceParam, paramType);
+      if (callbackDiagnostic !== null) {
+        return ffiSignatureDiag(binding.name, callbackDiagnostic, loc);
+      }
+    }
     const mapped = L.mapTypeOf(paramType);
     const expected = expectedParams[i]!;
     if (mapped === null || !typeEquals(mapped, expected)) {
       return ffiSignatureDiag(
         binding.name,
         `parameter ${i + 1} maps to '${mapped === null ? L.checker.typeToString(paramType) : L.fmt(mapped)}', ` +
-          `which does not fit manifest ${ffiParamDisplay(sourceParams[i]!)}`,
+          `which does not fit manifest ${ffiParamDisplay(sourceParam)}`,
         loc,
       );
     }

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -5,7 +5,7 @@
 import * as ts from "../ts7/adapter.js";
 import type { Lowerer } from "./lowerer.js";
 import { lowerGenMethodCall } from "./lower-generators.js";
-import { BOOL, BYTES_U8, CAUGHT, DYN, F64, IrExpr, IrFunction, IrLocal, IrParam, IrStmt, IrType, JSVAL, STRING, SYMBOL_T, SrcLoc, UNDEFINED_T, VOID, arrayOf, canBoxFuncIntoDyn, canConvertToDyn, canDynCheckTo, canMarshalTypedFuncIntoIsland, funcOf, isUnitType, shapeHasAccessorSlots, typeEquals } from "../../ir/nodes.js";
+import { BOOL, CAUGHT, DYN, F64, IrExpr, IrFunction, IrLocal, IrParam, IrStmt, IrType, JSVAL, STRING, SYMBOL_T, SrcLoc, UNDEFINED_T, VOID, arrayOf, canBoxFuncIntoDyn, canConvertToDyn, canDynCheckTo, canMarshalTypedFuncIntoIsland, ffiClassType, ffiSourceParamTypes, funcOf, isFfiCallbackParam, isFfiContextParam, isUnitType, shapeHasAccessorSlots, typeEquals } from "../../ir/nodes.js";
 import type { IrFfiImport } from "../../ir/nodes.js";
 import { isJsSourceFile, locOf } from "../program.js";
 import { isGenericCallableMemberType, typeKey } from "../types.js";
@@ -2471,21 +2471,15 @@ export function islandPrimitiveExit(L: Lowerer, call: ts.CallExpression, result:
     return null;
   }
 
-function ffiTypeForClass(
-  cls: IrFfiImport["params"][number] | IrFfiImport["returns"],
-): IrType {
-  switch (cls) {
-    case "bool":
-      return BOOL;
-    case "string":
-      return STRING;
-    case "bytes":
-      return BYTES_U8;
-    case "void":
-      return VOID;
-    default:
-      return F64;
-  }
+function ffiSourceParams(binding: IrFfiImport): Exclude<IrFfiImport["params"][number], { context: string }>[] {
+  return binding.params.filter((param) => !isFfiContextParam(param)) as Exclude<
+    IrFfiImport["params"][number],
+    { context: string }
+  >[];
+}
+
+function ffiParamDisplay(param: ReturnType<typeof ffiSourceParams>[number]): string {
+  return isFfiCallbackParam(param) ? `callback '${param.callback.id}'` : `class '${param}'`;
 }
 
 /** The declaration half of an outbound FFI binding. Kept independent of
@@ -2527,14 +2521,16 @@ function ffiDeclarationDiagnostic(
   }
   const signature = signatures[0]!;
   const params = signature.getParameters();
-  if (params.length !== binding.params.length) {
+  const sourceParams = ffiSourceParams(binding);
+  if (params.length !== sourceParams.length) {
     return ffiSignatureDiag(
       binding.name,
-      `the TypeScript declaration has ${params.length} parameter(s), but the manifest declares ${binding.params.length}`,
+      `the TypeScript declaration has ${params.length} parameter(s), but the manifest declares ${sourceParams.length} source parameter(s) ` +
+        `(${binding.params.length - sourceParams.length} additional native context slot(s) are compiler-supplied)`,
       loc,
     );
   }
-  const expectedParams = binding.params.map(ffiTypeForClass);
+  const expectedParams = ffiSourceParamTypes(binding.params);
   for (let i = 0; i < params.length; i++) {
     const paramType = L.checker.getTypeOfSymbol(params[i]!);
     // `mapType` deliberately gives uninhabited value positions a cheap f64
@@ -2554,7 +2550,7 @@ function ffiDeclarationDiagnostic(
       return ffiSignatureDiag(
         binding.name,
         `parameter ${i + 1} maps to '${mapped === null ? L.checker.typeToString(paramType) : L.fmt(mapped)}', ` +
-          `which does not fit manifest class '${binding.params[i]}'`,
+          `which does not fit manifest ${ffiParamDisplay(sourceParams[i]!)}`,
         loc,
       );
     }
@@ -2571,7 +2567,7 @@ function ffiDeclarationDiagnostic(
     );
   }
   const declaredReturn = L.mapTypeOf(returnType);
-  const expectedReturn = ffiTypeForClass(binding.returns);
+  const expectedReturn = ffiClassType(binding.returns);
   if (declaredReturn === null || !typeEquals(declaredReturn, expectedReturn)) {
     return ffiSignatureDiag(
       binding.name,
@@ -2704,13 +2700,13 @@ export function lowerFfiCall(L: Lowerer, expr: ts.CallExpression): IrExpr | null
     if (expr.arguments.some(ts.isSpreadElement)) {
       signatureError("spread arguments do not have a fixed native ABI");
     }
-    if (expr.arguments.length !== binding.params.length) {
+    const expectedParams = ffiSourceParamTypes(binding.params);
+    if (expr.arguments.length !== expectedParams.length) {
       signatureError(
-        `this call passes ${expr.arguments.length} argument(s), but the native ABI requires exactly ${binding.params.length}`,
+        `this call passes ${expr.arguments.length} argument(s), but the native binding requires exactly ${expectedParams.length}`,
       );
     }
-    const expectedParams = binding.params.map(ffiTypeForClass);
-    const expectedReturn = ffiTypeForClass(binding.returns);
+    const expectedReturn = ffiClassType(binding.returns);
     const args = expr.arguments.map((arg, i) =>
       L.lowerExprExpecting(arg, expectedParams[i]!)
     );

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -76,12 +76,17 @@ export {
 } from "./library/profile.js";
 export {
   loadFfiProfile,
+  FFI_CALLBACK_PARAM_CLASSES,
   FFI_PARAM_CLASSES,
   FFI_RETURN_CLASSES,
+  type FfiCallbackParam,
+  type FfiCallbackParamClass,
+  type FfiContextParam,
   type FfiFunction,
   type FfiParamClass,
   type FfiProfile,
   type FfiReturnClass,
+  type FfiValueParamClass,
 } from "./ffi/profile.js";
 export {
   assembleTrapTeaching,

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -755,18 +755,87 @@ export interface IrModule {
   lib?: IrLibSection;
 }
 
-/** One outbound native FFI declaration, copied from the validated format-1
- * manifest onto the IR so both backends emit the same C ABI. `string` and
- * `bytes` parameters each expand to `(const uint8_t *, size_t)`; their
- * storage is borrowed only until the native call returns. Integer inputs
- * use JavaScript's ToUint32/ToInt32 coercions before narrowing. */
+export type IrFfiValueParamClass = "f64" | "bool" | "u8" | "u32" | "i32" | "string" | "bytes";
+export type IrFfiCallbackParamClass = "f64" | "bool" | "u8" | "u32" | "i32";
+export type IrFfiReturnClass = "f64" | "bool" | "u8" | "u32" | "i32" | "void";
+
+export interface IrFfiContextParam {
+  /** Manifest-local id of the callback whose ScrClosure* occupies this ABI slot. */
+  context: string;
+}
+
+export interface IrFfiCallbackParam {
+  callback: {
+    id: string;
+    /** Exact callback ABI order; context entries consume no TS argument. */
+    params: (IrFfiCallbackParamClass | IrFfiContextParam)[];
+    returns: IrFfiReturnClass;
+    lifetime: "call";
+  };
+}
+
+export type IrFfiParam = IrFfiValueParamClass | IrFfiCallbackParam | IrFfiContextParam;
+
+export function isFfiCallbackParam(param: IrFfiParam): param is IrFfiCallbackParam {
+  return typeof param === "object" && "callback" in param;
+}
+
+export function isFfiContextParam(
+  param: IrFfiParam | IrFfiCallbackParam["callback"]["params"][number],
+): param is IrFfiContextParam {
+  return typeof param === "object" && "context" in param;
+}
+
+/** Script-side type represented by one scalar/span FFI class. */
+export function ffiClassType(cls: IrFfiValueParamClass | IrFfiReturnClass): IrType {
+  switch (cls) {
+    case "bool":
+      return BOOL;
+    case "string":
+      return STRING;
+    case "bytes":
+      return BYTES_U8;
+    case "void":
+      return VOID;
+    default:
+      return F64;
+  }
+}
+
+/** The ordinary TypeScript function type a native callback descriptor consumes. */
+export function ffiCallbackType(
+  callback: IrFfiCallbackParam["callback"],
+): IrType & { kind: "func" } {
+  return {
+    kind: "func",
+    params: callback.params
+      .filter((param): param is IrFfiCallbackParamClass => !isFfiContextParam(param))
+      .map(ffiClassType),
+    ret: ffiClassType(callback.returns),
+  };
+}
+
+/** Source parameters consume values; synthetic context ABI entries do not. */
+export function ffiSourceParamTypes(params: readonly IrFfiParam[]): IrType[] {
+  return params.flatMap((param): IrType[] => {
+    if (isFfiContextParam(param)) return [];
+    if (isFfiCallbackParam(param)) return [ffiCallbackType(param.callback)];
+    return [ffiClassType(param)];
+  });
+}
+
+/** One outbound native FFI declaration. Format 1 contains only value
+ * classes. Format 2 additionally carries exact-position callback/context
+ * entries. String/bytes still expand to pointer+length pairs; callbacks
+ * and contexts are each one native pointer slot. Callback lifetimes are
+ * call-scoped and their closure/context storage is borrowed. */
 export interface IrFfiImport {
   /** The signature-only ambient TypeScript binding name. */
   name: string;
   /** The external C symbol. */
   symbol: string;
-  params: ("f64" | "bool" | "u8" | "u32" | "i32" | "string" | "bytes")[];
-  returns: "f64" | "bool" | "u8" | "u32" | "i32" | "void";
+  params: IrFfiParam[];
+  returns: IrFfiReturnClass;
 }
 
 /** One export-map entry, resolved: the external ccc symbol, the IR

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -18,7 +18,7 @@ import type {
   IrUnionDef,
   SrcLoc,
 } from "./nodes.js";
-import { arrayOf, BOOL, BYTES_U8, bytesOf, canAdaptDynFuncTo, canConvertToDyn, canExitIslandToType, canMarshalIntoIsland, canMarshalTypedFuncIntoIsland, CHILD_T, CHILDSTREAM_T, DATE_T, DGRAMSOCK_T, DYN, DYN_HANDLE_KINDS, F64, FILEHANDLE_T, FSWATCHER_T, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, islandPromisePayloadTag, isJsonSafeType, isRefCounted, isSupportedIndexValue, isSupportedMapKey, isSupportedMapValue, isSupportedSetElem, isUnitType, jsOpResultKind, JSVAL, NETSERVER_T, NETSOCKET_T, PROCSTREAM_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, SEARCH_PARAMS_T, SECURECTX_T, SPAWNRES_T, STATS_T, STRING, SYMBOL_T, TESTCTX_T, typeEquals, typeKey, unionFuncSetArmsOk, URL_T, VOID } from "./nodes.js";
+import { arrayOf, BOOL, BYTES_U8, bytesOf, canAdaptDynFuncTo, canConvertToDyn, canExitIslandToType, canMarshalIntoIsland, canMarshalTypedFuncIntoIsland, CHILD_T, CHILDSTREAM_T, DATE_T, DGRAMSOCK_T, DYN, DYN_HANDLE_KINDS, F64, ffiClassType, ffiSourceParamTypes, FILEHANDLE_T, FSWATCHER_T, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, islandPromisePayloadTag, isJsonSafeType, isRefCounted, isSupportedIndexValue, isSupportedMapKey, isSupportedMapValue, isSupportedSetElem, isUnitType, jsOpResultKind, JSVAL, NETSERVER_T, NETSOCKET_T, PROCSTREAM_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, SEARCH_PARAMS_T, SECURECTX_T, SPAWNRES_T, STATS_T, STRING, SYMBOL_T, TESTCTX_T, typeEquals, typeKey, unionFuncSetArmsOk, URL_T, VOID } from "./nodes.js";
 
 /** Per-method signature for strIntrinsic: `argTypes` lists every argument
  * position (optional ones included); `minArgs` is how many may be omitted
@@ -1149,23 +1149,6 @@ function callSiteReturnType(fn: IrFunction): IrType {
     return { kind: "generator", yieldT: fn.generator.yieldT, retT: fn.returnType, nextT: fn.generator.nextT };
   }
   return fn.returnType;
-}
-
-/** IR type carried by one native FFI marshalling class. Integer classes
- * are represented as f64 inside scriptc and narrow only at the C edge. */
-function ffiClassType(cls: string): IrType {
-  switch (cls) {
-    case "bool":
-      return BOOL;
-    case "string":
-      return STRING;
-    case "bytes":
-      return BYTES_U8;
-    case "void":
-      return VOID;
-    default:
-      return F64;
-  }
 }
 
 export function validateModule(mod: IrModule): IrValidationError[] {
@@ -2636,16 +2619,17 @@ function validateFunction(
           err(`FFI call to undeclared import "${e.import}"`, e.loc);
           break;
         }
-        if (entry.params.length !== e.args.length) {
+        const sourceParamTypes = ffiSourceParamTypes(entry.params);
+        if (sourceParamTypes.length !== e.args.length) {
           err(
-            `FFI call ${e.import}: ${e.args.length} args, expected ${entry.params.length}`,
+            `FFI call ${e.import}: ${e.args.length} args, expected ${sourceParamTypes.length}`,
             e.loc,
           );
         }
         e.args.forEach((arg, i) => {
-          const cls = entry.params[i];
-          if (cls !== undefined) {
-            expectType(arg, ffiClassType(cls), `FFI call ${e.import} arg ${i}`);
+          const expectedParam = sourceParamTypes[i];
+          if (expectedParam !== undefined) {
+            expectType(arg, expectedParam, `FFI call ${e.import} arg ${i}`);
           }
         });
         const expected = ffiClassType(entry.returns);

--- a/tests/ffi/main.ts
+++ b/tests/ffi/main.ts
@@ -13,6 +13,8 @@ declare function nativeCombineRaw(
   right: (value: number) => number,
   value: number,
 ): number;
+declare function nativeCallbackSymbolCollision(callback: (value: number) => number): number;
+declare function nativeCallbackTlsCollision(value: number): number;
 declare function nativeCallbackMix(
   callback: (
     truth: boolean,
@@ -38,6 +40,8 @@ console.log(nativeApply((value) => value + offset, 5));
 const leftOffset = 3;
 const rightFactor = 4;
 console.log(nativeCombineRaw((value) => value + leftOffset, (value) => value * rightFactor, 5));
+console.log(nativeCallbackSymbolCollision((value) => value + 1));
+console.log(nativeCallbackTlsCollision(41));
 
 console.log(nativeCallbackMix((truth, byte, wide, signedValue, fraction) => {
   console.log(truth, byte, wide, signedValue, fraction);

--- a/tests/ffi/main.ts
+++ b/tests/ffi/main.ts
@@ -7,6 +7,22 @@ declare function nativeTextSum(value: string): number;
 declare function nativeBytesSum(value: Uint8Array): number;
 declare function nativeNote(value: number): void;
 declare function nativeLastNote(): number;
+declare function nativeApply(callback: (value: number) => number, value: number): number;
+declare function nativeCombineRaw(
+  left: (value: number) => number,
+  right: (value: number) => number,
+  value: number,
+): number;
+declare function nativeCallbackMix(
+  callback: (
+    truth: boolean,
+    byte: number,
+    wide: number,
+    signedValue: number,
+    fraction: number,
+  ) => number,
+): number;
+declare function nativeEach(callback: (value: number) => void): void;
 
 console.log(nativeScale(21));
 console.log(nativeInvert(false), nativeInvert(true));
@@ -15,3 +31,29 @@ console.log(nativeTextSum("A\0é"));
 console.log(nativeBytesSum(new Uint8Array([1, 2, 3])));
 nativeNote(12.5);
 console.log(nativeLastNote());
+
+const offset = 7;
+console.log(nativeApply((value) => value + offset, 5));
+
+const leftOffset = 3;
+const rightFactor = 4;
+console.log(nativeCombineRaw((value) => value + leftOffset, (value) => value * rightFactor, 5));
+
+console.log(nativeCallbackMix((truth, byte, wide, signedValue, fraction) => {
+  console.log(truth, byte, wide, signedValue, fraction);
+  return -1;
+}));
+
+let total = 0;
+nativeEach((value) => {
+  total += value;
+});
+console.log(total);
+
+try {
+  nativeApply(() => {
+    throw new Error("callback boom");
+  }, 1);
+} catch (error) {
+  console.log("caught", (error as Error).message);
+}

--- a/tests/ffi/native.c
+++ b/tests/ffi/native.c
@@ -42,3 +42,31 @@ void sf_note(double value) {
 double sf_last_note(void) {
   return last_note;
 }
+
+typedef double (*sf_apply_cb)(double value, void *context);
+
+double sf_apply(sf_apply_cb callback, double value, void *context) {
+  return callback(value, context);
+}
+
+typedef double (*sf_raw_cb)(double value);
+
+double sf_combine_raw(sf_raw_cb left, sf_raw_cb right, double value) {
+  return left(value) + right(value);
+}
+
+typedef uint32_t (*sf_mix_cb)(uint8_t truth, uint8_t byte, uint32_t wide,
+                              int32_t signed_value, double fraction,
+                              void *context);
+
+uint32_t sf_callback_mix(sf_mix_cb callback, void *context) {
+  return callback(2, 255, 4000000000u, -7, 0.5, context);
+}
+
+typedef void (*sf_each_cb)(double value, void *context);
+
+void sf_each(sf_each_cb callback, void *context) {
+  callback(1, context);
+  callback(2, context);
+  callback(3, context);
+}

--- a/tests/ffi/native.c
+++ b/tests/ffi/native.c
@@ -55,6 +55,16 @@ double sf_combine_raw(sf_raw_cb left, sf_raw_cb right, double value) {
   return left(value) + right(value);
 }
 
+/* These valid external names deliberately overlap the emitter's preferred
+ * callback-trampoline and raw-callback TLS names. */
+double sc_ffi_cb_0(sf_raw_cb callback) {
+  return callback(8);
+}
+
+double sc_ffi_cb_ctx_2(double value) {
+  return value + 1;
+}
+
 typedef uint32_t (*sf_mix_cb)(uint8_t truth, uint8_t byte, uint32_t wide,
                               int32_t signed_value, double fraction,
                               void *context);

--- a/tests/ffi/profile.json
+++ b/tests/ffi/profile.json
@@ -52,6 +52,27 @@
       "returns": "f64"
     },
     {
+      "name": "nativeCallbackSymbolCollision",
+      "symbol": "sc_ffi_cb_0",
+      "params": [
+        {
+          "callback": {
+            "id": "collision",
+            "params": ["f64"],
+            "returns": "f64",
+            "lifetime": "call"
+          }
+        }
+      ],
+      "returns": "f64"
+    },
+    {
+      "name": "nativeCallbackTlsCollision",
+      "symbol": "sc_ffi_cb_ctx_2",
+      "params": ["f64"],
+      "returns": "f64"
+    },
+    {
       "name": "nativeCallbackMix",
       "symbol": "sf_callback_mix",
       "params": [

--- a/tests/ffi/profile.json
+++ b/tests/ffi/profile.json
@@ -1,5 +1,5 @@
 {
-  "ffi_format": 1,
+  "ffi_format": 2,
   "functions": [
     { "name": "nativeScale", "symbol": "sf_scale", "params": ["f64"], "returns": "f64" },
     { "name": "nativeInvert", "symbol": "sf_invert", "params": ["bool"], "returns": "bool" },
@@ -9,7 +9,80 @@
     { "name": "nativeTextSum", "symbol": "sf_text_sum", "params": ["string"], "returns": "f64" },
     { "name": "nativeBytesSum", "symbol": "sf_bytes_sum", "params": ["bytes"], "returns": "f64" },
     { "name": "nativeNote", "symbol": "sf_note", "params": ["f64"], "returns": "void" },
-    { "name": "nativeLastNote", "symbol": "sf_last_note", "params": [], "returns": "f64" }
+    { "name": "nativeLastNote", "symbol": "sf_last_note", "params": [], "returns": "f64" },
+    {
+      "name": "nativeApply",
+      "symbol": "sf_apply",
+      "params": [
+        {
+          "callback": {
+            "id": "apply",
+            "params": ["f64", { "context": "apply" }],
+            "returns": "f64",
+            "lifetime": "call"
+          }
+        },
+        "f64",
+        { "context": "apply" }
+      ],
+      "returns": "f64"
+    },
+    {
+      "name": "nativeCombineRaw",
+      "symbol": "sf_combine_raw",
+      "params": [
+        {
+          "callback": {
+            "id": "left",
+            "params": ["f64"],
+            "returns": "f64",
+            "lifetime": "call"
+          }
+        },
+        {
+          "callback": {
+            "id": "right",
+            "params": ["f64"],
+            "returns": "f64",
+            "lifetime": "call"
+          }
+        },
+        "f64"
+      ],
+      "returns": "f64"
+    },
+    {
+      "name": "nativeCallbackMix",
+      "symbol": "sf_callback_mix",
+      "params": [
+        {
+          "callback": {
+            "id": "mix",
+            "params": ["bool", "u8", "u32", "i32", "f64", { "context": "mix" }],
+            "returns": "u32",
+            "lifetime": "call"
+          }
+        },
+        { "context": "mix" }
+      ],
+      "returns": "u32"
+    },
+    {
+      "name": "nativeEach",
+      "symbol": "sf_each",
+      "params": [
+        {
+          "callback": {
+            "id": "each",
+            "params": ["f64", { "context": "each" }],
+            "returns": "void",
+            "lifetime": "call"
+          }
+        },
+        { "context": "each" }
+      ],
+      "returns": "void"
+    }
   ],
   "libraries": [],
   "system_libraries": []

--- a/tests/harness/ffi.test.ts
+++ b/tests/harness/ffi.test.ts
@@ -60,6 +60,8 @@ const expected = [
   "12.5",
   "12",
   "28",
+  "9",
+  "42",
   "true 255 4000000000 -7 0.5",
   "4294967295",
   "6",
@@ -294,6 +296,69 @@ test.each([
     expect(result.diagnostics[0]?.message).toContain(message);
   }
 });
+
+test.each([
+  { id: "number-literal", type: "0", nativeClass: "f64", domain: "number", prefix: null },
+  {
+    id: "numeric-enum",
+    type: "NativeValue",
+    nativeClass: "f64",
+    domain: "number",
+    prefix: "enum NativeValue { Zero }",
+  },
+  { id: "never", type: "never", nativeClass: "f64", domain: "number", prefix: null },
+  { id: "boolean-literal", type: "true", nativeClass: "bool", domain: "boolean", prefix: null },
+])(
+  "rejects a narrowed $id native-to-script callback parameter",
+  async ({ id, type, nativeClass, domain, prefix }) => {
+    const outDir = join(cacheRoot, `reject-callback-${id}`);
+    mkdirSync(outDir, { recursive: true });
+    const entry = join(outDir, "main.ts");
+    const profilePath = join(outDir, "profile.json");
+    writeFileSync(
+      entry,
+      [
+        ...(prefix === null ? [] : [prefix]),
+        `declare function nativeVisit(callback: (value: ${type}) => void): void;`,
+        "console.log('ok');",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      profilePath,
+      JSON.stringify({
+        ffi_format: 2,
+        functions: [{
+          name: "nativeVisit",
+          symbol: "sf_visit",
+          params: [{
+            callback: {
+              id: "visit",
+              params: [nativeClass],
+              returns: "void",
+              lifetime: "call",
+            },
+          }],
+          returns: "void",
+        }],
+      }),
+    );
+
+    const result = await compile(entry, {
+      outDir,
+      outPath: join(outDir, "program"),
+      ffiProfilePath: profilePath,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.diagnostics[0]?.code).toBe("SC5003");
+      expect(result.diagnostics[0]?.message).toContain(
+        `callback 'visit' parameter 1 is '${type}'`,
+      );
+      expect(result.diagnostics[0]?.message).toContain(`declare it as '${domain}'`);
+    }
+  },
+);
 
 describe.each(["c", "llvm"] as const)("FFI binding identity, %s backend", (backend) => {
   test("a local same-named function remains ordinary TypeScript with Node-byte parity", async () => {

--- a/tests/harness/ffi.test.ts
+++ b/tests/harness/ffi.test.ts
@@ -1,9 +1,10 @@
 /* Outbound native FFI is an integration lane rather than a corpus case:
  * Node has no equivalent static-link surface to differential-run. The same
  * TypeScript and native archive run through BOTH scriptc backends, and the
- * result bytes must match. The fixture covers every format-1 ABI class,
- * integer coercion, embedded-NUL/UTF-8 string spans, byte spans, and a void
- * call with observable native state. */
+ * result bytes must match. The fixture covers every value ABI class,
+ * integer coercion, embedded-NUL/UTF-8 string spans, byte spans, and format-2
+ * raw/context callbacks (captures, exact context positions, conversion,
+ * mutation, and catchable throws). */
 import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -57,11 +58,17 @@ const expected = [
   "429",
   "6",
   "12.5",
+  "12",
+  "28",
+  "true 255 4000000000 -7 0.5",
+  "4294967295",
+  "6",
+  "caught callback boom",
   "",
 ].join("\n");
 
 describe.each(["c", "llvm"] as const)("outbound native FFI, %s backend", (backend) => {
-  test("calls the manifest-bound archive across every v1 ABI class", async () => {
+  test("calls the manifest-bound archive across every v1 ABI class plus v2 callback ABI classes", async () => {
     const outDir = join(cacheRoot, backend);
     mkdirSync(outDir, { recursive: true });
     const result = await compile(join(fixtureRoot, "main.ts"), {
@@ -118,6 +125,75 @@ test("manifest validation reports a missing native link input", () => {
   if (!result.ok) {
     expect(result.diagnostics[0]?.code).toBe("SC5001");
     expect(result.diagnostics[0]?.message).toContain("cannot be read");
+  }
+});
+
+test.each([
+  {
+    name: "a callback in format 1",
+    profile: {
+      ffi_format: 1,
+      functions: [{
+        name: "visit",
+        symbol: "sf_visit",
+        params: [{ callback: { id: "visit", params: ["f64"], returns: "void", lifetime: "call" } }],
+        returns: "void",
+      }],
+    },
+    message: "must be one of",
+  },
+  {
+    name: "an orphaned context",
+    profile: {
+      ffi_format: 2,
+      functions: [{ name: "visit", symbol: "sf_visit", params: [{ context: "visit" }], returns: "void" }],
+    },
+    message: "has no matching callback",
+  },
+  {
+    name: "a context present on only one side",
+    profile: {
+      ffi_format: 2,
+      functions: [{
+        name: "visit",
+        symbol: "sf_visit",
+        params: [{
+          callback: {
+            id: "visit",
+            params: ["f64", { context: "visit" }],
+            returns: "void",
+            lifetime: "call",
+          },
+        }],
+        returns: "void",
+      }],
+    },
+    message: "exactly once in both",
+  },
+  {
+    name: "a retained callback lifetime",
+    profile: {
+      ffi_format: 2,
+      functions: [{
+        name: "visit",
+        symbol: "sf_visit",
+        params: [{
+          callback: { id: "visit", params: ["f64"], returns: "void", lifetime: "retained" },
+        }],
+        returns: "void",
+      }],
+    },
+    message: "lifetime' must be 'call",
+  },
+])("manifest validation rejects $name", ({ name, profile, message }) => {
+  const path = join(cacheRoot, `invalid-callback-${name.replaceAll(" ", "-")}.json`);
+  mkdirSync(cacheRoot, { recursive: true });
+  writeFileSync(path, JSON.stringify(profile));
+  const result = loadFfiProfile(path);
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.diagnostics[0]?.code).toBe("SC5001");
+    expect(result.diagnostics[0]?.message).toContain(message);
   }
 });
 


### PR DESCRIPTION
- Add format-2 callback/context declarations with exact ABI positions and strict lifetime validation.
- Emit capture-aware C and LLVM trampolines with scalar coercion and exception propagation.
- Document the callback contract and cover both backends in plain and sanitized tests.