### PR TITLE
fix(runtime): trust Windows root certificates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,6 +158,26 @@ jobs:
           if ($actual -ne "hello world") {
             throw "unexpected scriptc output: $actual"
           }
+      - name: Windows CA-store differential
+        shell: pwsh
+        run: |
+          $nodeOutput = & node tests/corpus/2557-tls-ca-store.ts
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $nativeOutput = & node packages/cli/dist/main.js run tests/corpus/2557-tls-ca-store.ts --backend c
+          if ($LASTEXITCODE -ne 0) {
+            exit $LASTEXITCODE
+          }
+          $expected = ($nodeOutput -join "`n").Trim()
+          $actual = ($nativeOutput -join "`n").Trim()
+          if ($actual -ne $expected) {
+            throw "Windows CA-store output differed:`nNODE:`n$expected`nNATIVE:`n$actual"
+          }
+      - name: Windows CA EKU policy
+        run: >-
+          pnpm exec vitest run packages/compiler/test/cc-driver.test.ts
+          --testNamePattern "Windows CA roots honor"
 
   # Aggregate gate with the pre-matrix job's name, so anything keyed on the
   # single "test" check (branch protection, badges) keeps resolving. Fails

--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -2378,7 +2378,7 @@ declare module "tls" {
   /** The CA-store introspection surface (scr_tls_ca.c): per-type cached
    * PEM string arrays. The host bundle stands in for Node's compiled-in
    * Mozilla roots ('bundled', and rootCertificates) AND the platform
-   * store ('system') — the Windows ROOT stores or POSIX bundle probe;
+   * store ('system') — the Windows certificate stores or POSIX bundle probe;
    * 'extra' reads NODE_EXTRA_CA_CERTS. An unknown type string throws
    * Node's ERR_INVALID_ARG_VALUE TypeError. */
   export function getCACertificates(type?: string): string[];

--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -2378,7 +2378,7 @@ declare module "tls" {
   /** The CA-store introspection surface (scr_tls_ca.c): per-type cached
    * PEM string arrays. The host bundle stands in for Node's compiled-in
    * Mozilla roots ('bundled', and rootCertificates) AND the platform
-   * store ('system') — the Windows ROOT store or POSIX bundle probe;
+   * store ('system') — the Windows ROOT stores or POSIX bundle probe;
    * 'extra' reads NODE_EXTRA_CA_CERTS. An unknown type string throws
    * Node's ERR_INVALID_ARG_VALUE TypeError. */
   export function getCACertificates(type?: string): string[];

--- a/packages/compiler/ambient/scriptc-node-fallback.d.ts
+++ b/packages/compiler/ambient/scriptc-node-fallback.d.ts
@@ -2378,7 +2378,7 @@ declare module "tls" {
   /** The CA-store introspection surface (scr_tls_ca.c): per-type cached
    * PEM string arrays. The host bundle stands in for Node's compiled-in
    * Mozilla roots ('bundled', and rootCertificates) AND the platform
-   * store ('system') — the /etc/ssl/cert.pem stance, documented;
+   * store ('system') — the Windows ROOT store or POSIX bundle probe;
    * 'extra' reads NODE_EXTRA_CA_CERTS. An unknown type string throws
    * Node's ERR_INVALID_ARG_VALUE TypeError. */
   export function getCACertificates(type?: string): string[];

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -358,11 +358,11 @@ export interface CcOptions {
   tls?: boolean;
   /** The program uses the CA-store introspection surface (moduleUsesTlsCa
    * on the IR — getCACertificates / rootCertificates /
-   * setDefaultCACertificates): compiles scr_tls_ca.c, plain PEM-block
-   * bookkeeping with NO mbedTLS dependency, so an introspection-only
-   * binary never builds the archive. The unit also compiles whenever
-   * `tls` does — scr_tls.c consults its default-set override for the
-   * client trust anchors. */
+   * setDefaultCACertificates): compiles scr_tls_ca.c, PEM-block bookkeeping
+   * plus the platform ROOT-store reader on Windows, with NO mbedTLS
+   * dependency, so an introspection-only binary never builds the archive.
+   * The unit also compiles whenever `tls` does — scr_tls.c consults its
+   * default-set override and shared Windows-root enumerator. */
   tlsCa?: boolean;
 }
 
@@ -421,7 +421,8 @@ export function runtimeSrcDir(): string {
  * tls, and the engine archive (--dynamic) all build per target through
  * their win32 arms (mbedTLS compiles unchanged for the triple — its own _WIN32
  * port covers entropy and timing; the TLS link adds bcrypt for
- * BCryptGenRandom and crypt32 for the Windows ROOT certificate store).
+ * BCryptGenRandom, while the CA-store unit adds crypt32 for the Windows
+ * ROOT certificate store).
  * They additionally compile
  * scr_win.c, the win32 libc shim TU (stpcpy, arc4random_buf — see the
  * _WIN32 block in scr_runtime.h), linking -ladvapi32 for its CSPRNG
@@ -3355,6 +3356,7 @@ export async function compileC(opts: CcOptions): Promise<void> {
   const net = (opts.net ?? false) || nativeFetch || netIsland;
   const http = (opts.http ?? false) || nativeFetch || netIsland;
   const tls = (opts.tls ?? false) || nativeFetch || netIsland;
+  const tlsCa = (opts.tlsCa ?? false) || tls;
   const driver = resolveCc();
   // Mobile triples produce library archives, never standalone executables:
   // the executable-lane runtime (event loop, sockets, child processes) is
@@ -3611,20 +3613,23 @@ export async function compileC(opts: CcOptions): Promise<void> {
     ...(opts.nodeTest ? [rt(join(rtDir, "scr_test.c"))] : []),
     // The CA-store unit rides its own gate OR the tls one: scr_tls.c
     // references its default-set override unconditionally.
-    ...(opts.tlsCa || tls ? [rt(join(rtDir, "scr_tls_ca.c"))] : []),
+    ...(tlsCa ? [rt(join(rtDir, "scr_tls_ca.c"))] : []),
     ...(tlsArchive
       ? [
           "-I", join(vendorTlsDir(), "include"),
           rt(join(rtDir, "scr_tls.c")),
           tlsArchive,
-          // mbedTLS's win32 entropy poll is BCryptGenRandom (bcrypt.h),
-          // while scr_tls.c imports the platform ROOT certificate store
-          // from crypt32. The unconditional win32 libs above carry neither.
+          // mbedTLS's win32 entropy poll is BCryptGenRandom (bcrypt.h).
+          // The unconditional win32 libs above do not carry it.
           // Never present on the default path, so the historical TLS
           // link line cannot change.
-          ...(targetPlatform(driver) === "win32" ? ["-lbcrypt", "-lcrypt32"] : []),
+          ...(targetPlatform(driver) === "win32" ? ["-lbcrypt"] : []),
         ]
         : []),
+    // scr_tls_ca.c enumerates and PEM-encodes Windows ROOT-store entries.
+    // This is independent of the mbedTLS archive: getCACertificates-only
+    // programs need crypt32 too, while TLS programs imply the CA unit.
+    ...(tlsCa && targetPlatform(driver) === "win32" ? ["-lcrypt32"] : []),
     // Static fetch is the engine-free half of scr_fetch.c. Dynamic builds
     // compile the same source beside scr_island.c below, where its
     // SCR_DYNAMIC half installs the full web surface.
@@ -3835,7 +3840,8 @@ export async function compileC(opts: CcOptions): Promise<void> {
     ...(targetPlatform(driver) === "win32"
       ? ["-ladvapi32", "-liphlpapi", "-lws2_32"]
       : []),
-    ...(tls && targetPlatform(driver) === "win32" ? ["-lbcrypt", "-lcrypt32"] : []),
+    ...(tls && targetPlatform(driver) === "win32" ? ["-lbcrypt"] : []),
+    ...(tlsCa && targetPlatform(driver) === "win32" ? ["-lcrypt32"] : []),
     ...(curlFetch && driver.target === null ? ["-lcurl"] : []),
     ...(dynamic && !driver.linkArgs.includes("-lm") ? ["-lm"] : []),
     ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null ? ["-lz"] : []),
@@ -3849,7 +3855,8 @@ export async function compileC(opts: CcOptions): Promise<void> {
     ...(targetPlatform(driver) === "win32"
       ? ["-ladvapi32", "-liphlpapi", "-lws2_32"]
       : []),
-    ...(tls && targetPlatform(driver) === "win32" ? ["-lbcrypt", "-lcrypt32"] : []),
+    ...(tls && targetPlatform(driver) === "win32" ? ["-lbcrypt"] : []),
+    ...(tlsCa && targetPlatform(driver) === "win32" ? ["-lcrypt32"] : []),
     ...(curlStubDir !== null ? [`-L${curlStubDir}`] : []),
     ...(curlFetch && driver.target === null ? ["-lcurl"] : []),
     ...(dynamic && !driver.linkArgs.includes("-lm") ? ["-lm"] : []),

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -359,10 +359,10 @@ export interface CcOptions {
   /** The program uses the CA-store introspection surface (moduleUsesTlsCa
    * on the IR — getCACertificates / rootCertificates /
    * setDefaultCACertificates): compiles scr_tls_ca.c, PEM-block bookkeeping
-   * plus the platform ROOT-store reader on Windows, with NO mbedTLS
+   * plus the platform certificate-store reader on Windows, with NO mbedTLS
    * dependency, so an introspection-only binary never builds the archive.
    * The unit also compiles whenever `tls` does — scr_tls.c consults its
-   * default-set override and shared Windows-root enumerator. */
+   * default-set override and shared Windows-certificate enumerator. */
   tlsCa?: boolean;
 }
 
@@ -422,7 +422,7 @@ export function runtimeSrcDir(): string {
  * their win32 arms (mbedTLS compiles unchanged for the triple — its own _WIN32
  * port covers entropy and timing; the TLS link adds bcrypt for
  * BCryptGenRandom, while the CA-store unit adds crypt32 for the Windows
- * ROOT certificate store).
+ * system certificate stores).
  * They additionally compile
  * scr_win.c, the win32 libc shim TU (stpcpy, arc4random_buf — see the
  * _WIN32 block in scr_runtime.h), linking -ladvapi32 for its CSPRNG
@@ -3626,7 +3626,7 @@ export async function compileC(opts: CcOptions): Promise<void> {
           ...(targetPlatform(driver) === "win32" ? ["-lbcrypt"] : []),
         ]
         : []),
-    // scr_tls_ca.c enumerates and PEM-encodes Windows ROOT-store entries.
+    // scr_tls_ca.c enumerates and PEM-encodes Windows system-store entries.
     // This is independent of the mbedTLS archive: getCACertificates-only
     // programs need crypt32 too, while TLS programs imply the CA unit.
     ...(tlsCa && targetPlatform(driver) === "win32" ? ["-lcrypt32"] : []),

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -420,8 +420,9 @@ export function runtimeSrcDir(): string {
  * have no gates left: events, net/http, fetch, watch, zlib, dgram/dns,
  * tls, and the engine archive (--dynamic) all build per target through
  * their win32 arms (mbedTLS compiles unchanged for the triple — its own _WIN32
- * port covers entropy and timing; the archive link adds -lbcrypt for
- * BCryptGenRandom there). They additionally compile
+ * port covers entropy and timing; the TLS link adds bcrypt for
+ * BCryptGenRandom and crypt32 for the Windows ROOT certificate store).
+ * They additionally compile
  * scr_win.c, the win32 libc shim TU (stpcpy, arc4random_buf — see the
  * _WIN32 block in scr_runtime.h), linking -ladvapi32 for its CSPRNG
  * (RtlGenRandom) and GetUserNameA. Native zigcc builds (no SCRIPTC_TARGET)
@@ -3616,11 +3617,12 @@ export async function compileC(opts: CcOptions): Promise<void> {
           "-I", join(vendorTlsDir(), "include"),
           rt(join(rtDir, "scr_tls.c")),
           tlsArchive,
-          // mbedTLS's win32 entropy poll is BCryptGenRandom (bcrypt.h) —
-          // an import the unconditional win32 libs above don't carry.
+          // mbedTLS's win32 entropy poll is BCryptGenRandom (bcrypt.h),
+          // while scr_tls.c imports the platform ROOT certificate store
+          // from crypt32. The unconditional win32 libs above carry neither.
           // Never present on the default path, so the historical TLS
           // link line cannot change.
-          ...(targetPlatform(driver) === "win32" ? ["-lbcrypt"] : []),
+          ...(targetPlatform(driver) === "win32" ? ["-lbcrypt", "-lcrypt32"] : []),
         ]
         : []),
     // Static fetch is the engine-free half of scr_fetch.c. Dynamic builds
@@ -3833,7 +3835,7 @@ export async function compileC(opts: CcOptions): Promise<void> {
     ...(targetPlatform(driver) === "win32"
       ? ["-ladvapi32", "-liphlpapi", "-lws2_32"]
       : []),
-    ...(tls && targetPlatform(driver) === "win32" ? ["-lbcrypt"] : []),
+    ...(tls && targetPlatform(driver) === "win32" ? ["-lbcrypt", "-lcrypt32"] : []),
     ...(curlFetch && driver.target === null ? ["-lcurl"] : []),
     ...(dynamic && !driver.linkArgs.includes("-lm") ? ["-lm"] : []),
     ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null ? ["-lz"] : []),
@@ -3847,7 +3849,7 @@ export async function compileC(opts: CcOptions): Promise<void> {
     ...(targetPlatform(driver) === "win32"
       ? ["-ladvapi32", "-liphlpapi", "-lws2_32"]
       : []),
-    ...(tls && targetPlatform(driver) === "win32" ? ["-lbcrypt"] : []),
+    ...(tls && targetPlatform(driver) === "win32" ? ["-lbcrypt", "-lcrypt32"] : []),
     ...(curlStubDir !== null ? [`-L${curlStubDir}`] : []),
     ...(curlFetch && driver.target === null ? ["-lcurl"] : []),
     ...(dynamic && !driver.linkArgs.includes("-lm") ? ["-lm"] : []),

--- a/packages/compiler/test/cc-driver.test.ts
+++ b/packages/compiler/test/cc-driver.test.ts
@@ -202,6 +202,66 @@ int main(void) {
   return getcontext(&here);
 }
 `;
+const WINDOWS_CA_EKU_C = String.raw`
+#include "scr_runtime.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <windows.h>
+#include <wincrypt.h>
+
+int main(int argc, char **argv) {
+  if (argc != 2) return 2;
+  FILE *file = fopen(argv[1], "rb");
+  if (file == NULL) return 3;
+  if (fseek(file, 0, SEEK_END) != 0) return 4;
+  long pem_len = ftell(file);
+  if (pem_len <= 0 || pem_len > UINT32_MAX) return 5;
+  rewind(file);
+  char *pem = malloc((size_t)pem_len + 1);
+  if (pem == NULL) return 6;
+  size_t got = fread(pem, 1, (size_t)pem_len, file);
+  fclose(file);
+  pem[got] = 0;
+
+  DWORD der_len = 0;
+  if (!CryptStringToBinaryA(pem, (DWORD)got, CRYPT_STRING_BASE64HEADER,
+                            NULL, &der_len, NULL, NULL)) return 7;
+  BYTE *der = malloc((size_t)der_len);
+  if (der == NULL) return 8;
+  if (!CryptStringToBinaryA(pem, (DWORD)got, CRYPT_STRING_BASE64HEADER,
+                            der, &der_len, NULL, NULL)) return 9;
+  free(pem);
+  PCCERT_CONTEXT cert = CertCreateCertificateContext(
+      X509_ASN_ENCODING, der, der_len);
+  free(der);
+  if (cert == NULL) return 10;
+
+  LPSTR code_signing = szOID_PKIX_KP_CODE_SIGNING;
+  CERT_ENHKEY_USAGE usage = {1, &code_signing};
+  if (!CertSetEnhancedKeyUsage(cert, &usage)) return 11;
+  if (scr_tls_ca_windows_cert_server_auth(cert)) return 12;
+
+  LPSTR server_auth = szOID_PKIX_KP_SERVER_AUTH;
+  usage.rgpszUsageIdentifier = &server_auth;
+  if (!CertSetEnhancedKeyUsage(cert, &usage)) return 13;
+  if (!scr_tls_ca_windows_cert_server_auth(cert)) return 14;
+
+  LPSTR any_usage = szOID_ANY_ENHANCED_KEY_USAGE;
+  usage.rgpszUsageIdentifier = &any_usage;
+  if (!CertSetEnhancedKeyUsage(cert, &usage)) return 15;
+  if (!scr_tls_ca_windows_cert_server_auth(cert)) return 16;
+
+  usage.cUsageIdentifier = 0;
+  usage.rgpszUsageIdentifier = NULL;
+  if (!CertSetEnhancedKeyUsage(cert, &usage)) return 17;
+  if (scr_tls_ca_windows_cert_server_auth(cert)) return 18;
+
+  CertFreeCertificateContext(cert);
+  fputs("windows EKU policy ok\n", stdout);
+  return 0;
+}
+`;
 
 describe.skipIf(!zigOnPath())("zig cc builds (zig on PATH)", () => {
   test("host-native zigcc build compiles the runtime and runs", async () => {
@@ -289,12 +349,21 @@ describe.skipIf(!zigOnPath())("zig cc builds (zig on PATH)", () => {
   test("cross build for x86_64-windows-gnu produces a PE and accepts events/net/http/dgram/tls/watch/zlib/--dynamic/fetch", async () => {
     const dir = await mkdtemp(join(tmpdir(), "scr-zigcc-win-"));
     const cPath = join(dir, "program.c");
+    const caProbePath = join(dir, "ca-eku.c");
     await writeFile(cPath, HELLO_C);
+    await writeFile(caProbePath, WINDOWS_CA_EKU_C);
     const outPath = join(dir, "program.exe");
+    const caOutPath = join(dir, "ca-probe.exe");
     await withCcEnv("zigcc", "x86_64-windows-gnu", async () => {
       await compileC({ cPath, outPath });
       const magic = (await readFile(outPath)).subarray(0, 2);
       expect([...magic]).toEqual([0x4d, 0x5a]); // MZ
+      // CA introspection is mbedTLS-free but imports and PEM-encodes the
+      // same filtered ROOT-store entries that the TLS client consumes.
+      await compileC({ cPath: caProbePath, outPath: caOutPath, tlsCa: true });
+      const caPe = await readFile(caOutPath);
+      expect(caPe.includes("CRYPT32.dll")).toBe(true);
+      expect(caPe.includes("bcrypt.dll")).toBe(false);
       // The units with Windows arms link and produce a PE: events (CRT
       // signal + stdin probes), net/http (winsock + the WSAPoll poller
       // backend), dgram/dns (the winsock datagram arm + ws2tcpip's
@@ -329,6 +398,26 @@ describe.skipIf(!zigOnPath())("zig cc builds (zig on PATH)", () => {
       }
     });
   }, 600_000);
+
+  test.skipIf(process.platform !== "win32")(
+    "Windows CA roots honor the effective server-auth EKU property",
+    async () => {
+      const dir = await mkdtemp(join(tmpdir(), "scr-zigcc-win-ca-eku-"));
+      const cPath = join(dir, "program.c");
+      const outPath = join(dir, "program.exe");
+      await writeFile(cPath, WINDOWS_CA_EKU_C);
+      await withCcEnv("zigcc", "x86_64-windows-gnu", () =>
+        compileC({ cPath, outPath, tlsCa: true }),
+      );
+      const caPath = join(
+        import.meta.dirname,
+        "../../../tests/fixtures/server/certs/ca.pem",
+      );
+      const { stdout } = await execFileAsync(outPath, [caPath]);
+      expect(stdout).toBe("windows EKU policy ok\n");
+    },
+    600_000,
+  );
 
   test("regex cross-compiles: the vendored libregexp objects build per target", async () => {
     const dir = await mkdtemp(join(tmpdir(), "scr-zigcc-lre-"));

--- a/packages/compiler/test/cc-driver.test.ts
+++ b/packages/compiler/test/cc-driver.test.ts
@@ -16,7 +16,7 @@
  */
 import { execFile, execFileSync } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
+import { EOL, tmpdir } from "node:os";
 import { join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, test } from "vitest";
@@ -414,7 +414,7 @@ describe.skipIf(!zigOnPath())("zig cc builds (zig on PATH)", () => {
         "../../../tests/fixtures/server/certs/ca.pem",
       );
       const { stdout } = await execFileAsync(outPath, [caPath]);
-      expect(stdout).toBe("windows EKU policy ok\n");
+      expect(stdout).toBe(`windows EKU policy ok${EOL}`);
     },
     600_000,
   );

--- a/packages/compiler/test/cc-driver.test.ts
+++ b/packages/compiler/test/cc-driver.test.ts
@@ -299,11 +299,14 @@ describe.skipIf(!zigOnPath())("zig cc builds (zig on PATH)", () => {
       // signal + stdin probes), net/http (winsock + the WSAPoll poller
       // backend), dgram/dns (the winsock datagram arm + ws2tcpip's
       // getaddrinfo), tls (mbedTLS compiled for the triple, -lbcrypt for
-      // its entropy poll), watch (ReadDirectoryChangesW), zlib
+      // its entropy poll and -lcrypt32 for the ROOT certificate store),
+      // watch (ReadDirectoryChangesW), zlib
       // (per-target vendored objects).
       await compileC({ cPath, outPath, events: true, net: true, http: true, dgram: true, watch: true, zlib: true, tls: true });
-      const magic2 = (await readFile(outPath)).subarray(0, 2);
+      const tlsPe = await readFile(outPath);
+      const magic2 = tlsPe.subarray(0, 2);
       expect([...magic2]).toEqual([0x4d, 0x5a]);
+      expect(tlsPe.includes("CRYPT32.dll")).toBe(true);
       // --dynamic: the engine archive cross-builds for the windows triple
       // (buildEngineArchiveCross), the island's win32 arms (_msize, the
       // winsock hostname) compile, and the link carries the 8MB PE stack

--- a/packages/compiler/test/cc-driver.test.ts
+++ b/packages/compiler/test/cc-driver.test.ts
@@ -359,11 +359,13 @@ describe.skipIf(!zigOnPath())("zig cc builds (zig on PATH)", () => {
       const magic = (await readFile(outPath)).subarray(0, 2);
       expect([...magic]).toEqual([0x4d, 0x5a]); // MZ
       // CA introspection is mbedTLS-free but imports and PEM-encodes the
-      // same filtered ROOT-store entries that the TLS client consumes.
+      // same filtered Windows certificate-store entries that the TLS client
+      // consumes.
       await compileC({ cPath: caProbePath, outPath: caOutPath, tlsCa: true });
       const caPe = await readFile(caOutPath);
       expect(caPe.includes("CRYPT32.dll")).toBe(true);
       expect(caPe.includes("bcrypt.dll")).toBe(false);
+      expect(caPe.includes("TrustedPeople")).toBe(true);
       // The units with Windows arms link and produce a PE: events (CRT
       // signal + stdin probes), net/http (winsock + the WSAPoll poller
       // backend), dgram/dns (the winsock datagram arm + ws2tcpip's

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5493,18 +5493,25 @@ long scr_secure_ctx_live_count(void);
 #endif
 
 /* ── node:tls, the CA-store introspection slice (scr_tls_ca.c — its own
- * unit and link gate; plain PEM-block bookkeeping, NO mbedTLS, so a
- * getCACertificates-only binary never builds the archive; cc.ts also
- * compiles it whenever scr_tls.c does). The HOST bundle (the
- * /etc/ssl/cert.pem probe order scr_tls.c documents) stands in for both
- * Node's compiled-in Mozilla roots ('bundled', rootCertificates) and the
- * platform store ('system') — the established SEMANTICS divergence,
- * extended to introspection; 'extra' uses the NODE_EXTRA_CA_CERTS file
- * captured before user code runs. Arrays are cached per type (+1 retained
- * answers each call — Node's own caching, and the identity the suite pins
- * with strictEqual). */
+ * unit and link gate; NO mbedTLS, so a getCACertificates-only binary never
+ * builds the archive; cc.ts also compiles it whenever scr_tls.c does). The
+ * HOST roots (Windows' logical ROOT store, the established bundle probe on
+ * POSIX) stand in for both Node's compiled-in Mozilla roots ('bundled',
+ * rootCertificates) and the platform store ('system') — the established
+ * SEMANTICS divergence, extended to introspection; 'extra' uses the
+ * NODE_EXTRA_CA_CERTS file captured before user code runs. Arrays are cached
+ * per type (+1 retained answers each call — Node's own caching, and the
+ * identity the suite pins with strictEqual). */
 void scr_tls_ca_install(void); /* snapshots NODE_EXTRA_CA_CERTS + file bytes */
 bool scr_tls_ca_extra_pem(const char **pem, size_t *len); /* borrowed launch snapshot */
+#ifdef _WIN32
+/* Enumerates the current user's logical ROOT store (including inherited
+ * machine roots), yielding only certificates whose effective Windows EKU
+ * policy permits TLS server authentication. DER is borrowed for the call. */
+typedef void (*ScrTlsCaWindowsRootFn)(void *ctx, const unsigned char *der, size_t len);
+bool scr_tls_ca_windows_cert_server_auth(const void *cert_context);
+void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx);
+#endif
 ScrArr *scr_tls_ca_get(ScrStr *type); /* +1; throws ERR_INVALID_ARG_VALUE on unknown types */
 ScrArr *scr_tls_ca_root(void);        /* +1; === getCACertificates("bundled") */
 /* Replaces the 'default' set: entries filter to their PEM certificate

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5495,7 +5495,7 @@ long scr_secure_ctx_live_count(void);
 /* ── node:tls, the CA-store introspection slice (scr_tls_ca.c — its own
  * unit and link gate; NO mbedTLS, so a getCACertificates-only binary never
  * builds the archive; cc.ts also compiles it whenever scr_tls.c does). The
- * HOST roots (Windows' system ROOT stores, the established bundle probe on
+ * HOST roots (Windows' system certificate stores, the established bundle probe on
  * POSIX) stand in for both Node's compiled-in Mozilla roots ('bundled',
  * rootCertificates) and the platform store ('system') — the established
  * SEMANTICS divergence, extended to introspection; 'extra' uses the
@@ -5505,12 +5505,12 @@ long scr_secure_ctx_live_count(void);
 void scr_tls_ca_install(void); /* snapshots NODE_EXTRA_CA_CERTS + file bytes */
 bool scr_tls_ca_extra_pem(const char **pem, size_t *len); /* borrowed launch snapshot */
 #ifdef _WIN32
-/* Enumerates the machine, enterprise, current-user, and policy ROOT-store
+/* Enumerates Windows' trusted ROOT, intermediate CA, and TrustedPeople store
  * locations, yielding only certificates whose effective Windows EKU policy
  * permits TLS server authentication. DER is borrowed for the call. */
-typedef void (*ScrTlsCaWindowsRootFn)(void *ctx, const unsigned char *der, size_t len);
+typedef void (*ScrTlsCaWindowsCertFn)(void *ctx, const unsigned char *der, size_t len);
 bool scr_tls_ca_windows_cert_server_auth(const void *cert_context);
-void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx);
+void scr_tls_ca_windows_certs(ScrTlsCaWindowsCertFn fn, void *ctx);
 #endif
 ScrArr *scr_tls_ca_get(ScrStr *type); /* +1; throws ERR_INVALID_ARG_VALUE on unknown types */
 ScrArr *scr_tls_ca_root(void);        /* +1; === getCACertificates("bundled") */

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -5495,7 +5495,7 @@ long scr_secure_ctx_live_count(void);
 /* ── node:tls, the CA-store introspection slice (scr_tls_ca.c — its own
  * unit and link gate; NO mbedTLS, so a getCACertificates-only binary never
  * builds the archive; cc.ts also compiles it whenever scr_tls.c does). The
- * HOST roots (Windows' logical ROOT store, the established bundle probe on
+ * HOST roots (Windows' system ROOT stores, the established bundle probe on
  * POSIX) stand in for both Node's compiled-in Mozilla roots ('bundled',
  * rootCertificates) and the platform store ('system') — the established
  * SEMANTICS divergence, extended to introspection; 'extra' uses the
@@ -5505,9 +5505,9 @@ long scr_secure_ctx_live_count(void);
 void scr_tls_ca_install(void); /* snapshots NODE_EXTRA_CA_CERTS + file bytes */
 bool scr_tls_ca_extra_pem(const char **pem, size_t *len); /* borrowed launch snapshot */
 #ifdef _WIN32
-/* Enumerates the current user's logical ROOT store (including inherited
- * machine roots), yielding only certificates whose effective Windows EKU
- * policy permits TLS server authentication. DER is borrowed for the call. */
+/* Enumerates the machine, enterprise, current-user, and policy ROOT-store
+ * locations, yielding only certificates whose effective Windows EKU policy
+ * permits TLS server authentication. DER is borrowed for the call. */
 typedef void (*ScrTlsCaWindowsRootFn)(void *ctx, const unsigned char *der, size_t len);
 bool scr_tls_ca_windows_cert_server_auth(const void *cert_context);
 void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx);

--- a/packages/runtime/src/scr_tls.c
+++ b/packages/runtime/src/scr_tls.c
@@ -338,9 +338,9 @@ typedef struct ScrTlsCli {
 
 /* The default trust anchors when no `ca` option is given: the host trust
  * store, standing in for Node's compiled-in Mozilla roots, plus
- * NODE_EXTRA_CA_CERTS. Windows certificates live as DER entries in the
- * current user's logical ROOT store, which includes the inherited machine
- * roots; mbedTLS copies each successfully parsed entry into its own chain.
+ * NODE_EXTRA_CA_CERTS. Windows certificates live as DER entries across the
+ * machine, enterprise, current-user, and policy ROOT-store locations;
+ * mbedTLS copies each successfully parsed entry into its own chain.
  * POSIX hosts probe the established bundle spellings — /etc/ssl/cert.pem
  * first (macOS ships it; Alpine links it), then Debian/Ubuntu's
  * ca-certificates.crt, Fedora/RHEL's ca-bundle.crt, and openSUSE's

--- a/packages/runtime/src/scr_tls.c
+++ b/packages/runtime/src/scr_tls.c
@@ -339,8 +339,8 @@ typedef struct ScrTlsCli {
 /* The default trust anchors when no `ca` option is given: the host trust
  * store, standing in for Node's compiled-in Mozilla roots, plus
  * NODE_EXTRA_CA_CERTS. Windows certificates live as DER entries across the
- * machine, enterprise, current-user, and policy ROOT-store locations;
- * mbedTLS copies each successfully parsed entry into its own chain.
+ * machine, enterprise, current-user, and policy ROOT/CA/TrustedPeople store
+ * locations; mbedTLS copies each successfully parsed entry into its own chain.
  * POSIX hosts probe the established bundle spellings — /etc/ssl/cert.pem
  * first (macOS ships it; Alpine links it), then Debian/Ubuntu's
  * ca-certificates.crt, Fedora/RHEL's ca-bundle.crt, and openSUSE's
@@ -357,7 +357,7 @@ static mbedtls_x509_crt scr_tls_override_roots;
 static uint64_t scr_tls_override_parsed_gen = 0;
 
 #ifdef _WIN32
-static void scr_tls_add_windows_root(void *ctx, const unsigned char *der, size_t len) {
+static void scr_tls_add_windows_ca(void *ctx, const unsigned char *der, size_t len) {
   (void)mbedtls_x509_crt_parse_der((mbedtls_x509_crt *)ctx, der, len);
 }
 #endif
@@ -385,7 +385,7 @@ static mbedtls_x509_crt *scr_tls_system_ca(void) {
     /* The shared enumerator applies Windows' effective server-auth EKU
      * policy before yielding DER. mbedTLS copies every successfully parsed
      * entry, so the store contexts may die immediately after each callback. */
-    scr_tls_ca_windows_roots(scr_tls_add_windows_root, &scr_tls_system_roots);
+    scr_tls_ca_windows_certs(scr_tls_add_windows_ca, &scr_tls_system_roots);
 #else
     static const char *const bundles[] = {
         "/etc/ssl/cert.pem",                  /* macOS, Alpine */

--- a/packages/runtime/src/scr_tls.c
+++ b/packages/runtime/src/scr_tls.c
@@ -56,7 +56,7 @@
  * head buffers in the socket's write buffer until the handshake
  * establishes (the mid-connect buffering path, reused verbatim).
  * rejectUnauthorized:false maps to VERIFY_NONE; `ca` replaces the trust
- * anchors; with neither, /etc/ssl/cert.pem stands in for Node's bundled
+ * anchors; with neither, the host trust store stands in for Node's bundled
  * Mozilla roots (SEMANTICS.md documents the divergence). Verify
  * failures surface as Node-shaped 'error' messages on the request
  * ("self-signed certificate", "self-signed certificate in certificate
@@ -81,6 +81,7 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h> /* inet_pton, in6_addr */
+#include <wincrypt.h> /* ROOT certificate store */
 #else
 #include <arpa/inet.h>
 #endif
@@ -336,15 +337,15 @@ typedef struct ScrTlsCli {
   bool verify_recorded;
 } ScrTlsCli;
 
-/* The default trust anchors when no `ca` option is given: the system
- * bundle, standing in for Node's compiled-in Mozilla roots, plus
- * NODE_EXTRA_CA_CERTS. The system bundle is probed once across the distro
- * spellings — /etc/ssl/cert.pem first (macOS ships it; Alpine links it),
- * then Debian/Ubuntu's ca-certificates.crt, Fedora/RHEL's ca-bundle.crt,
- * and openSUSE's ca-bundle.pem. On macOS only the first path exists, so
- * the probe order changes nothing there. A host with none leaves only the
- * optional extra chain. Windows is that host by construction (no PEM
- * bundle ships; the OS store is cert-database-shaped). */
+/* The default trust anchors when no `ca` option is given: the host trust
+ * store, standing in for Node's compiled-in Mozilla roots, plus
+ * NODE_EXTRA_CA_CERTS. Windows certificates live as DER entries in the
+ * current user's logical ROOT store, which includes the inherited machine
+ * roots; mbedTLS copies each successfully parsed entry into its own chain.
+ * POSIX hosts probe the established bundle spellings — /etc/ssl/cert.pem
+ * first (macOS ships it; Alpine links it), then Debian/Ubuntu's
+ * ca-certificates.crt, Fedora/RHEL's ca-bundle.crt, and openSUSE's
+ * ca-bundle.pem. */
 static mbedtls_x509_crt scr_tls_system_roots;
 static bool scr_tls_system_roots_loaded = false;
 
@@ -375,6 +376,21 @@ static mbedtls_x509_crt *scr_tls_system_ca(void) {
   if (!scr_tls_system_roots_loaded) {
     scr_tls_system_roots_loaded = true;
     mbedtls_x509_crt_init(&scr_tls_system_roots);
+#ifdef _WIN32
+    HCERTSTORE store = CertOpenSystemStoreA(0, "ROOT");
+    if (store != NULL) {
+      PCCERT_CONTEXT cert = NULL;
+      /* CertEnumCertificatesInStore frees the previous context on every
+       * call, including the final NULL result. mbedTLS copies DER bytes, so
+       * closing the store after enumeration cannot invalidate the chain. */
+      while ((cert = CertEnumCertificatesInStore(store, cert)) != NULL) {
+        (void)mbedtls_x509_crt_parse_der(
+            &scr_tls_system_roots, cert->pbCertEncoded,
+            (size_t)cert->cbCertEncoded);
+      }
+      (void)CertCloseStore(store, 0);
+    }
+#else
     static const char *const bundles[] = {
         "/etc/ssl/cert.pem",                  /* macOS, Alpine */
         "/etc/ssl/certs/ca-certificates.crt", /* Debian/Ubuntu */
@@ -384,6 +400,7 @@ static mbedtls_x509_crt *scr_tls_system_ca(void) {
     for (size_t i = 0; i < sizeof bundles / sizeof bundles[0]; i++) {
       if (mbedtls_x509_crt_parse_file(&scr_tls_system_roots, bundles[i]) == 0) break;
     }
+#endif
     const char *extra = NULL;
     size_t extra_len = 0;
     if (scr_tls_ca_extra_pem(&extra, &extra_len) && extra_len > 0) {

--- a/packages/runtime/src/scr_tls.c
+++ b/packages/runtime/src/scr_tls.c
@@ -81,7 +81,6 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h> /* inet_pton, in6_addr */
-#include <wincrypt.h> /* ROOT certificate store */
 #else
 #include <arpa/inet.h>
 #endif
@@ -357,6 +356,12 @@ static bool scr_tls_system_roots_loaded = false;
 static mbedtls_x509_crt scr_tls_override_roots;
 static uint64_t scr_tls_override_parsed_gen = 0;
 
+#ifdef _WIN32
+static void scr_tls_add_windows_root(void *ctx, const unsigned char *der, size_t len) {
+  (void)mbedtls_x509_crt_parse_der((mbedtls_x509_crt *)ctx, der, len);
+}
+#endif
+
 static mbedtls_x509_crt *scr_tls_system_ca(void) {
   const char *pem = NULL;
   size_t pem_len = 0;
@@ -377,19 +382,10 @@ static mbedtls_x509_crt *scr_tls_system_ca(void) {
     scr_tls_system_roots_loaded = true;
     mbedtls_x509_crt_init(&scr_tls_system_roots);
 #ifdef _WIN32
-    HCERTSTORE store = CertOpenSystemStoreA(0, "ROOT");
-    if (store != NULL) {
-      PCCERT_CONTEXT cert = NULL;
-      /* CertEnumCertificatesInStore frees the previous context on every
-       * call, including the final NULL result. mbedTLS copies DER bytes, so
-       * closing the store after enumeration cannot invalidate the chain. */
-      while ((cert = CertEnumCertificatesInStore(store, cert)) != NULL) {
-        (void)mbedtls_x509_crt_parse_der(
-            &scr_tls_system_roots, cert->pbCertEncoded,
-            (size_t)cert->cbCertEncoded);
-      }
-      (void)CertCloseStore(store, 0);
-    }
+    /* The shared enumerator applies Windows' effective server-auth EKU
+     * policy before yielding DER. mbedTLS copies every successfully parsed
+     * entry, so the store contexts may die immediately after each callback. */
+    scr_tls_ca_windows_roots(scr_tls_add_windows_root, &scr_tls_system_roots);
 #else
     static const char *const bundles[] = {
         "/etc/ssl/cert.pem",                  /* macOS, Alpine */

--- a/packages/runtime/src/scr_tls_ca.c
+++ b/packages/runtime/src/scr_tls_ca.c
@@ -192,7 +192,7 @@ bool scr_tls_ca_windows_cert_server_auth(const void *cert_context) {
 }
 
 static void scr_tls_ca_windows_roots_at(
-    DWORD location, ScrTlsCaWindowsRootFn fn, void *ctx) {
+    DWORD location, HCERTSTORE seen, ScrTlsCaWindowsRootFn fn, void *ctx) {
   HCERTSTORE store = CertOpenStore(
       CERT_STORE_PROV_SYSTEM_A, 0, 0,
       location | CERT_STORE_OPEN_EXISTING_FLAG | CERT_STORE_READONLY_FLAG,
@@ -202,7 +202,12 @@ static void scr_tls_ca_windows_roots_at(
   /* CertEnumCertificatesInStore frees the previous context on every call,
    * including the final NULL result. Each callback must copy DER it keeps. */
   while ((cert = CertEnumCertificatesInStore(store, cert)) != NULL) {
-    if (scr_tls_ca_windows_cert_server_auth(cert)) {
+    /* The logical stores overlap (notably CurrentUser inherits machine
+     * roots). CERT_STORE_ADD_NEW turns the memory store into a process-local
+     * identity set: only the first allowed context reaches the consumer. */
+    if (scr_tls_ca_windows_cert_server_auth(cert) &&
+        CertAddCertificateContextToStore(
+            seen, cert, CERT_STORE_ADD_NEW, NULL)) {
       fn(ctx, cert->pbCertEncoded, (size_t)cert->cbCertEncoded);
     }
   }
@@ -214,7 +219,7 @@ void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx) {
    * the ordinary current-user ROOT collection does not include the
    * current-user Group Policy store. Match Node's ROOT-location coverage so
    * organization-managed roots reach both TLS verification and CA-store
-   * introspection. Duplicate entries are harmless and match Node's gather. */
+   * introspection. A memory store deduplicates their overlapping contents. */
   static const DWORD locations[] = {
       CERT_SYSTEM_STORE_LOCAL_MACHINE,
       CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY,
@@ -222,9 +227,13 @@ void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx) {
       CERT_SYSTEM_STORE_CURRENT_USER,
       CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY,
   };
+  HCERTSTORE seen = CertOpenStore(
+      CERT_STORE_PROV_MEMORY, 0, 0, CERT_STORE_CREATE_NEW_FLAG, NULL);
+  if (seen == NULL) return;
   for (size_t i = 0; i < sizeof locations / sizeof locations[0]; i++) {
-    scr_tls_ca_windows_roots_at(locations[i], fn, ctx);
+    scr_tls_ca_windows_roots_at(locations[i], seen, fn, ctx);
   }
+  (void)CertCloseStore(seen, 0);
 }
 
 static void scr_ca_push_windows_root(void *ctx, const unsigned char *der, size_t len) {

--- a/packages/runtime/src/scr_tls_ca.c
+++ b/packages/runtime/src/scr_tls_ca.c
@@ -11,7 +11,7 @@
  *
  * Divergences, documented: the host bundle stands in for Node's
  * compiled-in Mozilla roots ('bundled' and rootCertificates) AND for the
- * platform store ('system') — Windows' system ROOT stores and the POSIX
+ * platform store ('system') — Windows' system certificate stores and the POSIX
  * bundle probe are the same sources scr_tls.c's anchors use; and set-time
  * validation is PEM-BLOCK shaped (a well-formed block with corrupt DER
  * inside is kept here where Node's X509 parse would drop it — such a cert
@@ -191,12 +191,13 @@ bool scr_tls_ca_windows_cert_server_auth(const void *cert_context) {
   return allowed;
 }
 
-static void scr_tls_ca_windows_roots_at(
-    DWORD location, HCERTSTORE seen, ScrTlsCaWindowsRootFn fn, void *ctx) {
+static void scr_tls_ca_windows_certs_at(
+    DWORD location, const char *store_name, HCERTSTORE seen,
+    ScrTlsCaWindowsCertFn fn, void *ctx) {
   HCERTSTORE store = CertOpenStore(
       CERT_STORE_PROV_SYSTEM_A, 0, 0,
       location | CERT_STORE_OPEN_EXISTING_FLAG | CERT_STORE_READONLY_FLAG,
-      "ROOT");
+      store_name);
   if (store == NULL) return;
   PCCERT_CONTEXT cert = NULL;
   /* CertEnumCertificatesInStore frees the previous context on every call,
@@ -214,29 +215,41 @@ static void scr_tls_ca_windows_roots_at(
   (void)CertCloseStore(store, 0);
 }
 
-void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx) {
-  /* Windows keeps policy and enterprise roots in distinct store locations;
-   * the ordinary current-user ROOT collection does not include the
-   * current-user Group Policy store. Match Node's ROOT-location coverage so
-   * organization-managed roots reach both TLS verification and CA-store
-   * introspection. A memory store deduplicates their overlapping contents. */
-  static const DWORD locations[] = {
-      CERT_SYSTEM_STORE_LOCAL_MACHINE,
-      CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY,
-      CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE,
-      CERT_SYSTEM_STORE_CURRENT_USER,
-      CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY,
+void scr_tls_ca_windows_certs(ScrTlsCaWindowsCertFn fn, void *ctx) {
+  /* Match Node's Windows system-certificate sources: roots and intermediate
+   * CAs from all five applicable locations, plus explicitly trusted server
+   * certificates from the three local-machine TrustedPeople locations.
+   * A memory store deduplicates their overlapping contents. */
+  typedef struct ScrTlsCaWindowsStore {
+    DWORD location;
+    const char *name;
+  } ScrTlsCaWindowsStore;
+  static const ScrTlsCaWindowsStore stores[] = {
+      {CERT_SYSTEM_STORE_LOCAL_MACHINE, "ROOT"},
+      {CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, "ROOT"},
+      {CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, "ROOT"},
+      {CERT_SYSTEM_STORE_CURRENT_USER, "ROOT"},
+      {CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, "ROOT"},
+      {CERT_SYSTEM_STORE_LOCAL_MACHINE, "CA"},
+      {CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, "CA"},
+      {CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, "CA"},
+      {CERT_SYSTEM_STORE_CURRENT_USER, "CA"},
+      {CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY, "CA"},
+      {CERT_SYSTEM_STORE_LOCAL_MACHINE, "TrustedPeople"},
+      {CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY, "TrustedPeople"},
+      {CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE, "TrustedPeople"},
   };
   HCERTSTORE seen = CertOpenStore(
       CERT_STORE_PROV_MEMORY, 0, 0, CERT_STORE_CREATE_NEW_FLAG, NULL);
   if (seen == NULL) return;
-  for (size_t i = 0; i < sizeof locations / sizeof locations[0]; i++) {
-    scr_tls_ca_windows_roots_at(locations[i], seen, fn, ctx);
+  for (size_t i = 0; i < sizeof stores / sizeof stores[0]; i++) {
+    scr_tls_ca_windows_certs_at(
+        stores[i].location, stores[i].name, seen, fn, ctx);
   }
   (void)CertCloseStore(seen, 0);
 }
 
-static void scr_ca_push_windows_root(void *ctx, const unsigned char *der, size_t len) {
+static void scr_ca_push_windows_cert(void *ctx, const unsigned char *der, size_t len) {
   if (len > UINT32_MAX) return;
   DWORD pem_cap = 0;
   DWORD flags = CRYPT_STRING_BASE64HEADER | CRYPT_STRING_NOCR;
@@ -259,7 +272,7 @@ static void scr_ca_push_windows_root(void *ctx, const unsigned char *der, size_t
 static ScrArr *scr_ca_load_host_bundle(void) {
   ScrArr *arr = scr_arr_new(SCR_ELEM_STR, 128);
 #ifdef _WIN32
-  scr_tls_ca_windows_roots(scr_ca_push_windows_root, arr);
+  scr_tls_ca_windows_certs(scr_ca_push_windows_cert, arr);
 #else
   static const char *const bundles[] = {
       "/etc/ssl/cert.pem",                  /* macOS, Alpine */

--- a/packages/runtime/src/scr_tls_ca.c
+++ b/packages/runtime/src/scr_tls_ca.c
@@ -2,28 +2,33 @@
  * rootCertificates, and setDefaultCACertificates (scr_runtime.h has the
  * contracts). Its own link gate ("tlsca." libCalls), deliberately free
  * of mbedTLS: everything here is PEM-BLOCK bookkeeping over the host
- * bundle, so a program that only inspects the CA store keeps the lean
- * link line. scr_tls.c (when it links — cc.ts compiles this unit
- * alongside it) consults scr_tls_ca_default_override for its client
- * trust anchors, which is what makes setDefaultCACertificates LIVE
- * semantics: the next https/tls dial verifies against the replaced set.
+ * roots (plus crypt32 store access on Windows), so a program that only
+ * inspects the CA store never builds the TLS archive. scr_tls.c (when it
+ * links — cc.ts compiles this unit alongside it) consults
+ * scr_tls_ca_default_override for its client trust anchors, which is what
+ * makes setDefaultCACertificates LIVE semantics: the next https/tls dial
+ * verifies against the replaced set.
  *
  * Divergences, documented: the host bundle stands in for Node's
  * compiled-in Mozilla roots ('bundled' and rootCertificates) AND for the
- * platform store ('system') — the same /etc/ssl/cert.pem stance
- * scr_tls.c's anchors established; and set-time validation is PEM-BLOCK
- * shaped (a well-formed block with corrupt DER inside is kept here where
- * Node's X509 parse would drop it — such a cert then fails verification
- * instead, the same observable outcome one step later). Deduplication is
- * byte-exact over the extracted block where Node compares parsed X509
- * identities; re-encoded duplicates of one certificate stay distinct
- * entries, which no equality the tests observe can distinguish without a
- * parser. */
+ * platform store ('system') — Windows' logical ROOT store and the POSIX
+ * bundle probe are the same sources scr_tls.c's anchors use; and set-time
+ * validation is PEM-BLOCK shaped (a well-formed block with corrupt DER
+ * inside is kept here where Node's X509 parse would drop it — such a cert
+ * then fails verification instead, the same observable outcome one step
+ * later). Deduplication is byte-exact over the extracted block where Node
+ * compares parsed X509 identities; re-encoded duplicates of one certificate
+ * stay distinct entries, which no equality the tests observe can distinguish
+ * without a parser. */
 #include "scr_runtime.h"
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <windows.h>
+#include <wincrypt.h>
+#endif
 
 /* The per-type caches: +1 held here for the process lifetime (an atexit
  * teardown releases them so the RC audit stays clean). 'default' also
@@ -154,9 +159,81 @@ bool scr_tls_ca_extra_pem(const char **pem, size_t *len) {
   return true;
 }
 
-/* The host bundle, probed in scr_tls.c's documented order. */
+#ifdef _WIN32
+/* Windows can restrict a certificate's purposes in a store property that is
+ * not part of its DER. CertGetEnhancedKeyUsage with flags 0 intersects that
+ * property with the encoded EKU extension. An empty result means either all
+ * purposes (CRYPT_E_NOT_FOUND) or no purposes (ERROR_SUCCESS); every other
+ * API failure is fail-closed too. */
+bool scr_tls_ca_windows_cert_server_auth(const void *cert_context) {
+  PCCERT_CONTEXT cert = (PCCERT_CONTEXT)cert_context;
+  DWORD usage_len = 0;
+  if (!CertGetEnhancedKeyUsage(cert, 0, NULL, &usage_len) || usage_len == 0) {
+    return false;
+  }
+  CERT_ENHKEY_USAGE *usage = malloc((size_t)usage_len);
+  if (usage == NULL) scr_ca_oom();
+  if (!CertGetEnhancedKeyUsage(cert, 0, usage, &usage_len)) {
+    free(usage);
+    return false;
+  }
+  DWORD usage_error = GetLastError();
+  bool allowed = usage->cUsageIdentifier == 0 &&
+      usage_error == CRYPT_E_NOT_FOUND;
+  for (DWORD i = 0; !allowed && usage->rgpszUsageIdentifier != NULL &&
+       i < usage->cUsageIdentifier; i++) {
+    const char *oid = usage->rgpszUsageIdentifier[i];
+    allowed = oid != NULL &&
+        (strcmp(oid, szOID_PKIX_KP_SERVER_AUTH) == 0 ||
+         strcmp(oid, szOID_ANY_ENHANCED_KEY_USAGE) == 0);
+  }
+  free(usage);
+  return allowed;
+}
+
+void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx) {
+  HCERTSTORE store = CertOpenStore(
+      CERT_STORE_PROV_SYSTEM_A, 0, 0,
+      CERT_SYSTEM_STORE_CURRENT_USER | CERT_STORE_OPEN_EXISTING_FLAG |
+          CERT_STORE_READONLY_FLAG,
+      "ROOT");
+  if (store == NULL) return;
+  PCCERT_CONTEXT cert = NULL;
+  /* CertEnumCertificatesInStore frees the previous context on every call,
+   * including the final NULL result. Each callback must copy DER it keeps. */
+  while ((cert = CertEnumCertificatesInStore(store, cert)) != NULL) {
+    if (scr_tls_ca_windows_cert_server_auth(cert)) {
+      fn(ctx, cert->pbCertEncoded, (size_t)cert->cbCertEncoded);
+    }
+  }
+  (void)CertCloseStore(store, 0);
+}
+
+static void scr_ca_push_windows_root(void *ctx, const unsigned char *der, size_t len) {
+  if (len > UINT32_MAX) return;
+  DWORD pem_cap = 0;
+  DWORD flags = CRYPT_STRING_BASE64HEADER | CRYPT_STRING_NOCR;
+  if (!CryptBinaryToStringA(der, (DWORD)len, flags, NULL, &pem_cap) ||
+      pem_cap == 0) {
+    return;
+  }
+  char *pem = malloc((size_t)pem_cap);
+  if (pem == NULL) scr_ca_oom();
+  DWORD pem_len = pem_cap;
+  if (CryptBinaryToStringA(der, (DWORD)len, flags, pem, &pem_len)) {
+    scr_arr_push_ref((ScrArr *)ctx, scr_str_new(pem, (size_t)pem_len));
+  }
+  free(pem);
+}
+#endif
+
+/* The host roots, from the Windows logical store or the POSIX bundle probe
+ * shared with scr_tls.c. */
 static ScrArr *scr_ca_load_host_bundle(void) {
   ScrArr *arr = scr_arr_new(SCR_ELEM_STR, 128);
+#ifdef _WIN32
+  scr_tls_ca_windows_roots(scr_ca_push_windows_root, arr);
+#else
   static const char *const bundles[] = {
       "/etc/ssl/cert.pem",                  /* macOS, Alpine */
       "/etc/ssl/certs/ca-certificates.crt", /* Debian/Ubuntu */
@@ -171,6 +248,7 @@ static ScrArr *scr_ca_load_host_bundle(void) {
     free(text);
     break; /* first bundle wins, like the anchor probe */
   }
+#endif
   return arr;
 }
 

--- a/packages/runtime/src/scr_tls_ca.c
+++ b/packages/runtime/src/scr_tls_ca.c
@@ -11,7 +11,7 @@
  *
  * Divergences, documented: the host bundle stands in for Node's
  * compiled-in Mozilla roots ('bundled' and rootCertificates) AND for the
- * platform store ('system') — Windows' logical ROOT store and the POSIX
+ * platform store ('system') — Windows' system ROOT stores and the POSIX
  * bundle probe are the same sources scr_tls.c's anchors use; and set-time
  * validation is PEM-BLOCK shaped (a well-formed block with corrupt DER
  * inside is kept here where Node's X509 parse would drop it — such a cert
@@ -191,11 +191,11 @@ bool scr_tls_ca_windows_cert_server_auth(const void *cert_context) {
   return allowed;
 }
 
-void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx) {
+static void scr_tls_ca_windows_roots_at(
+    DWORD location, ScrTlsCaWindowsRootFn fn, void *ctx) {
   HCERTSTORE store = CertOpenStore(
       CERT_STORE_PROV_SYSTEM_A, 0, 0,
-      CERT_SYSTEM_STORE_CURRENT_USER | CERT_STORE_OPEN_EXISTING_FLAG |
-          CERT_STORE_READONLY_FLAG,
+      location | CERT_STORE_OPEN_EXISTING_FLAG | CERT_STORE_READONLY_FLAG,
       "ROOT");
   if (store == NULL) return;
   PCCERT_CONTEXT cert = NULL;
@@ -207,6 +207,24 @@ void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx) {
     }
   }
   (void)CertCloseStore(store, 0);
+}
+
+void scr_tls_ca_windows_roots(ScrTlsCaWindowsRootFn fn, void *ctx) {
+  /* Windows keeps policy and enterprise roots in distinct store locations;
+   * the ordinary current-user ROOT collection does not include the
+   * current-user Group Policy store. Match Node's ROOT-location coverage so
+   * organization-managed roots reach both TLS verification and CA-store
+   * introspection. Duplicate entries are harmless and match Node's gather. */
+  static const DWORD locations[] = {
+      CERT_SYSTEM_STORE_LOCAL_MACHINE,
+      CERT_SYSTEM_STORE_LOCAL_MACHINE_GROUP_POLICY,
+      CERT_SYSTEM_STORE_LOCAL_MACHINE_ENTERPRISE,
+      CERT_SYSTEM_STORE_CURRENT_USER,
+      CERT_SYSTEM_STORE_CURRENT_USER_GROUP_POLICY,
+  };
+  for (size_t i = 0; i < sizeof locations / sizeof locations[0]; i++) {
+    scr_tls_ca_windows_roots_at(locations[i], fn, ctx);
+  }
 }
 
 static void scr_ca_push_windows_root(void *ctx, const unsigned char *der, size_t len) {

--- a/tests/corpus/2557-tls-ca-store.ts
+++ b/tests/corpus/2557-tls-ca-store.ts
@@ -26,8 +26,14 @@ console.log("bundled-pem", allPem);
 console.log("cached", getCACertificates("bundled") === bundled);
 console.log("roots", rootCertificates === bundled, tls.rootCertificates === bundled);
 console.log("default-cached", getCACertificates() === getCACertificates("default"));
-console.log("system-cached", getCACertificates("system") === getCACertificates("system"));
+const system = getCACertificates("system");
+console.log("system-cached", system === getCACertificates("system"));
+console.log("system-nonempty", system.length > 0);
 console.log("extra-cached", getCACertificates("extra") === getCACertificates("extra"));
+
+// Node's documented recipe must retain a non-empty trust set on every host.
+tls.setDefaultCACertificates(system);
+console.log("system-default", getCACertificates("default").length > 0);
 
 // A fixed self-signed certificate (only its identity matters here).
 const PEM = `-----BEGIN CERTIFICATE-----

--- a/tests/corpus/2557-tls-ca-store.ts
+++ b/tests/corpus/2557-tls-ca-store.ts
@@ -28,12 +28,16 @@ console.log("roots", rootCertificates === bundled, tls.rootCertificates === bund
 console.log("default-cached", getCACertificates() === getCACertificates("default"));
 const system = getCACertificates("system");
 console.log("system-cached", system === getCACertificates("system"));
-console.log("system-nonempty", system.length > 0);
 console.log("extra-cached", getCACertificates("extra") === getCACertificates("extra"));
 
-// Node's documented recipe must retain a non-empty trust set on every host.
-tls.setDefaultCACertificates(system);
-console.log("system-default", getCACertificates("default").length > 0);
+// Windows is the store-backed implementation this case needs to pin. Other
+// hosts may legitimately expose an empty/inaccessible system store, and
+// scriptc's documented POSIX bundle source need not share that cardinality.
+if (process.platform === "win32") {
+  console.log("system-nonempty", system.length > 0);
+  tls.setDefaultCACertificates(system);
+  console.log("system-default", getCACertificates("default").length > 0);
+}
 
 // A fixed self-signed certificate (only its identity matters here).
 const PEM = `-----BEGIN CERTIFICATE-----

--- a/tests/harness/differential.test.ts
+++ b/tests/harness/differential.test.ts
@@ -264,16 +264,20 @@ function oracleKeyBase(): Promise<string> {
  * spawn Node live. VOLATILE-HOST programs ride the same exclusion:
  * os.networkInterfaces output changes under the harness's feet (macOS
  * rotates the awdl0/llw0 link-local address), so a cached Node verdict
- * goes stale against a live native read (observed with 1480). */
-function usesRealTime(inputs: string[]): boolean {
+ * goes stale against a live native read (observed with 1480). The platform
+ * certificate store is mutable host state too: a cached system-CA predicate
+ * must not outlive an administrator or keychain change. */
+function usesVolatileHostState(inputs: string[]): boolean {
   return inputs.some((f) =>
-    /set(Timeout|Interval)|Promise\.(race|any)|networkInterfaces/.test(readFileSync(f, "utf8")),
+    /set(Timeout|Interval)|Promise\.(race|any)|networkInterfaces|getCACertificates\s*\(\s*["']system["']/.test(
+      readFileSync(f, "utf8"),
+    ),
   );
 }
 
 async function runNode(file: string): Promise<RunResult> {
   let cachePath: string | null = null;
-  if (oracleDir !== null && !usesRealTime(programInputs(file))) {
+  if (oracleDir !== null && !usesVolatileHostState(programInputs(file))) {
     const h = createHash("sha256").update(await oracleKeyBase());
     for (const f of programInputs(file)) {
       h.update(f.slice(repoRoot.length)).update("\0").update(readFileSync(f)).update("\0");


### PR DESCRIPTION
- Load default TLS roots from the Windows ROOT store.
- Link crypt32 for Windows TLS builds.
- Cover the certificate-store import in cross-build tests.