### PR TITLE
fix(compiler): recognize tuples in Array.isArray

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -4803,8 +4803,9 @@ const DYN_STRING_ONLY_METHODS = new Set([
     }
     if (arg.type.kind === "union") {
       // A union answers by its RUNTIME TAG: true iff the active arm is an
-      // array kind (bytes arms answer false — Array.isArray(new Uint8Array)
-      // is false in JS too). One array arm compiles to the plain tag test
+      // array value (homogeneous array or fixed tuple; bytes arms answer
+      // false — Array.isArray(new Uint8Array) is false in JS too). One
+      // array arm compiles to the plain tag test
       // (`Array.isArray(tlds)` on `string | readonly string[]` — the
       // narrowing test tsc's control flow then builds on); several array
       // arms OR their tag tests, and zero arms fold to false — both only
@@ -4813,7 +4814,7 @@ const DYN_STRING_ONLY_METHODS = new Set([
       // static tag answer and keep the narrow-first fence.
       const def = L.unions.get(arg.type.unionId);
       const opaque = !def || def.arms.some((a) => a.kind === "dyn" || a.kind === "caught" || a.kind === "jsval");
-      const arrayTags = def ? def.arms.flatMap((a, i) => (a.kind === "array" ? [i] : [])) : [];
+      const arrayTags = L.arrayValueTags(arg.type.unionId);
       const freeRead = arg.kind === "varRef" || arg.kind === "recordGet" || arg.kind === "fieldGet";
       if (!opaque && arrayTags.length === 1) {
         return { kind: "unionIsTag", unionId: arg.type.unionId, tag: arrayTags[0]!, negated: false, value: arg, type: BOOL, loc };
@@ -4834,7 +4835,7 @@ const DYN_STRING_ONLY_METHODS = new Set([
     }
     if (arg.type.kind === "jsval" || arg.type.kind === "caught") return null;
     if (arg.kind === "varRef" || arg.kind === "recordGet" || arg.kind === "fieldGet") {
-      return { kind: "boolLit", value: arg.type.kind === "array", type: BOOL, loc };
+      return { kind: "boolLit", value: L.isArrayValueType(arg.type), type: BOOL, loc };
     }
     L.unsupported(
       "SC1090",

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -708,11 +708,21 @@ function lowerSplitLimitArg(L: Lowerer, node: ts.Expression | undefined, loc: Sr
     const name = access.name.text;
     if (name !== "slice" && name !== "map") return null;
     if (!L.isStdlibMember(access)) return null;
-    const receiverIr = L.mapTypeOf(L.typeOf(access.expression));
+    let receiverIr = L.mapTypeOf(L.typeOf(access.expression));
+    let receiver: IrExpr | null = null;
+    // A readonly tuple union under Array.isArray is checker-typed as an
+    // unmappable intersection with any[], while maybeNarrow still extracts
+    // its one tuple arm. Dispatch the supported tuple read methods from
+    // that lowered representation, like tuple indexing and `.length`.
+    const checkerArray = L.checkerArrayValue(access.expression);
+    if (checkerArray?.type.kind === "record") {
+      receiverIr = checkerArray.type;
+      receiver = checkerArray;
+    }
     if (receiverIr?.kind !== "record") return null;
     const shape = L.shapes.get(receiverIr.shapeId);
     if (!shape?.tuple) return null;
-    const receiver = L.lowerExpr(access.expression);
+    receiver ??= L.lowerExpr(access.expression);
     if (receiver.type.kind !== "record") return null;
     if (!pureReemittable(receiver)) {
       L.noLowering(

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -6004,10 +6004,8 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
     // shape. maybeNarrow on the receiver uses the runtime tag proof to
     // extract the one array-valued arm; dispatch element access from that
     // lowered representation, like the existing any[] array-method path.
-    if (L.checkerAnyArray(expr.expression)) {
-      const probe = L.lowerExpr(expr.expression);
-      if (L.isArrayValueType(probe.type)) receiverIr = probe.type;
-    }
+    const checkerArray = L.checkerArrayValue(expr.expression);
+    if (checkerArray) receiverIr = checkerArray.type;
     if (receiverIr?.kind === "jsval") {
       // Dispatch follows the RUNTIME world (383(d)): a checker-'any'
       // receiver whose value LOWERED checked-dynamic (`bag.list[0]` where
@@ -9955,7 +9953,13 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
     const target = L.fieldTarget(expr);
     if (target) return L.fieldGetExpr(target, locOf(expr), expr);
     if (expr.questionDotToken) return null;
-    const receiverIr = L.mapTypeOf(L.typeOf(expr.expression));
+    let receiverIr = L.mapTypeOf(L.typeOf(expr.expression));
+    // The readonly-tuple Array.isArray narrow has no directly mappable
+    // checker type (`Result & any[]`), but maybeNarrow extracted the tuple
+    // record behind it. Route tuple properties such as `.length` from that
+    // lowered value, the element-access bridge's twin.
+    const checkerArray = L.checkerArrayValue(expr.expression);
+    if (checkerArray?.type.kind === "record") receiverIr = checkerArray.type;
     if (
       receiverIr?.kind === "object" &&
       (L.findMethodOn(L.classes.get(receiverIr.className) ?? null, expr.name.text) ||

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -2257,26 +2257,20 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
       return expr;
     }
     if (expr.type.kind !== "union") return expr;
-    const narrowed = L.mapTypeOf(L.typeOf(node));
-    // `Array.isArray(u)` on a `string | readonly string[]` union: the lib
-    // predicate narrows the READONLY arm to `any[]` (tsc's readonly-array
-    // quirk), which maps to the island's array-of-handles (or nothing) —
-    // but the tag test proved the union's one array arm, so the bridge is
-    // the same trusted unionNarrow the mapped case below builds (the
-    // certs configuredTlds shape).
-    if (!narrowed || (narrowed.kind === "array" && narrowed.elem.kind === "jsval")) {
-      const t = L.typeOf(node);
-      const anyElem =
-        L.checker.isArrayType(t) &&
-        ((L.checker.getTypeArguments(t as ts.TypeReference)[0]?.flags ?? 0) &
-          (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
-      if (anyElem) {
-        const def = L.unions.get(expr.type.unionId);
-        const arrayTags = L.arrayValueTags(expr.type.unionId);
-        if (arrayTags.length === 1) {
-          const arm = def!.arms[arrayTags[0]!]!;
-          return { kind: "unionNarrow", unionId: expr.type.unionId, tag: arrayTags[0]!, value: expr, type: arm, loc: expr.loc };
-        }
+    const narrowedTs = L.typeOf(node);
+    const narrowed = L.mapTypeOf(narrowedTs);
+    // `Array.isArray(u)` on a union with one readonly array/tuple arm: the
+    // lib predicate narrows to `any[]`, either directly or intersected
+    // with the original union. That checker type can map to the island's
+    // array-of-handles, nothing, or a synthetic intersection record — but
+    // the tag test proved the union's one array-valued arm, so bridge to it
+    // with the same trusted unionNarrow the mapped case below builds.
+    if (L.checkerAnyArrayType(narrowedTs)) {
+      const def = L.unions.get(expr.type.unionId);
+      const arrayTags = L.arrayValueTags(expr.type.unionId);
+      if (arrayTags.length === 1) {
+        const arm = def!.arms[arrayTags[0]!]!;
+        return { kind: "unionNarrow", unionId: expr.type.unionId, tag: arrayTags[0]!, value: expr, type: arm, loc: expr.loc };
       }
     }
     // A checker type narrowed to a UNIT arm (the `=== undefined` branch)
@@ -6002,9 +5996,18 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
     // `const cmd = ['pwd', []]`, whose binding lowered checked-dynamic)
     // dispatches as unmapped so the dyn-receiver branch below reads
     // through the checked-dynamic tree instead of dynChecking into never's f64 residue.
-    const receiverIr = neverTaintedJsType(L, expr.expression, L.typeOf(expr.expression))
+    let receiverIr = neverTaintedJsType(L, expr.expression, L.typeOf(expr.expression))
       ? null
       : L.mapTypeOf(L.typeOf(expr.expression));
+    // A readonly tuple union under Array.isArray is checker-typed as an
+    // intersection with any[], whose structural mapping is not the tuple
+    // shape. maybeNarrow on the receiver uses the runtime tag proof to
+    // extract the one array-valued arm; dispatch element access from that
+    // lowered representation, like the existing any[] array-method path.
+    if (L.checkerAnyArray(expr.expression)) {
+      const probe = L.lowerExpr(expr.expression);
+      if (L.isArrayValueType(probe.type)) receiverIr = probe.type;
+    }
     if (receiverIr?.kind === "jsval") {
       // Dispatch follows the RUNTIME world (383(d)): a checker-'any'
       // receiver whose value LOWERED checked-dynamic (`bag.list[0]` where

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -1976,10 +1976,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
           const constituents = t.isUnionType() ? t.getTypes() : [];
           const nonArray = constituents.filter((a) => !L.checker.isArrayType(a) && !L.checker.isTupleType(a));
           const mapped = L.mapTypeOf(t);
-          const armCount =
-            mapped?.kind === "union"
-              ? (L.unions.get(mapped.unionId)?.arms.filter((a) => a.kind === "array").length ?? 0)
-              : 0;
+          const armCount = mapped?.kind === "union" ? L.arrayValueTags(mapped.unionId).length : 0;
           if (sym && nonArray.length === 1 && armCount === 1) {
             falseArmNarrowType = nonArray[0]!;
             const collect = (n: ts.Node): void => {
@@ -2275,7 +2272,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
           (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
       if (anyElem) {
         const def = L.unions.get(expr.type.unionId);
-        const arrayTags = def ? def.arms.flatMap((a, i) => (a.kind === "array" ? [i] : [])) : [];
+        const arrayTags = L.arrayValueTags(expr.type.unionId);
         if (arrayTags.length === 1) {
           const arm = def!.arms[arrayTags[0]!]!;
           return { kind: "unionNarrow", unionId: expr.type.unionId, tag: arrayTags[0]!, value: expr, type: arm, loc: expr.loc };

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -3313,13 +3313,14 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
     // adopt the initializer's type. Checker-`any[]` decls take the same
     // rule (`const tlds = Array.isArray(u) ? u : [u]` — tsc's readonly
     // Array.isArray quirk types the ternary any[], while the arms lower
-    // to the union's real array arm). Const only — an evolving-`any`
+    // to the union's real array arm; readonly fixed-tuple narrows adopt
+    // their tuple record likewise). Const only — an evolving-`any`
     // `let` may be reassigned a different shape later; genuine `any`
     // only — every other unmappable keeps its own diagnostic.
     if (
       type === null && !isLet &&
       ((L.typeOf(decl.name).flags & ts.TypeFlags.Any) !== 0 ||
-        (L.checkerAnyArray(decl.name) && init.type.kind === "array") ||
+        (L.checkerAnyArray(decl.name) && L.isArrayValueType(init.type)) ||
         // JS declarations carry no annotations: an unmappable inferred
         // type (a union with a fence-folded arm — the typeof-'bigint'
         // dual-mode ternary) adopts the initializer's static type, the

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -3124,6 +3124,17 @@ export class Lowerer {
     return visit(t);
   }
 
+  /** The lowered static array/tuple value behind checkerAnyArray's
+   * synthetic `any[]` spelling. Array.isArray can leave readonly tuple
+   * unions as intersections that do not map directly, while maybeNarrow
+   * still extracts the runtime-proven array arm from the original union.
+   * Receiver dispatchers use this bridge instead of the synthetic type. */
+  checkerArrayValue(node: ts.Expression): IrExpr | null {
+    if (!this.checkerAnyArray(node)) return null;
+    const value = this.lowerExpr(node);
+    return this.isArrayValueType(value.type) ? value : null;
+  }
+
   /** Substitutes a bound type parameter anywhere inside mapType's recursion
    * (`T`, `T[]`, `{ v: T }`, `(x: T) => T` all resolve). Inert outside
    * generic instantiation. */

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -3024,6 +3024,22 @@ export class Lowerer {
     return formatIrType(t, this.shapes, this.unions);
   }
 
+  /** Whether an IR value has JavaScript Array identity. Homogeneous arrays
+   * use the native array representation; non-empty fixed tuples use a
+   * positional record shape so their slots can keep distinct types, but
+   * Array.isArray must still answer true for both representations. */
+  isArrayValueType(t: IrType): boolean {
+    return t.kind === "array" || (t.kind === "record" && this.shapes.get(t.shapeId)?.tuple === true);
+  }
+
+  /** Runtime tags of every JavaScript-array arm in one union. Kept beside
+   * isArrayValueType so Array.isArray's predicate and its narrowing bridge
+   * cannot disagree about fixed tuple arms. */
+  arrayValueTags(unionId: string): number[] {
+    const def = this.unions.get(unionId);
+    return def ? def.arms.flatMap((arm, tag) => (this.isArrayValueType(arm) ? [tag] : [])) : [];
+  }
+
   /** isJsonSafeType with this Lowerer's registries — the shared fence for
    * what JSON.stringify accepts and what a checked cast can validate. */
   jsonSafe(t: IrType): boolean {

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -3090,20 +3090,38 @@ export class Lowerer {
     return isIslandExpr(this, node);
   }
 
-  /** True when this node's CHECKER type is `any[]`/`unknown[]` — the type
-   * tsc's Array.isArray predicate narrows readonly arrays to (its `arg is
-   * any[]` quirk), and what a union collapses to when such an arm absorbs
-   * its siblings. The VALUE behind it can still be a real static array
-   * (maybeNarrow's isArray bridge extracts the union's array arm), so
-   * receiver-typed dispatch falls back to the LOWERED type under this
-   * test. */
+  /** True when this node's CHECKER type is proven `any[]`/`unknown[]`,
+   * directly or through the intersection tsc builds for a readonly tuple
+   * union (`(Model | readonly [Model, Command]) & any[]`; TS7 distributes
+   * this over the union arms). These are forms of the `arg is any[]`
+   * Array.isArray predicate; the VALUE behind them can still be a real
+   * static array/tuple (maybeNarrow's bridge extracts the union's one
+   * array-valued arm), so receiver-typed dispatch falls back to the LOWERED
+   * type under this test. */
   checkerAnyArray(node: ts.Expression): boolean {
-    const t = this.typeOf(node);
-    return (
-      this.checker.isArrayType(t) &&
-      ((this.checker.getTypeArguments(t as ts.TypeReference)[0]?.flags ?? 0) &
-        (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0
-    );
+    return this.checkerAnyArrayType(this.typeOf(node));
+  }
+
+  /** Type-level half of checkerAnyArray, for narrowing sites that already
+   * queried the checker type from a general AST node. */
+  checkerAnyArrayType(t: ts.Type): boolean {
+    const isAnyArray = (part: ts.Type): boolean =>
+      this.checker.isArrayType(part) &&
+      ((this.checker.getTypeArguments(part as ts.TypeReference)[0]?.flags ?? 0) &
+        (ts.TypeFlags.Any | ts.TypeFlags.Unknown)) !== 0;
+    const visit = (part: ts.Type): boolean => {
+      if (isAnyArray(part)) return true;
+      // 5.9 leaves `(U) & any[]` as one intersection; 7 distributes it
+      // into `(A & any[]) | (B & any[])`. An intersection is array-proven
+      // when one constituent is; a union is array-proven only when EVERY
+      // arm is, so an ordinary `any[] | string` never qualifies.
+      if ((part.flags & ts.TypeFlags.Intersection) !== 0) {
+        return (part as ts.UnionOrIntersectionType).getTypes().some(visit);
+      }
+      if (part.isUnionType()) return part.getTypes().every(visit);
+      return false;
+    };
+    return visit(t);
   }
 
   /** Substitutes a bound type parameter anywhere inside mapType's recursion

--- a/tests/corpus/1549-array-isarray-unions.ts
+++ b/tests/corpus/1549-array-isarray-unions.ts
@@ -85,6 +85,18 @@ function describeReadonlyTuple(value: ReadonlyTupleResult): string {
   return "plain";
 }
 
+// The checker keeps the same synthetic intersection for neighboring tuple
+// operations. A const alias must retain the lowered tuple representation;
+// then length, the supported read-only methods, and iteration all dispatch
+// from that representation too.
+function summarizeReadonlyTuple(value: ReadonlyTupleResult): string {
+  if (!Array.isArray(value)) return "plain";
+  const tuple = value;
+  let visits = 0;
+  for (const _part of tuple) visits++;
+  return `${value.length}:${value.slice(0).length}:${value.map(() => "v").join("")}:${tuple.length}:${tuple.slice(0).length}:${tuple.map(() => "t").join("")}:${visits}`;
+}
+
 const plainResult = normalizeTuple({ n: 7 }, false);
 console.log(plainResult[0].n, plainResult[1]);
 const tupleResult = normalizeTuple({ n: 9 }, true);
@@ -93,3 +105,5 @@ console.log(isFixedTuple([{ n: 11 }, { op: "direct" }]));
 const readonlyTuple: readonly [TupleModel, TupleCommand] = [{ n: 12 }, { op: "readonly" }];
 console.log(describeReadonlyTuple({ n: 13 }));
 console.log(describeReadonlyTuple(readonlyTuple));
+console.log(summarizeReadonlyTuple({ n: 14 }));
+console.log(summarizeReadonlyTuple(readonlyTuple));

--- a/tests/corpus/1549-array-isarray-unions.ts
+++ b/tests/corpus/1549-array-isarray-unions.ts
@@ -75,8 +75,21 @@ function isFixedTuple(value: [TupleModel, TupleCommand]): boolean {
   return Array.isArray(value);
 }
 
+// For a readonly tuple union, tsc narrows the guarded value to an
+// intersection with any[] rather than directly to an array type. The
+// runtime tag still proves the tuple arm, so positional reads must bridge
+// back to its fixed shape.
+type ReadonlyTupleResult = TupleModel | readonly [TupleModel, TupleCommand];
+function describeReadonlyTuple(value: ReadonlyTupleResult): string {
+  if (Array.isArray(value)) return `${value[0].n}:${value[1].op}`;
+  return "plain";
+}
+
 const plainResult = normalizeTuple({ n: 7 }, false);
 console.log(plainResult[0].n, plainResult[1]);
 const tupleResult = normalizeTuple({ n: 9 }, true);
 console.log(tupleResult[0].n, tupleResult[1]);
 console.log(isFixedTuple([{ n: 11 }, { op: "direct" }]));
+const readonlyTuple: readonly [TupleModel, TupleCommand] = [{ n: 12 }, { op: "readonly" }];
+console.log(describeReadonlyTuple({ n: 13 }));
+console.log(describeReadonlyTuple(readonlyTuple));

--- a/tests/corpus/1549-array-isarray-unions.ts
+++ b/tests/corpus/1549-array-isarray-unions.ts
@@ -47,3 +47,36 @@ const mixed: string[] | number[] | undefined = [3, 4] as string[] | number[] | u
 console.log(Array.isArray(mixed));
 const missing: string[] | number[] | undefined = undefined;
 console.log(Array.isArray(missing));
+
+// Fixed tuples use a positional record-shaped IR representation so each
+// slot can keep its own type, but they are still JavaScript arrays. This is
+// the Native SDK facade shape: an update returns either its model record or
+// [model, command], then Array.isArray selects the tuple before indexing it.
+interface TupleModel {
+  n: number;
+}
+
+interface TupleCommand {
+  op: string;
+}
+
+function tupleUpdate(model: TupleModel, effect: boolean): TupleModel | [TupleModel, TupleCommand] {
+  if (!effect) return model;
+  return [model, { op: "spawn" }];
+}
+
+function normalizeTuple(model: TupleModel, effect: boolean): [TupleModel, string] {
+  const out = tupleUpdate(model, effect);
+  if (Array.isArray(out)) return [out[0], out[1].op];
+  return [out, "none"];
+}
+
+function isFixedTuple(value: [TupleModel, TupleCommand]): boolean {
+  return Array.isArray(value);
+}
+
+const plainResult = normalizeTuple({ n: 7 }, false);
+console.log(plainResult[0].n, plainResult[1]);
+const tupleResult = normalizeTuple({ n: 9 }, true);
+console.log(tupleResult[0].n, tupleResult[1]);
+console.log(isFixedTuple([{ n: 11 }, { op: "direct" }]));


### PR DESCRIPTION
- Treat fixed tuple record shapes as JavaScript arrays.
- Keep union tag tests and narrowing aligned.
- Add Native SDK facade regression coverage.