### PR TITLE
feat: extend runtime symbol localization to Windows hosts and cross targets

### DIFF
--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -1101,9 +1101,12 @@ async function ensureTlsArchive(
  * units a library may reach are the pure-data ones (regex + the vendored matcher, assert,
  * inspect, symbol, searchParams, emitter+dyn_handle, zlib); every
  * loop-hooked or ambient unit was refused at SC4005 before emission.
- * External-symbol contract: undefined references only to libc/libm — which
- * is why zlib rides the VENDORED per-flavor objects here even on hosts
- * (the executable lane's system `-lz` cannot ride inside an archive). */
+ * External-symbol contract: undefined references only to the target's C/math
+ * runtime and system APIs. Windows embedders additionally link advapi32,
+ * iphlpapi, and ws2_32; the platform driver supplies its ordinary CRT and
+ * kernel imports. Zlib rides the VENDORED per-flavor objects here even on
+ * hosts because the executable lane's system `-lz` cannot ride inside an
+ * archive. */
 
 /** The library base: the executable lane's unconditional sources minus the
  * fiber/loop and child-process units, plus the library-mode TU. */
@@ -1129,11 +1132,12 @@ export interface LibArchiveOptions {
    * symbol. Toolchain sanitizer ABI remains external as required,
    * so N archives built under pairwise-distinct prefixes link into one
    * process with no symbol collisions and no shared mutable runtime state.
-   * Undefined references (libc/libm, plus sanitizer ABI in instrumented
-   * builds) keep their global binding. Omitted = the classic archive,
-   * byte-for-byte. Admitted for darwin/linux/win32 native hosts, linux and
-   * windows cross triples from any host, and macos cross triples from a
-   * darwin host (compileLibrary owns the refusal fence). */
+   * Undefined references (the target C/math runtime and system APIs, plus
+   * sanitizer ABI in instrumented builds) keep their global binding. Windows
+   * embedders additionally link advapi32, iphlpapi, and ws2_32. Omitted = the
+   * classic archive, byte-for-byte. Admitted for darwin/linux/win32 native
+   * hosts, linux and windows cross triples from any host, and macos cross
+   * triples from a darwin host (compileLibrary owns the refusal fence). */
   localizeSymbols?: readonly string[];
   /** Thread-instanced state (the profile's abi.instance_per_thread): every
    * TU of the archive compiles with -DSCR_THREAD_INSTANCES, moving the
@@ -1559,9 +1563,11 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
  * renamed apart — they stop being visible to the embedder's linker at all,
  * so a second archive built under a different prefix brings its own private
  * copy of the whole runtime (allocator, collector, arena, panic sink) into
- * the same process. Undefined references (libc/libm, plus sanitizer ABI in
- * instrumented builds) keep their global binding: the C library and
- * sanitizer are the embedder's, shared by design.
+ * the same process. Undefined references (the target C/math runtime and
+ * system APIs, plus sanitizer ABI in instrumented builds) keep their global
+ * binding: those platform services and the sanitizer are the embedder's,
+ * shared by design. Windows embedders additionally link advapi32, iphlpapi,
+ * and ws2_32.
  *
  * Member selection matters: a classic archive's unused members (and their
  * undefined references to units library mode excludes, like the

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -6,6 +6,7 @@ import { access, chmod, copyFile, link, mkdir, mkdtemp, readdir, readFile, realp
 import { availableParallelism, homedir, tmpdir } from "node:os";
 import { basename, delimiter, dirname, extname, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
+import { localizeElfObject, mergeAndLocalizeCoffObjects } from "./object-localize.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -1130,7 +1131,9 @@ export interface LibArchiveOptions {
    * process with no symbol collisions and no shared mutable runtime state.
    * Undefined references (libc/libm, plus sanitizer ABI in instrumented
    * builds) keep their global binding. Omitted = the classic archive,
-   * byte-for-byte. Host-native builds only. */
+   * byte-for-byte. Admitted for darwin/linux/win32 native hosts, linux and
+   * windows cross triples from any host, and macos cross triples from a
+   * darwin host (compileLibrary owns the refusal fence). */
   localizeSymbols?: readonly string[];
   /** Thread-instanced state (the profile's abi.instance_per_thread): every
    * TU of the archive compiles with -DSCR_THREAD_INSTANCES, moving the
@@ -1262,9 +1265,10 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
     `${toolchainEnv}\0${implicitToolchain ?? "<uncached>"}`,
   );
   // Runtime-localized archives skip the completed-archive tier: their bytes
-  // additionally depend on the host's ld/objcopy identities, which the
-  // archive key does not fingerprint. The runtime-object tier still serves
-  // them (localization consumes the same per-flavor objects).
+  // additionally depend on the localization toolchain's identity (host ld/
+  // objcopy or the cross driver's lld), which the archive key does not
+  // fingerprint. The runtime-object tier still serves them (localization
+  // consumes the same per-flavor objects).
   const cacheCompleteArchive =
     opts.localizeSymbols === undefined &&
     root !== null && await archiverSupportsPersistentCache(arArgv, driver);
@@ -1565,26 +1569,37 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
  * blind merge of every object would carry those references into the one
  * combined member. Staging the support objects into an intermediate
  * archive keeps the linker's own member semantics: `ld -r` pulls only the
- * members the program object transitively needs.
+ * members the program object transitively needs (the COFF arm implements
+ * the same member semantics in process).
  *
- *   darwin — one ld64 invocation: -r merges program + needed members,
+ *   Mach-O — one host-ld64 invocation: -r merges program + needed members,
  *            -exported_symbols_list demotes every unlisted global to
  *            private extern, and -r without -keep_private_externs writes
  *            private externs out as non-external symbols. Apple ASan's
  *            image-registration COMMON remains shared so the final Mach-O
- *            image registers its globals once.
- *   linux  — ld -r merges with --force-group-allocation (ASan's
- *            instrumented globals ride ELF section groups whose signatures
- *            repeat across archives sharing runtime objects; resolving the
- *            groups into the combined member keeps a later multi-archive
- *            link from discarding one archive's copies), then binutils
- *            objcopy --keep-global-symbols localizes every other DEFINED
- *            global (objcopy leaves undefined symbols global by its own
- *            rule).
- *
- * Host-native only: compileLibrary refuses localization for cross targets
- * before emission (this step runs the host's ld/objcopy over host-format
- * objects). */
+ *            image registers its globals once. ld64 reads every macOS
+ *            architecture, so darwin-host macos cross triples ride the
+ *            same arm; compileLibrary refuses macos targets elsewhere.
+ *   ELF, native linux host — ld -r merges with --force-group-allocation
+ *            (ASan's instrumented globals ride ELF section groups whose
+ *            signatures repeat across archives sharing runtime objects;
+ *            resolving the groups into the combined member keeps a later
+ *            multi-archive link from discarding one archive's copies),
+ *            then binutils objcopy --keep-global-symbols localizes every
+ *            other DEFINED global (objcopy leaves undefined symbols
+ *            global by its own rule). The exact historical recipe.
+ *   ELF, cross triples from any host — `zig cc -target <triple> -r`
+ *            merges (zig is already the cross driver's hard requirement),
+ *            then localizeElfObject demotes in process and resolves
+ *            section groups the way --force-group-allocation does, with
+ *            no host binutils/llvm-objcopy dependency.
+ *   COFF, native win32 hosts and windows cross triples from any host —
+ *            mergeAndLocalizeCoffObjects performs member selection, the
+ *            merge, cross-object symbol resolution, and demotion in
+ *            process: no linker offers a COFF relocatable mode (lld-link
+ *            mirrors MSVC link.exe; zig's COFF driver refuses multi-object
+ *            merges) and llvm-objcopy rejects symbol-scope flags for
+ *            COFF, so no tool pairing exists to shell out to. */
 async function localizeLibraryObjects(
   driver: CcDriver,
   arArgv: readonly string[],
@@ -1605,21 +1620,62 @@ async function localizeLibraryObjects(
       const stderr = (err as { stderr?: string }).stderr ?? String(err);
       throw new Error(
         `${argv[0]} failed while localizing the library archive's runtime symbols (abi.localize_runtime).\n` +
-          `Runtime symbol localization needs the host toolchain's ${platform === "darwin" ? "ld" : "ld and objcopy"} beside the C compiler.\n\n${stderr}`,
+          `Runtime symbol localization needs the ${platform === "darwin" ? "host toolchain's ld" : driver.target === null ? "host toolchain's ld and objcopy" : "cross driver's relocatable link"} beside the C compiler.\n\n${stderr}`,
       );
     }
   };
+  if (platform === "win32") {
+    // COFF has no relocatable-link tool to stage through; the member
+    // selection and combine+demote happen in process over the object bytes.
+    const [program, ...support] = await Promise.all(
+      [programObject, ...supportObjects].map((path) => readFile(path)),
+    );
+    try {
+      await writeFile(
+        combined,
+        mergeAndLocalizeCoffObjects(program!, support, new Set(keepSymbols), {
+          program: basename(programObject),
+          support: supportObjects.map((path) => basename(path)),
+        }),
+      );
+    } catch (err) {
+      throw new Error(
+        `COFF symbol localization failed while localizing the library archive's runtime symbols (abi.localize_runtime).\n\n${(err as Error).message}`,
+      );
+    }
+    return combined;
+  }
   await run([arArgv[0] ?? "ar", ...arArgv.slice(1), "rcs", staging, ...supportObjects]);
   if (platform === "darwin") {
     await writeFile(keepFile, keepSymbols.map((s) => `_${s}\n`).join(""));
     await run(["ld", "-r", programObject, staging, "-o", combined, "-exported_symbols_list", keepFile]);
-  } else if (platform === "linux") {
+  } else if (platform === "linux" && driver.target === null) {
     await writeFile(keepFile, keepSymbols.map((s) => `${s}\n`).join(""));
     await run(["ld", "-r", "--force-group-allocation", programObject, staging, "-o", combined]);
     await run(["objcopy", `--keep-global-symbols=${keepFile}`, combined]);
+  } else if (platform === "linux") {
+    // Cross ELF: the cross driver's own lld performs the relocatable merge
+    // (with the staging archive's member semantics); demotion and section-
+    // group resolution happen in process. -nostdlib keeps zig from feeding
+    // libc/compiler-rt inputs into the merge.
+    await run([
+      driver.argv[0] ?? "zig",
+      ...driver.argv.slice(1),
+      "-target", driver.target!,
+      "-nostdlib",
+      "-r", programObject, staging,
+      "-o", combined,
+    ]);
+    try {
+      await writeFile(combined, localizeElfObject(await readFile(combined), new Set(keepSymbols)));
+    } catch (err) {
+      throw new Error(
+        `ELF symbol localization failed while localizing the library archive's runtime symbols (abi.localize_runtime).\n\n${(err as Error).message}`,
+      );
+    }
   } else {
     throw new Error(
-      `runtime symbol localization (abi.localize_runtime) supports darwin and linux host builds; this build targets ${platform}`,
+      `runtime symbol localization (abi.localize_runtime) has no ${platform} arm; compileLibrary admits darwin, linux, and win32 builds only`,
     );
   }
   return combined;

--- a/packages/compiler/src/backend/object-localize.test.ts
+++ b/packages/compiler/src/backend/object-localize.test.ts
@@ -260,6 +260,7 @@ interface CoffSectionSpec {
   characteristics?: number;
   relocs?: { va: number; sym: number; type: number }[];
   comdatSelection?: number;
+  comdatAssoc?: number;
 }
 
 interface CoffSymbolSpec {
@@ -329,7 +330,7 @@ function buildCoff(sections: CoffSectionSpec[], symbols: CoffSymbolSpec[]): Uint
       const spec = sections[s.section - 1]!;
       view.setUint32(auxAt, spec.data.length, true);
       view.setUint16(auxAt + 4, (spec.relocs ?? []).length, true);
-      view.setUint16(auxAt + 12, s.section, true);
+      view.setUint16(auxAt + 12, spec.comdatAssoc ?? s.section, true);
       view.setUint8(auxAt + 14, spec.comdatSelection ?? 0);
       raw += 1;
     }
@@ -341,7 +342,7 @@ function buildCoff(sections: CoffSectionSpec[], symbols: CoffSymbolSpec[]): Uint
 }
 
 interface ReadCoff {
-  sections: { name: string; characteristics: number; relocs: { sym: number }[] }[];
+  sections: { name: string; characteristics: number; data: Uint8Array; relocs: { sym: number }[] }[];
   symbols: { name: string; section: number; storageClass: number; index: number }[];
 }
 
@@ -361,11 +362,18 @@ function readCoff(bytes: Uint8Array): ReadCoff {
     const h = 20 + i * 40;
     let name = new TextDecoder().decode(bytes.subarray(h, h + 8)).replace(/\0+$/, "");
     if (name.startsWith("/")) name = cstr(strtabAt + Number.parseInt(name.slice(1), 10));
+    const rawSize = view.getUint32(h + 16, true);
+    const rawAt = view.getUint32(h + 20, true);
     const relocAt = view.getUint32(h + 24, true);
     const relocCount = view.getUint16(h + 32, true);
     const relocs = [] as { sym: number }[];
     for (let r = 0; r < relocCount; r++) relocs.push({ sym: view.getUint32(relocAt + r * 10 + 4, true) });
-    sections.push({ name, characteristics: view.getUint32(h + 36, true), relocs });
+    sections.push({
+      name,
+      characteristics: view.getUint32(h + 36, true),
+      data: bytes.subarray(rawAt, rawAt + rawSize),
+      relocs,
+    });
   }
   const symbols = [] as ReadCoff["symbols"];
   for (let i = 0; i < symbolCount; ) {
@@ -531,6 +539,122 @@ describe("mergeAndLocalizeCoffObjects", () => {
     const stubs = merged.symbols.filter((s) => s.name === ".refptr.shared");
     expect(stubs.length).toBe(1);
     expect(stubs[0]!.storageClass).toBe(IMAGE_SYM_CLASS_STATIC);
+  });
+
+  const comdatPair = (
+    selection: number,
+    firstData: Uint8Array,
+    secondData: Uint8Array,
+  ): { program: Uint8Array; support: Uint8Array[] } => {
+    const program = buildCoff(
+      [text([{ va: 0, sym: 3, type: 4 }, { va: 4, sym: 4, type: 4 }])],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "entry", section: 1 },
+        { name: "need_one", section: 0 },
+        { name: "need_two", section: 0 },
+      ],
+    );
+    const member = (needed: string, data: Uint8Array): Uint8Array =>
+      buildCoff(
+        [
+          text(),
+          {
+            name: ".rdata",
+            data,
+            characteristics: 0x40000040 | IMAGE_SCN_LNK_COMDAT,
+            comdatSelection: selection,
+          },
+        ],
+        [
+          { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+          { name: ".rdata", section: 2, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+          { name: needed, section: 1 },
+          { name: "shared", section: 2 },
+        ],
+      );
+    return { program, support: [member("need_one", firstData), member("need_two", secondData)] };
+  };
+
+  test("COMDAT LARGEST retains the largest selected definition", () => {
+    const pair = comdatPair(6, new Uint8Array([1, 2, 3, 4]), new Uint8Array([5, 6, 7, 8, 9]));
+    const merged = readCoff(mergeAndLocalizeCoffObjects(pair.program, pair.support, new Set(["entry"])));
+    const rdata = merged.sections.filter((section) => section.name === ".rdata");
+    expect(rdata).toHaveLength(1);
+    expect([...rdata[0]!.data]).toEqual([5, 6, 7, 8, 9]);
+  });
+
+  test("associative COMDATs follow a LARGEST winner chosen from a later object", () => {
+    const pair = comdatPair(6, new Uint8Array(4), new Uint8Array(8));
+    const withAssociate = (marker: number): Uint8Array => {
+      // Rebuild the support member so its third section associates with the
+      // LARGEST parent in section 2. Both selected members use the same
+      // leader names; only the later/larger pair should survive.
+      const needed = marker === 1 ? "need_one" : "need_two";
+      return buildCoff(
+        [
+          text(),
+          {
+            name: ".rdata",
+            data: marker === 1 ? new Uint8Array(4) : new Uint8Array(8),
+            characteristics: 0x40000040 | IMAGE_SCN_LNK_COMDAT,
+            comdatSelection: 6,
+          },
+          {
+            name: ".assoc",
+            data: new Uint8Array([marker]),
+            characteristics: 0x40000040 | IMAGE_SCN_LNK_COMDAT,
+            comdatSelection: 5,
+            comdatAssoc: 2,
+          },
+        ],
+        [
+          { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+          { name: ".rdata", section: 2, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+          { name: "shared", section: 2 },
+          { name: ".assoc", section: 3, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+          { name: "assoc_shared", section: 3 },
+          { name: needed, section: 1 },
+        ],
+      );
+    };
+    const merged = readCoff(
+      mergeAndLocalizeCoffObjects(
+        pair.program,
+        [withAssociate(1), withAssociate(2)],
+        new Set(["entry"]),
+      ),
+    );
+    const associates = merged.sections.filter((section) => section.name === ".assoc");
+    expect(associates).toHaveLength(1);
+    expect([...associates[0]!.data]).toEqual([2]);
+  });
+
+  test("COMDAT SAME_SIZE refuses definitions with different sizes", () => {
+    const pair = comdatPair(3, new Uint8Array(4), new Uint8Array(8));
+    expect(() =>
+      mergeAndLocalizeCoffObjects(pair.program, pair.support, new Set(), {
+        program: "program.o",
+        support: ["one.o", "two.o"],
+      }),
+    ).toThrow(/SAME_SIZE mismatch.*one\.o.*two\.o/);
+  });
+
+  test("COMDAT EXACT_MATCH refuses equal-size definitions with different contents", () => {
+    const pair = comdatPair(4, new Uint8Array([1, 2, 3, 4]), new Uint8Array([1, 2, 3, 5]));
+    expect(() =>
+      mergeAndLocalizeCoffObjects(pair.program, pair.support, new Set(), {
+        program: "program.o",
+        support: ["one.o", "two.o"],
+      }),
+    ).toThrow(/EXACT_MATCH mismatch.*one\.o.*two\.o/);
+  });
+
+  test("COMDAT duplicates refuse conflicting selection kinds", () => {
+    const one = comdatPair(2, new Uint8Array(4), new Uint8Array(4));
+    const two = comdatPair(3, new Uint8Array(4), new Uint8Array(4));
+    expect(() => mergeAndLocalizeCoffObjects(one.program, [one.support[0]!, two.support[1]!], new Set()))
+      .toThrow(/conflicting COMDAT selections/);
   });
 
   test("duplicate strong definitions refuse with both members named", () => {

--- a/packages/compiler/src/backend/object-localize.test.ts
+++ b/packages/compiler/src/backend/object-localize.test.ts
@@ -1,0 +1,527 @@
+/* Deterministic coverage for the in-process localization transforms: the
+ * fixtures are synthesized byte-level objects (no toolchain), so every
+ * suite exercises these paths — the toolchain-driven integration lives in
+ * tests/harness/library-multi.test.ts (M10/M11) behind SCRIPTC_CROSS. */
+import { describe, expect, test } from "vitest";
+import { localizeElfObject, mergeAndLocalizeCoffObjects } from "./object-localize.js";
+
+/* ── minimal ELF64 builder ──────────────────────────────────────────────── */
+
+interface ElfSectionSpec {
+  name: string;
+  type: number;
+  flags?: bigint;
+  data?: Uint8Array;
+  link?: number;
+  info?: number;
+  entsize?: bigint;
+  addralign?: bigint;
+}
+
+const SHT_PROGBITS = 1;
+const SHT_SYMTAB = 2;
+const SHT_STRTAB = 3;
+const SHT_RELA = 4;
+const SHT_GROUP = 17;
+const SHF_ALLOC = 0x2n;
+const SHF_EXECINSTR = 0x4n;
+const SHF_GROUP = 0x200n;
+const STB_GLOBAL = 1;
+const STB_WEAK = 2;
+const SHN_COMMON = 0xfff2;
+
+interface ElfSymbolSpec {
+  name: string;
+  binding: number;
+  shndx: number;
+  value?: bigint;
+}
+
+function buildStrtab(names: string[]): { data: Uint8Array; offsets: Map<string, number> } {
+  const offsets = new Map<string, number>();
+  let size = 1;
+  for (const name of names) {
+    if (!offsets.has(name)) {
+      offsets.set(name, size);
+      size += name.length + 1;
+    }
+  }
+  const data = new Uint8Array(size);
+  for (const [name, at] of offsets) data.set(new TextEncoder().encode(name), at);
+  return { data, offsets };
+}
+
+/** Assemble an ET_REL ELF64LE: caller supplies content sections; the
+ * builder appends .symtab, .strtab, .shstrtab (their indices are
+ * sections.length, +1, +2). Symbols must list locals first. */
+function buildElf(sections: ElfSectionSpec[], symbols: ElfSymbolSpec[], localCount: number): Uint8Array {
+  const strtab = buildStrtab(symbols.map((s) => s.name).filter((n) => n !== ""));
+  const symData = new Uint8Array((symbols.length + 1) * 24);
+  const symView = new DataView(symData.buffer);
+  symbols.forEach((sym, i) => {
+    const at = (i + 1) * 24;
+    symView.setUint32(at, sym.name === "" ? 0 : strtab.offsets.get(sym.name)!, true);
+    symView.setUint8(at + 4, (sym.binding << 4) | 0);
+    symView.setUint16(at + 6, sym.shndx, true);
+    symView.setBigUint64(at + 8, sym.value ?? 0n, true);
+  });
+  const all: ElfSectionSpec[] = [
+    { name: "", type: 0 },
+    ...sections,
+    { name: ".symtab", type: SHT_SYMTAB, data: symData, link: sections.length + 2, info: localCount + 1, entsize: 24n },
+    { name: ".strtab", type: SHT_STRTAB, data: strtab.data },
+    { name: ".shstrtab", type: SHT_STRTAB },
+  ];
+  const shstr = buildStrtab(all.map((s) => s.name).filter((n) => n !== ""));
+  all[all.length - 1]!.data = shstr.data;
+  let offset = 64;
+  const offsets = all.map((s) => {
+    const data = s.data ?? new Uint8Array(0);
+    offset = Math.ceil(offset / 8) * 8;
+    const at = offset;
+    offset += data.length;
+    return at;
+  });
+  const shoff = Math.ceil(offset / 8) * 8;
+  const out = new Uint8Array(shoff + all.length * 64);
+  const view = new DataView(out.buffer);
+  view.setUint32(0, 0x7f454c46, false);
+  out[4] = 2; // ELFCLASS64
+  out[5] = 1; // little-endian
+  out[6] = 1; // EV_CURRENT
+  view.setUint16(16, 1, true); // ET_REL
+  view.setUint16(18, 0x3e, true); // EM_X86_64
+  view.setUint32(20, 1, true);
+  view.setBigUint64(40, BigInt(shoff), true);
+  view.setUint16(52, 64, true);
+  view.setUint16(58, 64, true);
+  view.setUint16(60, all.length, true);
+  view.setUint16(62, all.length - 1, true);
+  all.forEach((s, i) => {
+    const at = shoff + i * 64;
+    const data = s.data ?? new Uint8Array(0);
+    out.set(data, offsets[i]!);
+    view.setUint32(at, s.name === "" ? 0 : shstr.offsets.get(s.name)!, true);
+    view.setUint32(at + 4, s.type, true);
+    view.setBigUint64(at + 8, s.flags ?? 0n, true);
+    view.setBigUint64(at + 24, BigInt(s.type === 0 ? 0 : offsets[i]!), true);
+    view.setBigUint64(at + 32, BigInt(data.length), true);
+    view.setUint32(at + 40, s.link ?? 0, true);
+    view.setUint32(at + 44, s.info ?? 0, true);
+    view.setBigUint64(at + 48, s.addralign ?? 1n, true);
+    view.setBigUint64(at + 56, s.entsize ?? 0n, true);
+  });
+  return out;
+}
+
+/* Tiny independent reader for assertions. */
+interface ReadElf {
+  sections: { name: string; type: number; flags: bigint; link: number; info: number; data: Uint8Array }[];
+  symbols: { name: string; binding: number; shndx: number }[];
+  symtabInfo: number;
+}
+
+function readElf(bytes: Uint8Array): ReadElf {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const shoff = Number(view.getBigUint64(40, true));
+  const shnum = view.getUint16(60, true);
+  const shstrndx = view.getUint16(62, true);
+  const raw = [] as { nameOff: number; type: number; flags: bigint; offset: number; size: number; link: number; info: number }[];
+  for (let i = 0; i < shnum; i++) {
+    const at = shoff + i * 64;
+    raw.push({
+      nameOff: view.getUint32(at, true),
+      type: view.getUint32(at + 4, true),
+      flags: view.getBigUint64(at + 8, true),
+      offset: Number(view.getBigUint64(at + 24, true)),
+      size: Number(view.getBigUint64(at + 32, true)),
+      link: view.getUint32(at + 40, true),
+      info: view.getUint32(at + 44, true),
+    });
+  }
+  const shstr = raw[shstrndx]!;
+  const name = (table: { offset: number; size: number }, at: number): string => {
+    let end = table.offset + at;
+    while (bytes[end] !== 0) end++;
+    return new TextDecoder().decode(bytes.subarray(table.offset + at, end));
+  };
+  const sections = raw.map((s) => ({
+    name: name(shstr, s.nameOff),
+    type: s.type,
+    flags: s.flags,
+    link: s.link,
+    info: s.info,
+    data: bytes.subarray(s.offset, s.offset + s.size),
+  }));
+  const symtabIdx = raw.findIndex((s) => s.type === SHT_SYMTAB);
+  const symtab = raw[symtabIdx]!;
+  const strtab = raw[symtab.link]!;
+  const symbols = [] as ReadElf["symbols"];
+  for (let at = symtab.offset; at < symtab.offset + symtab.size; at += 24) {
+    symbols.push({
+      name: name(strtab, view.getUint32(at, true)),
+      binding: view.getUint8(at + 4) >> 4,
+      shndx: view.getUint16(at + 6, true),
+    });
+  }
+  return { sections, symbols, symtabInfo: symtab.info };
+}
+
+describe("localizeElfObject", () => {
+  test("demotes unlisted globals, keeps the keep set / undefineds / commons, remaps relocations", () => {
+    // .text with two functions; a relocation referencing the global that
+    // gets demoted; one undefined and one COMMON symbol.
+    const rela = new Uint8Array(24);
+    const relaView = new DataView(rela.buffer);
+    relaView.setBigUint64(8, (3n << 32n) | 2n, true); // sym 3 (helper), R_X86_64_PC32
+    const object = buildElf(
+      [
+        { name: ".text", type: SHT_PROGBITS, flags: SHF_ALLOC | SHF_EXECINSTR, data: new Uint8Array(16) },
+        { name: ".rela.text", type: SHT_RELA, data: rela, link: 3, info: 1, entsize: 24n },
+      ],
+      [
+        { name: "", binding: 0, shndx: 1 }, // local section-ish symbol
+        { name: "keep_me", binding: STB_GLOBAL, shndx: 1 },
+        { name: "helper", binding: STB_GLOBAL, shndx: 1, value: 8n },
+        { name: "libc_ref", binding: STB_GLOBAL, shndx: 0 },
+        { name: "shared_common", binding: STB_GLOBAL, shndx: SHN_COMMON, value: 8n },
+        { name: "weak_def", binding: STB_WEAK, shndx: 1 },
+      ],
+      1,
+    );
+    const localized = readElf(localizeElfObject(object, new Set(["keep_me"])));
+    const byName = new Map(localized.symbols.map((s) => [s.name, s]));
+    expect(byName.get("helper")!.binding).toBe(0);
+    expect(byName.get("weak_def")!.binding).toBe(0);
+    expect(byName.get("keep_me")!.binding).toBe(STB_GLOBAL);
+    expect(byName.get("libc_ref")!.binding).toBe(STB_GLOBAL);
+    expect(byName.get("libc_ref")!.shndx).toBe(0);
+    expect(byName.get("shared_common")!.binding).toBe(STB_GLOBAL);
+    expect(byName.get("shared_common")!.shndx).toBe(SHN_COMMON);
+    // Locals precede globals and sh_info agrees.
+    const firstGlobal = localized.symbols.findIndex((s) => s.binding !== 0);
+    expect(localized.symbols.slice(firstGlobal).every((s) => s.binding !== 0)).toBe(true);
+    expect(localized.symtabInfo).toBe(firstGlobal);
+    // The relocation follows helper to its new index.
+    const relaOut = localized.sections.find((s) => s.name === ".rela.text")!;
+    const info = new DataView(relaOut.data.buffer, relaOut.data.byteOffset).getBigUint64(8, true);
+    const target = localized.symbols[Number(info >> 32n)]!;
+    expect(target.name).toBe("helper");
+    expect(info & 0xffffffffn).toBe(2n);
+  });
+
+  test("resolves section groups: SHT_GROUP dropped, SHF_GROUP cleared, members and indices intact", () => {
+    const group = new Uint8Array(8);
+    const groupView = new DataView(group.buffer);
+    groupView.setUint32(0, 1, true); // GRP_COMDAT
+    groupView.setUint32(4, 2, true); // member: .text.grouped
+    const object = buildElf(
+      [
+        { name: ".group", type: SHT_GROUP, data: group, link: 3, info: 2, entsize: 4n },
+        { name: ".text.grouped", type: SHT_PROGBITS, flags: SHF_ALLOC | SHF_EXECINSTR | SHF_GROUP, data: new Uint8Array(4) },
+      ],
+      [
+        { name: "", binding: 0, shndx: 1 }, // the group's own section symbol
+        { name: "signature", binding: STB_GLOBAL, shndx: 2 },
+        { name: "kept", binding: STB_GLOBAL, shndx: 2 },
+      ],
+      1,
+    );
+    const localized = readElf(localizeElfObject(object, new Set(["kept"])));
+    expect(localized.sections.some((s) => s.type === SHT_GROUP)).toBe(false);
+    const member = localized.sections.find((s) => s.name === ".text.grouped")!;
+    expect(member.flags & SHF_GROUP).toBe(0n);
+    const byName = new Map(localized.symbols.map((s) => [s.name, s]));
+    expect(byName.get("signature")!.binding).toBe(0);
+    expect(byName.get("kept")!.binding).toBe(STB_GLOBAL);
+    // The member's section index shifted down by the dropped group.
+    expect(byName.get("kept")!.shndx).toBe(
+      localized.sections.findIndex((s) => s.name === ".text.grouped"),
+    );
+  });
+
+  test("refuses non-relocatable input", () => {
+    const object = buildElf([], [], 0);
+    new DataView(object.buffer).setUint16(16, 2, true); // ET_EXEC
+    expect(() => localizeElfObject(object, new Set())).toThrow(/ET_REL/);
+  });
+});
+
+/* ── minimal COFF builder ───────────────────────────────────────────────── */
+
+const IMAGE_FILE_MACHINE_AMD64 = 0x8664;
+const IMAGE_SCN_LNK_COMDAT = 0x00001000;
+const IMAGE_SYM_CLASS_EXTERNAL = 2;
+const IMAGE_SYM_CLASS_STATIC = 3;
+
+interface CoffSectionSpec {
+  name: string;
+  data: Uint8Array;
+  characteristics?: number;
+  relocs?: { va: number; sym: number; type: number }[];
+  comdatSelection?: number;
+}
+
+interface CoffSymbolSpec {
+  name: string;
+  section: number; // 1-based, 0 undefined, -1 absolute
+  value?: number;
+  storageClass?: number;
+  sectionDef?: boolean; // emit a section-definition aux record
+}
+
+function buildCoff(sections: CoffSectionSpec[], symbols: CoffSymbolSpec[]): Uint8Array {
+  const auxCounts: number[] = symbols.map((s) => (s.sectionDef === true ? 1 : 0));
+  const rawCount = symbols.length + auxCounts.reduce((a, b) => a + b, 0);
+  const headerSize = 20 + sections.length * 40;
+  let at = headerSize;
+  const dataAt = sections.map((s) => {
+    const here = at;
+    at += s.data.length;
+    return here;
+  });
+  const relocAt = sections.map((s) => {
+    if ((s.relocs ?? []).length === 0) return 0;
+    const here = at;
+    at += s.relocs!.length * 10;
+    return here;
+  });
+  const symtabAt = at;
+  const longNames = symbols.filter((s) => s.name.length > 8).map((s) => s.name);
+  const strtab = buildStrtab(longNames);
+  const out = new Uint8Array(symtabAt + rawCount * 18 + 4 + strtab.data.length - 1 + 3);
+  const view = new DataView(out.buffer);
+  view.setUint16(0, IMAGE_FILE_MACHINE_AMD64, true);
+  view.setUint16(2, sections.length, true);
+  view.setUint32(8, symtabAt, true);
+  view.setUint32(12, rawCount, true);
+  sections.forEach((s, i) => {
+    const h = 20 + i * 40;
+    out.set(new TextEncoder().encode(s.name.slice(0, 8)), h);
+    view.setUint32(h + 16, s.data.length, true);
+    view.setUint32(h + 20, dataAt[i]!, true);
+    view.setUint32(h + 24, relocAt[i]!, true);
+    view.setUint16(h + 32, (s.relocs ?? []).length, true);
+    view.setUint32(h + 36, s.characteristics ?? 0x60000020, true);
+    out.set(s.data, dataAt[i]!);
+    (s.relocs ?? []).forEach((r, ri) => {
+      const ra = relocAt[i]! + ri * 10;
+      view.setUint32(ra, r.va, true);
+      view.setUint32(ra + 4, r.sym, true);
+      view.setUint16(ra + 8, r.type, true);
+    });
+  });
+  let raw = 0;
+  symbols.forEach((s, i) => {
+    const a = symtabAt + raw * 18;
+    if (s.name.length > 8) {
+      view.setUint32(a + 4, 3 + strtab.offsets.get(s.name)!, true);
+    } else {
+      out.set(new TextEncoder().encode(s.name), a);
+    }
+    view.setUint32(a + 8, s.value ?? 0, true);
+    view.setInt16(a + 12, s.section, true);
+    view.setUint8(a + 16, s.storageClass ?? IMAGE_SYM_CLASS_EXTERNAL);
+    view.setUint8(a + 17, auxCounts[i]!);
+    raw += 1;
+    if (s.sectionDef === true) {
+      const auxAt = symtabAt + raw * 18;
+      const spec = sections[s.section - 1]!;
+      view.setUint32(auxAt, spec.data.length, true);
+      view.setUint16(auxAt + 4, (spec.relocs ?? []).length, true);
+      view.setUint16(auxAt + 12, s.section, true);
+      view.setUint8(auxAt + 14, spec.comdatSelection ?? 0);
+      raw += 1;
+    }
+  });
+  const strtabAt = symtabAt + rawCount * 18;
+  view.setUint32(strtabAt, 4 + strtab.data.length - 1, true);
+  out.set(strtab.data.subarray(1), strtabAt + 4);
+  return out.subarray(0, strtabAt + 4 + strtab.data.length - 1);
+}
+
+interface ReadCoff {
+  sections: { name: string; characteristics: number; relocs: { sym: number }[] }[];
+  symbols: { name: string; section: number; storageClass: number; index: number }[];
+}
+
+function readCoff(bytes: Uint8Array): ReadCoff {
+  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const sectionCount = view.getUint16(2, true);
+  const symtabAt = view.getUint32(8, true);
+  const symbolCount = view.getUint32(12, true);
+  const strtabAt = symtabAt + symbolCount * 18;
+  const cstr = (at: number): string => {
+    let end = at;
+    while (bytes[end] !== 0) end++;
+    return new TextDecoder().decode(bytes.subarray(at, end));
+  };
+  const sections = [] as ReadCoff["sections"];
+  for (let i = 0; i < sectionCount; i++) {
+    const h = 20 + i * 40;
+    let name = new TextDecoder().decode(bytes.subarray(h, h + 8)).replace(/\0+$/, "");
+    if (name.startsWith("/")) name = cstr(strtabAt + Number.parseInt(name.slice(1), 10));
+    const relocAt = view.getUint32(h + 24, true);
+    const relocCount = view.getUint16(h + 32, true);
+    const relocs = [] as { sym: number }[];
+    for (let r = 0; r < relocCount; r++) relocs.push({ sym: view.getUint32(relocAt + r * 10 + 4, true) });
+    sections.push({ name, characteristics: view.getUint32(h + 36, true), relocs });
+  }
+  const symbols = [] as ReadCoff["symbols"];
+  for (let i = 0; i < symbolCount; ) {
+    const a = symtabAt + i * 18;
+    const name =
+      view.getUint32(a, true) === 0
+        ? cstr(strtabAt + view.getUint32(a + 4, true))
+        : new TextDecoder().decode(bytes.subarray(a, a + 8)).replace(/\0+$/, "");
+    symbols.push({
+      name,
+      section: view.getInt16(a + 12, true),
+      storageClass: view.getUint8(a + 16),
+      index: i,
+    });
+    i += 1 + view.getUint8(a + 17);
+  }
+  return { sections, symbols };
+}
+
+describe("mergeAndLocalizeCoffObjects", () => {
+  const text = (relocs?: { va: number; sym: number; type: number }[]): CoffSectionSpec => ({
+    name: ".text",
+    data: new Uint8Array(8),
+    characteristics: 0x60000020,
+    ...(relocs !== undefined ? { relocs } : {}),
+  });
+
+  test("pulls support on demand, resolves references to the demoted definition, keeps the keep set", () => {
+    // program: defines keep_me, references helper (reloc via undefined sym 2)
+    // raw symbol indices: .text 0 (aux 1), keep_me 2, helper 3, memcpy 4
+    const program = buildCoff(
+      [text([{ va: 0, sym: 3, type: 4 }])],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "keep_me", section: 1 },
+        { name: "helper", section: 0 },
+        { name: "memcpy", section: 0 },
+      ],
+    );
+    // needed support: defines helper
+    const needed = buildCoff(
+      [text()],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "helper", section: 1, value: 4 },
+      ],
+    );
+    // unneeded support: defines lonely, references a unit library mode excludes
+    const unneeded = buildCoff(
+      [text()],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "lonely", section: 1 },
+        { name: "excluded_unit_ref", section: 0 },
+      ],
+    );
+    const merged = readCoff(
+      mergeAndLocalizeCoffObjects(program, [needed, unneeded], new Set(["keep_me"])),
+    );
+    const byName = new Map(merged.symbols.map((s) => [s.name, s]));
+    expect(byName.get("keep_me")!.storageClass).toBe(IMAGE_SYM_CLASS_EXTERNAL);
+    expect(byName.get("helper")!.storageClass).toBe(IMAGE_SYM_CLASS_STATIC);
+    expect(byName.get("helper")!.section).toBeGreaterThan(0);
+    expect(byName.get("memcpy")!.storageClass).toBe(IMAGE_SYM_CLASS_EXTERNAL);
+    expect(byName.get("memcpy")!.section).toBe(0);
+    // The unneeded member never joined: no lonely, no leaked reference.
+    expect(byName.has("lonely")).toBe(false);
+    expect(byName.has("excluded_unit_ref")).toBe(false);
+    // The program's relocation now addresses the demoted definition.
+    expect(merged.sections[0]!.relocs[0]!.sym).toBe(byName.get("helper")!.index);
+  });
+
+  test("COMDAT duplicates deduplicate inside the merge and the flag clears in the output", () => {
+    // Both objects carry a .refptr.shared COMDAT ANY stub (the mingw
+    // pattern: one per referencing TU); the program pulls the support
+    // object through an undefined reference. Raw symbol indices per
+    // object: .text 0 (aux 1), .rdata 2 (aux 3), then the named symbols.
+    const program = buildCoff(
+      [
+        text([{ va: 0, sym: 5, type: 4 }]),
+        {
+          name: ".rdata",
+          data: new Uint8Array(8),
+          characteristics: 0x40000040 | IMAGE_SCN_LNK_COMDAT,
+          comdatSelection: 2,
+          relocs: [],
+        },
+      ],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: ".rdata", section: 2, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "keep_me", section: 1 },
+        { name: "support_fn", section: 0 },
+        { name: ".refptr.shared", section: 2 },
+      ],
+    );
+    const support = buildCoff(
+      [
+        text(),
+        {
+          name: ".rdata",
+          data: new Uint8Array(8),
+          characteristics: 0x40000040 | IMAGE_SCN_LNK_COMDAT,
+          comdatSelection: 2,
+          relocs: [],
+        },
+      ],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: ".rdata", section: 2, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "support_fn", section: 1 },
+        { name: ".refptr.shared", section: 2 },
+      ],
+    );
+    const merged = readCoff(mergeAndLocalizeCoffObjects(program, [support], new Set(["keep_me"])));
+    // One survivor section carries the stub; no COMDAT flag remains anywhere.
+    const rdata = merged.sections.filter((s) => s.name === ".rdata");
+    expect(rdata.length).toBe(1);
+    for (const section of merged.sections) {
+      expect(section.characteristics & IMAGE_SCN_LNK_COMDAT).toBe(0);
+    }
+    // The stub's symbol demoted with everything else; exactly one copy.
+    const stubs = merged.symbols.filter((s) => s.name === ".refptr.shared");
+    expect(stubs.length).toBe(1);
+    expect(stubs[0]!.storageClass).toBe(IMAGE_SYM_CLASS_STATIC);
+  });
+
+  test("duplicate strong definitions refuse with both members named", () => {
+    const one = buildCoff(
+      [text()],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "keep_me", section: 1 },
+        { name: "dup", section: 1 },
+        { name: "pull", section: 0 },
+      ],
+    );
+    const two = buildCoff(
+      [text()],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "pull", section: 1 },
+        { name: "dup", section: 1 },
+      ],
+    );
+    expect(() =>
+      mergeAndLocalizeCoffObjects(one, [two], new Set(["keep_me"]), {
+        program: "one.o",
+        support: ["two.o"],
+      }),
+    ).toThrow(/duplicate external symbol dup.*one\.o.*two\.o/);
+  });
+
+  test("refuses non-AMD64 machines", () => {
+    const object = buildCoff([text()], [{ name: "x", section: 1 }]);
+    new DataView(object.buffer, object.byteOffset).setUint16(0, 0xaa64, true);
+    expect(() => mergeAndLocalizeCoffObjects(object, [], new Set())).toThrow(/machine/);
+  });
+});

