### PR TITLE
fix(compiler): keep maybeNaN on the failed edge of ordered comparisons

### DIFF
--- a/packages/compiler/src/library/int-infer.test.ts
+++ b/packages/compiler/src/library/int-infer.test.ts
@@ -49,6 +49,7 @@ const send = (value: IrExpr, callee = "send"): IrStmt => ({
 const decl = (localId: string, init: IrExpr): IrStmt => ({ kind: "varDecl", localId, init, loc });
 const assign = (localId: string, value: IrExpr): IrStmt => ({ kind: "assign", localId, value, loc });
 const iff = (cond: IrExpr, then: IrStmt[]): IrStmt => ({ kind: "if", cond, then, else_: null, loc });
+const ret = (): IrStmt => ({ kind: "return", value: null, loc });
 const forLoop = (init: IrStmt, cond: IrExpr, update: IrStmt, body: IrStmt[]): IrStmt => ({
   kind: "for", init, cond, update, body, loc,
 });
@@ -506,6 +507,71 @@ describe("the domain's edges beyond the corpus", () => {
     expect(v.outcome).toBe("refuse");
     expect(v.obligation).toBe("wholeness");
     expect(v.detail).toContain("NaN");
+  });
+
+  test("the failed edge of an ordered comparison keeps NaN alive (guard clauses)", () => {
+    // if (a < 0) return; if (a > 100) return; send(Math.trunc(a)) — NaN
+    // fails BOTH guards (NaN < 0 and NaN > 100 are false), reaches the
+    // slot, and Math.trunc(NaN) is NaN: ¬(a < b) must not clear maybeNaN.
+    const v = only(
+      caseModule(["a"], [], [
+        iff(bin("<", ref("a.0"), num(0)), [ret()]),
+        iff(bin(">", ref("a.0"), num(100)), [ret()]),
+        send(math("trunc", ref("a.0"))),
+      ]),
+    );
+    expect(v.outcome).toBe("refuse");
+    expect(v.obligation).toBe("wholeness");
+    expect(v.detail).toContain("NaN");
+  });
+
+  test("the else spelling of the failed edge keeps NaN alive too", () => {
+    const inner: IrStmt = {
+      kind: "if",
+      cond: bin(">", ref("a.0"), num(100)),
+      then: [],
+      else_: [send(math("trunc", ref("a.0")))],
+      loc,
+    };
+    const v = only(
+      caseModule(["a"], [], [
+        { kind: "if", cond: bin("<", ref("a.0"), num(0)), then: [], else_: [inner], loc },
+      ]),
+    );
+    expect(v.outcome).toBe("refuse");
+    expect(v.obligation).toBe("wholeness");
+    expect(v.detail).toContain("NaN");
+  });
+
+  test("a u64 slot behind failed-edge guards refuses instead of fabricating [0, 100]", () => {
+    const v = only(
+      caseModule(["a"], [], [
+        iff(bin("<", ref("a.0"), num(0)), [ret()]),
+        iff(bin(">", ref("a.0"), num(100)), [ret()]),
+        send(math("trunc", ref("a.0")), "sendU64"),
+      ]),
+    );
+    expect(v.outcome).toBe("refuse");
+    expect(v.obligation).toBe("wholeness");
+    expect(v.detail).toContain("NaN");
+  });
+
+  test("failed edges still refine numeric members once NaN is excluded", () => {
+    // if (a === a) { guards } — === held excludes NaN; the guards' failed
+    // edges then prove [0, 100] exactly (the negated comparison keeps
+    // refining the numeric members, as the refine doc comment pins).
+    const v = only(
+      caseModule(["a"], [], [
+        iff(bin("===", ref("a.0"), ref("a.0")), [
+          iff(bin("<", ref("a.0"), num(0)), [ret()]),
+          iff(bin(">", ref("a.0"), num(100)), [ret()]),
+          send(math("trunc", ref("a.0"))),
+        ]),
+      ]),
+    );
+    expect(v.outcome).toBe("prove");
+    expect(v.provenLo).toBe(0);
+    expect(v.provenHi).toBe(100);
   });
 });
 

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -1209,10 +1209,12 @@ class FnAnalyzer {
         if (cond.left.type.kind !== "f64" || cond.right.type.kind !== "f64") return env;
         if (!this.isPure(cond.left) || !this.isPure(cond.right)) return env;
         const op = branch ? cond.op : NEGATE[cond.op]!;
-        // NaN makes < <= > >= === evaluate false, so the edge where one of
-        // those was TRUE proves both operands NaN-free (!== held excludes
-        // nothing — NaN !== x is true).
-        const clearNaN = op !== "!==";
+        // NaN makes < <= > >= === evaluate false, so only the edge where one
+        // of those HELD proves both operands NaN-free; on the failed edge NaN
+        // survives (¬(a < b) does not imply a >= b — both are false when a is
+        // NaN), though the negated comparison still refines the numeric
+        // members. !== is the mirror image: its FAILED edge means === held.
+        const clearNaN = branch !== (cond.op === "!==");
         const a = this.evalPure(cond.left, env);
         const b = this.evalPure(cond.right, env);
         const out = cloneEnv(env);

--- a/tests/harness/library-int.test.ts
+++ b/tests/harness/library-int.test.ts
@@ -199,6 +199,19 @@ const CORPUS: CorpusCase[] = [
     evidence: ["NaN"],
   },
   {
+    name: "nan-survives-failed-guard-edge",
+    // NaN < 0 and NaN > 100 are both false, so a NaN dividend (a = 0)
+    // falls through BOTH guard clauses into the slot: the failed edge of
+    // an ordered comparison excludes nothing.
+    body: `const q = a / a;\nif (q < 0) return;\nif (q > 100) return;\nsend(Math.trunc(q));`,
+    param: true,
+    expected: "refuse",
+    obligation: "wholeness",
+    code: "SC4022",
+    slot: "exports.send.params[0]",
+    evidence: ["NaN"],
+  },
+  {
     name: "infinity-reaches-slot",
     body: `send(1 / 0);`,
     expected: "refuse",


### PR DESCRIPTION
Fixes #139

## What

`refine()` derived its NaN-exclusion from the **negated** operator instead of the relation that actually held on the edge:

```ts
const op = branch ? cond.op : NEGATE[cond.op]!;   // NEGATE["<"] === ">="
const clearNaN = op !== "!==";
```

`¬(a < b)` does not imply `a >= b` — both are false when `a` is NaN. So on the false edge of `<`, `<=`, `>`, `>=` the analyzer refined as if the reversed comparison had held **and** dropped `maybeNaN`, which lets the guard-clause spelling

```ts
const q = a / b;
if (q < 0) return 0;
if (q > 100) return 100;
return Math.trunc(q);   // NaN falls through both guards
```

"prove" a runtime NaN as an integer in `[0, 100]`. The build then succeeds, the sidecar attests the class, and the NaN crosses the C ABI through a bare `(int64_t)` cast / `fptosi` — UB in C, poison in LLVM IR, and a platform-dependent value in practice (`0` on arm64, `INT64_MIN` on x86-64). The function's own doc comment already states the intended rule ("on the failed edge NaN survives while the negated comparison still refines the numeric members"); this change makes the code match it.

## Fix

One line: derive `clearNaN` from the relation that actually held on this edge, not its negated spelling —

```ts
const clearNaN = branch !== (cond.op === "!==");
```

The interval refinement on the failed edge is untouched (it is sound for the non-NaN members); only the NaN bit is preserved. `!==` keeps its mirror-image behavior: its *failed* edge means `===` held, which does exclude NaN.

## Regression tests

- `packages/compiler/src/library/int-infer.test.ts`: four new cases in "the domain's edges beyond the corpus" — the guard-clause shape, the `else` spelling, a `u64` slot behind failed-edge guards (all REFUSE on wholeness with the NaN teaching; they reported `prove` with fabricated bounds `[0, 100]` before the fix), and a control pinning that failed edges still refine numeric members to an exact PROVE once `a === a` excludes NaN.
- `tests/harness/library-int.test.ts`: one new end-to-end corpus case (`nan-survives-failed-guard-edge`) driving the real pipeline on both emissions to the SC4022 refusal.

## Test evidence

With the fix:

```
$ npx vitest run packages/compiler/src/library/int-infer.test.ts
      Tests  43 passed (43)          # 39 existing + 4 new

$ SCRIPTC_TEST_WORKERS=4 npx vitest run tests/harness/library-int.test.ts
      Tests  84 passed (84)          # includes the new corpus case, both emissions
```

With the `int-infer.ts` fix stashed and the new tests kept (red check):

```
 ❯ packages/compiler/src/library/int-infer.test.ts (43 tests | 3 failed)
   × the failed edge of an ordered comparison keeps NaN alive (guard clauses)
     → expected 'prove' to be 'refuse'
   × the else spelling of the failed edge keeps NaN alive too
     → expected 'prove' to be 'refuse'
   × a u64 slot behind failed-edge guards refuses instead of fabricating [0, 100]
     → expected 'prove' to be 'refuse'
```

Not run: the full sandbox gate (`pnpm test:sandbox` — no Vercel Sandbox credentials on this machine).

---

*This fix was prepared with AI assistance; the author reproduced the bug locally (unit-level and end-to-end through the C ABI) and reviewed every change.*
