### PR TITLE
Optimize same-shape record spreads

### DIFF
--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -4,7 +4,7 @@
 import type { CEmitter, Temp } from "./emitter.js";
 import { arrayOf, BOOL, BYTES_U8, bytesOf, canMarshalFuncIntoIsland, CHILDSTREAM_T, DYN, F64, IrExpr, IrRecordShape, IrType, islandPromisePayloadTag, isFfiCallbackParam, isFfiContextParam, isFfiReleaseParam, isRefCounted, isUnitType, MAY_THROW_LIB_FNS, RUNTIME_ERROR_CLASSES, STRING, typeEquals, typeKey } from "../../ir/nodes.js";
 import { boxAccess, BYTES_NUM_KIND_C, BYTES_NUM_VAR_C, bytesElemKindC, cDecl, cFnPtrCast, cNumberLiteral, cStringLiteral, cType, DV_GET_KIND_C, DV_SET_KIND_C, elemAccess, mapKeyAccess, mapKeyKindC, mapValKindC, releaseCallC, retainCallC, vAdapters } from "./emit-types.js";
-import { mangleClassNew, mangleClassRetain, mangleClassStruct, mangleField, mangleFnClosure, mangleFunction, mangleGlobal, mangleLocal, mangleRecordNew, mangleRecordStruct, mangleVtStruct } from "../mangle.js";
+import { mangleClassNew, mangleClassRetain, mangleClassStruct, mangleField, mangleFnClosure, mangleFunction, mangleGlobal, mangleLocal, mangleRecordClone, mangleRecordNew, mangleRecordStruct, mangleVtStruct } from "../mangle.js";
 import { OVERFLOW_MEMBER } from "./emit-shapes.js";
 import { dynDestrCheckHelper, dynIterNHelper, dynKeyGetHelper } from "./emit-walkers.js";
 import { collectFfiRetainedOps, parseFfiCallbackKey } from "../ffi-callbacks.js";
@@ -2468,6 +2468,29 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           }
           if (isRefCounted(v.type)) E.moveTemp(v);
           E.line(`${rec.name}->${mangleField(f.name)} = ${v.name};`);
+        }
+        return rec;
+      }
+      case "recordClone": {
+        if (e.type.kind !== "record") throw new Error("emitter bug: recordClone of non-record type");
+        E.recordCloneShapes.add(e.type.shapeId);
+        // Source first, then each override in source order. The helper
+        // returns a fully retained owned clone; replacement unlinks before
+        // releasing the copied value, matching recordSet's cycle discipline.
+        const source = E.emitExpr(e.source);
+        const rec = E.newTemp(e.type, `${mangleRecordClone(e.type.shapeId)}(${source.name})`);
+        for (const f of e.overrides) {
+          const v = E.emitExpr(f.value);
+          const field = `${rec.name}->${mangleField(f.name)}`;
+          if (isRefCounted(v.type)) {
+            E.moveTemp(v);
+            const old = `sc_t${E.tempCounter++}`;
+            E.line(`${cDecl(v.type, old)} = ${field};`);
+            E.line(`${field} = ${v.name};`);
+            E.releaseValue(old, v.type);
+          } else {
+            E.line(`${field} = ${v.name};`);
+          }
         }
         return rec;
       }

--- a/packages/compiler/src/backend/emission/emit-shapes.ts
+++ b/packages/compiler/src/backend/emission/emit-shapes.ts
@@ -6,8 +6,8 @@
 import type { CEmitter } from "./emitter.js";
 import type { IrFunction } from "../../ir/nodes.js";
 import { IrClassDef, IrType, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, isRefCounted, mapOf, STRING } from "../../ir/nodes.js";
-import { mangleClassGcFree, mangleClassNew, mangleClassRelease, mangleClassReleaseDirect, mangleClassRetain, mangleClassStruct, mangleClassTrace, mangleCtorThunk, mangleField, mangleFunction, mangleRecordGcFree, mangleRecordNew, mangleRecordRelease, mangleRecordRetain, mangleRecordStruct, mangleRecordTrace, mangleVtAdapter, mangleVtInstance, mangleVtStruct } from "../mangle.js";
-import { boxKindC, cDecl, cType, elemKindC, mapValKindC, releaseCallC, vAdapters } from "./emit-types.js";
+import { mangleClassGcFree, mangleClassNew, mangleClassRelease, mangleClassReleaseDirect, mangleClassRetain, mangleClassStruct, mangleClassTrace, mangleCtorThunk, mangleField, mangleFunction, mangleRecordClone, mangleRecordGcFree, mangleRecordNew, mangleRecordRelease, mangleRecordRetain, mangleRecordStruct, mangleRecordTrace, mangleVtAdapter, mangleVtInstance, mangleVtStruct } from "../mangle.js";
+import { boxKindC, cDecl, cType, elemKindC, mapValKindC, releaseCallC, retainCallC, vAdapters } from "./emit-types.js";
 
 /** The overflow map's C member name on index-signature record structs.
  * User fields mangle to `sc_fld_*`, so no field can collide. */
@@ -83,6 +83,8 @@ export interface ClassMeta {
        * new/release/trace treat as one more (map-typed) field. */
       indexValue?: IrType;
       comment: string;
+      /** Record shape id; absent for classes. */
+      recordId?: string;
       /** Class shapes only; hierarchy members get the vtable machinery. */
       meta: ClassMeta | null;
     }