--- a/packages/compiler/src/backend/object-localize.test.ts
+++ b/packages/compiler/src/backend/object-localize.test.ts
@@ -438,6 +438,46 @@ describe("mergeAndLocalizeCoffObjects", () => {
     expect(merged.sections[0]!.relocs[0]!.sym).toBe(byName.get("helper")!.index);
   });
 
+  test("does not pull an alternate definition when a selected object already satisfies the reference", () => {
+    // program defines foo and needs bar; the first support member defines
+    // bar and calls back into foo. A real archive link stops there. The
+    // later alternate foo member must remain unselected rather than causing
+    // a false duplicate definition during the merge.
+    const program = buildCoff(
+      [text([{ va: 0, sym: 3, type: 4 }])],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "foo", section: 1 },
+        { name: "bar", section: 0 },
+      ],
+    );
+    const needed = buildCoff(
+      [text([{ va: 0, sym: 3, type: 4 }])],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "bar", section: 1 },
+        { name: "foo", section: 0 },
+      ],
+    );
+    const alternate = buildCoff(
+      [text()],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "foo", section: 1 },
+        { name: "alternate_only", section: 1 },
+      ],
+    );
+
+    const merged = readCoff(
+      mergeAndLocalizeCoffObjects(program, [needed, alternate], new Set()),
+    );
+    const byName = new Map(merged.symbols.map((s) => [s.name, s]));
+    expect(byName.has("alternate_only")).toBe(false);
+    expect(merged.sections.filter((s) => s.name === ".text")).toHaveLength(2);
+    expect(merged.sections[0]!.relocs[0]!.sym).toBe(byName.get("bar")!.index);
+    expect(merged.sections[1]!.relocs[0]!.sym).toBe(byName.get("foo")!.index);
+  });
+
   test("COMDAT duplicates deduplicate inside the merge and the flag clears in the output", () => {
     // Both objects carry a .refptr.shared COMDAT ANY stub (the mingw
     // pattern: one per referencing TU); the program pulls the support

--- a/packages/compiler/src/backend/object-localize.ts
+++ b/packages/compiler/src/backend/object-localize.ts
@@ -1,0 +1,982 @@
+/* Format-aware symbol localization for multi-instance library mode
+ * (abi.localize_runtime) — the in-process half of cc.ts's
+ * localizeLibraryObjects. Host toolchains cover the classic pairings
+ * (darwin's ld64 does combine+demote in one step; host-linux binutils runs
+ * `ld -r` + objcopy), but no portable toolchain performs the COFF
+ * equivalent at all — lld-link has no relocatable mode (mirroring MSVC
+ * link.exe) and llvm-objcopy rejects symbol-scope flags for COFF — and
+ * cross ELF demotion would otherwise require a host binutils/llvm-objcopy
+ * that neither `zig cc` nor a stock macOS ships. These transforms close
+ * both gaps with no external tool:
+ *
+ *   localizeElfObject      demote every defined global/weak symbol outside
+ *                          the keep set to a local symbol in a relocatable
+ *                          ELF64 object (the output of `zig cc -r`), and
+ *                          resolve COMDAT section groups the way binutils'
+ *                          --force-group-allocation does — a group whose
+ *                          signature repeats across archives sharing
+ *                          runtime objects must not be deduplicated against
+ *                          another archive's copy at the embedder's link.
+ *
+ *   mergeAndLocalizeCoffObjects
+ *                          the COFF combine+demote in one pass: pull
+ *                          support objects on undefined-symbol demand (the
+ *                          staging-archive member semantics `ld -r` gives
+ *                          the other formats), concatenate the selected
+ *                          objects' sections, resolve cross-object symbol
+ *                          references by index, then demote every defined
+ *                          external outside the keep set to a static
+ *                          symbol.
+ *
+ * Shared demotion rule (GNU objcopy --keep-global-symbols semantics):
+ * undefined references keep their global binding (libc/libm and sanitizer
+ * ABI are the embedder's by design), and COMMON symbols stay global —
+ * sanitizer image-registration guards are COMMONs whose merging across
+ * archives is the documented single-registration discipline. */
+
+const textDecoder = new TextDecoder();
+const textEncoder = new TextEncoder();
+
+class ObjectFormatError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ObjectFormatError";
+  }
+}
+
+function fail(message: string): never {
+  throw new ObjectFormatError(message);
+}
+
+/* ────────────────────────────── ELF64 ─────────────────────────────────── */
+
+const SHT_NULL = 0;
+const SHT_SYMTAB = 2;
+const SHT_RELA = 4;
+const SHT_NOBITS = 8;
+const SHT_REL = 9;
+const SHT_GROUP = 17;
+const SHT_SYMTAB_SHNDX = 18;
+const SHT_LLVM_ADDRSIG = 0x6fff4c03;
+const SHF_GROUP = 0x200n;
+const SHN_UNDEF = 0;
+const SHN_LORESERVE = 0xff00;
+const SHN_COMMON = 0xfff2;
+const SHN_XINDEX = 0xffff;
+const STB_LOCAL = 0;
+
+interface ElfSection {
+  nameOffset: number;
+  type: number;
+  flags: bigint;
+  addr: bigint;
+  size: bigint;
+  link: number;
+  info: number;
+  addralign: bigint;
+  entsize: bigint;
+  data: Uint8Array;
+}
+
+interface ElfSymbol {
+  nameOffset: number;
+  name: string;
+  info: number;
+  other: number;
+  /** Resolved section index (SHT_SYMTAB_SHNDX applied), or a reserved
+   * SHN_* value below/at SHN_LORESERVE semantics. */
+  shndx: number;
+}
+
+/** Demote every defined global/weak symbol not named in `keep` to a local
+ * symbol in a relocatable ELF64 little-endian object, resolving COMDAT
+ * section groups in the same pass. The input is the combined object a
+ * relocatable link produced; the output is byte-rebuilt (fresh layout,
+ * same section content). */
+export function localizeElfObject(object: Uint8Array, keep: ReadonlySet<string>): Uint8Array {
+  const view = new DataView(object.buffer, object.byteOffset, object.byteLength);
+  if (object.byteLength < 64 || view.getUint32(0, false) !== 0x7f454c46) {
+    fail("not an ELF object");
+  }
+  if (object[4] !== 2 || object[5] !== 1) {
+    fail("unsupported ELF class/encoding (need ELF64, little-endian)");
+  }
+  if (view.getUint16(16, true) !== 1) fail("not a relocatable ELF object (ET_REL)");
+  const machine = view.getUint16(18, true);
+  const flags = view.getUint32(48, true);
+  const shoff = Number(view.getBigUint64(40, true));
+  const shentsize = view.getUint16(58, true);
+  if (shentsize !== 64) fail(`unsupported ELF section header size ${shentsize}`);
+  let shnum = view.getUint16(60, true);
+  let shstrndx = view.getUint16(62, true);
+  if (shnum === 0) shnum = Number(view.getBigUint64(shoff + 32, true));
+  if (shstrndx === SHN_XINDEX) shstrndx = view.getUint32(shoff + 40, true);
+
+  const sections: ElfSection[] = [];
+  for (let i = 0; i < shnum; i++) {
+    const at = shoff + i * 64;
+    const type = view.getUint32(at + 4, true);
+    const offset = Number(view.getBigUint64(at + 24, true));
+    const size = view.getBigUint64(at + 32, true);
+    sections.push({
+      nameOffset: view.getUint32(at, true),
+      type,
+      flags: view.getBigUint64(at + 8, true),
+      addr: view.getBigUint64(at + 16, true),
+      size,
+      link: view.getUint32(at + 40, true),
+      info: view.getUint32(at + 44, true),
+      addralign: view.getBigUint64(at + 48, true),
+      entsize: view.getBigUint64(at + 56, true),
+      data:
+        type === SHT_NOBITS || type === SHT_NULL
+          ? new Uint8Array(0)
+          : object.subarray(offset, offset + Number(size)),
+    });
+  }
+
+  const symtabIndex = sections.findIndex((s) => s.type === SHT_SYMTAB);
+  if (symtabIndex < 0) fail("ELF object has no symbol table");
+  const symtab = sections[symtabIndex]!;
+  const strtab = sections[symtab.link];
+  if (strtab === undefined) fail("ELF symbol table names an invalid string table");
+
+  // SHT_SYMTAB_SHNDX (only present when section indices overflow st_shndx):
+  // resolve the real indices up front and drop the section — the rebuilt
+  // object's section count only shrinks, so inline indices always fit.
+  const shndxSection = sections.find(
+    (s) => s.type === SHT_SYMTAB_SHNDX && sections[s.link] === symtab,
+  );
+  const shndxView =
+    shndxSection === undefined
+      ? null
+      : new DataView(
+          shndxSection.data.buffer,
+          shndxSection.data.byteOffset,
+          shndxSection.data.byteLength,
+        );
+
+  const symbolName = (offset: number): string => {
+    const bytes = strtab!.data;
+    let end = offset;
+    while (end < bytes.length && bytes[end] !== 0) end++;
+    return textDecoder.decode(bytes.subarray(offset, end));
+  };
+
+  const symCount = Number(symtab.size) / 24;
+  const symView = new DataView(symtab.data.buffer, symtab.data.byteOffset, symtab.data.byteLength);
+  const symbols: ElfSymbol[] = [];
+  for (let i = 0; i < symCount; i++) {
+    const at = i * 24;
+    let shndx: number = symView.getUint16(at + 6, true);
+    if (shndx === SHN_XINDEX) {
+      if (shndxView === null) fail("ELF symbol uses SHN_XINDEX without a SHT_SYMTAB_SHNDX table");
+      shndx = shndxView.getUint32(i * 4, true);
+    }
+    symbols.push({
+      nameOffset: symView.getUint32(at, true),
+      name: symbolName(symView.getUint32(at, true)),
+      info: symView.getUint8(at + 4),
+      other: symView.getUint8(at + 5),
+      shndx,
+    });
+  }
+
+  // Section groups resolve away (the --force-group-allocation discipline),
+  // and .llvm_addrsig drops — its symbol indices go stale under the symbol
+  // reorder below, and its only consumer (ICF safety analysis) treats
+  // absence conservatively.
+  const sectionKept: boolean[] = sections.map(
+    (s) =>
+      s.type !== SHT_GROUP &&
+      s.type !== SHT_LLVM_ADDRSIG &&
+      !(shndxSection !== undefined && s === shndxSection),
+  );
+  const sectionMap: number[] = [];
+  {
+    let next = 0;
+    for (let i = 0; i < sections.length; i++) sectionMap.push(sectionKept[i] === true ? next++ : -1);
+  }
+  for (let i = 0; i < sections.length; i++) {
+    if (sectionKept[i] === true) sections[i]!.flags &= ~SHF_GROUP;
+  }
+
+  // Demote and drop decisions per symbol. A symbol anchored to a dropped
+  // section (a group's own section symbol) leaves with it; nothing may
+  // still reference it afterwards.
+  const symbolKept: boolean[] = [];
+  for (let i = 0; i < symCount; i++) {
+    const sym = symbols[i]!;
+    const regular = sym.shndx > SHN_UNDEF && sym.shndx < SHN_LORESERVE;
+    symbolKept.push(!(regular && sectionKept[sym.shndx] !== true));
+    if (i === 0) continue;
+    const binding = sym.info >> 4;
+    const defined = sym.shndx !== SHN_UNDEF && sym.shndx !== SHN_COMMON;
+    if (binding !== STB_LOCAL && defined && !keep.has(sym.name)) {
+      sym.info = (STB_LOCAL << 4) | (sym.info & 0xf);
+    }
+  }
+
+  // Reorder: locals first (the spec's symbol-table contract), stable within
+  // each half, index 0 pinned.
+  const localOrder: number[] = [];
+  const globalOrder: number[] = [];
+  for (let i = 0; i < symCount; i++) {
+    if (symbolKept[i] !== true) continue;
+    ((symbols[i]!.info >> 4) === STB_LOCAL ? localOrder : globalOrder).push(i);
+  }
+  const symbolOrder = [...localOrder, ...globalOrder];
+  const symbolMap: number[] = new Array<number>(symCount).fill(-1);
+  symbolOrder.forEach((oldIndex, newIndex) => (symbolMap[oldIndex] = newIndex));
+
+  const newSymtabData = new Uint8Array(symbolOrder.length * 24);
+  const newSymtabView = new DataView(newSymtabData.buffer);
+  symbolOrder.forEach((oldIndex, newIndex) => {
+    const sym = symbols[oldIndex]!;
+    const at = newIndex * 24;
+    newSymtabView.setUint32(at, sym.nameOffset, true);
+    newSymtabView.setUint8(at + 4, sym.info);
+    newSymtabView.setUint8(at + 5, sym.other);
+    const shndx =
+      sym.shndx > SHN_UNDEF && sym.shndx < SHN_LORESERVE ? sectionMap[sym.shndx]! : sym.shndx;
+    newSymtabView.setUint16(at + 6, shndx, true);
+    newSymtabView.setBigUint64(at + 8, symView.getBigUint64(oldIndex * 24 + 8, true), true);
+    newSymtabView.setBigUint64(at + 16, symView.getBigUint64(oldIndex * 24 + 16, true), true);
+  });
+  symtab.data = newSymtabData;
+  symtab.size = BigInt(newSymtabData.length);
+  symtab.info = localOrder.length;
+
+  // Relocation sections against this symbol table: remap symbol indices.
+  for (const section of sections) {
+    if ((section.type !== SHT_RELA && section.type !== SHT_REL) || section.link !== symtabIndex) {
+      continue;
+    }
+    const entry = section.type === SHT_RELA ? 24 : 16;
+    const data = new Uint8Array(section.data); // private copy — inputs may be shared
+    const relView = new DataView(data.buffer);
+    for (let at = 0; at + entry <= data.length; at += entry) {
+      const info = relView.getBigUint64(at + 8, true);
+      const oldSym = Number(info >> 32n);
+      if (oldSym === 0) continue;
+      const newSym = symbolMap[oldSym];
+      if (newSym === undefined || newSym < 0) {
+        fail("ELF relocation references a symbol dropped with its section group");
+      }
+      relView.setBigUint64(at + 8, (BigInt(newSym) << 32n) | (info & 0xffffffffn), true);
+    }
+    section.data = data;
+  }
+
+  // Rebuild. sh_link is a section index in every use this object can carry;
+  // sh_info is one only on relocation sections.
+  const kept = sections.filter((_, i) => sectionKept[i] === true);
+  let offset = 64;
+  const offsets: number[] = [];
+  for (const section of kept) {
+    if (section.type === SHT_NULL || section.type === SHT_NOBITS) {
+      offsets.push(0);
+      continue;
+    }
+    const align = Number(section.addralign > 1n ? section.addralign : 1n);
+    offset = Math.ceil(offset / align) * align;
+    offsets.push(offset);
+    offset += section.data.length;
+  }
+  const shoffOut = Math.ceil(offset / 8) * 8;
+  const out = new Uint8Array(shoffOut + kept.length * 64);
+  const outView = new DataView(out.buffer);
+  out.set(object.subarray(0, 64));
+  outView.setBigUint64(24, 0n, true); // e_entry
+  outView.setBigUint64(32, 0n, true); // e_phoff
+  outView.setUint16(18, machine, true);
+  outView.setUint32(48, flags, true);
+  outView.setBigUint64(40, BigInt(shoffOut), true);
+  outView.setUint16(54, 0, true); // e_phentsize
+  outView.setUint16(56, 0, true); // e_phnum
+  outView.setUint16(60, kept.length, true);
+  outView.setUint16(62, sectionMap[shstrndx]!, true);
+  kept.forEach((section, i) => {
+    if (section.type !== SHT_NULL && section.type !== SHT_NOBITS) {
+      out.set(section.data, offsets[i]!);
+    }
+    const at = shoffOut + i * 64;
+    outView.setUint32(at, section.nameOffset, true);
+    outView.setUint32(at + 4, section.type, true);
+    outView.setBigUint64(at + 8, section.flags, true);
+    outView.setBigUint64(at + 16, section.addr, true);
+    outView.setBigUint64(at + 24, BigInt(offsets[i]!), true);
+    outView.setBigUint64(
+      at + 32,
+      section.type === SHT_NOBITS ? section.size : BigInt(section.data.length),
+      true,
+    );
+    outView.setUint32(at + 40, section.link === 0 ? 0 : sectionMap[section.link] ?? 0, true);
+    outView.setUint32(
+      at + 44,
+      section.type === SHT_RELA || section.type === SHT_REL
+        ? sectionMap[section.info] ?? 0
+        : section === symtab
+          ? symtab.info
+          : section.info,
+      true,
+    );
+    outView.setBigUint64(at + 48, section.addralign, true);
+    outView.setBigUint64(at + 56, section.entsize, true);
+  });
+  return out;
+}
+
+/* ────────────────────────────── COFF ──────────────────────────────────── */
+
+const IMAGE_FILE_MACHINE_AMD64 = 0x8664;
+const IMAGE_SCN_LNK_NRELOC_OVFL = 0x01000000;
+const IMAGE_SCN_LNK_COMDAT = 0x00001000;
+const IMAGE_SYM_UNDEFINED = 0;
+const IMAGE_SYM_ABSOLUTE = -1;
+const IMAGE_SYM_CLASS_EXTERNAL = 2;
+const IMAGE_SYM_CLASS_STATIC = 3;
+const IMAGE_SYM_CLASS_SECTION = 104;
+const IMAGE_SYM_CLASS_WEAK_EXTERNAL = 105;
+
+interface CoffReloc {
+  virtualAddress: number;
+  symbolIndex: number;
+  type: number;
+}
+
+interface CoffSection {
+  name: string;
+  virtualSize: number;
+  virtualAddress: number;
+  characteristics: number;
+  data: Uint8Array | null; // null = uninitialized (.bss)
+  rawSize: number;
+  relocs: CoffReloc[];
+  /** COMDAT selection (aux of the section symbol), 0 when not COMDAT. */
+  comdatSelection: number;
+  /** 1-based associated section for IMAGE_COMDAT_SELECT_ASSOCIATIVE. */
+  comdatAssoc: number;
+  /** Primary index of the COMDAT symbol (the record after the section
+   * symbol anchored here) — the linker's deduplication name. */
+  comdatLeader: number;
+}
+
+interface CoffSymbol {
+  name: string;
+  value: number;
+  sectionNumber: number; // 1-based, or 0 / -1 / -2
+  type: number;
+  storageClass: number;
+  aux: Uint8Array; // raw aux records, 18 bytes each
+}
+
+interface CoffObject {
+  machine: number;
+  sections: CoffSection[];
+  symbols: CoffSymbol[]; // primary records only; aux rides on its symbol
+  /** primary-record index (into `symbols`) by original symbol-table index */
+  primaryByRaw: Map<number, number>;
+  /** original symbol-table index by primary-record index */
+  rawByPrimary: number[];
+  label: string;
+}
+
+function readCString(bytes: Uint8Array, offset: number): string {
+  let end = offset;
+  while (end < bytes.length && bytes[end] !== 0) end++;
+  return textDecoder.decode(bytes.subarray(offset, end));
+}
+
+function parseCoff(object: Uint8Array, label: string): CoffObject {
+  const view = new DataView(object.buffer, object.byteOffset, object.byteLength);
+  if (object.byteLength < 20) fail(`${label}: not a COFF object`);
+  const machine = view.getUint16(0, true);
+  if (machine === 0 && view.getUint16(2, true) === 0xffff) {
+    fail(`${label}: bigobj/import-descriptor COFF members are not supported here`);
+  }
+  const sectionCount = view.getUint16(2, true);
+  const symtabOffset = view.getUint32(8, true);
+  const symbolCount = view.getUint32(12, true);
+  if (view.getUint16(16, true) !== 0) fail(`${label}: unexpected optional header in a COFF object`);
+  const strtabOffset = symtabOffset + symbolCount * 18;
+  const strtab = object.subarray(strtabOffset);
+
+  const sectionName = (raw: Uint8Array): string => {
+    if (raw[0] === 0x2f /* '/' */) {
+      const spelled = textDecoder.decode(raw.subarray(1)).replace(/\0+$/, "").trim();
+      const offset = Number.parseInt(spelled, 10);
+      if (!Number.isFinite(offset)) fail(`${label}: malformed long section name`);
+      return readCString(strtab, offset);
+    }
+    let end = 0;
+    while (end < 8 && raw[end] !== 0) end++;
+    return textDecoder.decode(raw.subarray(0, end));
+  };
+
+  const sections: CoffSection[] = [];
+  for (let i = 0; i < sectionCount; i++) {
+    const at = 20 + i * 40;
+    const rawSize = view.getUint32(at + 16, true);
+    const rawPointer = view.getUint32(at + 20, true);
+    const relocPointer = view.getUint32(at + 24, true);
+    let relocCount: number = view.getUint16(at + 32, true);
+    const characteristics = view.getUint32(at + 36, true);
+    let relocAt = relocPointer;
+    if ((characteristics & IMAGE_SCN_LNK_NRELOC_OVFL) !== 0 && relocCount === 0xffff) {
+      relocCount = view.getUint32(relocPointer, true) - 1;
+      relocAt += 10;
+    }
+    const relocs: CoffReloc[] = [];
+    for (let r = 0; r < relocCount; r++) {
+      const rAt = relocAt + r * 10;
+      relocs.push({
+        virtualAddress: view.getUint32(rAt, true),
+        symbolIndex: view.getUint32(rAt + 4, true),
+        type: view.getUint16(rAt + 8, true),
+      });
+    }
+    sections.push({
+      name: sectionName(object.subarray(at, at + 8)),
+      virtualSize: view.getUint32(at + 8, true),
+      virtualAddress: view.getUint32(at + 12, true),
+      characteristics,
+      data: rawPointer === 0 ? null : object.subarray(rawPointer, rawPointer + rawSize),
+      rawSize,
+      relocs,
+      comdatSelection: 0,
+      comdatAssoc: 0,
+      comdatLeader: -1,
+    });
+  }
+
+  const symbols: CoffSymbol[] = [];
+  const primaryByRaw = new Map<number, number>();
+  const rawByPrimary: number[] = [];
+  for (let i = 0; i < symbolCount; ) {
+    const at = symtabOffset + i * 18;
+    const nameIsLong = view.getUint32(at, true) === 0;
+    const name = nameIsLong
+      ? readCString(strtab, view.getUint32(at + 4, true))
+      : (() => {
+          const raw = object.subarray(at, at + 8);
+          let end = 0;
+          while (end < 8 && raw[end] !== 0) end++;
+          return textDecoder.decode(raw.subarray(0, end));
+        })();
+    const auxCount = view.getUint8(at + 17);
+    primaryByRaw.set(i, symbols.length);
+    rawByPrimary.push(i);
+    symbols.push({
+      name,
+      value: view.getUint32(at + 8, true),
+      sectionNumber: view.getInt16(at + 12, true),
+      type: view.getUint16(at + 14, true),
+      storageClass: view.getUint8(at + 16),
+      aux: object.slice(at + 18, at + 18 + auxCount * 18),
+    });
+    i += 1 + auxCount;
+  }
+  // COMDAT metadata rides the section symbol's aux record (selection,
+  // associated section) and the record after it (the COMDAT symbol — the
+  // linker's deduplication name).
+  for (let sectionIndex = 1; sectionIndex <= sections.length; sectionIndex++) {
+    const section = sections[sectionIndex - 1]!;
+    if ((section.characteristics & IMAGE_SCN_LNK_COMDAT) === 0) continue;
+    let sawSectionSymbol = false;
+    for (let primary = 0; primary < symbols.length; primary++) {
+      const sym = symbols[primary]!;
+      if (sym.sectionNumber !== sectionIndex) continue;
+      if (!sawSectionSymbol && sym.value === 0 && sym.name === section.name && sym.aux.length >= 18) {
+        sawSectionSymbol = true;
+        const auxView = new DataView(sym.aux.buffer, sym.aux.byteOffset, sym.aux.byteLength);
+        section.comdatSelection = auxView.getUint8(14);
+        section.comdatAssoc = auxView.getUint16(12, true);
+        continue;
+      }
+      section.comdatLeader = primary;
+      break;
+    }
+    if (!sawSectionSymbol) fail(`${label}: COMDAT section ${section.name} has no section symbol`);
+  }
+  return { machine, sections, symbols, primaryByRaw, rawByPrimary, label };
+}
+
+function coffDefines(sym: CoffSymbol): boolean {
+  return (
+    (sym.storageClass === IMAGE_SYM_CLASS_EXTERNAL &&
+      (sym.sectionNumber > 0 || sym.sectionNumber === IMAGE_SYM_ABSOLUTE)) ||
+    coffIsCommon(sym)
+  );
+}
+
+function coffIsCommon(sym: CoffSymbol): boolean {
+  return (
+    sym.storageClass === IMAGE_SYM_CLASS_EXTERNAL &&
+    sym.sectionNumber === IMAGE_SYM_UNDEFINED &&
+    sym.value > 0
+  );
+}
+
+function coffIsUndefined(sym: CoffSymbol): boolean {
+  return (
+    (sym.storageClass === IMAGE_SYM_CLASS_EXTERNAL &&
+      sym.sectionNumber === IMAGE_SYM_UNDEFINED &&
+      sym.value === 0) ||
+    sym.storageClass === IMAGE_SYM_CLASS_WEAK_EXTERNAL
+  );
+}
+
+/** Combine a program object with the support objects it (transitively)
+ * needs into ONE COFF object, then demote every defined external outside
+ * `keep` to a static symbol. Support objects join on undefined-symbol
+ * demand — the staging-archive member semantics the other formats get from
+ * `ld -r` — so an unused member's undefined references never reach the
+ * embedder's link. x86_64 only (the one COFF target scriptc produces). */
+export function mergeAndLocalizeCoffObjects(
+  program: Uint8Array,
+  support: readonly Uint8Array[],
+  keep: ReadonlySet<string>,
+  labels?: { program?: string; support?: readonly string[] },
+): Uint8Array {
+  const objects = [
+    parseCoff(program, labels?.program ?? "program object"),
+    ...support.map((bytes, i) => parseCoff(bytes, labels?.support?.[i] ?? `support object ${i}`)),
+  ];
+  for (const object of objects) {
+    if (object.machine !== IMAGE_FILE_MACHINE_AMD64) {
+      fail(`${object.label}: unsupported COFF machine 0x${object.machine.toString(16)}`);
+    }
+  }
+
+  // Member selection: archive semantics over the support list. A definition
+  // (including a COMMON) satisfies an undefined reference; first definer in
+  // list order wins the pull, matching `ar` member order.
+  const definers = new Map<string, number[]>();
+  objects.forEach((object, index) => {
+    if (index === 0) return;
+    for (const sym of object.symbols) {
+      if (!coffDefines(sym)) continue;
+      const list = definers.get(sym.name);
+      if (list === undefined) definers.set(sym.name, [index]);
+      else list.push(index);
+    }
+  });
+  const included: boolean[] = objects.map((_, i) => i === 0);
+  const queue = [0];
+  while (queue.length > 0) {
+    const object = objects[queue.shift()!]!;
+    for (const sym of object.symbols) {
+      if (!coffIsUndefined(sym)) continue;
+      for (const candidate of definers.get(sym.name) ?? []) {
+        if (included[candidate] !== true) {
+          included[candidate] = true;
+          queue.push(candidate);
+        }
+        break;
+      }
+    }
+  }
+  const selected = objects.filter((_, i) => included[i] === true);
+
+  // COMDAT resolution, the ELF arm's --force-group-allocation analog:
+  // deduplicate by COMDAT-symbol name inside THIS merge (mingw emits one
+  // .refptr.<name> pointer stub per referencing TU, selection ANY), then
+  // clear the COMDAT flag on the survivors at emission — a section whose
+  // deduplication name repeats across archives sharing runtime objects
+  // must not be deduplicated against another archive's copy at the
+  // embedder's link, where its relocations bind that archive's private
+  // (demoted) definitions.
+  const sectionDropped = new Map<CoffObject, boolean[]>();
+  const comdatKept = new Map<string, { object: CoffObject; index: number }>();
+  for (const object of selected) {
+    const dropped: boolean[] = object.sections.map(() => false);
+    sectionDropped.set(object, dropped);
+    object.sections.forEach((section, i) => {
+      // .llvm_addrsig: its ULEB symbol indices go stale under the merge and
+      // its absence is read conservatively. .debug$S/.debug$T (CodeView):
+      // item indices resolve against the OWNING object's .debug$T, a
+      // per-object contract no single merged object can express — the
+      // localized member carries no CodeView, like an objcopy'd ELF member
+      // carries its DWARF untouched but a stripped one loses it.
+      if (section.name === ".llvm_addrsig" || section.name.startsWith(".debug$")) {
+        dropped[i] = true;
+        return;
+      }
+      if ((section.characteristics & IMAGE_SCN_LNK_COMDAT) === 0) return;
+      if (section.comdatSelection === 5) return; // associative: fate follows below
+      const leader = section.comdatLeader >= 0 ? object.symbols[section.comdatLeader] : undefined;
+      if (leader === undefined || leader.storageClass !== IMAGE_SYM_CLASS_EXTERNAL) return;
+      const existing = comdatKept.get(leader.name);
+      if (existing === undefined) {
+        comdatKept.set(leader.name, { object, index: i });
+        return;
+      }
+      if (section.comdatSelection === 1) {
+        fail(`duplicate IMAGE_COMDAT_SELECT_NODUPLICATES section ${section.name} (${existing.object.label} and ${object.label})`);
+      }
+      dropped[i] = true;
+    });
+    // Associative sections follow their target's fate (chase chains, with a
+    // bound so a malformed cycle cannot loop).
+    for (let pass = 0; pass < object.sections.length; pass++) {
+      let changed = false;
+      object.sections.forEach((section, i) => {
+        if (dropped[i] === true || section.comdatSelection !== 5) return;
+        const target = section.comdatAssoc - 1;
+        if (target < 0 || target >= object.sections.length) {
+          fail(`${object.label}: associative COMDAT ${section.name} names an invalid section`);
+        }
+        if (dropped[target] === true) {
+          dropped[i] = true;
+          changed = true;
+        }
+      });
+      if (!changed) break;
+    }
+  }
+
+  // Global resolution: one canonical entry per external name. Definitions
+  // win over commons, commons (largest size) over undefineds. Symbols
+  // anchored in dropped sections stand aside: a dropped duplicate's COMDAT
+  // symbol resolves to the kept copy's.
+  interface Canonical {
+    kind: "defined" | "common" | "undefined";
+    definer?: string;
+    commonSize: number;
+    outIndex: number; // raw output symbol-table index, assigned in pass 2
+    outSlot?: number; // index into outSymbols for in-place definition landing
+  }
+  const canonical = new Map<string, Canonical>();
+  for (const object of selected) {
+    const dropped = sectionDropped.get(object)!;
+    for (const sym of object.symbols) {
+      if (sym.storageClass !== IMAGE_SYM_CLASS_EXTERNAL) continue;
+      if (sym.sectionNumber > 0 && dropped[sym.sectionNumber - 1] === true) continue;
+      const existing = canonical.get(sym.name);
+      if (coffDefines(sym) && !coffIsCommon(sym)) {
+        if (existing?.kind === "defined") {
+          fail(
+            `duplicate external symbol ${sym.name} (${existing.definer ?? "?"} and ${object.label})`,
+          );
+        }
+        canonical.set(sym.name, {
+          kind: "defined",
+          definer: object.label,
+          commonSize: 0,
+          outIndex: -1,
+        });
+      } else if (coffIsCommon(sym)) {
+        if (existing === undefined || existing.kind === "undefined") {
+          canonical.set(sym.name, { kind: "common", commonSize: sym.value, outIndex: -1 });
+        } else if (existing.kind === "common" && sym.value > existing.commonSize) {
+          existing.commonSize = sym.value;
+        }
+      } else if (existing === undefined) {
+        canonical.set(sym.name, { kind: "undefined", commonSize: 0, outIndex: -1 });
+      }
+    }
+  }
+  // A weak external's resolution happens at the embedder's link; a weak
+  // reference to a name this pass demotes would dangle there. scriptc's
+  // toolchains emit no weak externals in these objects — refuse rather than
+  // approximate if one ever appears against a demoted name.
+  for (const object of selected) {
+    for (const sym of object.symbols) {
+      if (sym.storageClass !== IMAGE_SYM_CLASS_WEAK_EXTERNAL) continue;
+      const target = canonical.get(sym.name);
+      if (target?.kind === "defined" && !keep.has(sym.name)) {
+        fail(`${object.label}: weak external ${sym.name} would dangle after localization`);
+      }
+    }
+  }
+
+  // Pass 1 — output sections (dropping .llvm_addrsig: its ULEB symbol
+  // indices go stale under the merge, and its absence is read
+  // conservatively). Section map: (object, 1-based index) → 1-based output.
+  interface OutSection {
+    section: CoffSection;
+    object: CoffObject;
+  }
+  const outSections: OutSection[] = [];
+  const sectionMaps = new Map<CoffObject, number[]>();
+  for (const object of selected) {
+    const map: number[] = [0];
+    const dropped = sectionDropped.get(object)!;
+    object.sections.forEach((section, i) => {
+      if (dropped[i] === true) {
+        map.push(0);
+        return;
+      }
+      outSections.push({ section, object });
+      map.push(outSections.length);
+    });
+    sectionMaps.set(object, map);
+  }
+  if (outSections.length > 0xfffe) fail("merged COFF object exceeds the section-count limit");
+
+  // Pass 2 — assign output symbol indices. Statics and section symbols copy
+  // per object; externals emit once at their first appearance.
+  interface OutSymbol {
+    sym: CoffSymbol;
+    object: CoffObject;
+    sectionNumber: number;
+    storageClass: number;
+    value: number;
+  }
+  const outSymbols: OutSymbol[] = [];
+  const symbolMaps = new Map<CoffObject, Map<number, number>>(); // raw old → raw new
+  let rawOut = 0;
+  for (const object of selected) {
+    const map = new Map<number, number>();
+    symbolMaps.set(object, map);
+    const sectionMap = sectionMaps.get(object)!;
+    object.symbols.forEach((sym, primaryIndex) => {
+      const rawOld = object.rawByPrimary[primaryIndex]!;
+      const mapSection = (): number =>
+        sym.sectionNumber > 0 ? sectionMap[sym.sectionNumber] ?? 0 : sym.sectionNumber;
+      if (sym.storageClass === IMAGE_SYM_CLASS_EXTERNAL) {
+        const inDroppedSection =
+          sym.sectionNumber > 0 &&
+          sectionDropped.get(object)![sym.sectionNumber - 1] === true;
+        const entry = canonical.get(sym.name)!;
+        if (entry.outIndex >= 0) {
+          // Later appearance of a known external: reference the canonical
+          // entry, unless THIS record is the definition that must land (a
+          // dropped duplicate COMDAT's symbol is a reference to the kept
+          // copy, never a second landing).
+          const isTheDefinition =
+            entry.kind === "defined" && coffDefines(sym) && !coffIsCommon(sym) && !inDroppedSection;
+          if (!isTheDefinition) {
+            map.set(rawOld, entry.outIndex);
+            return;
+          }
+          // The canonical slot was created by an earlier reference; the
+          // definition replaces it in place.
+          const slot = outSymbols[entry.outSlot!]!;
+          slot.sym = sym;
+          slot.object = object;
+          slot.sectionNumber = mapSection();
+          slot.value = sym.value;
+          slot.storageClass = keep.has(sym.name)
+            ? IMAGE_SYM_CLASS_EXTERNAL
+            : IMAGE_SYM_CLASS_STATIC;
+          map.set(rawOld, entry.outIndex);
+          return;
+        }
+        const sectionNumber =
+          entry.kind === "defined" && coffDefines(sym) && !coffIsCommon(sym)
+            ? mapSection()
+            : IMAGE_SYM_UNDEFINED;
+        const value = entry.kind === "common" ? entry.commonSize : entry.kind === "defined" && !coffIsCommon(sym) ? sym.value : 0;
+        const demote =
+          entry.kind === "defined" &&
+          coffDefines(sym) &&
+          !coffIsCommon(sym) &&
+          !keep.has(sym.name);
+        entry.outIndex = rawOut;
+        entry.outSlot = outSymbols.length;
+        outSymbols.push({
+          sym,
+          object,
+          sectionNumber,
+          storageClass: demote ? IMAGE_SYM_CLASS_STATIC : IMAGE_SYM_CLASS_EXTERNAL,
+          value,
+        });
+        map.set(rawOld, rawOut);
+        rawOut += 1; // externals carry no aux records in this pipeline
+        if (sym.aux.length > 0) {
+          fail(`${object.label}: external symbol ${sym.name} carries aux records`);
+        }
+        return;
+      }
+      // A record anchored to a dropped section (.llvm_addrsig's section
+      // symbol) leaves with it; nothing may still reference it afterwards.
+      if (sym.sectionNumber > 0 && sectionMap[sym.sectionNumber] === 0) return;
+      // Non-external record: copy through with a remapped section number.
+      map.set(rawOld, rawOut);
+      outSymbols.push({
+        sym,
+        object,
+        sectionNumber: mapSection(),
+        storageClass: sym.storageClass,
+        value: sym.value,
+      });
+      rawOut += 1 + sym.aux.length / 18;
+    });
+  }
+
+  // Pass 3 — remap relocations and aux records now every index is known.
+  for (const { section, object } of outSections) {
+    const map = symbolMaps.get(object)!;
+    for (const reloc of section.relocs) {
+      const mapped = map.get(reloc.symbolIndex);
+      if (mapped === undefined) {
+        // Relocations may address a record via its primary index only.
+        fail(`${object.label}: relocation in ${section.name} references a non-primary symbol`);
+      }
+      reloc.symbolIndex = mapped;
+    }
+  }
+
+  // Serialize.
+  const strings: Uint8Array[] = [];
+  let strtabSize = 4;
+  const stringOffsets = new Map<string, number>();
+  const internString = (name: string): number => {
+    const existing = stringOffsets.get(name);
+    if (existing !== undefined) return existing;
+    const bytes = textEncoder.encode(`${name}\0`);
+    strings.push(bytes);
+    const offset = strtabSize;
+    stringOffsets.set(name, offset);
+    strtabSize += bytes.length;
+    return offset;
+  };
+
+  const headerSize = 20 + outSections.length * 40;
+  let dataOffset = headerSize;
+  const dataOffsets: number[] = [];
+  for (const { section } of outSections) {
+    if (section.data === null) {
+      dataOffsets.push(0);
+      continue;
+    }
+    dataOffset = Math.ceil(dataOffset / 4) * 4;
+    dataOffsets.push(dataOffset);
+    dataOffset += section.rawSize;
+  }
+  const relocOffsets: number[] = [];
+  for (const { section } of outSections) {
+    if (section.relocs.length === 0) {
+      relocOffsets.push(0);
+      continue;
+    }
+    dataOffset = Math.ceil(dataOffset / 2) * 2;
+    relocOffsets.push(dataOffset);
+    dataOffset += (section.relocs.length + (section.relocs.length > 0xfffe ? 1 : 0)) * 10;
+  }
+  const symtabOffset = Math.ceil(dataOffset / 4) * 4;
+
+  const totalSymbols = rawOut;
+  const preStrtab = symtabOffset + totalSymbols * 18;
+  const buffers: { at: number; bytes: Uint8Array }[] = [];
+
+  const header = new Uint8Array(headerSize);
+  const headerView = new DataView(header.buffer);
+  headerView.setUint16(0, IMAGE_FILE_MACHINE_AMD64, true);
+  headerView.setUint16(2, outSections.length, true);
+  headerView.setUint32(4, 0, true); // deterministic timestamp
+  headerView.setUint32(8, symtabOffset, true);
+  headerView.setUint32(12, totalSymbols, true);
+  outSections.forEach(({ section }, i) => {
+    const at = 20 + i * 40;
+    const nameBytes = textEncoder.encode(section.name);
+    if (nameBytes.length <= 8) {
+      header.set(nameBytes, at);
+    } else {
+      header.set(textEncoder.encode(`/${internString(section.name)}`), at);
+    }
+    headerView.setUint32(at + 8, section.virtualSize, true);
+    headerView.setUint32(at + 12, section.virtualAddress, true);
+    headerView.setUint32(at + 16, section.rawSize, true);
+    headerView.setUint32(at + 20, dataOffsets[i]!, true);
+    headerView.setUint32(at + 24, relocOffsets[i]!, true);
+    headerView.setUint32(at + 28, 0, true); // line numbers (deprecated)
+    const overflow = section.relocs.length > 0xfffe;
+    headerView.setUint16(at + 32, overflow ? 0xffff : section.relocs.length, true);
+    headerView.setUint16(at + 34, 0, true);
+    const characteristics = section.characteristics & ~IMAGE_SCN_LNK_COMDAT;
+    headerView.setUint32(
+      at + 36,
+      overflow
+        ? characteristics | IMAGE_SCN_LNK_NRELOC_OVFL
+        : characteristics & ~IMAGE_SCN_LNK_NRELOC_OVFL,
+      true,
+    );
+  });
+  buffers.push({ at: 0, bytes: header });
+
+  outSections.forEach(({ section }, i) => {
+    if (section.data !== null) buffers.push({ at: dataOffsets[i]!, bytes: section.data });
+    if (section.relocs.length === 0) return;
+    const overflow = section.relocs.length > 0xfffe;
+    const relocBytes = new Uint8Array((section.relocs.length + (overflow ? 1 : 0)) * 10);
+    const relocView = new DataView(relocBytes.buffer);
+    let at = 0;
+    if (overflow) {
+      relocView.setUint32(0, section.relocs.length + 1, true);
+      at = 10;
+    }
+    for (const reloc of section.relocs) {
+      relocView.setUint32(at, reloc.virtualAddress, true);
+      relocView.setUint32(at + 4, reloc.symbolIndex, true);
+      relocView.setUint16(at + 8, reloc.type, true);
+      at += 10;
+    }
+    buffers.push({ at: relocOffsets[i]!, bytes: relocBytes });
+  });
+
+  const symtabBytes = new Uint8Array(totalSymbols * 18);
+  const symtabView = new DataView(symtabBytes.buffer);
+  {
+    let raw = 0;
+    for (const out of outSymbols) {
+      const at = raw * 18;
+      const nameBytes = textEncoder.encode(out.sym.name);
+      if (nameBytes.length <= 8) {
+        symtabBytes.set(nameBytes, at);
+      } else {
+        symtabView.setUint32(at, 0, true);
+        symtabView.setUint32(at + 4, internString(out.sym.name), true);
+      }
+      symtabView.setUint32(at + 8, out.value, true);
+      symtabView.setInt16(at + 12, out.sectionNumber, true);
+      symtabView.setUint16(at + 14, out.sym.type, true);
+      symtabView.setUint8(at + 16, out.storageClass);
+      symtabView.setUint8(at + 17, out.sym.aux.length / 18);
+      // Aux records: remap the fields that carry indices. Section
+      // definitions (on section symbols) carry an associated section
+      // number; weak externals carry a default-symbol index. Others copy
+      // raw (.file's aux is the filename bytes).
+      const aux = new Uint8Array(out.sym.aux); // private copy
+      if (
+        (out.storageClass === IMAGE_SYM_CLASS_STATIC ||
+          out.storageClass === IMAGE_SYM_CLASS_SECTION) &&
+        aux.length === 18 &&
+        out.sym.value === 0 &&
+        out.sym.sectionNumber > 0
+      ) {
+        const auxView = new DataView(aux.buffer);
+        const assoc = auxView.getUint16(12, true);
+        const sectionMap = sectionMaps.get(out.object)!;
+        auxView.setUint16(12, assoc > 0 ? sectionMap[assoc] ?? 0 : 0, true);
+        auxView.setUint8(14, 0); // COMDAT selection cleared with the flag
+      } else if (out.storageClass === IMAGE_SYM_CLASS_WEAK_EXTERNAL && aux.length >= 18) {
+        const auxView = new DataView(aux.buffer);
+        const tag = auxView.getUint32(0, true);
+        const mapped = symbolMaps.get(out.object)!.get(tag);
+        if (mapped === undefined) fail(`${out.object.label}: weak external tag is not a primary symbol`);
+        auxView.setUint32(0, mapped, true);
+      }
+      symtabBytes.set(aux, at + 18);
+      raw += 1 + aux.length / 18;
+    }
+  }
+  buffers.push({ at: symtabOffset, bytes: symtabBytes });
+
+  const strtabBytes = new Uint8Array(strtabSize);
+  new DataView(strtabBytes.buffer).setUint32(0, strtabSize, true);
+  {
+    let at = 4;
+    for (const chunk of strings) {
+      strtabBytes.set(chunk, at);
+      at += chunk.length;
+    }
+  }
+  buffers.push({ at: preStrtab, bytes: strtabBytes });
+
+  const out = new Uint8Array(preStrtab + strtabSize);
+  for (const { at, bytes } of buffers) out.set(bytes, at);
+  return out;
+}

