### PR TITLE
feat(ffi): copy callback strings and spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to scriptc will be documented in this file.
 
 ## Unreleased
 
+### Features
+
+- **Native callbacks copy in strings and byte spans.** FFI format 3 adds callback-only `cstring` parameters plus length-delimited `string` and `bytes` parameters. Trampolines in both backends copy native memory into owned scriptc values, decode malformed UTF-8 with U+FFFD replacement, preserve embedded NUL bytes in spans, and trap precise invalid null pointers before invoking the closure.
+
 <!-- release:start -->
 
 ## 0.0.32

--- a/docs/src/app/ffi/page.mdx
+++ b/docs/src/app/ffi/page.mdx
@@ -101,17 +101,24 @@ The manifest is the native ABI authority. TypeScript has only `number`, so its d
       <td>yes</td>
     </tr>
     <tr>
+      <td><code>cstring</code></td>
+      <td><code>string</code></td>
+      <td><code>const char *</code>; callback input only, copied through lossy UTF-8 decoding</td>
+      <td>callback only (format 3)</td>
+      <td>no</td>
+    </tr>
+    <tr>
       <td><code>string</code></td>
       <td><code>string</code></td>
       <td><code>const uint8_t *, size_t</code>; UTF-8 bytes, length-delimited</td>
-      <td>yes</td>
+      <td>yes; callback input in format 3</td>
       <td>no</td>
     </tr>
     <tr>
       <td><code>bytes</code></td>
       <td><code>Uint8Array</code> or <code>Buffer</code></td>
       <td><code>const uint8_t *, size_t</code>; raw bytes, length-delimited</td>
-      <td>yes</td>
+      <td>yes; callback input in format 3</td>
       <td>no</td>
     </tr>
     <tr>
@@ -124,7 +131,7 @@ The manifest is the native ABI authority. TypeScript has only `number`, so its d
   </tbody>
 </table>
 
-String and byte pointers are borrowed only for the duration of the call. Native code must not mutate, free, or retain them. Strings may contain embedded NUL bytes, so always use the supplied length; an empty span may have a null pointer. The current formats deliberately have no pointer, string, or byte return because those need an explicit ownership and allocator contract.
+For ordinary outbound parameters, string and byte pointers are borrowed only for the duration of the call. Native code must not mutate, free, or retain them. Strings may contain embedded NUL bytes, so always use the supplied length; an empty span may have a null pointer. The current formats deliberately have no pointer, string, or byte return because those need an explicit ownership and allocator contract.
 
 For C++, export the symbol with `extern "C"` so it keeps the manifest's unmangled C name.
 