@@ -112,6 +114,7 @@ export interface ClassMeta {
         gcFree: mangleRecordGcFree(rec.id),
         traced: E.tracedShapes.has(`record:${rec.id}`),
         fields: rec.fields,
+        recordId: rec.id,
         ...(rec.indexValue ? { indexValue: rec.indexValue } : {}),
         comment: `record ${rec.id} { ${rec.fields.map((f) => f.name).join("; ")}${rec.indexValue ? "; [key: string]" : ""} }`,
         meta: null,
@@ -205,6 +208,9 @@ export interface ClassMeta {
         `static void ${s.release}(${s.struct} *o);`,
         `static ${s.struct} *${s.newFn}(void);`,
       );
+      if (s.recordId !== undefined && E.recordCloneShapes.has(s.recordId)) {
+        out.push(`static ${s.struct} *${mangleRecordClone(s.recordId)}(${s.struct} *src);`);
+      }
       if (inHierarchy(s)) {
         out.push(`static void ${mangleClassReleaseDirect(s.meta!.def.name)}(void *o0);`);
       }
@@ -253,6 +259,9 @@ export interface ClassMeta {
           `  scr_obj_alloc_note();`,
           `  return o;`,
           `}`,
+          ...(s.recordId !== undefined && E.recordCloneShapes.has(s.recordId)
+            ? emitRecordCloneC(s.recordId, s.struct, s.fields, s.newFn)
+            : []),
           `static void *${s.retain}_v(void *o) { return ${s.retain}((${s.struct} *)o); }`,
           `static void ${s.release}_v(void *o) { ${s.release}((${s.struct} *)o); }`,
           ``,
@@ -298,6 +307,9 @@ export interface ClassMeta {
         `  scr_obj_alloc_note();`,
         `  return o;`,
         `}`,
+        ...(s.recordId !== undefined && E.recordCloneShapes.has(s.recordId)
+          ? emitRecordCloneC(s.recordId, s.struct, s.fields, s.newFn)
+          : []),
         `static void ${s.trace}(void *o0, ScrTraceVisit visit, void *ctx) {`,
         `  ${s.struct} *o = (${s.struct} *)o0;`,
         ...tracedFields.map(
@@ -323,6 +335,37 @@ export interface ClassMeta {
       );
     }
   }
+
+/** One deliberately non-inlined same-shape clone helper. Keeping the copy
+ * here makes each `{ ...largeRecord, override }` site constant-sized while
+ * preserving the ordinary type-directed retain rules. */
+function emitRecordCloneC(
+  shapeId: string,
+  struct: string,
+  fields: { name: string; type: IrType }[],
+  newFn: string,
+): string[] {
+  const noinline = fields.length >= 16;
+  return [
+    ...(noinline
+      ? [
+          `#if defined(_MSC_VER)`,
+          `__declspec(noinline)`,
+          `#else`,
+          `__attribute__((noinline))`,
+          `#endif`,
+        ]
+      : []),
+    `static ${struct} *${mangleRecordClone(shapeId)}(${struct} *src) {`,
+    `  ${struct} *o = ${newFn}();`,
+    ...fields.map((f) => {
+      const member = mangleField(f.name);
+      return `  o->${member} = ${isRefCounted(f.type) ? retainCallC(f.type, `src->${member}`) : `src->${member}`};`;
+    }),
+    `  return o;`,
+    `}`,
+  ];
+}
 
 /** The root's slot list as seen by one class: the implementation the
    * class dispatches to, or null outside the slot's declaring subtree (a

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -253,6 +253,9 @@ export class CEmitter {
   /** Active optional-chain bind temps, by chain id (chainRecv reads). */
   readonly chainTemps = new Map<string, Temp>();
   readonly recordsById = new Map<string, IrRecordShape>();
+  /** Record shapes whose bodies emitted recordClone. Filled while function
+   * bodies emit, before emitStructDefs assembles per-shape helpers. */
+  readonly recordCloneShapes = new Set<string>();
   /** Type-directed JSON walkers, interned per typeKey — one serializer per
    * type used in jsonStringify position (sc_jw_*), one match predicate
    * (sc_dm_*) and one checked builder (sc_dc_*) per type used in dynCheck

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -83,7 +83,7 @@ import { canMarshalFuncIntoIsland, CAUGHT, DYN, F64, ffiCallbackType, islandCall
 import { matchIntegerBytesForLoop } from "../../ir/integer-loops.js";
 import { allocateFfiCallbackAdapters, collectFfiRetainedOps, hasForeignFfiCallback, hasRetainedFfiCallback, parseFfiCallbackKey, type FfiCallbackAdapter } from "../ffi-callbacks.js";
 import { computeMayThrow } from "../emission/may-throw.js";
-import { mangleArgPack, mangleAsyncSpawn, mangleClassNew, mangleClassObj, mangleClassRetain, mangleFnClosure, mangleFunction, mangleGenDrop, mangleGenResThunk, mangleGenSpawn, mangleGlobal, mangleLocal, mangleRecordNew, mangleRecordStruct, mangleResolveThunk, mangleTrampoline, mangleVtStruct, mangleWrapper } from "../mangle.js";
+import { mangleArgPack, mangleAsyncSpawn, mangleClassNew, mangleClassObj, mangleClassRetain, mangleFnClosure, mangleFunction, mangleGenDrop, mangleGenResThunk, mangleGenSpawn, mangleGlobal, mangleLocal, mangleRecordClone, mangleRecordNew, mangleRecordStruct, mangleResolveThunk, mangleTrampoline, mangleVtStruct, mangleWrapper } from "../mangle.js";
 import { BlockBuilder } from "./blocks.js";
 import {
   buildClassGraph,
@@ -1053,6 +1053,7 @@ class LlEmitter {
   private readonly dynPromiseAdapters = new Map<string, string>();
   readonly unionsById = new Map<string, IrUnionDef>();
   readonly recordsById = new Map<string, IrRecordShape>();
+  readonly recordCloneShapes = new Set<string>();
   readonly tracedShapes: Set<string>;
   readonly tracedUnions: Set<string>;
   /** The class graph (buildClassGraph): preorder numbering, hierarchy
@@ -1567,6 +1568,9 @@ class LlEmitter {
     const wrappers = this.emitFnValueDefs();
     const asyncDefs = this.emitAsyncScaffolding();
     const ffiCallbacks = this.emitFfiCallbackDefs();
+    const hasNoInlineRecordClone = [...this.recordCloneShapes].some(
+      (shapeId) => (this.recordsById.get(shapeId)?.fields.length ?? 0) >= 16,
+    );
     const embedded = this.mod.embedded;
     const usesIsland = embedded !== undefined && embedded.modules.length > 0;
     const storeNpmText = (text: string): { bytes: Buffer; raw: number } => {
@@ -2068,6 +2072,7 @@ class LlEmitter {
       out.push(...this.emitLibDefs(globals, globalReleaseLines, stamps));
       out.push(`attributes #0 = { sanitize_address }`);
       if (this.wasi) out.push(`attributes #1 = { sanitize_address presplitcoroutine }`);
+      if (hasNoInlineRecordClone) out.push(`attributes #2 = { noinline sanitize_address }`);
       out.push(``);
       return out.join("\n");
     }
@@ -2192,6 +2197,7 @@ class LlEmitter {
       // emitted functions too (the runtime TUs get theirs from clang).
       `attributes #0 = { sanitize_address }`,
       ...(this.wasi ? [`attributes #1 = { sanitize_address presplitcoroutine }`] : []),
+      ...(hasNoInlineRecordClone ? [`attributes #2 = { noinline sanitize_address }`] : []),
       ``,
     );
     return out.join("\n");
@@ -5291,6 +5297,28 @@ class LlEmitter {
           if (isRefCounted(v.type)) this.moveTemp(v);
           const { ptr, type } = this.recordFieldPtr(rec, shapeId, f.name);
           this.storeField(ptr, type, v.name);
+        }
+        return out;
+      }
+      case "recordClone": {
+        if (e.type.kind !== "record") throw new Error("llvm emitter bug: recordClone of non-record type");
+        this.recordCloneShapes.add(e.type.shapeId);
+        const source = this.emitExpr(e.source);
+        const rec = B.tmp();
+        B.line(`${rec} = call ptr @${mangleRecordClone(e.type.shapeId)}(ptr ${source.name})`);
+        const out = this.own({ name: rec, type: e.type });
+        for (const f of e.overrides) {
+          const v = this.emitExpr(f.value);
+          const { ptr, type } = this.recordFieldPtr(rec, e.type.shapeId, f.name);
+          if (isRefCounted(type)) {
+            this.moveTemp(v);
+            const old = B.tmp();
+            B.line(`${old} = load ptr, ptr ${ptr}`);
+            this.storeField(ptr, type, v.name);
+            this.releaseValue(old, type);
+          } else {
+            this.storeField(ptr, type, v.name);
+          }
         }
         return out;
       }

--- a/packages/compiler/src/backend/llvm/shapes.ts
+++ b/packages/compiler/src/backend/llvm/shapes.ts
@@ -17,6 +17,7 @@ import {
   mangleClassRetain,
   mangleClassTrace,
   mangleRecordGcFree,
+  mangleRecordClone,
   mangleRecordNew,
   mangleRecordRelease,
   mangleRecordRetain,
@@ -38,6 +39,7 @@ export interface ShapeHost {
   readonly tracedShapes: Set<string>;
   readonly tracedUnions: Set<string>;
   readonly recordsById: Map<string, IrRecordShape>;
+  readonly recordCloneShapes: ReadonlySet<string>;
 }
 
 /** Every emitted function/helper carries #0 = { sanitize_address } — see
@@ -817,6 +819,37 @@ export function emitRecordShapes(host: ShapeHost, mod: IrModule): { typeDefs: st
     }
     nw.push(`  call void @scr_obj_alloc_note()`, `  ret ptr %o`, `}`, ``);
     defs.push(...nw);
+
+    if (host.recordCloneShapes.has(shape.id)) {
+      const attrs = shape.fields.length >= 16 ? "#2" : FN_ATTRS;
+      const clone: string[] = [
+        `define internal ptr @${mangleRecordClone(shape.id)}(ptr %src) ${attrs} {`,
+        `entry:`,
+        `  %o = call ptr @${mangleRecordNew(shape.id)}()`,
+      ];
+      let i = 0;
+      for (const field of shape.fields) {
+        const index = i + 1;
+        const fieldTy = llFieldType(field.type);
+        clone.push(
+          `  %sp${i} = getelementptr inbounds %${struct}, ptr %src, i64 0, i32 ${index}`,
+          `  %sv${i} = load ${fieldTy}, ptr %sp${i}`,
+        );
+        const stored = isRefCounted(field.type)
+          ? `%sr${i}`
+          : `%sv${i}`;
+        if (isRefCounted(field.type)) {
+          clone.push(`  ${stored} = call ptr ${retainSym(host, field.type)}(ptr %sv${i})`);
+        }
+        clone.push(
+          `  %dp${i} = getelementptr inbounds %${struct}, ptr %o, i64 0, i32 ${index}`,
+          `  store ${fieldTy} ${stored}, ptr %dp${i} ; ${field.name}`,
+        );
+        i++;
+      }
+      clone.push(`  ret ptr %o`, `}`, ``);
+      defs.push(...clone);
+    }
 
     if (traced) {
       // trace: visit exactly the cycle-capable members; gcFree: release

--- a/packages/compiler/src/backend/mangle.ts
+++ b/packages/compiler/src/backend/mangle.ts
@@ -117,6 +117,9 @@ export function mangleRecordStruct(shapeId: string): string {
 export function mangleRecordNew(shapeId: string): string {
   return `sc_rnew_${sanitize(shapeId)}`;
 }
+export function mangleRecordClone(shapeId: string): string {
+  return `sc_rclone_${sanitize(shapeId)}`;
+}
 export function mangleRecordRetain(shapeId: string): string {
   return `sc_rretain_${sanitize(shapeId)}`;
 }

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -2641,6 +2641,8 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
         return e.elems.every(droppableStatic);
       case "recordLit":
         return e.fields.every((f) => droppableStatic(f.value));
+      case "recordClone":
+        return droppableStatic(e.source) && e.overrides.every((f) => droppableStatic(f.value));
       case "closure":
         return true;
       default:
@@ -4817,6 +4819,68 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
       }
     }
     const fieldTypes = new Map(shape.fields.map((f) => [f.name, f.type]));
+
+    // The overwhelmingly common immutable-update form over a record:
+    // `{ ...model, changed, other: value }`. The historic lowering expanded
+    // the spread into one recordGet per untouched field at EVERY site, then
+    // the backends inlined all of those retains and stores into the caller.
+    // A 178-field model updated hundreds of times consequently produced a
+    // half-million-line LLVM function. Keep the same evaluation/ownership
+    // semantics in one compact IR node: source first, explicit overrides in
+    // source order, and one backend clone helper per shape.
+    //
+    // Stay deliberately narrow. Tuple/index/accessor shapes, conditional or
+    // multiple spreads, spread-after-explicit order, and shape-changing width
+    // copies retain their existing lowering and diagnostics.
+    if (
+      !isJsSourceFile(expr.getSourceFile()) &&
+      !shape.indexValue &&
+      !shape.tuple &&
+      !shapeHasAccessorSlots(shape) &&
+      expr.properties.length >= 2 &&
+      ts.isSpreadAssignment(expr.properties[0]!) &&
+      !conditionalSpreadOf(expr.properties[0]!.expression) &&
+      expr.properties.slice(1).every(
+        (p) =>
+          (ts.isPropertyAssignment(p) || ts.isShorthandPropertyAssignment(p)) &&
+          p.name !== undefined &&
+          (ts.isIdentifier(p.name) ||
+            ts.isStringLiteral(p.name) ||
+            ts.isNumericLiteral(p.name) ||
+            (ts.isComputedPropertyName(p.name) && literalComputedKey(L, p.name) !== null)),
+      )
+    ) {
+      const spread = expr.properties[0]! as ts.SpreadAssignment;
+      const props = expr.properties.slice(1) as (
+        | ts.PropertyAssignment
+        | ts.ShorthandPropertyAssignment
+      )[];
+      const names = props.map((p) => propNameText(L, p.name!));
+      const unique = new Set(names);
+      const sourceType = L.mapTypeOf(L.typeOf(spread.expression));
+      if (
+        sourceType?.kind === "record" &&
+        sourceType.shapeId === type.shapeId &&
+        unique.size === names.length &&
+        names.every((name) => fieldTypes.has(name))
+      ) {
+        const source = L.lowerExpr(spread.expression);
+        const overrides: { name: string; value: IrExpr }[] = [];
+        for (let i = 0; i < props.length; i++) {
+          const p = props[i]!;
+          const name = names[i]!;
+          const fieldType = fieldTypes.get(name)!;
+          const valueNode = ts.isPropertyAssignment(p) ? p.initializer : p;
+          let value = ts.isPropertyAssignment(p)
+            ? L.lowerExpr(p.initializer)
+            : L.lowerShorthandValue(p);
+          value = L.coerceInto(valueNode, value, fieldType);
+          if (!typeEquals(value.type, fieldType)) L.badType(valueNode, L.typeOf(valueNode));
+          overrides.push({ name, value });
+        }
+        return { kind: "recordClone", source, overrides, type, loc };
+      }
+    }
 
     // A PURE index-signature target with spreads — `{ ...process.env }`,
     // `{ ...process.env, ...extraEnv }`, `{ ...env, PATH: p }` (the

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -4819,6 +4819,11 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
       }
     }
     const fieldTypes = new Map(shape.fields.map((f) => [f.name, f.type]));
+    // The clone probe may lower the leading spread before declining (a
+    // static `as` cast can make the checker-visible shape match while its
+    // erased IR value keeps a wider shape). Reuse that exact value in the
+    // ordinary spread path so lowering still happens once.
+    let leadingSpreadLowered: IrExpr | null = null;
 
     // The overwhelmingly common immutable-update form over a record:
     // `{ ...model, changed, other: value }`. The historic lowering expanded
@@ -4865,20 +4870,23 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
         names.every((name) => fieldTypes.has(name))
       ) {
         const source = L.lowerExpr(spread.expression);
-        const overrides: { name: string; value: IrExpr }[] = [];
-        for (let i = 0; i < props.length; i++) {
-          const p = props[i]!;
-          const name = names[i]!;
-          const fieldType = fieldTypes.get(name)!;
-          const valueNode = ts.isPropertyAssignment(p) ? p.initializer : p;
-          let value = ts.isPropertyAssignment(p)
-            ? L.lowerExpr(p.initializer)
-            : L.lowerShorthandValue(p);
-          value = L.coerceInto(valueNode, value, fieldType);
-          if (!typeEquals(value.type, fieldType)) L.badType(valueNode, L.typeOf(valueNode));
-          overrides.push({ name, value });
+        if (source.type.kind === "record" && source.type.shapeId === type.shapeId) {
+          const overrides: { name: string; value: IrExpr }[] = [];
+          for (let i = 0; i < props.length; i++) {
+            const p = props[i]!;
+            const name = names[i]!;
+            const fieldType = fieldTypes.get(name)!;
+            const valueNode = ts.isPropertyAssignment(p) ? p.initializer : p;
+            let value = ts.isPropertyAssignment(p)
+              ? L.lowerExpr(p.initializer)
+              : L.lowerShorthandValue(p);
+            value = L.coerceInto(valueNode, value, fieldType);
+            if (!typeEquals(value.type, fieldType)) L.badType(valueNode, L.typeOf(valueNode));
+            overrides.push({ name, value });
+          }
+          return { kind: "recordClone", source, overrides, type, loc };
         }
-        return { kind: "recordClone", source, overrides, type, loc };
+        leadingSpreadLowered = source;
       }
     }
 
@@ -5155,7 +5163,12 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
         }
         let srcNode: ts.Expression = prop.expression;
         while (ts.isParenthesizedExpression(srcNode)) srcNode = srcNode.expression;
-        const srcLowered = ts.isIdentifier(srcNode) ? null : L.lowerExpr(srcNode);
+        const srcLowered =
+          prop === expr.properties[0] && leadingSpreadLowered !== null
+            ? leadingSpreadLowered
+            : ts.isIdentifier(srcNode)
+              ? null
+              : L.lowerExpr(srcNode);
         const srcType = srcLowered ? srcLowered.type : L.mapTypeOf(L.typeOf(srcNode));
         // `...options.installConfig` — a spread of `Partial<X> | undefined`
         // (the optional-options merge idiom `{ ...DEFAULTS, ...overrides }`):

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -2272,7 +2272,7 @@ export class Lowerer {
       this.diags.length > 0
         ? null
         : {
-            irVersion: 5,
+            irVersion: 6,
             sourceFile: this.entry.fileName,
             functions,
             classes: artifacts.classes,

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -693,7 +693,7 @@ export function isRefCounted(t: IrType): boolean {
 
 export interface IrModule {
   /** Bumped on any breaking IR change; serialize.ts refuses mismatches. */
-  irVersion: 5;
+  irVersion: 6;
   sourceFile: string;
   functions: IrFunction[];
   /** Class shapes. Constructors and methods are ordinary module functions
@@ -4680,6 +4680,14 @@ export type IrExpr =
    * with the statement frame. Any value type is legal here, void included
    * (an awaited Promise<void>). */
   | { kind: "recordLit"; fields: { name: string; value: IrExpr; overflow?: true; drop?: true }[]; type: IrType; loc: SrcLoc }
+  /** Same-shape object spread with explicit overrides: `{ ...source,
+   * field: value }`. `source` is evaluated first and borrowed by one
+   * per-shape clone helper; `overrides` then evaluate in source order and
+   * replace the cloned slots. Refcounted override values MOVE in and the
+   * replaced cloned values release after unlinking. Restricted to plain
+   * declared-field records (no tuple/index/accessor shapes), so every
+   * omitted field is copied exactly once by the helper. */
+  | { kind: "recordClone"; source: IrExpr; overrides: { name: string; value: IrExpr }[]; type: IrType; loc: SrcLoc }
   /** Record field read `r.f` — mirrors `fieldGet`: refcounted fields come
    * out retained (+1). */
   | { kind: "recordGet"; obj: IrExpr; shapeId: string; field: string; type: IrType; loc: SrcLoc }

--- a/packages/compiler/src/ir/serialize.ts
+++ b/packages/compiler/src/ir/serialize.ts
@@ -5,7 +5,7 @@
  */
 import type { IrModule } from "./nodes.js";
 
-export const IR_VERSION = 5 as const;
+export const IR_VERSION = 6 as const;
 
 export function serializeModule(mod: IrModule): string {
   return JSON.stringify(mod, (_key, value) => {

--- a/packages/compiler/src/ir/validate.ts
+++ b/packages/compiler/src/ir/validate.ts
@@ -18,7 +18,7 @@ import type {
   IrUnionDef,
   SrcLoc,
 } from "./nodes.js";
-import { arrayOf, BOOL, BYTES_U8, bytesOf, canAdaptDynFuncTo, canConvertToDyn, canExitIslandToType, canMarshalIntoIsland, canMarshalTypedFuncIntoIsland, CHILD_T, CHILDSTREAM_T, DATE_T, DGRAMSOCK_T, DYN, DYN_HANDLE_KINDS, F64, ffiClassType, ffiSourceParamTypes, FILEHANDLE_T, FSWATCHER_T, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, islandPromisePayloadTag, isFfiCallbackParam, isFfiContextParam, isFfiReleaseParam, isJsonSafeType, isRefCounted, isSupportedIndexValue, isSupportedMapKey, isSupportedMapValue, isSupportedSetElem, isUnitType, jsOpResultKind, JSVAL, NETSERVER_T, NETSOCKET_T, PROCSTREAM_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, SEARCH_PARAMS_T, SECURECTX_T, SPAWNRES_T, STATS_T, STRING, SYMBOL_T, TESTCTX_T, typeEquals, typeKey, unionFuncSetArmsOk, URL_T, VOID } from "./nodes.js";
+import { arrayOf, BOOL, BYTES_U8, bytesOf, canAdaptDynFuncTo, canConvertToDyn, canExitIslandToType, canMarshalIntoIsland, canMarshalTypedFuncIntoIsland, CHILD_T, CHILDSTREAM_T, DATE_T, DGRAMSOCK_T, DYN, DYN_HANDLE_KINDS, F64, ffiClassType, ffiSourceParamTypes, FILEHANDLE_T, FSWATCHER_T, HTTP2SESSION_T, HTTP2STREAM_T, HTTPCLIENTREQ_T, HTTPREQ_T, HTTPRES_T, islandPromisePayloadTag, isFfiCallbackParam, isFfiContextParam, isFfiReleaseParam, isJsonSafeType, isRefCounted, isSupportedIndexValue, isSupportedMapKey, isSupportedMapValue, isSupportedSetElem, isUnitType, jsOpResultKind, JSVAL, NETSERVER_T, NETSOCKET_T, PROCSTREAM_T, REF_TRUTHY_KINDS, REGEX, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, SEARCH_PARAMS_T, SECURECTX_T, shapeHasAccessorSlots, SPAWNRES_T, STATS_T, STRING, SYMBOL_T, TESTCTX_T, typeEquals, typeKey, unionFuncSetArmsOk, URL_T, VOID } from "./nodes.js";
 
 /** Per-method signature for strIntrinsic: `argTypes` lists every argument
  * position (optional ones included); `minArgs` is how many may be omitted
@@ -3120,6 +3120,33 @@ function validateFunction(
         }
         if (e.fields.filter((f) => !f.overflow && !f.drop).length !== shape.fields.length) {
           err(`recordLit does not initialize every field of shape ${shape.id}`, e.loc);
+        }
+        break;
+      }
+      case "recordClone": {
+        checkExpr(e.source);
+        if (e.type.kind !== "record") {
+          err(`recordClone must be record-typed, got ${e.type.kind}`, e.loc);
+          break;
+        }
+        const shape = records.get(e.type.shapeId);
+        if (!shape) {
+          err(`recordClone of undeclared shape "${e.type.shapeId}"`, e.loc);
+          break;
+        }
+        if (shape.tuple || shape.indexValue || shapeHasAccessorSlots(shape)) {
+          err(`recordClone requires a plain declared-field shape, got ${shape.id}`, e.loc);
+        }
+        expectType(e.source, e.type, "recordClone source");
+        const want = new Map(shape.fields.map((f) => [f.name, f.type]));
+        const seen = new Set<string>();
+        for (const f of e.overrides) {
+          checkExpr(f.value);
+          if (seen.has(f.name)) err(`recordClone overrides field "${f.name}" twice`, e.loc);
+          seen.add(f.name);
+          const ft = want.get(f.name);
+          if (!ft) err(`shape ${shape.id} has no field "${f.name}"`, e.loc);
+          else expectType(f.value, ft, `recordClone field "${f.name}"`);
         }
         break;
       }

--- a/packages/compiler/src/library/int-infer.test.ts
+++ b/packages/compiler/src/library/int-infer.test.ts
@@ -65,7 +65,7 @@ const sink = (name: string): IrFunction => ({
 /** A module holding the case function plus the two declared sinks. */
 function caseModule(params: string[], locals: string[], body: IrStmt[]): IrModule {
   return {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: "corpus.ts",
     functions: [
       sink("send"),
@@ -136,7 +136,7 @@ const RECORD_CFG: IntSlotConfig = {
 
 function recordCase(body: IrStmt[], names = ["m"], extraFns: IrFunction[] = []): IrModule {
   return {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: "fields.ts",
     functions: [
       ...extraFns,
@@ -177,7 +177,7 @@ const classCountRead = (): IrExpr => ({
 
 function onlyOrdinaryClass(body: IrStmt[]): IntVerdict {
   const mod: IrModule = {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: "class-fields.ts",
     functions: [
       sink("send"),
@@ -391,7 +391,7 @@ describe("the domain's edges beyond the corpus", () => {
       loc,
     };
     const mod: IrModule = {
-      irVersion: 5,
+      irVersion: 6,
       sourceFile: "optional.ts",
       functions: [{
         name: "normalize",
@@ -751,6 +751,24 @@ describe("straight-line ordinary-field refinement", () => {
 });
 
 describe("straight-line declared-field refinement", () => {
+  test("recordClone checks explicit integer-slot overrides", () => {
+    const clone: IrStmt = {
+      kind: "exprStmt",
+      expr: {
+        kind: "recordClone",
+        source: recordRef(),
+        overrides: [{ name: "count", value: math("trunc", num(42)) }],
+        type: MODEL,
+        loc,
+      },
+      loc,
+    };
+    const v = onlyRecord([clone]);
+    expect(v.outcome).toBe("prove");
+    expect(v.provenLo).toBe(42);
+    expect(v.provenHi).toBe(42);
+  });
+
   test("an if guard refines the repeated field read through its boundary write", () => {
     const v = onlyRecord([
       iff(bin("<", countRead(), num(1000)), [

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -1625,6 +1625,20 @@ class FnAnalyzer {
         }
         return { ...TOP };
       }
+      case "recordClone": {
+        // The clone copies already-proven field values. Only explicit
+        // overrides create new writes that must discharge integer slots.
+        this.evalExpr(e.source, env);
+        const slotMap = this.cfg.records.get((e.type as { kind: "record"; shapeId: string }).shapeId);
+        for (const f of e.overrides) {
+          const v = this.evalExpr(f.value, env);
+          const slot = slotMap?.get(f.name);
+          if (slot !== undefined && numberCarrierKind(f.value.type, this.mod) !== null) {
+            this.emitRecordSlot(v, slot, f.value.loc);
+          }
+        }
+        return { ...TOP };
+      }
       case "recordGet": {
         // A declared record-field slot is an assumption on the read side,
         // exactly like a declared parameter inside its callee: every write

--- a/packages/compiler/test/bytes-element-emission.test.ts
+++ b/packages/compiler/test/bytes-element-emission.test.ts
@@ -66,7 +66,7 @@ function fixture(): IrModule {
   );
 
   return {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: loc.file,
     entry: "__main",
     functions: [{ name: "__main", params: [], returnType: VOID, locals, body, loc }],
@@ -136,7 +136,7 @@ function receiverReassignmentFixture(): IrModule {
   ];
 
   return {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: loc.file,
     entry: "__main",
     functions: [{ name: "__main", params: [], returnType: VOID, locals, body, loc }],
@@ -201,7 +201,7 @@ function integerLoopFixture(mutatesIndex = false): IrModule {
     { kind: "bytesSet", arr: bytesRef(), index: indexRef(), value: ref("sum"), loc },
   );
   return {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: loc.file,
     entry: "__main",
     functions: [{
@@ -321,4 +321,41 @@ test("a body mutation keeps the byte loop on the general f64 path", () => {
   expect(ll).not.toContain("integer induction index");
   expect(ll).toContain("bytes.index.range");
   expect(ll).toContain("fptoui double");
+});
+
+test("large record clones stay outlined while small clones remain inlineable", () => {
+  const record = (id: string, count: number): IrModule => {
+    const fields = Array.from({ length: count }, (_, i) => ({ name: `f${i}`, type: F64 }));
+    const type = { kind: "record", shapeId: id } as const;
+    return {
+      irVersion: 6,
+      sourceFile: "record-clone.ts",
+      entry: "__main",
+      records: [{ id, fields }],
+      functions: [{
+        name: "__main",
+        params: [],
+        returnType: VOID,
+        locals: [{ id: "source", name: "source", type, mutable: false }],
+        body: [{
+          kind: "exprStmt",
+          expr: {
+            kind: "recordClone",
+            source: { kind: "varRef", localId: "source", type, loc },
+            overrides: [{ name: "f0", value: { kind: "numLit", value: 1, type: F64, loc } }],
+            type,
+            loc,
+          },
+          loc,
+        }],
+        loc,
+      }],
+    };
+  };
+  const small = emitLlvmModule(record("small", 2));
+  const large = emitLlvmModule(record("large", 16));
+  expect(small).toContain("define internal ptr @sc_rclone_small(ptr %src) #0");
+  expect(small).not.toContain("attributes #2");
+  expect(large).toContain("define internal ptr @sc_rclone_large(ptr %src) #2");
+  expect(large).toContain("attributes #2 = { noinline sanitize_address }");
 });

--- a/packages/compiler/test/emit-c.test.ts
+++ b/packages/compiler/test/emit-c.test.ts
@@ -35,7 +35,7 @@ test("strings: literals, concat in a loop, toString, RC-clean under audit", asyn
   // while (i < 3) { acc = acc + ("-" + i); i = i + 1; }
   // console.log(acc, acc === "x-0-1-2", "α∂" < "β");
   const mod: IrModule = {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: "s.ts",
     entry: "__main",
     functions: [
@@ -113,7 +113,7 @@ test("short-circuit: right operand of && only evaluates when left is true", asyn
   // if (false && sideEffect()) {} ; if (true || sideEffect()) {}
   // console.log("done")
   const mod: IrModule = {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: "l.ts",
     entry: "__main",
     functions: [
@@ -161,7 +161,7 @@ test("string params: callee owns and releases; returns transfer ownership", asyn
   // function greet(who: string): string { return "hi " + who; }
   // console.log(greet("world"));
   const mod: IrModule = {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: "p.ts",
     entry: "__main",
     functions: [

--- a/packages/compiler/test/fixtures/fib-ir.ts
+++ b/packages/compiler/test/fixtures/fib-ir.ts
@@ -18,7 +18,7 @@ const n = (localId: string): IrExpr => ({ kind: "varRef", localId, type: F64, lo
 const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
 
 export const fibModule: IrModule = {
-  irVersion: 5,
+  irVersion: 6,
   sourceFile: "fib.ts",
   entry: "__main",
   functions: [

--- a/packages/compiler/test/ir.test.ts
+++ b/packages/compiler/test/ir.test.ts
@@ -22,7 +22,7 @@ test("fib module JSON round-trips", () => {
 test("validator rejects type mismatches and bad references", () => {
   const loc = { file: "t.ts", start: 0, end: 0 };
   const bad: IrModule = {
-    irVersion: 5,
+    irVersion: 6,
     sourceFile: "t.ts",
     entry: "__main",
     functions: [
@@ -83,6 +83,55 @@ test("serializer round-trips ±Infinity and refuses NaN", () => {
 });
 
 test("deserializer rejects the previous IR version", () => {
-  const json = serializeModule(fibModule).replace('"irVersion": 5', '"irVersion": 4');
+  const json = serializeModule(fibModule).replace('"irVersion": 6', '"irVersion": 5');
   expect(() => deserializeModule(json)).toThrow(/version mismatch/);
+});
+
+test("recordClone survives the IR JSON round trip", () => {
+  const loc = { file: "clone.ts", start: 0, end: 1 };
+  const type = { kind: "record", shapeId: "r0" } as const;
+  const mod = structuredClone(fibModule);
+  mod.records = [{
+    id: "r0",
+    fields: [{ name: "name", type: { kind: "string" } }],
+  }];
+  mod.functions[0]!.locals.push({ id: "source.0", name: "source", type, mutable: false });
+  mod.functions[0]!.body.unshift({
+    kind: "exprStmt",
+    expr: {
+      kind: "recordClone",
+      source: { kind: "varRef", localId: "source.0", type, loc },
+      overrides: [{ name: "name", value: { kind: "strLit", value: "next", type: { kind: "string" }, loc } }],
+      type,
+      loc,
+    },
+    loc,
+  });
+  expect(deserializeModule(serializeModule(mod))).toEqual(mod);
+});
+
+test("validator fences malformed recordClone nodes", () => {
+  const loc = { file: "clone.ts", start: 0, end: 1 };
+  const type = { kind: "record", shapeId: "r0" } as const;
+  const mod = structuredClone(fibModule);
+  mod.records = [{ id: "r0", fields: [{ name: "count", type: F64 }] }];
+  mod.functions[0]!.locals.push({ id: "source.0", name: "source", type, mutable: false });
+  mod.functions[0]!.body.unshift({
+    kind: "exprStmt",
+    expr: {
+      kind: "recordClone",
+      source: { kind: "varRef", localId: "source.0", type, loc },
+      overrides: [
+        { name: "missing", value: { kind: "numLit", value: 1, type: F64, loc } },
+        { name: "missing", value: { kind: "numLit", value: 2, type: F64, loc } },
+      ],
+      type,
+      loc,
+    },
+    loc,
+  });
+  expect(validateModule(mod).map((e) => e.message)).toEqual(expect.arrayContaining([
+    expect.stringContaining('has no field "missing"'),
+    expect.stringContaining('overrides field "missing" twice'),
+  ]));
 });

--- a/tests/corpus/2026-width-spread.ts
+++ b/tests/corpus/2026-width-spread.ts
@@ -24,6 +24,12 @@ console.log(c1.inner.keep);
 const a2: A = { ...extra1, b: "override" };
 console.log(a2.a, a2.b);
 
+// A shape-changing static cast is erased in IR. The same-shape clone
+// optimization must inspect that lowered value and decline to this width
+// copy instead of cloning it as the asserted narrower shape.
+const a3: A = { ...(extra1 as A), b: "cast override" };
+console.log(a3.a, a3.b);
+
 // The optional-source merge idiom keeps its present-test semantics next
 // to the new lifts.
 type Opts = { mode?: string };

--- a/tests/corpus/2676-record-clone-overrides.ts
+++ b/tests/corpus/2676-record-clone-overrides.ts
@@ -1,0 +1,70 @@
+// Same-shape immutable record updates lower through one per-shape clone
+// helper. Pin source-before-overrides evaluation, refcounted replacement,
+// scalar replacement, source immutability, and nested/cyclic ownership.
+interface Child {
+  label: string;
+  parent?: Node;
+}
+
+interface Node {
+  name: string;
+  count: number;
+  child: Child;
+  tags: string[];
+  f0: number;
+  f1: number;
+  f2: number;
+  f3: number;
+  f4: number;
+  f5: number;
+  f6: number;
+  f7: number;
+  f8: number;
+  f9: number;
+  f10: number;
+  f11: number;
+}
+
+const order: string[] = [];
+
+function source(value: Node): Node {
+  order.push("source");
+  return value;
+}
+
+function replacement(name: string): string {
+  order.push(name);
+  return name;
+}
+
+const original: Node = {
+  name: "before",
+  count: 1,
+  child: { label: "kept" },
+  tags: ["a", "b"],
+  f0: 0,
+  f1: 1,
+  f2: 2,
+  f3: 3,
+  f4: 4,
+  f5: 5,
+  f6: 6,
+  f7: 7,
+  f8: 8,
+  f9: 9,
+  f10: 10,
+  f11: 11,
+};
+original.child.parent = original;
+
+const first = {
+  ...source(original),
+  name: replacement("after"),
+  count: original.count + 1,
+};
+const second = { ...first, child: { label: replacement("new-child") } };
+
+console.log(order.join(","));
+console.log(original.name, original.count, original.child.label, original.tags.join(""));
+console.log(first.name, first.count, first.child.label, first.tags.join(""));
+console.log(second.name, second.count, second.child.label, second.tags.join(""));


### PR DESCRIPTION
- Lower TypeScript record updates through reusable clone helpers
- Outline large record clones in C and LLVM to reduce generated code
- Add ownership, IR, integer-proof, and differential coverage