### PR TITLE
docs: reflect Windows HTTP and fetch support

### DIFF
--- a/docs/src/app/dependencies/page.mdx
+++ b/docs/src/app/dependencies/page.mdx
@@ -62,6 +62,5 @@ The design goal is unmodified real-world packages. The measuring stick used duri
 
 ## Current limits
 
-- **Cross-compiled `--dynamic` binaries are not there yet** — the engine archive is built per target; today `--dynamic` is host-native. See [Platform Support](/platforms).
 - Packages without shipped or installed type declarations fail the typecheck gate (the standard `Could not find a declaration file` error) — add `@types/<pkg>` or a local declaration, as you would in any strict TypeScript project.
 - Class instances and promises can't flow *into* `any` slots (no island representation); closures cross as host functions in specific shapes. Each refusal is a compile error naming the fix.

--- a/docs/src/app/limitations/page.mdx
+++ b/docs/src/app/limitations/page.mdx
@@ -82,11 +82,9 @@ const who = process.argv.length > 2 ? process.argv[2] : "world";
 - **Island microtask interleaving**: static fibers drain first, then the engine's jobs at loop quiescence — a static `await` racing a package promise resolves in a documented, deterministic order that can differ from Node's interleaving.
 - **Top-level `await` in embedded ESM packages** is not supported yet. It does compile in your program's own ESM graph and in npm packages compiled through `--npm-static`; the remaining limit is package code running inside the `--dynamic` island.
 - **`--npm-static` and `--provenance-sources` are experimental** — see [npm Dependencies](/dependencies) for the maturity notes.
-- **Cross-compiled `--dynamic` binaries are not supported yet** — the engine archive is host-native today.
 
 ## Tooling gaps
 
 - `scriptc run` does not forward extra CLI arguments to the program — `build` and invoke the binary directly.
 - Native FFI is a direct, manifest-declared C ABI link surface. Callback parameters are synchronous, call-scoped, and same-thread; retained or foreign-thread callbacks are not supported yet. Variadic calls, structs by value, owned pointer/string/byte returns, runtime dynamic-library loading, and library-mode builds also remain unsupported. See [Native FFI](/ffi).
 - Numbers are JS-exact f64 everywhere. Integer inference and ownership analysis — the systems-language performance ceiling — are roadmap, not shipped.
-- No Windows servers or `child_process` yet — see [Platform Support](/platforms).

--- a/docs/src/app/platforms/page.mdx
+++ b/docs/src/app/platforms/page.mdx
@@ -33,11 +33,10 @@ $ file fib.exe
 fib.exe: PE32+ executable (console) x86-64, for MS Windows
 ```
 
-The language, stdlib, `fs`, and async surfaces pass a differential lane against Windows Node. **Not ported yet:** the socket/server stack (`net`/`http`/`https`/`tls`/`dgram`) and `child_process`.
+The full corpus runs in a differential lane against Windows Node, including `--dynamic` programs and `child_process`. The Windows fixture lanes also exercise real loopback traffic through `net`, `http`, `https`, `tls`, `http2`, `dgram`, and `dns`, plus the native `fetch` implementation (including redirects, streaming bodies, compression, cancellation, and proxy handling).
 
-## What doesn't cross-compile yet
+## Cross-target limits
 
-- **`--dynamic` binaries are host-native only.** The embedded engine archive is built per target; cross-compiling a `--dynamic` build is not supported today. Static programs cross-compile fully.
 - `--sanitize` is a host-build lane.
 
 ## Summary
@@ -59,12 +58,12 @@ The language, stdlib, `fs`, and async surfaces pass a differential lane against 
     <tr>
       <td>Linux arm64 / x86_64</td>
       <td><code>SCRIPTC_CC=zigcc SCRIPTC_TARGET=&lt;arch&gt;-linux-gnu.2.36</code></td>
-      <td>Static surface incl. servers, TLS, fs.watch; verified against Linux Node</td>
+      <td>Static and dynamic surfaces incl. servers, TLS, fetch, fs.watch, and child_process; verified against Linux Node</td>
     </tr>
     <tr>
       <td>Windows x86_64</td>
       <td><code>SCRIPTC_CC=zigcc SCRIPTC_TARGET=x86_64-windows-gnu</code></td>
-      <td>Language, stdlib, fs, async; no servers or child_process yet</td>
+      <td>Static and dynamic surfaces incl. servers, TLS, fetch, and child_process; verified against Windows Node</td>
     </tr>
   </tbody>
 </table>

--- a/tests/harness/windows-differential.test.ts
+++ b/tests/harness/windows-differential.test.ts
@@ -521,7 +521,12 @@ describe.skipIf(!enabled)(`windows differential (${target})`, () => {
       // the tls fixtures read certs cwd-relative from the lane dir and the
       // drivers resolve ../../certs from their own shipped location.
       const trees = [
-        ...(serverCases.length > 0 ? [join(repoRoot, "tests/fixtures/server")] : []),
+        // Fetch's shared server reads the loopback HTTPS proxy certificate
+        // from the server fixture tree. Keep that dependency staged even
+        // when SCRIPTC_WIN_FILTER narrows the run to fetch cases only.
+        ...(serverCases.length > 0 || fetchCases.length > 0
+          ? [join(repoRoot, "tests/fixtures/server")]
+          : []),
         ...(dgramCases.length > 0 ? [join(repoRoot, "tests/fixtures/dgram")] : []),
         // The fetch tree ships whole too: the box's Node runs the case
         // sources (their imports resolve into the shipped node_modules)
@@ -729,9 +734,24 @@ describe.skipIf(!enabled)(`windows differential (${target})`, () => {
      * parallel: both lanes drive real sockets against the same servers. */
     async function runFetchCase(c: { name: string; entry: string }, env: Record<string, string>): Promise<void> {
       await shipFetchFixture(c);
-      const argv = `${base} ${refused}`;
-      const nodeRes = await runOnBox(`node ${boxRel(c.entry)} ${argv}`, env);
-      const nativeRes = await runOnBox(`${c.name}.exe ${argv}`, env);
+      const argv = [base, refused];
+      // The fragment redirect route remembers a caller-provided key. Node
+      // and native must use distinct keys so the second lane also observes
+      // the redirect instead of inheriting the first lane's server state.
+      const nodeArgv = c.name === "redirect-resolution"
+        ? [...argv, "redirect-resolution-node"]
+        : argv;
+      const nativeArgv = c.name === "redirect-resolution"
+        ? [...argv, "redirect-resolution-native"]
+        : argv;
+      const nodeRes = await runOnBox(
+        `node ${boxRel(c.entry)} ${nodeArgv.join(" ")}`,
+        env,
+      );
+      const nativeRes = await runOnBox(
+        `${c.name}.exe ${nativeArgv.join(" ")}`,
+        env,
+      );
       if (!nodeRes.stdout.equals(nativeRes.stdout)) {
         expect(nativeRes.stdout.toString("utf8")).toBe(nodeRes.stdout.toString("utf8"));
         expect.unreachable("stdout differed at byte level but not after utf8 decode");


### PR DESCRIPTION
- Document static and dynamic HTTP/fetch support for Windows cross targets.
- Keep Windows fetch differential fixtures hermetic and parity-correct under filtering.