@@ -182,7 +189,9 @@ The callback id connects the two independently positioned context entries. Both 
 }
 ```
 
-A callback descriptor consumes one TypeScript function parameter and one native function-pointer slot. A context entry consumes no TypeScript parameter and one native `void *` slot. Callback parameter lists currently accept `f64`, `bool`, `u8`, `u32`, and `i32`, plus at most one context entry; callback returns accept those scalar classes or `void`.
+A callback descriptor consumes one TypeScript function parameter and one native function-pointer slot. A context entry consumes no TypeScript parameter and one native `void *` slot. Formats 2 and 3 accept `f64`, `bool`, `u8`, `u32`, and `i32` callback parameters plus at most one context entry. Format 3 additionally accepts `cstring`, `string`, and `bytes`; callback returns remain scalar or `void`.
+
+Format 3 string-bearing callback parameters copy native data before the closure runs. `cstring` reads one non-null, NUL-terminated `const char *`. `string` and `bytes` each consume a `const uint8_t *, size_t` pair; a null pointer is valid only when its length is zero. Text is decoded as UTF-8 with malformed sequences replaced by U+FFFD, matching `Buffer.toString("utf8")`. The resulting string or `Uint8Array` is freshly owned scriptc storage, so the closure may retain it without depending on the native buffer's lifetime. An unexpected null `cstring`, or a null non-empty span, traps at the boundary instead of being treated as empty.
 
 For a raw C callback type with no userdata, omit the context entry from both parameter lists. scriptc installs that closure in a binding-specific thread-local slot around the native call, so captures and nested calls still work. This remains call-scoped: the native function must invoke it synchronously on the thread that entered the native call.
 
@@ -194,10 +203,10 @@ If a callback throws, the adapter returns zero (or `void`) to native code and su
 
 <dl>
   <dt><code>ffi_format</code></dt>
-  <dd>Required. Format <code>1</code> supports value parameters; format <code>2</code> preserves them and adds callback/context entries.</dd>
+  <dd>Required. Format <code>1</code> supports value parameters; format <code>2</code> preserves them and adds callback/context entries; format <code>3</code> adds copy-in <code>cstring</code>, string-span, and byte-span callback parameters.</dd>
 
   <dt><code>functions</code></dt>
-  <dd>Required array. Every entry has exactly <code>name</code>, <code>symbol</code>, <code>params</code>, and <code>returns</code>. Binding names and symbols must be unique. In format 2, callback ids must be unique within a function and every context must match exactly one callback.</dd>
+  <dd>Required array. Every entry has exactly <code>name</code>, <code>symbol</code>, <code>params</code>, and <code>returns</code>. Binding names and symbols must be unique. In formats 2 and 3, callback ids must be unique within a function and every context must match exactly one callback.</dd>
 
   <dt><code>libraries</code></dt>
   <dd>Optional array of archive or object paths. Relative paths are resolved from the manifest directory and appended after the generated program at link time.</dd>

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -96,6 +96,8 @@ export function ffiNativeTypeC(
       return "uint32_t";
     case "i32":
       return "int32_t";
+    case "cstring":
+      return "const char *";
     case "string":
     case "bytes":
       throw new Error(`emitter bug: span class '${cls}' has no scalar C type`);
@@ -105,11 +107,16 @@ export function ffiNativeTypeC(
 }
 
 function ffiCallbackNativeParamsC(callback: IrFfiCallbackParam["callback"], named: boolean): string[] {
-  return callback.params.map((param, i) =>
-    isFfiContextParam(param)
-      ? `void *${named ? "sc_ctx" : ""}`.trim()
-      : `${ffiNativeTypeC(param)}${named ? ` sc_a${i}` : ""}`,
-  );
+  return callback.params.flatMap((param, i): string[] => {
+    if (isFfiContextParam(param)) return [`void *${named ? "sc_ctx" : ""}`.trim()];
+    if (param === "string" || param === "bytes") {
+      return [
+        `const uint8_t *${named ? `sc_a${i}` : ""}`.trim(),
+        `size_t${named ? ` sc_a${i}_len` : ""}`,
+      ];
+    }
+    return [`${ffiNativeTypeC(param)}${named ? ` sc_a${i}` : ""}`];
+  });
 }
 
 function ffiCallbackPointerTypeC(callback: IrFfiCallbackParam["callback"]): string {
@@ -1733,11 +1740,12 @@ export class CEmitter {
     return adapter;
   }
 
-  /** C-callable trampolines for format-2 callbacks. The external callback
-   * ABI is scalar C plus an optional exact-position context pointer; the
-   * internal side is scriptc's (ScrClosure *env, params...) convention.
-   * A raw callback borrows its closure through a distinct TLS slot for the
-   * dynamic extent of the outer call. */
+  /** C-callable trampolines for format-2/3 callbacks. The external callback
+   * ABI is scalar C, format-3 copy-in string/byte slots, plus an optional
+   * exact-position context pointer; the internal side is scriptc's
+   * (ScrClosure *env, params...) convention. A raw callback borrows its
+   * closure through a distinct TLS slot for the dynamic extent of the outer
+   * call. */
   emitFfiCallbackDefs(out: string[]): void {
     if (this.ffiCallbackAdapters.size === 0) return;
     for (const adapter of this.ffiCallbackAdapters.values()) {
@@ -1755,7 +1763,41 @@ export class CEmitter {
       );
       const dummy = ffiCallbackDummyC(cb);
       out.push(`  if (scr_exc_pending()) ${cb.returns === "void" ? "return;" : `return ${dummy};`}`);
+      // Reject every invalid native pointer before materializing any owned
+      // callback arguments, so the trap path cannot strand an earlier copy.
+      for (let i = 0; i < cb.params.length; i++) {
+        const param = cb.params[i]!;
+        if (param === "cstring") {
+          out.push(
+            `  if (sc_a${i} == NULL) scr_trap("scriptc: native callback passed a NULL cstring\\n");`,
+          );
+        } else if (param === "string" || param === "bytes") {
+          out.push(
+            `  if (sc_a${i} == NULL && sc_a${i}_len != 0) scr_trap("scriptc: native callback passed a NULL ${param} span with nonzero length\\n");`,
+          );
+        }
+      }
       const ft = ffiCallbackType(cb);
+      const materialized = new Map<number, string>();
+      for (let i = 0; i < cb.params.length; i++) {
+        const param = cb.params[i]!;
+        if (isFfiContextParam(param)) continue;
+        if (param === "cstring") {
+          const local = `sc_s${i}`;
+          out.push(
+            `  ScrStr *${local} = scr_str_from_utf8_lossy((const uint8_t *)sc_a${i}, strlen(sc_a${i}));`,
+          );
+          materialized.set(i, local);
+        } else if (param === "string") {
+          const local = `sc_s${i}`;
+          out.push(`  ScrStr *${local} = scr_str_from_utf8_lossy(sc_a${i}, sc_a${i}_len);`);
+          materialized.set(i, local);
+        } else if (param === "bytes") {
+          const local = `sc_s${i}`;
+          out.push(`  ScrBytes *${local} = scr_bytes_from_data(sc_a${i}, sc_a${i}_len);`);
+          materialized.set(i, local);
+        }
+      }
       const scriptArgs = cb.params.flatMap((param, i): string[] => {
         if (isFfiContextParam(param)) return [];
         switch (param) {
@@ -1767,6 +1809,10 @@ export class CEmitter {
           case "u32":
           case "i32":
             return [`(double)sc_a${i}`];
+          case "cstring":
+          case "string":
+          case "bytes":
+            return [materialized.get(i)!];
         }
       });
       const call = `(${cFnPtrCast(ft)}sc_cb->fn)(sc_cb${scriptArgs.length ? `, ${scriptArgs.join(", ")}` : ""})`;

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -119,6 +119,8 @@ function ffiNativeTypeLl(
     case "u32":
     case "i32":
       return "i32";
+    case "cstring":
+      return "ptr";
     case "string":
     case "bytes":
       throw new Error(`llvm emitter bug: span class '${cls}' has no scalar LLVM type`);
@@ -1290,9 +1292,13 @@ class LlEmitter {
     for (const adapter of this.ffiCallbackAdapters.values()) {
       const cb = adapter.callback;
       if (adapter.tls !== null) globals.push(`@${adapter.tls} = internal thread_local global ptr null`);
-      const params = cb.params.map((param, i) =>
-        isFfiContextParam(param) ? `ptr %ctx` : `${ffiNativeTypeLl(param)} %a${i}`,
-      );
+      const params = cb.params.flatMap((param, i): string[] => {
+        if (isFfiContextParam(param)) return [`ptr %ctx`];
+        if (param === "string" || param === "bytes") {
+          return [`ptr %a${i}`, `${this.sizeType} %a${i}_len`];
+        }
+        return [`${ffiNativeTypeLl(param)} %a${i}`];
+      });
       const ret = ffiNativeTypeLl(cb.returns);
       defs.push(
         `define internal ${ret} @${adapter.symbol}(${params.join(", ")}) ${FN_ATTRS} {`,
@@ -1309,6 +1315,34 @@ class LlEmitter {
         `skip:`,
         `  ret ${ffiCallbackDummyLl(cb)}`,
         `invoke:`,
+      );
+      // Validate every native pointer before allocating any copy-in value.
+      // A later bad slot therefore cannot leak an earlier materialization.
+      for (let i = 0; i < cb.params.length; i++) {
+        const param = cb.params[i]!;
+        if (param !== "cstring" && param !== "string" && param !== "bytes") continue;
+        const invalid = `%invalid${i}`;
+        defs.push(`  %null${i} = icmp eq ptr %a${i}, null`);
+        if (param === "cstring") {
+          defs.push(`  ${invalid} = or i1 %null${i}, false`);
+        } else {
+          defs.push(
+            `  %nonempty${i} = icmp ne ${this.sizeType} %a${i}_len, 0`,
+            `  ${invalid} = and i1 %null${i}, %nonempty${i}`,
+          );
+        }
+        const message = param === "cstring"
+          ? "scriptc: native callback passed a NULL cstring\n"
+          : `scriptc: native callback passed a NULL ${param} span with nonzero length\n`;
+        defs.push(
+          `  br i1 ${invalid}, label %invalid_param${i}, label %param_ok${i}`,
+          `invalid_param${i}:`,
+          `  call void @scr_trap(ptr ${this.cstr(message)})`,
+          `  unreachable`,
+          `param_ok${i}:`,
+        );
+      }
+      defs.push(
         `  %fnp = getelementptr inbounds %ScrClosure, ptr %cb, i64 0, i32 1`,
         `  %fn = load ptr, ptr %fnp`,
       );
@@ -1335,6 +1369,29 @@ class LlEmitter {
           case "i32":
             defs.push(`  %s${i} = sitofp i32 %a${i} to double`);
             scriptArgs.push(`double %s${i}`);
+            break;
+          case "cstring":
+            this.declare(`declare ${this.sizeType} @strlen(ptr)`);
+            this.declare(`declare ptr @scr_str_from_utf8_lossy(ptr, ${this.sizeType})`);
+            defs.push(
+              `  %len${i} = call ${this.sizeType} @strlen(ptr %a${i})`,
+              `  %s${i} = call ptr @scr_str_from_utf8_lossy(ptr %a${i}, ${this.sizeType} %len${i})`,
+            );
+            scriptArgs.push(`ptr %s${i}`);
+            break;
+          case "string":
+            this.declare(`declare ptr @scr_str_from_utf8_lossy(ptr, ${this.sizeType})`);
+            defs.push(
+              `  %s${i} = call ptr @scr_str_from_utf8_lossy(ptr %a${i}, ${this.sizeType} %a${i}_len)`,
+            );
+            scriptArgs.push(`ptr %s${i}`);
+            break;
+          case "bytes":
+            this.declare(`declare ptr @scr_bytes_from_data(ptr, ${this.sizeType})`);
+            defs.push(
+              `  %s${i} = call ptr @scr_bytes_from_data(ptr %a${i}, ${this.sizeType} %a${i}_len)`,
+            );
+            scriptArgs.push(`ptr %s${i}`);
             break;
         }
       }

--- a/packages/compiler/src/diagnostics/diagnostic.ts
+++ b/packages/compiler/src/diagnostics/diagnostic.ts
@@ -106,6 +106,7 @@ export function ffiSignatureDiag(name: string, detail: string, loc: SrcLoc): Scr
     hint:
       "FFI parameter classes: f64/u8/u32/i32 (TypeScript number), bool, string, and bytes " +
       "(Uint8Array/Buffer); format 2 also accepts call-scoped callback descriptors with explicit context slots; " +
+      "format 3 callback parameters additionally accept cstring/string (TypeScript string) and bytes (Uint8Array); " +
       "return classes: f64/u8/u32/i32, bool, and void",
   };
 }

--- a/packages/compiler/src/ffi/profile.ts
+++ b/packages/compiler/src/ffi/profile.ts
@@ -34,7 +34,12 @@
  * Context entries are compiler-supplied and consume no TypeScript
  * parameter. `lifetime: "call"` is deliberately the only policy today:
  * native code may invoke the callback synchronously on the calling thread
- * and must not retain either pointer after the outer call returns. */
+ * and must not retain either pointer after the outer call returns.
+ *
+ * Format 3 preserves format 2 and adds copy-in callback parameters:
+ * `cstring` is one NUL-terminated pointer, while `string` and `bytes` are
+ * pointer+length spans. The copies have ordinary scriptc ownership and no
+ * lifetime relationship to the native storage. */
 import { readFileSync, statSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { ffiProfileDiag, type ScrDiagnostic } from "../diagnostics/diagnostic.js";
@@ -50,7 +55,17 @@ export const FFI_PARAM_CLASSES = [
 ] as const;
 
 export const FFI_RETURN_CLASSES = ["f64", "bool", "u8", "u32", "i32", "void"] as const;
-export const FFI_CALLBACK_PARAM_CLASSES = ["f64", "bool", "u8", "u32", "i32"] as const;
+export const FFI_CALLBACK_PARAM_CLASSES = [
+  "f64",
+  "bool",
+  "u8",
+  "u32",
+  "i32",
+  "cstring",
+  "string",
+  "bytes",
+] as const;
+const FFI_FORMAT_2_CALLBACK_PARAM_CLASSES = ["f64", "bool", "u8", "u32", "i32"] as const;
 
 export type FfiValueParamClass = (typeof FFI_PARAM_CLASSES)[number];
 export type FfiReturnClass = (typeof FFI_RETURN_CLASSES)[number];
@@ -85,7 +100,7 @@ export interface FfiFunction {
 }
 
 export interface FfiProfile {
-  ffiFormat: 1 | 2;
+  ffiFormat: 1 | 2 | 3;
   functions: FfiFunction[];
   /** Absolute paths, resolved relative to the manifest. */
   libraries: string[];
@@ -137,7 +152,7 @@ function contextParam(value: unknown, path: string): FfiContextParam | null {
   return { context: stringField(rec["context"], `${path}.context`) };
 }
 
-function callbackParam(value: unknown, path: string): FfiCallbackParam | null {
+function callbackParam(value: unknown, path: string, format: 2 | 3): FfiCallbackParam | null {
   if (value === null || typeof value !== "object" || Array.isArray(value)) return null;
   const rec = value as Record<string, unknown>;
   if (!("callback" in rec)) return null;
@@ -157,16 +172,25 @@ function callbackParam(value: unknown, path: string): FfiCallbackParam | null {
   }
   const params = callback["params"].map((entry, i): FfiCallbackParamClass | FfiContextParam => {
     const entryPath = `${path}.callback.params[${i}]`;
+    const allowed = format === 3
+      ? FFI_CALLBACK_PARAM_CLASSES
+      : FFI_FORMAT_2_CALLBACK_PARAM_CLASSES;
+    if (
+      typeof entry === "string" &&
+      (allowed as readonly string[]).includes(entry)
+    ) {
+      return entry as FfiCallbackParamClass;
+    }
     if (
       typeof entry === "string" &&
       (FFI_CALLBACK_PARAM_CLASSES as readonly string[]).includes(entry)
     ) {
-      return entry as FfiCallbackParamClass;
+      throw new FfiProfileError(`'${entryPath}' class '${entry}' requires ffi_format 3`);
     }
     const context = contextParam(entry, entryPath);
     if (context !== null) return context;
     throw new FfiProfileError(
-      `'${entryPath}' must be one of ${FFI_CALLBACK_PARAM_CLASSES.join("/")} or a context entry`,
+      `'${entryPath}' must be one of ${allowed.join("/")} or a context entry`,
     );
   });
   const returns = stringField(callback["returns"], `${path}.callback.returns`);
@@ -214,11 +238,11 @@ export function loadFfiProfile(
     }
     const root = raw as Record<string, unknown>;
     const format = root["ffi_format"];
-    if (format !== 1 && format !== 2) {
+    if (format !== 1 && format !== 2 && format !== 3) {
       throw new FfiProfileError(
         typeof format === "number"
-          ? `unsupported ffi_format ${format} (this scriptc reads formats 1 and 2)`
-          : "'ffi_format' must be the number 1 or 2",
+          ? `unsupported ffi_format ${format} (this scriptc reads formats 1, 2, and 3)`
+          : "'ffi_format' must be the number 1, 2, or 3",
       );
     }
     rejectUnknownKeys(root, "", [
@@ -268,8 +292,8 @@ export function loadFfiProfile(
           typeof value !== "string" ||
           !(FFI_PARAM_CLASSES as readonly string[]).includes(value)
         ) {
-          if (format === 2) {
-            const callback = callbackParam(value, paramPath);
+          if (format >= 2) {
+            const callback = callbackParam(value, paramPath, format === 2 ? 2 : 3);
             if (callback !== null) return callback;
             const context = contextParam(value, paramPath);
             if (context !== null) return context;
@@ -282,7 +306,7 @@ export function loadFfiProfile(
         }
         return value as FfiValueParamClass;
       });
-      if (format === 2) {
+      if (format >= 2) {
         const callbacks = new Map<string, FfiCallbackParam["callback"]>();
         const outerContexts = new Map<string, number>();
         for (const param of params) {

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -2515,9 +2515,16 @@ function ffiCallbackInputDiagnostic(
       continue;
     }
 
-    const domain = nativeClass === "bool" ? "boolean" : "number";
+    if (nativeClass === "bytes") continue;
+    const domain = nativeClass === "bool"
+      ? "boolean"
+      : nativeClass === "cstring" || nativeClass === "string"
+      ? "string"
+      : "number";
     const coversDomain = nativeClass === "bool"
       ? (paramType.flags & ts.TypeFlags.Boolean) !== 0
+      : nativeClass === "cstring" || nativeClass === "string"
+      ? (paramType.flags & ts.TypeFlags.String) !== 0
       : (paramType.flags & ts.TypeFlags.Number) !== 0;
     if (!coversDomain) {
       return (

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -2255,7 +2255,7 @@ export class Lowerer {
       this.diags.length > 0
         ? null
         : {
-            irVersion: 3,
+            irVersion: 4,
             sourceFile: this.entry.fileName,
             functions,
             classes: artifacts.classes,

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -763,7 +763,15 @@ export interface IrModule {
 }
 
 export type IrFfiValueParamClass = "f64" | "bool" | "u8" | "u32" | "i32" | "string" | "bytes";
-export type IrFfiCallbackParamClass = "f64" | "bool" | "u8" | "u32" | "i32";
+export type IrFfiCallbackParamClass =
+  | "f64"
+  | "bool"
+  | "u8"
+  | "u32"
+  | "i32"
+  | "cstring"
+  | "string"
+  | "bytes";
 export type IrFfiReturnClass = "f64" | "bool" | "u8" | "u32" | "i32" | "void";
 
 export interface IrFfiContextParam {
@@ -794,10 +802,13 @@ export function isFfiContextParam(
 }
 
 /** Script-side type represented by one scalar/span FFI class. */
-export function ffiClassType(cls: IrFfiValueParamClass | IrFfiReturnClass): IrType {
+export function ffiClassType(
+  cls: IrFfiCallbackParamClass | IrFfiValueParamClass | IrFfiReturnClass,
+): IrType {
   switch (cls) {
     case "bool":
       return BOOL;
+    case "cstring":
     case "string":
       return STRING;
     case "bytes":
@@ -833,8 +844,9 @@ export function ffiSourceParamTypes(params: readonly IrFfiParam[]): IrType[] {
 
 /** One outbound native FFI declaration. Format 1 contains only value
  * classes. Format 2 additionally carries exact-position callback/context
- * entries. String/bytes still expand to pointer+length pairs; callbacks
- * and contexts are each one native pointer slot. Callback lifetimes are
+ * entries. Format 3 adds callback copy-in cstrings and spans. Outer
+ * string/bytes values still expand to pointer+length pairs; callbacks and
+ * contexts are each one native pointer slot. Callback lifetimes are
  * call-scoped and their closure/context storage is borrowed. */
 export interface IrFfiImport {
   /** The signature-only ambient TypeScript binding name. */

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -693,7 +693,7 @@ export function isRefCounted(t: IrType): boolean {
 
 export interface IrModule {
   /** Bumped on any breaking IR change; serialize.ts refuses mismatches. */
-  irVersion: 3;
+  irVersion: 4;
   sourceFile: string;
   functions: IrFunction[];
   /** Class shapes. Constructors and methods are ordinary module functions

--- a/packages/compiler/src/ir/serialize.ts
+++ b/packages/compiler/src/ir/serialize.ts
@@ -5,7 +5,7 @@
  */
 import type { IrModule } from "./nodes.js";
 
-export const IR_VERSION = 3 as const;
+export const IR_VERSION = 4 as const;
 
 export function serializeModule(mod: IrModule): string {
   return JSON.stringify(mod, (_key, value) => {

--- a/packages/compiler/src/library/int-infer.test.ts
+++ b/packages/compiler/src/library/int-infer.test.ts
@@ -65,7 +65,7 @@ const sink = (name: string): IrFunction => ({
 /** A module holding the case function plus the two declared sinks. */
 function caseModule(params: string[], locals: string[], body: IrStmt[]): IrModule {
   return {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: "corpus.ts",
     functions: [
       sink("send"),
@@ -136,7 +136,7 @@ const RECORD_CFG: IntSlotConfig = {
 
 function recordCase(body: IrStmt[], names = ["m"], extraFns: IrFunction[] = []): IrModule {
   return {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: "fields.ts",
     functions: [
       ...extraFns,
@@ -177,7 +177,7 @@ const classCountRead = (): IrExpr => ({
 
 function onlyOrdinaryClass(body: IrStmt[]): IntVerdict {
   const mod: IrModule = {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: "class-fields.ts",
     functions: [
       sink("send"),
@@ -391,7 +391,7 @@ describe("the domain's edges beyond the corpus", () => {
       loc,
     };
     const mod: IrModule = {
-      irVersion: 3,
+      irVersion: 4,
       sourceFile: "optional.ts",
       functions: [{
         name: "normalize",

--- a/packages/compiler/test/bytes-element-emission.test.ts
+++ b/packages/compiler/test/bytes-element-emission.test.ts
@@ -66,7 +66,7 @@ function fixture(): IrModule {
   );
 
   return {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: loc.file,
     entry: "__main",
     functions: [{ name: "__main", params: [], returnType: VOID, locals, body, loc }],
@@ -136,7 +136,7 @@ function receiverReassignmentFixture(): IrModule {
   ];
 
   return {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: loc.file,
     entry: "__main",
     functions: [{ name: "__main", params: [], returnType: VOID, locals, body, loc }],
@@ -201,7 +201,7 @@ function integerLoopFixture(mutatesIndex = false): IrModule {
     { kind: "bytesSet", arr: bytesRef(), index: indexRef(), value: ref("sum"), loc },
   );
   return {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: loc.file,
     entry: "__main",
     functions: [{

--- a/packages/compiler/test/emit-c.test.ts
+++ b/packages/compiler/test/emit-c.test.ts
@@ -35,7 +35,7 @@ test("strings: literals, concat in a loop, toString, RC-clean under audit", asyn
   // while (i < 3) { acc = acc + ("-" + i); i = i + 1; }
   // console.log(acc, acc === "x-0-1-2", "α∂" < "β");
   const mod: IrModule = {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: "s.ts",
     entry: "__main",
     functions: [
@@ -113,7 +113,7 @@ test("short-circuit: right operand of && only evaluates when left is true", asyn
   // if (false && sideEffect()) {} ; if (true || sideEffect()) {}
   // console.log("done")
   const mod: IrModule = {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: "l.ts",
     entry: "__main",
     functions: [
@@ -161,7 +161,7 @@ test("string params: callee owns and releases; returns transfer ownership", asyn
   // function greet(who: string): string { return "hi " + who; }
   // console.log(greet("world"));
   const mod: IrModule = {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: "p.ts",
     entry: "__main",
     functions: [

--- a/packages/compiler/test/fixtures/fib-ir.ts
+++ b/packages/compiler/test/fixtures/fib-ir.ts
@@ -18,7 +18,7 @@ const n = (localId: string): IrExpr => ({ kind: "varRef", localId, type: F64, lo
 const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
 
 export const fibModule: IrModule = {
-  irVersion: 3,
+  irVersion: 4,
   sourceFile: "fib.ts",
   entry: "__main",
   functions: [

--- a/packages/compiler/test/ir.test.ts
+++ b/packages/compiler/test/ir.test.ts
@@ -22,7 +22,7 @@ test("fib module JSON round-trips", () => {
 test("validator rejects type mismatches and bad references", () => {
   const loc = { file: "t.ts", start: 0, end: 0 };
   const bad: IrModule = {
-    irVersion: 3,
+    irVersion: 4,
     sourceFile: "t.ts",
     entry: "__main",
     functions: [
@@ -82,7 +82,7 @@ test("serializer round-trips ±Infinity and refuses NaN", () => {
   expect(() => serializeModule(mod)).toThrow(/NaN/);
 });
 
-test("deserializer enforces IR version", () => {
-  const json = serializeModule(fibModule).replace('"irVersion": 3', '"irVersion": 99');
+test("deserializer rejects the previous IR version", () => {
+  const json = serializeModule(fibModule).replace('"irVersion": 4', '"irVersion": 3');
   expect(() => deserializeModule(json)).toThrow(/version mismatch/);
 });

--- a/packages/runtime/src/scr_bytes.c
+++ b/packages/runtime/src/scr_bytes.c
@@ -63,6 +63,15 @@ ScrBytes *scr_bytes_new(ScrBytesElem elem, double n) {
   return scr_bytes_alloc(elem, (size_t)t);
 }
 
+ScrBytes *scr_bytes_from_data(const uint8_t *data, size_t len) {
+  if (data == NULL && len != 0) {
+    scr_trap("scriptc: native callback passed a NULL span with nonzero length\n");
+  }
+  ScrBytes *b = scr_bytes_alloc(SCR_BYTES_U8, len);
+  if (len != 0) memcpy(b->data, data, len);
+  return b;
+}
+
 ScrBytes *scr_bytes_copy(const ScrBytes *src) {
   ScrBytes *b = scr_bytes_alloc(src->elem, src->len);
   memcpy(b->data, src->data, src->len * scr_bytes_elem_size(src->elem));
@@ -410,6 +419,10 @@ static const char scr_hex_digits[] = "0123456789abcdef";
  * — what Buffer.prototype.toString("utf8") does. Output re-encodes as
  * (now valid) UTF-8: worst case 3 bytes per input byte. */
 static ScrStr *scr_bytes_decode_utf8(const uint8_t *in, size_t n) {
+  if (in == NULL && n != 0) {
+    scr_trap("scriptc: native callback passed a NULL span with nonzero length\n");
+  }
+  if (n > (SIZE_MAX - 1) / 3) scr_bytes_oom();
   char *out = malloc(n * 3 + 1);
   if (!out) scr_bytes_oom();
   size_t o = 0;
@@ -476,6 +489,10 @@ static ScrStr *scr_bytes_decode_utf8(const uint8_t *in, size_t n) {
   ScrStr *s = scr_str_new(out, o);
   free(out);
   return s;
+}
+
+ScrStr *scr_str_from_utf8_lossy(const uint8_t *bytes, size_t len) {
+  return scr_bytes_decode_utf8(bytes, len);
 }
 
 /* WHATWG TextDecoder.decode (utf-8, default options): the SAME maximal-

--- a/packages/runtime/src/scr_runtime.h
+++ b/packages/runtime/src/scr_runtime.h
@@ -389,6 +389,9 @@ typedef struct ScrStr {
 } ScrStr;
 
 ScrStr *scr_str_new(const char *bytes, size_t len); /* returns +1 */
+/* Native callback boundary: copy and WHATWG-decode a UTF-8 span, replacing
+ * malformed subsequences with U+FFFD. NULL with len == 0 is an empty span. */
+ScrStr *scr_str_from_utf8_lossy(const uint8_t *bytes, size_t len); /* +1 */
 
 /* Internal allocators for buffer builders (scr_json.c): a +1 string with
  * UNINITIALIZED data (the builder fills bytes, then len and the NUL), and
@@ -4735,6 +4738,9 @@ ScrJsval *scr_jsval_from_bytes(const ScrBytes *b);
  * THROWS Node's "Invalid typed array length" RangeError catchably and
  * returns NULL with the exception pending). */
 ScrBytes *scr_bytes_new(ScrBytesElem elem, double n); /* +1 */
+/* Native callback boundary: exact owned u8 copy. NULL with len == 0 is an
+ * empty span. */
+ScrBytes *scr_bytes_from_data(const uint8_t *data, size_t len); /* +1 */
 
 /* `new Uint8Array(src)` / Buffer.from(u8): a same-elem-kind copy (the
  * compiler fences cross-kind construction). Borrows src. Never throws. */

--- a/tests/ffi/main.ts
+++ b/tests/ffi/main.ts
@@ -25,6 +25,12 @@ declare function nativeCallbackMix(
   ) => number,
 ): number;
 declare function nativeEach(callback: (value: number) => void): void;
+declare function nativePropVisit(callback: (id: number, name: string) => void): void;
+declare function nativeCallbackSpans(
+  callback: (text: string, bytes: Uint8Array) => void,
+): void;
+declare function nativeCallbackStringThrow(callback: (value: string) => void): void;
+declare function nativeNullCString(callback: (value: string) => void): void;
 
 console.log(nativeScale(21));
 console.log(nativeInvert(false), nativeInvert(true));
@@ -54,10 +60,36 @@ nativeEach((value) => {
 });
 console.log(total);
 
+const properties: string[] = [];
+nativePropVisit((id, name) => {
+  properties.push(`${id}:${name}`);
+});
+console.log(properties.join("|"));
+
+let copiedText = "";
+let copiedBytes: Uint8Array = new Uint8Array(0);
+nativeCallbackSpans((text, bytes) => {
+  if (text.length === 0) {
+    console.log(text.length, text.charCodeAt(1), text.slice(2), bytes.join(","));
+  } else {
+    copiedText = text;
+    copiedBytes = bytes;
+  }
+});
+console.log(copiedText.length, copiedText.charCodeAt(1), copiedText.slice(2), copiedBytes.join(","));
+
 try {
   nativeApply(() => {
     throw new Error("callback boom");
   }, 1);
+} catch (error) {
+  console.log("caught", (error as Error).message);
+}
+
+try {
+  nativeCallbackStringThrow((value) => {
+    throw new Error(`string callback boom: ${value}`);
+  });
 } catch (error) {
   console.log("caught", (error as Error).message);
 }

--- a/tests/ffi/native.c
+++ b/tests/ffi/native.c
@@ -80,3 +80,43 @@ void sf_each(sf_each_cb callback, void *context) {
   callback(2, context);
   callback(3, context);
 }
+
+typedef void (*sf_prop_visit_cb)(void *context, int32_t id,
+                                 const char *name);
+
+void sf_prop_visit(sf_prop_visit_cb callback, void *context) {
+  char ascii[] = "alpha";
+  char utf8[] = "caf\xc3\xa9";
+  char invalid[] = {'b', 'a', 'd', ':', (char)0xc3, '(', 0};
+  callback(context, 1, ascii);
+  callback(context, 2, utf8);
+  callback(context, 3, invalid);
+  for (size_t i = 0; i + 1 < sizeof ascii; i++) ascii[i] = 'x';
+  for (size_t i = 0; i + 1 < sizeof utf8; i++) utf8[i] = 'x';
+  for (size_t i = 0; i + 1 < sizeof invalid; i++) invalid[i] = 'x';
+}
+
+typedef void (*sf_spans_cb)(const uint8_t *text, size_t text_len,
+                            const uint8_t *bytes, size_t bytes_len,
+                            void *context);
+
+void sf_callback_spans(sf_spans_cb callback, void *context) {
+  uint8_t text[] = {'A', 0, 'B', 0xc3, 0xa9};
+  uint8_t bytes[] = {0, 255, 1};
+  callback(text, sizeof text, bytes, sizeof bytes, context);
+  for (size_t i = 0; i < sizeof text; i++) text[i] = 'x';
+  for (size_t i = 0; i < sizeof bytes; i++) bytes[i] = 42;
+  callback(NULL, 0, NULL, 0, context);
+}
+
+typedef void (*sf_cstring_cb)(const char *value, void *context);
+
+void sf_callback_string_throw(sf_cstring_cb callback, void *context) {
+  callback("materialized", context);
+  /* A pending script exception suppresses this second invocation. */
+  callback("skipped", context);
+}
+
+void sf_null_cstring(sf_cstring_cb callback, void *context) {
+  callback(NULL, context);
+}

--- a/tests/ffi/profile.json
+++ b/tests/ffi/profile.json
@@ -1,5 +1,5 @@
 {
-  "ffi_format": 2,
+  "ffi_format": 3,
   "functions": [
     { "name": "nativeScale", "symbol": "sf_scale", "params": ["f64"], "returns": "f64" },
     { "name": "nativeInvert", "symbol": "sf_invert", "params": ["bool"], "returns": "bool" },
@@ -101,6 +101,70 @@
           }
         },
         { "context": "each" }
+      ],
+      "returns": "void"
+    },
+    {
+      "name": "nativePropVisit",
+      "symbol": "sf_prop_visit",
+      "params": [
+        {
+          "callback": {
+            "id": "prop",
+            "params": [{ "context": "prop" }, "i32", "cstring"],
+            "returns": "void",
+            "lifetime": "call"
+          }
+        },
+        { "context": "prop" }
+      ],
+      "returns": "void"
+    },
+    {
+      "name": "nativeCallbackSpans",
+      "symbol": "sf_callback_spans",
+      "params": [
+        {
+          "callback": {
+            "id": "spans",
+            "params": ["string", "bytes", { "context": "spans" }],
+            "returns": "void",
+            "lifetime": "call"
+          }
+        },
+        { "context": "spans" }
+      ],
+      "returns": "void"
+    },
+    {
+      "name": "nativeCallbackStringThrow",
+      "symbol": "sf_callback_string_throw",
+      "params": [
+        {
+          "callback": {
+            "id": "stringThrow",
+            "params": ["cstring", { "context": "stringThrow" }],
+            "returns": "void",
+            "lifetime": "call"
+          }
+        },
+        { "context": "stringThrow" }
+      ],
+      "returns": "void"
+    },
+    {
+      "name": "nativeNullCString",
+      "symbol": "sf_null_cstring",
+      "params": [
+        {
+          "callback": {
+            "id": "nullCString",
+            "params": ["cstring", { "context": "nullCString" }],
+            "returns": "void",
+            "lifetime": "call"
+          }
+        },
+        { "context": "nullCString" }
       ],
       "returns": "void"
     }

--- a/tests/harness/ffi.test.ts
+++ b/tests/harness/ffi.test.ts
@@ -2,9 +2,9 @@
  * Node has no equivalent static-link surface to differential-run. The same
  * TypeScript and native archive run through BOTH scriptc backends, and the
  * result bytes must match. The fixture covers every value ABI class,
- * integer coercion, embedded-NUL/UTF-8 string spans, byte spans, and format-2
- * raw/context callbacks (captures, exact context positions, conversion,
- * mutation, and catchable throws). */
+ * integer coercion, embedded-NUL/UTF-8 string spans, byte spans, format-2
+ * raw/context callbacks, and format-3 callback cstring/span copies (lossy
+ * UTF-8, exact bytes, empty spans, ownership, and catchable throws). */
 import { execFileSync, spawnSync } from "node:child_process";
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -65,12 +65,16 @@ const expected = [
   "true 255 4000000000 -7 0.5",
   "4294967295",
   "6",
+  "1:alpha|2:café|3:bad:�(",
+  "0 NaN  ",
+  "4 0 Bé 0,255,1",
   "caught callback boom",
+  "caught string callback boom: materialized",
   "",
 ].join("\n");
 
 describe.each(["c", "llvm"] as const)("outbound native FFI, %s backend", (backend) => {
-  test("calls the manifest-bound archive across every v1 ABI class plus v2 callback ABI classes", async () => {
+  test("calls the manifest-bound archive across every v1 ABI class plus v2/v3 callback ABI classes", async () => {
     const outDir = join(cacheRoot, backend);
     mkdirSync(outDir, { recursive: true });
     const result = await compile(join(fixtureRoot, "main.ts"), {
@@ -88,6 +92,54 @@ describe.each(["c", "llvm"] as const)("outbound native FFI, %s backend", (backen
     expect(
       execFileSync(result.binaryPath, [], { encoding: "utf8" }),
     ).toBe(expected);
+  });
+
+  test("traps a NULL callback cstring with a precise boundary error", async () => {
+    const outDir = join(cacheRoot, `null-cstring-${backend}`);
+    mkdirSync(outDir, { recursive: true });
+    const entry = join(outDir, "main.ts");
+    const profilePath = join(outDir, "profile.json");
+    writeFileSync(
+      entry,
+      [
+        "declare function nativeNullCString(callback: (value: string) => void): void;",
+        "nativeNullCString((value) => console.log(value));",
+        "",
+      ].join("\n"),
+    );
+    writeFileSync(
+      profilePath,
+      JSON.stringify({
+        ffi_format: 3,
+        functions: [{
+          name: "nativeNullCString",
+          symbol: "sf_null_cstring",
+          params: [{
+            callback: {
+              id: "nullCString",
+              params: ["cstring", { context: "nullCString" }],
+              returns: "void",
+              lifetime: "call",
+            },
+          }, { context: "nullCString" }],
+          returns: "void",
+        }],
+        libraries: [nativeArchive()],
+      }),
+    );
+    const result = await compile(entry, {
+      outDir,
+      outPath: join(outDir, "program"),
+      backend,
+      sanitize,
+      ffiProfilePath: profilePath,
+    });
+    if (!result.ok) {
+      throw new Error(result.diagnostics.map((d) => `${d.code}: ${d.message}`).join("\n"));
+    }
+    const run = spawnSync(result.binaryPath, [], { encoding: "utf8" });
+    expect(run.status).not.toBe(0);
+    expect(run.stderr).toContain("scriptc: native callback passed a NULL cstring");
   });
 });
 
@@ -186,6 +238,44 @@ test.each([
       }],
     },
     message: "lifetime' must be 'call",
+  },
+  {
+    name: "a format 3 callback class in format 2",
+    profile: {
+      ffi_format: 2,
+      functions: [{
+        name: "visit",
+        symbol: "sf_visit",
+        params: [{
+          callback: { id: "visit", params: ["cstring"], returns: "void", lifetime: "call" },
+        }],
+        returns: "void",
+      }],
+    },
+    message: "class 'cstring' requires ffi_format 3",
+  },
+  {
+    name: "cstring as a callback return",
+    profile: {
+      ffi_format: 3,
+      functions: [{
+        name: "visit",
+        symbol: "sf_visit",
+        params: [{
+          callback: { id: "visit", params: [], returns: "cstring", lifetime: "call" },
+        }],
+        returns: "void",
+      }],
+    },
+    message: "callback.returns' must be one of",
+  },
+  {
+    name: "cstring as an outer parameter",
+    profile: {
+      ffi_format: 3,
+      functions: [{ name: "visit", symbol: "sf_visit", params: ["cstring"], returns: "void" }],
+    },
+    message: "must be one of",
   },
 ])("manifest validation rejects $name", ({ name, profile, message }) => {
   const path = join(cacheRoot, `invalid-callback-${name.replaceAll(" ", "-")}.json`);
@@ -319,6 +409,8 @@ test.each([
   },
   { id: "never", type: "never", nativeClass: "f64", domain: "number", prefix: null },
   { id: "boolean-literal", type: "true", nativeClass: "bool", domain: "boolean", prefix: null },
+  { id: "string-literal", type: '"fixed"', nativeClass: "cstring", domain: "string", prefix: null },
+  { id: "span-string-literal", type: '"fixed"', nativeClass: "string", domain: "string", prefix: null },
 ])(
   "rejects a narrowed $id native-to-script callback parameter",
   async ({ id, type, nativeClass, domain, prefix }) => {
@@ -338,7 +430,7 @@ test.each([
     writeFileSync(
       profilePath,
       JSON.stringify({
-        ffi_format: 2,
+        ffi_format: nativeClass === "cstring" || nativeClass === "string" ? 3 : 2,
         functions: [{
           name: "nativeVisit",
           symbol: "sf_visit",


### PR DESCRIPTION
- Add format 3 callback classes for cstrings, UTF-8 spans, and byte spans.
- Materialize owned callback arguments in both backends with strict null handling.
- Cover validation, ownership, sanitizers, and document the boundary contract.