### PR TITLE
fix(compiler): lower dyn-backed record equality reads

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -6438,7 +6438,12 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
       if (dk.type.kind !== "string") {
         L.unsupported("SC1090", keyNode, "indexing records with non-string or non-number keys");
       }
-      return L.maybeNarrow({ kind: "dynKeyGet", key: dk, value: obj, type: DYN, loc }, expr);
+      const read: IrExpr = { kind: "dynKeyGet", key: dk, value: obj, type: DYN, loc };
+      // Absence probes must keep the checked-dynamic undefined produced by
+      // a missing key. The ordinary read narrows to the checker's declared
+      // index value (and therefore validates it); ===/!==, ||, and ?? need
+      // to observe the missing value instead of throwing during that check.
+      return includeUndefined ? read : L.maybeNarrow(read, expr);
     }
     if (litKey !== null) {
       const field = shape.fields.find((f) => f.name === litKey);
@@ -6527,6 +6532,13 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
     if (ts.isPropertyAccessExpression(expr)) {
       const target = L.fieldTarget(expr);
       if (target?.container !== "recordOvf") return null;
+      // A JS file-scope object-literal global is record-shaped to the
+      // checker but stored in the checked-dynamic tree to preserve object
+      // identity. Reuse the normal dyn-aware field read; constructing a
+      // recordKeyGet here would give the validator a dyn receiver.
+      if (target.obj.type.kind === "dyn") {
+        return L.fieldGetExpr(target, locOf(expr), expr);
+      }
       if (
         target.fieldType.kind === "union" &&
         L.armTag(target.fieldType.unionId, UNDEFINED_T) >= 0

--- a/tests/corpus/1593-js-jsdoc-records.js
+++ b/tests/corpus/1593-js-jsdoc-records.js
@@ -28,3 +28,18 @@ console.log("initials:", totals.size, "sum:", sum);
 // Inferred anonymous literals stringify in the checker's (alphabetical)
 // property order — keys chosen here so both orders agree.
 console.log(JSON.stringify({ best: best.name, count: players.length }));
+
+// JSDoc Record values declared at JS file scope live in the checked-dynamic
+// tree even though the checker sees a record shape. Strict equality uses an
+// absence-aware read so missing index keys remain undefined; dot and bracket
+// spelling must both dispatch through that runtime representation.
+/** @type {Record<string, string>} */
+const strings = { a: "x", b: "y" };
+console.log(strings.a === strings.a, strings.a !== strings.b);
+console.log(strings.a === strings["a"], strings["a"] !== strings.b);
+console.log(strings.missing === undefined, strings["missing"] !== undefined);
+
+/** @type {Record<string, { value: string }>} */
+const objects = { a: { value: "x" }, b: { value: "y" } };
+console.log(objects.a === objects.a, objects.a !== objects.b);
+console.log(objects["a"] === objects.a, objects["missing"] === undefined);


### PR DESCRIPTION
- Route JSDoc record absence probes through checked-dynamic keyed reads.
- Cover strict equality, missing keys, and object identity for dot and bracket access.