--- a/packages/compiler/src/backend/object-localize.ts
+++ b/packages/compiler/src/backend/object-localize.ts
@@ -563,14 +563,30 @@ export function mergeAndLocalizeCoffObjects(
     }
   });
   const included: boolean[] = objects.map((_, i) => i === 0);
+  // Archive extraction consults the linker's CURRENT symbol state: an
+  // undefined in a newly pulled member is already satisfied when the
+  // program object (or an earlier member) defines it. Record every
+  // selected definition as soon as its member joins, before that member's
+  // own undefineds are considered. Without this set, a support member can
+  // spuriously pull an alternate definition that a real archive link would
+  // leave untouched, and the merge later reports a false duplicate.
+  const selectedDefinitions = new Set<string>();
+  const addDefinitions = (object: CoffObject): void => {
+    for (const sym of object.symbols) {
+      if (coffDefines(sym)) selectedDefinitions.add(sym.name);
+    }
+  };
+  addDefinitions(objects[0]!);
   const queue = [0];
   while (queue.length > 0) {
     const object = objects[queue.shift()!]!;
     for (const sym of object.symbols) {
       if (!coffIsUndefined(sym)) continue;
+      if (selectedDefinitions.has(sym.name)) continue;
       for (const candidate of definers.get(sym.name) ?? []) {
         if (included[candidate] !== true) {
           included[candidate] = true;
+          addDefinitions(objects[candidate]!);
           queue.push(candidate);
         }
         break;

--- a/packages/compiler/src/backend/object-localize.ts
+++ b/packages/compiler/src/backend/object-localize.ts
@@ -338,6 +338,12 @@ const IMAGE_SYM_CLASS_EXTERNAL = 2;
 const IMAGE_SYM_CLASS_STATIC = 3;
 const IMAGE_SYM_CLASS_SECTION = 104;
 const IMAGE_SYM_CLASS_WEAK_EXTERNAL = 105;
+const IMAGE_COMDAT_SELECT_NODUPLICATES = 1;
+const IMAGE_COMDAT_SELECT_ANY = 2;
+const IMAGE_COMDAT_SELECT_SAME_SIZE = 3;
+const IMAGE_COMDAT_SELECT_EXACT_MATCH = 4;
+const IMAGE_COMDAT_SELECT_ASSOCIATIVE = 5;
+const IMAGE_COMDAT_SELECT_LARGEST = 6;
 
 interface CoffReloc {
   virtualAddress: number;
@@ -527,6 +533,16 @@ function coffIsUndefined(sym: CoffSymbol): boolean {
   );
 }
 
+function coffSectionContentsEqual(a: CoffSection, b: CoffSection): boolean {
+  if (a.rawSize !== b.rawSize) return false;
+  if (a.data === null || b.data === null) return a.data === b.data;
+  if (a.data.length !== b.data.length) return false;
+  for (let i = 0; i < a.data.length; i++) {
+    if (a.data[i] !== b.data[i]) return false;
+  }
+  return true;
+}
+
 /** Combine a program object with the support objects it (transitively)
  * needs into ONE COFF object, then demote every defined external outside
  * `keep` to a static symbol. Support objects join on undefined-symbol
@@ -596,13 +612,12 @@ export function mergeAndLocalizeCoffObjects(
   const selected = objects.filter((_, i) => included[i] === true);
 
   // COMDAT resolution, the ELF arm's --force-group-allocation analog:
-  // deduplicate by COMDAT-symbol name inside THIS merge (mingw emits one
-  // .refptr.<name> pointer stub per referencing TU, selection ANY), then
-  // clear the COMDAT flag on the survivors at emission — a section whose
-  // deduplication name repeats across archives sharing runtime objects
-  // must not be deduplicated against another archive's copy at the
-  // embedder's link, where its relocations bind that archive's private
-  // (demoted) definitions.
+  // resolve duplicate names inside THIS merge according to their selection
+  // contract (mingw's .refptr.<name> stubs use ANY), then clear the COMDAT
+  // flag on the survivors at emission. A section whose deduplication name
+  // repeats across archives sharing runtime objects must not be deduplicated
+  // against another archive's copy at the embedder's link, where its
+  // relocations bind that archive's private (demoted) definitions.
   const sectionDropped = new Map<CoffObject, boolean[]>();
   const comdatKept = new Map<string, { object: CoffObject; index: number }>();
   for (const object of selected) {
@@ -617,39 +632,100 @@ export function mergeAndLocalizeCoffObjects(
       // carries its DWARF untouched but a stripped one loses it.
       if (section.name === ".llvm_addrsig" || section.name.startsWith(".debug$")) {
         dropped[i] = true;
-        return;
       }
-      if ((section.characteristics & IMAGE_SCN_LNK_COMDAT) === 0) return;
-      if (section.comdatSelection === 5) return; // associative: fate follows below
+    });
+  }
+  for (const object of selected) {
+    const dropped = sectionDropped.get(object)!;
+    object.sections.forEach((section, i) => {
+      if (dropped[i] === true || (section.characteristics & IMAGE_SCN_LNK_COMDAT) === 0) return;
+      if (section.comdatSelection === IMAGE_COMDAT_SELECT_ASSOCIATIVE) return;
+      if (
+        section.comdatSelection !== IMAGE_COMDAT_SELECT_NODUPLICATES &&
+        section.comdatSelection !== IMAGE_COMDAT_SELECT_ANY &&
+        section.comdatSelection !== IMAGE_COMDAT_SELECT_SAME_SIZE &&
+        section.comdatSelection !== IMAGE_COMDAT_SELECT_EXACT_MATCH &&
+        section.comdatSelection !== IMAGE_COMDAT_SELECT_LARGEST
+      ) {
+        fail(`${object.label}: COMDAT section ${section.name} has unsupported selection ${section.comdatSelection}`);
+      }
       const leader = section.comdatLeader >= 0 ? object.symbols[section.comdatLeader] : undefined;
-      if (leader === undefined || leader.storageClass !== IMAGE_SYM_CLASS_EXTERNAL) return;
+      if (leader === undefined || leader.storageClass !== IMAGE_SYM_CLASS_EXTERNAL) {
+        fail(`${object.label}: COMDAT section ${section.name} has no external leader symbol`);
+      }
       const existing = comdatKept.get(leader.name);
       if (existing === undefined) {
         comdatKept.set(leader.name, { object, index: i });
         return;
       }
-      if (section.comdatSelection === 1) {
+      const existingSection = existing.object.sections[existing.index]!;
+      if (section.comdatSelection !== existingSection.comdatSelection) {
+        fail(
+          `conflicting COMDAT selections for ${leader.name} ` +
+            `(${existing.object.label}: ${existingSection.comdatSelection}, ${object.label}: ${section.comdatSelection})`,
+        );
+      }
+      if (section.comdatSelection === IMAGE_COMDAT_SELECT_NODUPLICATES) {
         fail(`duplicate IMAGE_COMDAT_SELECT_NODUPLICATES section ${section.name} (${existing.object.label} and ${object.label})`);
       }
-      dropped[i] = true;
+      if (
+        section.comdatSelection === IMAGE_COMDAT_SELECT_SAME_SIZE &&
+        section.rawSize !== existingSection.rawSize
+      ) {
+        fail(
+          `IMAGE_COMDAT_SELECT_SAME_SIZE mismatch for ${leader.name} ` +
+            `(${existing.object.label}: ${existingSection.rawSize} bytes, ${object.label}: ${section.rawSize} bytes)`,
+        );
+      }
+      if (
+        section.comdatSelection === IMAGE_COMDAT_SELECT_EXACT_MATCH &&
+        !coffSectionContentsEqual(existingSection, section)
+      ) {
+        fail(
+          `IMAGE_COMDAT_SELECT_EXACT_MATCH mismatch for ${leader.name} ` +
+            `(${existing.object.label} and ${object.label})`,
+        );
+      }
+      if (
+        section.comdatSelection === IMAGE_COMDAT_SELECT_LARGEST &&
+        section.rawSize > existingSection.rawSize
+      ) {
+        sectionDropped.get(existing.object)![existing.index] = true;
+        comdatKept.set(leader.name, { object, index: i });
+      } else {
+        dropped[i] = true;
+      }
     });
-    // Associative sections follow their target's fate (chase chains, with a
-    // bound so a malformed cycle cannot loop).
-    for (let pass = 0; pass < object.sections.length; pass++) {
-      let changed = false;
-      object.sections.forEach((section, i) => {
-        if (dropped[i] === true || section.comdatSelection !== 5) return;
-        const target = section.comdatAssoc - 1;
+  }
+  // Associative sections follow their target's final fate. Resolve these
+  // only after every non-associative winner is known: LARGEST can replace a
+  // section seen in an earlier object, whose associates must then leave too.
+  for (const object of selected) {
+    const dropped = sectionDropped.get(object)!;
+    object.sections.forEach((section, i) => {
+      if (dropped[i] === true || section.comdatSelection !== IMAGE_COMDAT_SELECT_ASSOCIATIVE) return;
+      const seen = new Set<number>([i]);
+      let target = section.comdatAssoc - 1;
+      while (true) {
         if (target < 0 || target >= object.sections.length) {
           fail(`${object.label}: associative COMDAT ${section.name} names an invalid section`);
         }
+        if (seen.has(target)) {
+          fail(`${object.label}: associative COMDAT ${section.name} contains an association cycle`);
+        }
+        seen.add(target);
+        const targetSection = object.sections[target]!;
+        if ((targetSection.characteristics & IMAGE_SCN_LNK_COMDAT) === 0) {
+          fail(`${object.label}: associative COMDAT ${section.name} targets a non-COMDAT section`);
+        }
         if (dropped[target] === true) {
           dropped[i] = true;
-          changed = true;
+          break;
         }
-      });
-      if (!changed) break;
-    }
+        if (targetSection.comdatSelection !== IMAGE_COMDAT_SELECT_ASSOCIATIVE) break;
+        target = targetSection.comdatAssoc - 1;
+      }
+    });
   }
 
   // Global resolution: one canonical entry per external name. Definitions

--- a/packages/compiler/src/backend/object-localize.ts
+++ b/packages/compiler/src/backend/object-localize.ts
@@ -29,10 +29,11 @@
  *                          symbol.
  *
  * Shared demotion rule (GNU objcopy --keep-global-symbols semantics):
- * undefined references keep their global binding (libc/libm and sanitizer
- * ABI are the embedder's by design), and COMMON symbols stay global —
- * sanitizer image-registration guards are COMMONs whose merging across
- * archives is the documented single-registration discipline. */
+ * undefined references keep their global binding (the target C/math runtime,
+ * system APIs, and sanitizer ABI are the embedder's by design), and COMMON
+ * symbols stay global — sanitizer image-registration guards are COMMONs whose
+ * merging across archives is the documented single-registration discipline.
+ * Windows embedders additionally link advapi32, iphlpapi, and ws2_32. */
 
 const textDecoder = new TextDecoder();
 const textEncoder = new TextEncoder();

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1455,21 +1455,30 @@ export async function compileLibrary(opts: CompileLibraryOptions): Promise<Compi
   const entryPath = profile.entry;
   const buildPlatform = buildTargetPlatform();
 
-  // Multi-instance library mode (abi.localize_runtime) is native on the
-  // two hosts whose localization toolchains are implemented. Cross-target
-  // builds and unsupported native hosts refuse before frontend/backend work
-  // rather than reaching the ld/objcopy step and throwing an unstructured
-  // toolchain error. WASI retains the general library-mode refusal below.
+  // Multi-instance library mode (abi.localize_runtime) localizes per
+  // OBJECT FORMAT: ELF and COFF archives localize from any host (cross
+  // ELF merges through the cross driver's own lld; COFF merges and
+  // demotes in process — see cc.ts's localizeLibraryObjects), and Mach-O
+  // localization runs the macOS host linker, so macos targets admit
+  // darwin hosts only. Everything else refuses before frontend/backend
+  // work, naming the pairing. WASI retains the general library-mode
+  // refusal below.
   if (profile.localizeRuntime && buildPlatform !== "wasi") {
     const driver = resolveCc();
     const platform = targetPlatform(driver);
-    if (driver.target !== null || (platform !== "darwin" && platform !== "linux")) {
+    const supported =
+      platform === "linux" ||
+      platform === "win32" ||
+      (platform === "darwin" && process.platform === "darwin");
+    if (!supported) {
       return {
         ok: false,
         diagnostics: decorateLibraryRefusals([
           targetRefusalDiag(
             driver.target ?? platform,
-            "runtime-localized (multi-instance) library archives",
+            platform === "darwin"
+              ? `runtime-localized (multi-instance) library archives on ${process.platform} hosts (Mach-O localization runs the macOS host linker)`
+              : "runtime-localized (multi-instance) library archives",
             { file: entryPath, start: 0, end: 0 },
           ),
         ], profile),

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1466,19 +1466,33 @@ export async function compileLibrary(opts: CompileLibraryOptions): Promise<Compi
   if (profile.localizeRuntime && buildPlatform !== "wasi") {
     const driver = resolveCc();
     const platform = targetPlatform(driver);
+    const targetArch = driver.target?.split("-", 1)[0] ?? null;
+    // Native Linux retains its host-binutils implementation. Cross ELF is
+    // rebuilt in process and currently accepts the two verified ELF64,
+    // little-endian architectures; COFF is rebuilt in process and accepts
+    // AMD64 only. Keep this preflight in lockstep with object-localize.ts so
+    // unsupported object classes refuse before frontend/backend work.
     const supported =
-      platform === "linux" ||
-      platform === "win32" ||
+      (platform === "linux" &&
+        (driver.target === null || targetArch === "x86_64" || targetArch === "aarch64")) ||
+      (platform === "win32" &&
+        (driver.target === null ? process.arch === "x64" : targetArch === "x86_64")) ||
       (platform === "darwin" && process.platform === "darwin");
     if (!supported) {
+      const subject =
+        platform === "win32"
+          ? "runtime-localized (multi-instance) library archives (COFF localization currently requires x86_64)"
+          : platform === "linux" && driver.target !== null
+            ? "runtime-localized (multi-instance) library archives (cross-ELF localization currently requires x86_64 or aarch64)"
+            : platform === "darwin"
+              ? `runtime-localized (multi-instance) library archives on ${process.platform} hosts (Mach-O localization runs the macOS host linker)`
+              : "runtime-localized (multi-instance) library archives";
       return {
         ok: false,
         diagnostics: decorateLibraryRefusals([
           targetRefusalDiag(
             driver.target ?? platform,
-            platform === "darwin"
-              ? `runtime-localized (multi-instance) library archives on ${process.platform} hosts (Mach-O localization runs the macOS host linker)`
-              : "runtime-localized (multi-instance) library archives",
+            subject,
             { file: entryPath, start: 0, end: 0 },
           ),
         ], profile),

--- a/packages/compiler/src/library/profile.ts
+++ b/packages/compiler/src/library/profile.ts
@@ -90,12 +90,15 @@
  * runtime internals — allocator, cycle collector, result arena, panic-sink
  * registration, every other piece of runtime state — are demoted to LOCAL
  * symbols behind the profile's prefix, so an ordinary archive's only
- * external definitions are the profile-declared symbols and its only
- * external references are libc/libm. Sanitized artifacts additionally carry
- * their sanitizer ABI; Darwin ASan's image-registration COMMON deliberately
- * remains shared so the final Mach-O image registers its globals exactly
- * once. N such archives, built under pairwise-distinct prefixes, then link
- * into ONE process with no scriptc-runtime symbol collisions or shared
+ * external definitions are the profile-declared symbols. External references
+ * are the target's C/math runtime and system APIs: Windows embedders
+ * additionally link advapi32, iphlpapi, and ws2_32, while the platform driver
+ * supplies its ordinary CRT and kernel imports. Sanitized artifacts also
+ * carry their sanitizer ABI; Darwin ASan's image-registration COMMON
+ * deliberately remains shared so the final Mach-O image registers its
+ * globals exactly once. N such archives, built under pairwise-distinct
+ * prefixes, then link into ONE process with no scriptc-runtime symbol
+ * collisions or shared
  * mutable state: each instance owns a private copy of the whole runtime,
  * panic sinks register per instance, and a trap poisons only the instance it
  * fired in. The embedder contract that makes this sound:

--- a/packages/compiler/src/library/profile.ts
+++ b/packages/compiler/src/library/profile.ts
@@ -109,8 +109,10 @@
  *     only through the embedder's own byte/record marshalling.
  *
  * Off by default: an absent or false `localize_runtime` produces the
- * classic artifact, byte-for-byte. Localization is host-native (darwin and
- * linux); cross-target archive builds refuse it with SC3002.
+ * classic artifact, byte-for-byte. Localization follows the archive's
+ * object format: ELF and COFF archives localize on any supported host
+ * (native or cross); Mach-O localization runs the macOS host linker, so
+ * macos targets build on darwin hosts and refuse elsewhere with SC3002.
  *
  * Thread-instanced state (`abi.instance_per_thread: true`): every mutable
  * piece of the archive's state — the runtime units' internals AND the

--- a/tests/harness/library-multi.test.ts
+++ b/tests/harness/library-multi.test.ts
@@ -342,6 +342,41 @@ test("M4: a macos cross target refuses runtime localization off a darwin host wi
   }
 });
 
+test.each([
+  ["aarch64-windows-gnu", "COFF localization currently requires x86_64"],
+  ["x86-linux-gnu", "cross-ELF localization currently requires x86_64 or aarch64"],
+] as const)(
+  "M4: unsupported localization object class %s refuses before emission with SC3002",
+  async (target, reason) => {
+    const outDir = join(cacheDir, `object-class-refusal-${target}`);
+    mkdirSync(outDir, { recursive: true });
+    const profile = JSON.parse(readFileSync(join(fixtureDir, "profile_a.json"), "utf8")) as {
+      entry: string;
+    };
+    profile.entry = join(fixtureDir, profile.entry);
+    const profilePath = join(outDir, "profile.json");
+    writeFileSync(profilePath, JSON.stringify(profile, null, 2));
+    const prevCc = process.env["SCRIPTC_CC"];
+    const prevTarget = process.env["SCRIPTC_TARGET"];
+    process.env["SCRIPTC_CC"] = "zigcc";
+    process.env["SCRIPTC_TARGET"] = target;
+    try {
+      const result = await compileLibrary({ profilePath, outDir });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.diagnostics[0]!.code).toBe("SC3002");
+        expect(result.diagnostics[0]!.message).toContain(target);
+        expect(result.diagnostics[0]!.message).toContain(reason);
+      }
+    } finally {
+      if (prevCc === undefined) delete process.env["SCRIPTC_CC"];
+      else process.env["SCRIPTC_CC"] = prevCc;
+      if (prevTarget === undefined) delete process.env["SCRIPTC_TARGET"];
+      else process.env["SCRIPTC_TARGET"] = prevTarget;
+    }
+  },
+);
+
 test("M4: an unsupported native host refuses runtime localization with SC3002", async () => {
   const outDir = join(cacheDir, "native-refusal");
   mkdirSync(outDir, { recursive: true });

--- a/tests/harness/library-multi.test.ts
+++ b/tests/harness/library-multi.test.ts
@@ -10,8 +10,9 @@
  *   M1 symbols-exact     nm over a localized archive: the external defined
  *                        set equals the profile-declared set EXACTLY (plus
  *                        ASan's one image-registration common in a
- *                        sanitized build), and undefineds stay libc/libm-
- *                        shaped apart from sanitizer ABI references
+ *                        sanitized build), and undefineds stay target-
+ *                        runtime/system-API-shaped apart from sanitizer ABI
+ *                        references
  *   M2 two-instance run  the acceptance probe: two archives (ma_/mb_), two
  *                        embedder threads (one per instance — the
  *                        documented contract), independent init and
@@ -207,8 +208,8 @@ describe.each(EMISSIONS)("localized archive symbols, %s emission", (emission) =>
         : [];
       expect([...defined].sort()).toEqual([...declared, ...toolchainDefinitions].sort());
       // Undefineds: no runtime-internal or prefix-carrying reference
-      // escapes; libc/libm (and sanitizer ABI) references keep their global
-      // binding.
+      // escapes; target-runtime/system-API (and sanitizer ABI) references
+      // keep their global binding.
       expect([...undef].filter((s) => s.startsWith("scr_") || s.startsWith("ma_") || s.startsWith("mb_"))).toEqual([]);
       // The ambient audit holds through the combine step: no
       // process-disposition or threading surface, no atexit teardown.

--- a/tests/harness/library-multi.test.ts
+++ b/tests/harness/library-multi.test.ts
@@ -790,10 +790,8 @@ describe.skipIf(!crossOn)("cross-target localization", () => {
   describe.each(CROSS_TARGETS)("target %s", (target) => {
     describe.each(EMISSIONS)("%s emission", (emission) => {
       test("M10: localized archives cross-build; symbols exact, ambient audit holds, probe links", async () => {
-        const [archiveA, archiveB] = await Promise.all([
-          buildInstanceCross("a", emission, target),
-          buildInstanceCross("b", emission, target),
-        ]);
+        const archiveA = await buildInstanceCross("a", emission, target);
+        const archiveB = await buildInstanceCross("b", emission, target);
         for (const [archive, declared] of [
           [archiveA, A_SYMBOLS],
           [archiveB, B_SYMBOLS],
@@ -826,10 +824,8 @@ describe.skipIf(!crossOn)("cross-target localization", () => {
     ] as const)(
       "M11: the two-instance probe runs in the container (%s, %s emission)",
       async ([target, emission]) => {
-        const [archiveA, archiveB] = await Promise.all([
-          buildInstanceCross("a", emission, target),
-          buildInstanceCross("b", emission, target),
-        ]);
+        const archiveA = await buildInstanceCross("a", emission, target);
+        const archiveB = await buildInstanceCross("b", emission, target);
         const probe = buildCrossProbe(
           [archiveA, archiveB],
           join(fixtureDir, "probe.c"),
@@ -858,10 +854,8 @@ describe.skipIf(!crossOn)("cross-target localization", () => {
       async (emission) => {
         const host = process.env["SCRIPTC_WIN_HOST"] ?? "windows-dev";
         const dirWin = "C:\\Users\\rdp\\work\\scriptc-mloc-lane";
-        const [archiveA, archiveB] = await Promise.all([
-          buildInstanceCross("a", emission, "x86_64-windows-gnu"),
-          buildInstanceCross("b", emission, "x86_64-windows-gnu"),
-        ]);
+        const archiveA = await buildInstanceCross("a", emission, "x86_64-windows-gnu");
+        const archiveB = await buildInstanceCross("b", emission, "x86_64-windows-gnu");
         const probe = buildCrossProbe(
           [archiveA, archiveB],
           join(fixtureDir, "probe.c"),

--- a/tests/harness/library-multi.test.ts
+++ b/tests/harness/library-multi.test.ts
@@ -22,8 +22,12 @@
  *                        emission and once with mixed emissions (one
  *                        archive per backend).
  *   M3 profile shape     abi.localize_runtime is strictly boolean (SC4001)
- *   M4 target posture    localization is host-native: a cross-target build
- *                        refuses SC3002 before emission
+ *   M4 target posture    localization is per OBJECT FORMAT: ELF and COFF
+ *                        localize from any host, Mach-O runs the macOS
+ *                        host linker — so a macos target off a darwin
+ *                        host, and any host outside darwin/linux/win32,
+ *                        refuses SC3002 before emission with the pairing
+ *                        named
  *
  * Thread-instanced state (the profile's abi.instance_per_thread): every
  * mutable static in the archive — runtime internals, module globals,
@@ -53,6 +57,27 @@
  *                        instrumented pairing too)
  *   M9 profile shape     abi.instance_per_thread is strictly boolean
  *                        (SC4001)
+ *
+ * Cross-target localization (SCRIPTC_CROSS=1 — zig on PATH, the
+ * library-cross lane's gate; never part of the default suites):
+ *
+ *   M10 cross conformance  per cross target and emission: localized a/b
+ *                        archives build, the external defined set equals
+ *                        the declared set exactly (host nm reads ELF,
+ *                        COFF, and Mach-O alike), no prefix-carrying
+ *                        undefined escapes, the ambient audit holds, and
+ *                        the two-archive probe LINKS with the target's
+ *                        libc (plus the documented win32 embedder libs)
+ *   M11 cross execution  the M2 acceptance probe runs on the real target:
+ *                        linux triples in the differential containers
+ *                        (SCRIPTC_LINUX=1), the windows triple on the ssh
+ *                        box (SCRIPTC_WIN=1) — including the M7-style
+ *                        thread-instanced+localized composition there
+ *
+ * Windows hosts run M1/M2/M6/M7 natively through the same gates as darwin
+ * and linux: probes compile with `zig cc` (the box's toolchain), archives
+ * carry CRLF-normalized probe output (the mingw CRT's text-mode stdout),
+ * and symbol checks ride llvm-nm when plain nm is absent.
  */
 import { execFileSync, spawnSync } from "node:child_process";
 import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
@@ -62,7 +87,29 @@ import { compileLibrary, loadLibraryProfile } from "@scriptc/compiler";
 
 const repoRoot = join(import.meta.dirname, "../..");
 const fixtureDir = join(repoRoot, "tests/library-mode/multi");
-const localizationTest = process.platform === "darwin" || process.platform === "linux" ? test : test.skip;
+const localizationTest =
+  process.platform === "darwin" || process.platform === "linux" || process.platform === "win32"
+    ? test
+    : test.skip;
+/* win32 boxes commonly carry llvm-nm (LLVM) rather than a bare nm; darwin's
+ * nm IS llvm-nm and linux binutils nm reads its own objects. */
+const nmTool = ((): string | null => {
+  for (const tool of process.platform === "win32" ? ["llvm-nm", "nm"] : ["nm"]) {
+    if (spawnSync(tool, ["--version"], { encoding: "utf8" }).status === 0) return tool;
+  }
+  return null;
+})();
+/* Probes are plain-C embedder hosts: clang on darwin/linux, `zig cc` on
+ * win32 (the windows box's C toolchain — winpthreads rides -pthread). */
+const probeCc = process.platform === "win32" ? ["zig", "cc"] : ["clang"];
+/* The documented win32 embedder link line beyond the CRT (library-cross
+ * pins the same set): advapi32 (CSPRNG, GetUserNameA), iphlpapi
+ * (GetAdaptersAddresses), ws2_32 (inet_ntop/htonl). */
+const WIN32_EMBEDDER_LIBS = ["-ladvapi32", "-liphlpapi", "-lws2_32"];
+/* The mingw CRT's text-mode stdout writes CRLF from the PROBE's own printf
+ * — a plain-C embedder host fact, folded back for comparison. */
+const normalizeProbeOut = (out: string): string =>
+  process.platform === "win32" ? out.replaceAll("\r\n", "\n") : out;
 /* Suite-flavor segment (the library suites' convention): the plain and
  * SCRIPTC_SAN=1 suites may run concurrently and must never share build
  * dirs. */
@@ -117,8 +164,8 @@ function nmSymbols(archive: string): { defined: Set<string>; undef: Set<string> 
     }
     return set;
   };
-  const defined = parse(execFileSync("nm", ["-gU", archive], { encoding: "utf8" }));
-  const undef = parse(execFileSync("nm", ["-u", archive], { encoding: "utf8" }));
+  const defined = parse(execFileSync(nmTool!, ["-gU", archive], { encoding: "utf8" }));
+  const undef = parse(execFileSync(nmTool!, ["-u", archive], { encoding: "utf8" }));
   return { defined, undef };
 }
 
@@ -137,7 +184,8 @@ b sink: calls=0
 /* ── M1: the localized archive's exact link surface ─────────────────────── */
 
 describe.each(EMISSIONS)("localized archive symbols, %s emission", (emission) => {
-  localizationTest("M1: external definitions equal the declared set exactly", async () => {
+  localizationTest("M1: external definitions equal the declared set exactly", async (ctx) => {
+    if (nmTool === null) ctx.skip("no nm/llvm-nm on PATH for the symbol-exactness check");
     const [archiveA, archiveB] = await Promise.all([
       buildInstance("a", emission),
       buildInstance("b", emission),
@@ -174,9 +222,10 @@ describe.each(EMISSIONS)("localized archive symbols, %s emission", (emission) =>
 /* ── M2: the two-instance, two-thread acceptance probe ──────────────────── */
 
 function buildProbe(archiveA: string, archiveB: string, outDir: string, tag: string): string {
-  const bin = join(outDir, `probe-${tag}`);
+  const bin = join(outDir, `probe-${tag}${process.platform === "win32" ? ".exe" : ""}`);
   mkdirSync(outDir, { recursive: true });
-  execFileSync("clang", [
+  execFileSync(probeCc[0]!, [
+    ...probeCc.slice(1),
     "-std=c11",
     "-pthread",
     ...(sanitize ? ["-fsanitize=address"] : []),
@@ -184,6 +233,7 @@ function buildProbe(archiveA: string, archiveB: string, outDir: string, tag: str
     archiveA,
     archiveB,
     "-lm",
+    ...(process.platform === "win32" ? WIN32_EMBEDDER_LIBS : []),
     "-o", bin,
   ]);
   return bin;
@@ -204,7 +254,7 @@ describe.each(PAIRINGS)("two instances, one process ($tag)", ({ tag, a, b }) => 
     const run = spawnSync(probe, { encoding: "utf8", timeout: 60_000 });
     expect(run.signal).toBeNull();
     expect(run.status).toBe(0);
-    expect(run.stdout).toBe(PROBE_EXPECTED);
+    expect(normalizeProbeOut(run.stdout)).toBe(PROBE_EXPECTED);
   });
 });
 
@@ -255,7 +305,7 @@ test("M3: abi.localize_runtime is strictly boolean", () => {
 
 /* ── M4: host-native posture ─────────────────────────────────────────────── */
 
-test("M4: a cross-target build refuses runtime localization with SC3002", async () => {
+test("M4: a macos cross target refuses runtime localization off a darwin host with SC3002", async () => {
   const outDir = join(cacheDir, "cross-refusal");
   mkdirSync(outDir, { recursive: true });
   const profile = JSON.parse(readFileSync(join(fixtureDir, "profile_a.json"), "utf8")) as {
@@ -266,19 +316,25 @@ test("M4: a cross-target build refuses runtime localization with SC3002", async 
   writeFileSync(profilePath, JSON.stringify(profile, null, 2));
   // compileLibrary reads SCRIPTC_CC/SCRIPTC_TARGET at call time; the
   // refusal fires before any toolchain runs, so zig need not exist here.
+  // Mach-O localization runs the macOS host linker, so a macos target is
+  // exactly the pairing a non-darwin host still refuses.
+  const platformDescriptor = Object.getOwnPropertyDescriptor(process, "platform")!;
   const prevCc = process.env["SCRIPTC_CC"];
   const prevTarget = process.env["SCRIPTC_TARGET"];
   process.env["SCRIPTC_CC"] = "zigcc";
-  process.env["SCRIPTC_TARGET"] = "x86_64-linux-musl";
+  process.env["SCRIPTC_TARGET"] = "x86_64-macos";
+  Object.defineProperty(process, "platform", { ...platformDescriptor, value: "linux" });
   try {
     const result = await compileLibrary({ profilePath, outDir });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.diagnostics[0]!.code).toBe("SC3002");
-      expect(result.diagnostics[0]!.message).toContain("x86_64-linux-musl");
+      expect(result.diagnostics[0]!.message).toContain("x86_64-macos");
       expect(result.diagnostics[0]!.message).toContain("runtime-localized");
+      expect(result.diagnostics[0]!.message).toContain("linux hosts");
     }
   } finally {
+    Object.defineProperty(process, "platform", platformDescriptor);
     if (prevCc === undefined) delete process.env["SCRIPTC_CC"];
     else process.env["SCRIPTC_CC"] = prevCc;
     if (prevTarget === undefined) delete process.env["SCRIPTC_TARGET"];
@@ -300,13 +356,13 @@ test("M4: an unsupported native host refuses runtime localization with SC3002", 
   const prevTarget = process.env["SCRIPTC_TARGET"];
   delete process.env["SCRIPTC_CC"];
   delete process.env["SCRIPTC_TARGET"];
-  Object.defineProperty(process, "platform", { ...platformDescriptor, value: "win32" });
+  Object.defineProperty(process, "platform", { ...platformDescriptor, value: "freebsd" });
   try {
     const result = await compileLibrary({ profilePath, outDir });
     expect(result.ok).toBe(false);
     if (!result.ok) {
       expect(result.diagnostics[0]!.code).toBe("SC3002");
-      expect(result.diagnostics[0]!.message).toContain("win32");
+      expect(result.diagnostics[0]!.message).toContain("freebsd");
       expect(result.diagnostics[0]!.message).toContain("runtime-localized");
     }
   } finally {
@@ -432,15 +488,17 @@ function buildThreadProbe(
   opts: { sanitize?: boolean } = {},
 ): string {
   const outDir = join(cacheDir, "probes");
-  const bin = join(outDir, `probe-${tag}`);
+  const bin = join(outDir, `probe-${tag}${process.platform === "win32" ? ".exe" : ""}`);
   mkdirSync(outDir, { recursive: true });
-  execFileSync("clang", [
+  execFileSync(probeCc[0]!, [
+    ...probeCc.slice(1),
     "-std=c11",
     "-pthread",
     ...((opts.sanitize ?? sanitize) ? ["-fsanitize=address"] : []),
     source,
     ...archives,
     "-lm",
+    ...(process.platform === "win32" ? WIN32_EMBEDDER_LIBS : []),
     "-o", bin,
   ]);
   return bin;
@@ -461,11 +519,17 @@ describe.each(EMISSIONS)("thread-instanced archive, %s emission", (emission) => 
     const run = spawnSync(probe, { encoding: "utf8", timeout: 60_000 });
     expect(run.signal).toBeNull();
     expect(run.status).toBe(0);
-    expect(run.stdout).toBe(THREADED_EXPECTED);
+    expect(normalizeProbeOut(run.stdout)).toBe(THREADED_EXPECTED);
   });
 });
 
-localizationTest("M6: util.inspect circular-reference state is thread-local", () => {
+/* The inspect-TLS probe's dead-strip technique (function/data sections +
+ * gc-sections over deliberately-unresolved runtime references) is an
+ * ELF/Mach-O link idiom; win32 hosts cover the seam through M6's archive
+ * probes. */
+const inspectTlsTest =
+  process.platform === "darwin" || process.platform === "linux" ? test : test.skip;
+inspectTlsTest("M6: util.inspect circular-reference state is thread-local", () => {
   const outDir = join(cacheDir, "inspect-tls-probe");
   const bin = join(outDir, "probe");
   mkdirSync(outDir, { recursive: true });
@@ -494,7 +558,8 @@ localizationTest("M6: util.inspect circular-reference state is thread-local", ()
   expect(run.stdout).toBe("1 1 1\n");
 });
 
-localizationTest("M7: thread-instanced and runtime-localized archives compose in one process", async () => {
+localizationTest("M7: thread-instanced and runtime-localized archives compose in one process", async (ctx) => {
+  if (nmTool === null) ctx.skip("no nm/llvm-nm on PATH for the symbol-exactness check");
   const [archiveT, archiveB] = await Promise.all([
     buildThreaded("llvm", { localize: true }),
     buildInstance("b", "c"),
@@ -519,7 +584,7 @@ localizationTest("M7: thread-instanced and runtime-localized archives compose in
   const run = spawnSync(probe, { encoding: "utf8", timeout: 60_000 });
   expect(run.signal).toBeNull();
   expect(run.status).toBe(0);
-  expect(run.stdout).toBe(`multi-b ready
+  expect(normalizeProbeOut(run.stdout)).toBe(`multi-b ready
 t0: bump x100 -> 101, calls_seen 100, sums_ok=1, trap fell through 0
 t0 sink: calls=1 ctx_ok=1 code=[SC4014] symbol=[mt_boom]
 t1: bump x200 -> 201, calls_seen 200, sums_ok=1, post_ok=1
@@ -528,7 +593,10 @@ other sinks: t1=0 b=0
 `);
 });
 
-localizationTest("M8: M6 under ASan", async () => {
+/* ASan has no x86_64-windows-gnu runtime; the sanitized pairing stays a
+ * darwin/linux contract. */
+const asanTest = process.platform === "darwin" || process.platform === "linux" ? test : test.skip;
+asanTest("M8: M6 under ASan", async () => {
   const archive = await buildThreaded("llvm", { sanitize: true });
   const probe = buildThreadProbe(join(threadFixtureDir, "probe.c"), [archive], "t-asan", { sanitize: true });
   // An instance's lifetime is its thread's, with no teardown at thread
@@ -585,4 +653,272 @@ test("M9: abi.instance_per_thread is strictly boolean", () => {
     expect(loaded.ok).toBe(true);
     if (loaded.ok) expect(loaded.profile.instancePerThread).toBe(expected);
   }
+});
+
+/* ── M10/M11: cross-target localization (SCRIPTC_CROSS=1) ─────────────────
+ * Gated exactly like library-cross.test.ts: zig on PATH is the lane's hard
+ * requirement, execution legs additionally gate on the docker daemon
+ * (SCRIPTC_LINUX=1) and the ssh box (SCRIPTC_WIN=1). Never part of the
+ * default suites. */
+
+const crossOn = process.env["SCRIPTC_CROSS"] === "1";
+
+/* The embedder-relevant cross list (library-cross's, minus the macos
+ * triple off darwin hosts — Mach-O localization runs the macOS host
+ * linker, and M4 pins that refusal). */
+const CROSS_TARGETS = [
+  "aarch64-linux-gnu.2.36",
+  "x86_64-linux-gnu.2.36",
+  "x86_64-linux-musl",
+  "x86_64-windows-gnu",
+  ...(process.platform === "darwin" ? (["x86_64-macos"] as const) : []),
+] as const;
+type CrossTarget = (typeof CROSS_TARGETS)[number];
+
+/** buildInstance with SCRIPTC_CC/SCRIPTC_TARGET threaded through the env
+ * the cc driver reads (the library-cross pattern — tests in this file run
+ * sequentially and every build is awaited, so the flips never interleave).
+ * Cross builds are plain-flavor: the sanitized lanes stay host contracts. */
+function buildInstanceCross(
+  instance: "a" | "b",
+  emission: Emission,
+  target: CrossTarget,
+): Promise<string> {
+  const key = `x-${instance}-${emission}-${target}`;
+  let archive = built.get(key);
+  if (archive === undefined) {
+    archive = (async () => {
+      const outDir = join(cacheDir, key);
+      mkdirSync(outDir, { recursive: true });
+      const profile = JSON.parse(readFileSync(join(fixtureDir, `profile_${instance}.json`), "utf8")) as {
+        entry: string;
+        emission: string;
+      };
+      profile.emission = emission;
+      profile.entry = join(fixtureDir, profile.entry);
+      const profilePath = join(outDir, "profile.json");
+      writeFileSync(profilePath, JSON.stringify(profile, null, 2));
+      const prevCc = process.env["SCRIPTC_CC"];
+      const prevTarget = process.env["SCRIPTC_TARGET"];
+      process.env["SCRIPTC_CC"] = "zigcc";
+      process.env["SCRIPTC_TARGET"] = target;
+      try {
+        const result = await compileLibrary({ profilePath, outDir });
+        if (!result.ok) {
+          throw new Error(result.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n"));
+        }
+        expect(result.backend).toBe(emission);
+        return result.archivePath;
+      } finally {
+        if (prevCc === undefined) delete process.env["SCRIPTC_CC"];
+        else process.env["SCRIPTC_CC"] = prevCc;
+        if (prevTarget === undefined) delete process.env["SCRIPTC_TARGET"];
+        else process.env["SCRIPTC_TARGET"] = prevTarget;
+      }
+    })();
+    built.set(key, archive);
+  }
+  return archive;
+}
+
+/** Cross-link the two-archive probe with `zig cc` — the target's libc/libm
+ * plus the documented win32 embedder libs. Link success is itself an
+ * assertion: every undefined in the localized member resolved against
+ * exactly what an embedder links. */
+function buildCrossProbe(archives: string[], source: string, tag: string, target: CrossTarget): string {
+  const outDir = join(cacheDir, "probes");
+  mkdirSync(outDir, { recursive: true });
+  const bin = join(outDir, `probe-${tag}${target.includes("windows") ? ".exe" : ""}`);
+  execFileSync("zig", [
+    "cc",
+    "-std=c11",
+    "-target", target,
+    "-pthread",
+    source,
+    ...archives,
+    "-lm",
+    ...(target.includes("windows") ? WIN32_EMBEDDER_LIBS : []),
+    "-o", bin,
+  ]);
+  return bin;
+}
+
+describe.skipIf(!crossOn)("cross-target localization", () => {
+  test("zig is on PATH", () => {
+    try {
+      execFileSync("zig", ["version"], { encoding: "utf8" });
+    } catch {
+      throw new Error("SCRIPTC_CROSS=1 needs zig on PATH (zigup) — the lane cross-compiles with `zig cc`.");
+    }
+  });
+
+  describe.each(CROSS_TARGETS)("target %s", (target) => {
+    describe.each(EMISSIONS)("%s emission", (emission) => {
+      test("M10: localized archives cross-build; symbols exact, ambient audit holds, probe links", async () => {
+        const [archiveA, archiveB] = await Promise.all([
+          buildInstanceCross("a", emission, target),
+          buildInstanceCross("b", emission, target),
+        ]);
+        for (const [archive, declared] of [
+          [archiveA, A_SYMBOLS],
+          [archiveB, B_SYMBOLS],
+        ] as const) {
+          const { defined, undef } = nmSymbols(archive);
+          expect([...defined].sort()).toEqual([...declared].sort());
+          expect([...undef].filter((s) => s.startsWith("scr_") || s.startsWith("ma_") || s.startsWith("mb_"))).toEqual([]);
+          for (const banned of ["sigaction", "signal", "pthread_create", "atexit", "setvbuf"]) {
+            for (const spelling of [banned, `_imp_${banned}`]) {
+              expect(undef.has(spelling), `undefined reference to ${spelling}`).toBe(false);
+            }
+          }
+        }
+        buildCrossProbe([archiveA, archiveB], join(fixtureDir, "probe.c"), `x-${emission}-${target}`, target);
+      });
+    });
+  });
+
+  /* ── M11: execution where infrastructure exists ─────────────────────── */
+  describe("M11 execution probes", () => {
+    const linuxOn = process.env["SCRIPTC_LINUX"] === "1";
+    const winOn = process.env["SCRIPTC_WIN"] === "1";
+    const nodeVersion = (): string => readFileSync(join(repoRoot, ".node-version"), "utf8").trim();
+
+    test.skipIf(!linuxOn).for([
+      ["aarch64-linux-gnu.2.36", "llvm"],
+      ["x86_64-linux-gnu.2.36", "llvm"],
+      ["x86_64-linux-gnu.2.36", "c"],
+      ["x86_64-linux-musl", "llvm"],
+    ] as const)(
+      "M11: the two-instance probe runs in the container (%s, %s emission)",
+      async ([target, emission]) => {
+        const [archiveA, archiveB] = await Promise.all([
+          buildInstanceCross("a", emission, target),
+          buildInstanceCross("b", emission, target),
+        ]);
+        const probe = buildCrossProbe(
+          [archiveA, archiveB],
+          join(fixtureDir, "probe.c"),
+          `x-run-${emission}-${target}`,
+          target,
+        );
+        const distro = target.includes("linux-musl") ? "alpine" : "bookworm";
+        const out = execFileSync(
+          "docker",
+          [
+            "run", "--rm",
+            "--platform", target.startsWith("x86_64") ? "linux/amd64" : "linux/arm64",
+            "-v", `${repoRoot}:${repoRoot}`,
+            `node:${nodeVersion()}-${distro}`,
+            probe,
+          ],
+          { encoding: "utf8", timeout: 240_000 },
+        );
+        expect(out).toBe(PROBE_EXPECTED);
+      },
+      300_000,
+    );
+
+    test.skipIf(!winOn).for(EMISSIONS)(
+      "M11: the two-instance probe runs on the Windows box (%s emission)",
+      async (emission) => {
+        const host = process.env["SCRIPTC_WIN_HOST"] ?? "windows-dev";
+        const dirWin = "C:\\Users\\rdp\\work\\scriptc-mloc-lane";
+        const [archiveA, archiveB] = await Promise.all([
+          buildInstanceCross("a", emission, "x86_64-windows-gnu"),
+          buildInstanceCross("b", emission, "x86_64-windows-gnu"),
+        ]);
+        const probe = buildCrossProbe(
+          [archiveA, archiveB],
+          join(fixtureDir, "probe.c"),
+          `x-run-${emission}-win`,
+          "x86_64-windows-gnu",
+        );
+        const ssh = (cmd: string): string =>
+          execFileSync("ssh", ["-o", "ConnectTimeout=15", host, cmd], { encoding: "utf8", timeout: 120_000 });
+        try {
+          ssh(`cmd /c if not exist ${dirWin} mkdir ${dirWin}`);
+          execFileSync("scp", ["-q", probe, `${host}:C:/Users/rdp/work/scriptc-mloc-lane/probe-${emission}.exe`], {
+            timeout: 120_000,
+          });
+          const out = ssh(`cd /d ${dirWin} && probe-${emission}.exe`);
+          // The PROBE's printf rides the mingw CRT's text-mode stdout
+          // (CRLF) — the library-cross windows leg's one normalization.
+          expect(out.replaceAll("\r\n", "\n")).toBe(PROBE_EXPECTED);
+        } finally {
+          try {
+            ssh(`cmd /c rmdir /S /Q ${dirWin}`);
+          } catch {
+            /* cleanup is best-effort — never mask the real failure */
+          }
+        }
+      },
+      300_000,
+    );
+
+    test.skipIf(!winOn)(
+      "M11: a thread-instanced and runtime-localized archive runs on the Windows box",
+      async () => {
+        const host = process.env["SCRIPTC_WIN_HOST"] ?? "windows-dev";
+        const dirWin = "C:\\Users\\rdp\\work\\scriptc-mloc-lane-t";
+        const key = "x-t-llvm-win";
+        let archive = built.get(key);
+        if (archive === undefined) {
+          archive = (async () => {
+            const outDir = join(cacheDir, key);
+            mkdirSync(outDir, { recursive: true });
+            const profile = JSON.parse(readFileSync(join(threadFixtureDir, "profile_t.json"), "utf8")) as {
+              entry: string;
+              emission: string;
+              abi: Record<string, unknown>;
+            };
+            profile.emission = "llvm";
+            profile.entry = join(threadFixtureDir, profile.entry);
+            profile.abi["localize_runtime"] = true;
+            const profilePath = join(outDir, "profile.json");
+            writeFileSync(profilePath, JSON.stringify(profile, null, 2));
+            const prevCc = process.env["SCRIPTC_CC"];
+            const prevTarget = process.env["SCRIPTC_TARGET"];
+            process.env["SCRIPTC_CC"] = "zigcc";
+            process.env["SCRIPTC_TARGET"] = "x86_64-windows-gnu";
+            try {
+              const result = await compileLibrary({ profilePath, outDir });
+              if (!result.ok) {
+                throw new Error(result.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n"));
+              }
+              return result.archivePath;
+            } finally {
+              if (prevCc === undefined) delete process.env["SCRIPTC_CC"];
+              else process.env["SCRIPTC_CC"] = prevCc;
+              if (prevTarget === undefined) delete process.env["SCRIPTC_TARGET"];
+              else process.env["SCRIPTC_TARGET"] = prevTarget;
+            }
+          })();
+          built.set(key, archive);
+        }
+        const probe = buildCrossProbe(
+          [await archive],
+          join(threadFixtureDir, "probe.c"),
+          "x-run-t-win",
+          "x86_64-windows-gnu",
+        );
+        const ssh = (cmd: string): string =>
+          execFileSync("ssh", ["-o", "ConnectTimeout=15", host, cmd], { encoding: "utf8", timeout: 120_000 });
+        try {
+          ssh(`cmd /c if not exist ${dirWin} mkdir ${dirWin}`);
+          execFileSync("scp", ["-q", probe, `${host}:C:/Users/rdp/work/scriptc-mloc-lane-t/probe-t.exe`], {
+            timeout: 120_000,
+          });
+          const out = ssh(`cd /d ${dirWin} && probe-t.exe`);
+          expect(out.replaceAll("\r\n", "\n")).toBe(THREADED_EXPECTED);
+        } finally {
+          try {
+            ssh(`cmd /c rmdir /S /Q ${dirWin}`);
+          } catch {
+            /* cleanup is best-effort — never mask the real failure */
+          }
+        }
+      },
+      300_000,
+    );
+  });
 });


### PR DESCRIPTION
`abi.localize_runtime` previously required building on the target's own platform (darwin or linux hosts only), because the combine-and-demote step ran the host's linker tools over host-format objects. This extends localization to Windows hosts and to cross-target builds.

## COFF (Windows)

No existing tool performs the step for COFF — lld-link has no relocatable mode, llvm-objcopy rejects symbol demotion for COFF, and PE-capable binutils would be a new host dependency. The step is now an in-process transform (`packages/compiler/src/backend/object-localize.ts`): archive member selection on undefined-symbol demand, section concatenation without coalescing, cross-object symbol resolution, COMDAT deduplication, then demotion of every defined external outside the keep set to static. Surviving COMDATs drop their COMDAT flag so one archive's stubs can never deduplicate against another archive's at the embedder's link. COFF commons stay global; per-object CodeView stays out of the merged member; import libraries never flow through this path. Windows TLS is native, so thread-instanced archives localize cleanly.

## Cross targets

- ELF from any supported host: `zig cc -target <triple> -r` merges (zig is already the cross driver's requirement — no new tools), then an in-process ELF transform demotes: locals-first symbol reorder, relocation index remap, commons kept global, and section-group resolution equivalent to `--force-group-allocation` (verified against sanitized cross builds).
- Mach-O cross-arch on darwin hosts: the host ld64 recipe now admits macos cross triples (x86_64 archive verified under Rosetta).
- Native darwin and linux recipes are unchanged.

Support matrix: linux and windows targets localize from darwin, linux, and windows hosts; macos targets localize on darwin hosts only (the refusal names the pairing); wasi and other pairings keep their existing refusal.

## Validation

- Windows-native: localized and thread-instanced archives built on a Windows 11 machine; symbol surface verified exact (only the profile-declared symbols external); the two-archive trap-isolation probe and the four-thread instancing probe pass natively; the multi-archive suite runs 19/19 on the box.
- Cross execution: 33/33 across five targets and both emissions — debian bookworm (x86_64 and aarch64), alpine (musl), Windows, and x86_64-macos under Rosetta, including a mixed-host composition (an archive built on Windows linked beside one built on macOS, isolating correctly in one process).
- Default suites 275 passed; 7 new toolchain-free unit tests pin the transforms over synthesized objects; both sandbox lanes pass; lint clean.
- Non-localized builds take an untouched code path; cross-built archives verified hash-identical before and after.

One consumer-visible note: the localized COFF member carries no CodeView debug info (classic members keep theirs) — symbolized runtime frames inside localized Windows archives are the one surface this defers.