### PR TITLE
perf: split large library program objects

### DIFF
--- a/packages/compiler/src/backend/cc-cache.test.ts
+++ b/packages/compiler/src/backend/cc-cache.test.ts
@@ -3183,6 +3183,103 @@ test.skipIf(!nativeShardMergeAvailable)(
 );
 
 test.skipIf(
+  process.platform === "win32" || clangExecutable === undefined || arExecutable === undefined ||
+  ldExecutable === undefined || (process.platform === "linux" && objcopyExecutable === undefined),
+)("LLVM merged-object caches follow in-place shard merge-tool replacements", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "scriptc-lib-program-shard-merge-tool-"));
+  scratch.push(dir);
+  const binDir = join(dir, "bin");
+  const cacheRoot = join(dir, "cache");
+  const mergeLog = join(dir, "merge.log");
+  const cPath = join(dir, "program.ll");
+  const oldCacheDir = process.env["SCRIPTC_CACHE_DIR"];
+  const oldNoCache = process.env["SCRIPTC_NO_CACHE"];
+  const oldPath = process.env["PATH"];
+  const oldRealLd = process.env["SCRIPTC_TEST_REAL_LD"];
+  const oldMergeLog = process.env["SCRIPTC_TEST_MERGE_LOG"];
+  const programSource = [
+    "define i64 @foo() {",
+    "entry:",
+    "  ret i64 1",
+    "}",
+    "",
+    "define i64 @bar() {",
+    "entry:",
+    "  ret i64 2",
+    "}",
+    "",
+  ].join("\n");
+  const programShards = [
+    {
+      name: "program-f000.ll",
+      source: "define i64 @foo() {\nentry:\n  ret i64 1\n}\ndeclare i64 @bar()\n",
+    },
+    {
+      name: "program-f001.ll",
+      source: "declare i64 @foo()\ndefine i64 @bar() {\nentry:\n  ret i64 2\n}\n",
+    },
+  ];
+  const ldWrapper = (generation: string): string => `#!/bin/sh
+printf '${generation}\\n' >> "$SCRIPTC_TEST_MERGE_LOG"
+exec "$SCRIPTC_TEST_REAL_LD" "$@"
+`;
+  try {
+    await Promise.all([mkdir(binDir), mkdir(cacheRoot, { mode: 0o700 })]);
+    await Promise.all([
+      symlink(clangExecutable!, join(binDir, "clang")),
+      symlink(arExecutable!, join(binDir, "ar")),
+      ...(process.platform === "linux"
+        ? [symlink(objcopyExecutable!, join(binDir, "objcopy"))]
+        : []),
+      writeFile(join(binDir, "ld"), ldWrapper("first")),
+      writeFile(cPath, programSource),
+    ]);
+    await chmod(join(binDir, "ld"), 0o755);
+    process.env["PATH"] = binDir;
+    process.env["SCRIPTC_CACHE_DIR"] = cacheRoot;
+    process.env["SCRIPTC_TEST_REAL_LD"] = ldExecutable!;
+    process.env["SCRIPTC_TEST_MERGE_LOG"] = mergeLog;
+    delete process.env["SCRIPTC_NO_CACHE"];
+    const build = (outPath: string): Promise<void> => compileLibArchive({
+      cPath,
+      programSource,
+      programShards,
+      programPublicSymbols: ["foo", "bar"],
+      outPath,
+      cacheIdentity: TEST_CACHE_IDENTITY,
+      optimization: "dev",
+    });
+
+    await build(join(dir, "first.lib.a"));
+    await writeFile(join(binDir, "ld"), ldWrapper("second"));
+    await chmod(join(binDir, "ld"), 0o755);
+    await build(join(dir, "second.lib.a"));
+
+    expect((await readFile(mergeLog, "utf8")).trim().split("\n")).toEqual(["first", "second"]);
+    expect(await completeArtifacts(cacheRoot, "lib")).toHaveLength(2);
+    expect(
+      (await readdir(join(cacheRoot, "program-obj"))).filter((name) => !name.endsWith(".sha256")),
+    ).toHaveLength(2);
+    // The compiler and shard IR did not change; only merged outputs split by
+    // localization-tool identity.
+    expect(
+      (await readdir(join(cacheRoot, "program-shard"))).filter((name) => !name.endsWith(".sha256")),
+    ).toHaveLength(2);
+  } finally {
+    if (oldCacheDir === undefined) delete process.env["SCRIPTC_CACHE_DIR"];
+    else process.env["SCRIPTC_CACHE_DIR"] = oldCacheDir;
+    if (oldNoCache === undefined) delete process.env["SCRIPTC_NO_CACHE"];
+    else process.env["SCRIPTC_NO_CACHE"] = oldNoCache;
+    if (oldPath === undefined) delete process.env["PATH"];
+    else process.env["PATH"] = oldPath;
+    if (oldRealLd === undefined) delete process.env["SCRIPTC_TEST_REAL_LD"];
+    else process.env["SCRIPTC_TEST_REAL_LD"] = oldRealLd;
+    if (oldMergeLog === undefined) delete process.env["SCRIPTC_TEST_MERGE_LOG"];
+    else process.env["SCRIPTC_TEST_MERGE_LOG"] = oldMergeLog;
+  }
+});
+
+test.skipIf(
   process.platform === "win32" || clangExecutable === undefined || arExecutable === undefined,
 )("LLVM library shards fall back to the canonical TU without host merge tools", async () => {
   const dir = await mkdtemp(join(tmpdir(), "scriptc-lib-program-shard-fallback-"));
@@ -3218,6 +3315,88 @@ test.skipIf(
       optimization: "dev",
     });
     expect(await readFile(outPath)).not.toHaveLength(0);
+  } finally {
+    if (oldCacheDir === undefined) delete process.env["SCRIPTC_CACHE_DIR"];
+    else process.env["SCRIPTC_CACHE_DIR"] = oldCacheDir;
+    if (oldNoCache === undefined) delete process.env["SCRIPTC_NO_CACHE"];
+    else process.env["SCRIPTC_NO_CACHE"] = oldNoCache;
+    if (oldPath === undefined) delete process.env["PATH"];
+    else process.env["PATH"] = oldPath;
+  }
+});
+
+test.skipIf(
+  process.platform === "win32" || clangExecutable === undefined || arExecutable === undefined ||
+  (process.platform === "linux" && objcopyExecutable === undefined),
+)("LLVM library shards fall back when an available host merge tool fails", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "scriptc-lib-program-shard-merge-failure-"));
+  scratch.push(dir);
+  const binDir = join(dir, "bin");
+  const cacheRoot = join(dir, "cache");
+  const cPath = join(dir, "program.ll");
+  const outPath = join(dir, "program.lib.a");
+  const oldCacheDir = process.env["SCRIPTC_CACHE_DIR"];
+  const oldNoCache = process.env["SCRIPTC_NO_CACHE"];
+  const oldPath = process.env["PATH"];
+  const programSource = [
+    "define i64 @public_value() {",
+    "entry:",
+    "  ret i64 7",
+    "}",
+    "",
+    "define i64 @other_value() {",
+    "entry:",
+    "  ret i64 9",
+    "}",
+    "",
+  ].join("\n");
+  try {
+    await Promise.all([mkdir(binDir), mkdir(cacheRoot, { mode: 0o700 })]);
+    await Promise.all([
+      symlink(clangExecutable!, join(binDir, "clang")),
+      symlink(arExecutable!, join(binDir, "ar")),
+      ...(process.platform === "linux"
+        ? [symlink(objcopyExecutable!, join(binDir, "objcopy"))]
+        : []),
+      writeFile(join(binDir, "ld"), "#!/bin/sh\nexit 1\n"),
+      writeFile(cPath, programSource),
+    ]);
+    await chmod(join(binDir, "ld"), 0o755);
+    process.env["PATH"] = binDir;
+    process.env["SCRIPTC_CACHE_DIR"] = cacheRoot;
+    delete process.env["SCRIPTC_NO_CACHE"];
+    await compileLibArchive({
+      cPath,
+      programSource,
+      programShards: [
+        {
+          name: "program-f000.ll",
+          source: "define i64 @public_value() {\nentry:\n  ret i64 7\n}\ndeclare i64 @other_value()\n",
+        },
+        {
+          name: "program-f001.ll",
+          source: "declare i64 @public_value()\ndefine i64 @other_value() {\nentry:\n  ret i64 9\n}\n",
+        },
+      ],
+      programPublicSymbols: ["public_value", "other_value"],
+      outPath,
+      cacheIdentity: TEST_CACHE_IDENTITY,
+      optimization: "dev",
+    });
+    const probeSource = join(dir, "probe.c");
+    const probe = join(dir, "probe");
+    await writeFile(
+      probeSource,
+      "long long public_value(void);\nint main(void) { return public_value() != 7; }\n",
+    );
+    execFileSync(clangExecutable!, [probeSource, outPath, "-lm", "-o", probe]);
+    expect(execFileSync(probe, { encoding: "utf8" })).toBe("");
+    // The canonical retry is valid for this invocation, but must not occupy a
+    // key describing merged shard bytes. A repaired merge tool retries the
+    // optimization instead of receiving a poisoned completed/object hit.
+    expect(await readdir(join(cacheRoot, "lib")).catch(() => [])).toEqual([]);
+    expect(await readdir(join(cacheRoot, "program-obj")).catch(() => [])).toEqual([]);
+    expect(await readdir(join(cacheRoot, "program-shard")).catch(() => [])).toEqual([]);
   } finally {
     if (oldCacheDir === undefined) delete process.env["SCRIPTC_CACHE_DIR"];
     else process.env["SCRIPTC_CACHE_DIR"] = oldCacheDir;

--- a/packages/compiler/src/backend/cc-cache.test.ts
+++ b/packages/compiler/src/backend/cc-cache.test.ts
@@ -64,10 +64,22 @@ const test = Object.assign(
 const trustInstrumentedCompilerWrapper = (): void => {
   process.env["SCRIPTC_TEST_TRUST_COMPILER_WRAPPER"] = "1";
 };
-const zigExecutable = (process.env["PATH"] ?? "")
-  .split(delimiter)
-  .map((entry) => join(entry === "" ? process.cwd() : entry, "zig"))
-  .find((candidate) => existsSync(candidate));
+const executableOnPath = (name: string): string | undefined =>
+  (process.env["PATH"] ?? "")
+    .split(delimiter)
+    .map((entry) => join(entry === "" ? process.cwd() : entry, name))
+    .find((candidate) => existsSync(candidate));
+const zigExecutable = executableOnPath("zig");
+const clangExecutable = executableOnPath("clang");
+const arExecutable = executableOnPath("ar");
+const ldExecutable = executableOnPath("ld");
+const objcopyExecutable = executableOnPath("objcopy");
+const nativeShardMergeAvailable =
+  process.platform === "darwin"
+    ? ldExecutable !== undefined
+    : process.platform === "linux"
+      ? ldExecutable !== undefined && objcopyExecutable !== undefined
+      : process.platform === "win32" && process.arch === "x64";
 const completeArtifacts = async (root: string, kind: "bin" | "lib"): Promise<string[]> =>
   (await readdir(join(root, kind))).filter((name) => !name.endsWith(".sha256"));
 const cacheTreeBytes = async (root: string): Promise<number> => {
@@ -3000,7 +3012,7 @@ test("library identity edits reuse the cached large program object", async () =>
   }
 });
 
-test.skipIf(process.platform === "win32")(
+test.skipIf(!nativeShardMergeAvailable)(
   "LLVM library shards reuse unaffected program objects after a localized edit",
   async () => {
     const dir = await mkdtemp(join(tmpdir(), "scriptc-lib-program-shards-"));
@@ -3085,6 +3097,136 @@ entry:
     }
   },
 );
+
+test.skipIf(!nativeShardMergeAvailable)(
+  "LLVM merged-object and archive caches separate shard projections and public-symbol keep sets",
+  async () => {
+    const dir = await mkdtemp(join(tmpdir(), "scriptc-lib-program-shard-abi-"));
+    scratch.push(dir);
+    const cacheRoot = join(dir, "cache");
+    const cPath = join(dir, "program.ll");
+    const oldCacheDir = process.env["SCRIPTC_CACHE_DIR"];
+    const oldNoCache = process.env["SCRIPTC_NO_CACHE"];
+    const programSource = [
+      "define i64 @foo() {",
+      "entry:",
+      "  ret i64 1",
+      "}",
+      "",
+      "define i64 @bar() {",
+      "entry:",
+      "  ret i64 2",
+      "}",
+      "",
+    ].join("\n");
+    const programShards = [
+      {
+        name: "program-f000.ll",
+        source: "define i64 @foo() {\nentry:\n  ret i64 1\n}\ndeclare i64 @bar()\n",
+      },
+      {
+        name: "program-f001.ll",
+        source: "declare i64 @foo()\ndefine i64 @bar() {\nentry:\n  ret i64 2\n}\n",
+      },
+    ];
+    try {
+      process.env["SCRIPTC_CACHE_DIR"] = cacheRoot;
+      delete process.env["SCRIPTC_NO_CACHE"];
+      await mkdir(cacheRoot, { mode: 0o700 });
+      await writeFile(cPath, programSource);
+      const build = async (
+        symbol: "foo" | "bar",
+        outPath: string,
+        shards = programShards,
+      ): Promise<void> => {
+        await compileLibArchive({
+          cPath,
+          programSource,
+          programShards: shards,
+          programPublicSymbols: [symbol],
+          outPath,
+          cacheIdentity: TEST_CACHE_IDENTITY,
+          optimization: "dev",
+        });
+      };
+      await build("foo", join(dir, "foo.lib.a"));
+      const barArchive = join(dir, "bar.lib.a");
+      await build("bar", barArchive);
+
+      expect(await completeArtifacts(cacheRoot, "lib")).toHaveLength(2);
+      expect(
+        (await readdir(join(cacheRoot, "program-obj"))).filter((name) => !name.endsWith(".sha256")),
+      ).toHaveLength(2);
+      const probeSource = join(dir, "probe.c");
+      const probe = join(dir, "probe");
+      await writeFile(probeSource, "long long bar(void);\nint main(void) { return bar() != 2; }\n");
+      execFileSync("clang", [probeSource, barArchive, "-lm", "-o", probe]);
+      expect(execFileSync(probe, { encoding: "utf8" })).toBe("");
+
+      // The canonical TU and ABI stay fixed, but the exact shard projection
+      // changes. The merged-object tier must not reuse the previous layout.
+      await build("bar", join(dir, "bar-commented.lib.a"), [
+        { ...programShards[0]!, source: `; projection edit\n${programShards[0]!.source}` },
+        programShards[1]!,
+      ]);
+      expect(await completeArtifacts(cacheRoot, "lib")).toHaveLength(3);
+      expect(
+        (await readdir(join(cacheRoot, "program-obj"))).filter((name) => !name.endsWith(".sha256")),
+      ).toHaveLength(3);
+    } finally {
+      if (oldCacheDir === undefined) delete process.env["SCRIPTC_CACHE_DIR"];
+      else process.env["SCRIPTC_CACHE_DIR"] = oldCacheDir;
+      if (oldNoCache === undefined) delete process.env["SCRIPTC_NO_CACHE"];
+      else process.env["SCRIPTC_NO_CACHE"] = oldNoCache;
+    }
+  },
+);
+
+test.skipIf(
+  process.platform === "win32" || clangExecutable === undefined || arExecutable === undefined,
+)("LLVM library shards fall back to the canonical TU without host merge tools", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "scriptc-lib-program-shard-fallback-"));
+  scratch.push(dir);
+  const binDir = join(dir, "bin");
+  const cPath = join(dir, "program.ll");
+  const outPath = join(dir, "program.lib.a");
+  const oldCacheDir = process.env["SCRIPTC_CACHE_DIR"];
+  const oldNoCache = process.env["SCRIPTC_NO_CACHE"];
+  const oldPath = process.env["PATH"];
+  const programSource = "define i64 @public_value() {\nentry:\n  ret i64 7\n}\n";
+  try {
+    await mkdir(binDir);
+    await Promise.all([
+      symlink(clangExecutable!, join(binDir, "clang")),
+      symlink(arExecutable!, join(binDir, "ar")),
+    ]);
+    process.env["PATH"] = binDir;
+    process.env["SCRIPTC_NO_CACHE"] = "1";
+    delete process.env["SCRIPTC_CACHE_DIR"];
+    await writeFile(cPath, programSource);
+    await compileLibArchive({
+      cPath,
+      programSource,
+      // If compilation reaches either shard, this build fails. Missing ld
+      // (and objcopy on Linux) must select the valid canonical TU instead.
+      programShards: [
+        { name: "program-f000.ll", source: "not valid LLVM IR\n" },
+        { name: "program-f001.ll", source: "also not valid LLVM IR\n" },
+      ],
+      programPublicSymbols: ["public_value"],
+      outPath,
+      optimization: "dev",
+    });
+    expect(await readFile(outPath)).not.toHaveLength(0);
+  } finally {
+    if (oldCacheDir === undefined) delete process.env["SCRIPTC_CACHE_DIR"];
+    else process.env["SCRIPTC_CACHE_DIR"] = oldCacheDir;
+    if (oldNoCache === undefined) delete process.env["SCRIPTC_NO_CACHE"];
+    else process.env["SCRIPTC_NO_CACHE"] = oldNoCache;
+    if (oldPath === undefined) delete process.env["PATH"];
+    else process.env["PATH"] = oldPath;
+  }
+});
 
 test.skipIf(process.platform === "win32" || zigExecutable === undefined)(
   "cross-ELF localized archives retain unreferenced identity roots",

--- a/packages/compiler/src/backend/cc-cache.test.ts
+++ b/packages/compiler/src/backend/cc-cache.test.ts
@@ -21,6 +21,7 @@ import {
   vendorCacheBuildIdentity,
   vendorCacheTargetFlavor,
 } from "./cc.js";
+import { splitLlvmProgram } from "./llvm/split.js";
 
 const scratch: string[] = [];
 const TEST_CACHE_IDENTITY = "cc-cache-tests-v1";
@@ -2998,6 +2999,92 @@ test("library identity edits reuse the cached large program object", async () =>
     else process.env["SCRIPTC_NO_CACHE"] = oldNoCache;
   }
 });
+
+test.skipIf(process.platform === "win32")(
+  "LLVM library shards reuse unaffected program objects after a localized edit",
+  async () => {
+    const dir = await mkdtemp(join(tmpdir(), "scriptc-lib-program-shards-"));
+    scratch.push(dir);
+    const cacheRoot = join(dir, "cache");
+    const cPath = join(dir, "program.ll");
+    const outPath = join(dir, "program.lib.a");
+    const oldCacheDir = process.env["SCRIPTC_CACHE_DIR"];
+    const oldNoCache = process.env["SCRIPTC_NO_CACHE"];
+    const source = (value: number): string => `%Pair = type { i64, i64 }
+@private_value = internal global i64 ${value}
+
+define internal i64 @left() {
+entry:
+  %v = load i64, ptr @private_value
+  ret i64 %v
+}
+
+define internal i64 @right() {
+entry:
+  %v = call i64 @left()
+  ret i64 %v
+}
+
+define i64 @scriptc_public_value() {
+entry:
+  %v = call i64 @right()
+  ret i64 %v
+}
+`;
+    try {
+      process.env["SCRIPTC_CACHE_DIR"] = cacheRoot;
+      delete process.env["SCRIPTC_NO_CACHE"];
+      await mkdir(cacheRoot, { mode: 0o700 });
+      const build = async (value: number): Promise<void> => {
+        const programSource = source(value);
+        const split = splitLlvmProgram(programSource, { minimumBytes: 0, targetBytes: 64 * 1024 });
+        expect(split?.shards).toHaveLength(3);
+        await writeFile(cPath, programSource);
+        await compileLibArchive({
+          cPath,
+          programSource,
+          programShards: split!.shards,
+          programPublicSymbols: split!.publicSymbols,
+          outPath,
+          cacheIdentity: TEST_CACHE_IDENTITY,
+          optimization: "dev",
+        });
+      };
+      await build(7);
+      const initial = (await readdir(join(cacheRoot, "program-shard")))
+        .filter((name) => !name.endsWith(".sha256"));
+      expect(initial).toHaveLength(3);
+
+      await build(9);
+      const after = (await readdir(join(cacheRoot, "program-shard")))
+        .filter((name) => !name.endsWith(".sha256"));
+      expect(after).toHaveLength(4);
+      expect(initial.filter((name) => after.includes(name))).toHaveLength(3);
+      const old = new Date("2000-01-01T00:00:00.000Z");
+      await Promise.all(after.map((name) => utimes(join(cacheRoot, "program-shard", name), old, old)));
+      await build(9);
+      for (const name of after) {
+        // The completed archive hit returns before shard lookup/merge; exact
+        // repeats do not even touch the per-bucket object cache.
+        expect((await stat(join(cacheRoot, "program-shard", name))).mtimeMs).toBe(old.getTime());
+      }
+
+      const probeSource = join(dir, "probe.c");
+      const probe = join(dir, "probe");
+      await writeFile(
+        probeSource,
+        "#include <stdio.h>\nlong long scriptc_public_value(void);\nint main(void) { printf(\"%lld\\n\", scriptc_public_value()); }\n",
+      );
+      execFileSync("clang", [probeSource, outPath, "-lm", "-o", probe]);
+      expect(execFileSync(probe, { encoding: "utf8" })).toBe("9\n");
+    } finally {
+      if (oldCacheDir === undefined) delete process.env["SCRIPTC_CACHE_DIR"];
+      else process.env["SCRIPTC_CACHE_DIR"] = oldCacheDir;
+      if (oldNoCache === undefined) delete process.env["SCRIPTC_NO_CACHE"];
+      else process.env["SCRIPTC_NO_CACHE"] = oldNoCache;
+    }
+  },
+);
 
 test.skipIf(process.platform === "win32" || zigExecutable === undefined)(
   "cross-ELF localized archives retain unreferenced identity roots",

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -1464,9 +1464,79 @@ export interface LibArchiveOptions {
   textDecoderLegacy?: boolean;
 }
 
+function updateProgramShardCacheIdentity(
+  hash: ReturnType<typeof createHash>,
+  shards: readonly { name: string; source: string }[] | undefined,
+  publicSymbols: readonly string[] | undefined,
+): void {
+  hash.update("\0program-shards\0");
+  if (shards === undefined) {
+    hash.update("<none>\0");
+  } else {
+    hash.update("<present>\0");
+    for (const shard of shards) {
+      hash.update(shard.name).update("\0").update(shard.source).update("\0");
+    }
+  }
+  hash.update("\0program-public-symbols\0");
+  if (publicSymbols === undefined) {
+    hash.update("<none>\0");
+  } else {
+    hash.update("<present>\0");
+    for (const symbol of publicSymbols) hash.update(symbol).update("\0");
+  }
+}
+
+/** Whether this target can turn LLVM shard objects back into the canonical
+ * program member. Sharding is only a build optimization: a missing host merge
+ * tool or an object class the in-process localizers do not support must retain
+ * the ordinary single-TU compile instead of making a valid library fail. */
+async function libraryProgramShardMergeAvailable(driver: CcDriver): Promise<boolean> {
+  const platform = targetPlatform(driver);
+  // Mach-O merging uses the host's ld64. A Darwin target produced from a
+  // non-Darwin host can still compile as one canonical Zig TU, but the host's
+  // ELF/COFF linker cannot combine those objects.
+  if (platform === "darwin") {
+    return process.platform === "darwin" && await resolvedTool("ld") !== null;
+  }
+  if (platform === "linux") {
+    if (driver.target === null) {
+      const [ld, objcopy] = await Promise.all([resolvedTool("ld"), resolvedTool("objcopy")]);
+      return ld !== null && objcopy !== null;
+    }
+    const arch = driver.target.split("-", 1)[0];
+    return arch === "x86_64" || arch === "aarch64";
+  }
+  if (platform === "win32") {
+    const arch = driver.target?.split("-", 1)[0] ?? process.arch;
+    return arch === "x86_64" || arch === "x64";
+  }
+  return false;
+}
+
 export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> {
   const rtDir = runtimeSrcDir();
   const driver = resolveCc();
+  const shardNames = new Set<string>();
+  const programShardsValid = opts.programShards?.every((shard) => {
+    if (
+      basename(shard.name) !== shard.name || !shard.name.endsWith(".ll") ||
+      shardNames.has(shard.name)
+    ) return false;
+    shardNames.add(shard.name);
+    return true;
+  }) === true;
+  const programShardsRequested =
+    opts.cPath.endsWith(".ll") &&
+    programShardsValid && opts.programShards !== undefined && opts.programShards.length > 1 &&
+    opts.programPublicSymbols !== undefined
+      ? opts.programShards
+      : null;
+  const programShards =
+    programShardsRequested !== null && await libraryProgramShardMergeAvailable(driver)
+      ? programShardsRequested
+      : null;
+  const programPublicSymbols = programShards === null ? undefined : opts.programPublicSymbols;
   const sanitize = opts.sanitize ?? false;
   const optimization = opts.optimization ?? "release";
   const regex = opts.regex ?? false;
@@ -1616,10 +1686,11 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
         const av = await toolVersionOnce(arArgv, toolchainEnv, true);
         archiverVersion = av;
         const key = createHash("sha256")
-          // v8 adds the optional native program-shard set. The canonical TU
-          // still keys source semantics; shard bytes key the exact archive
-          // object layout so single- and multi-TU producers never collide.
-          .update("lib-v8\0")
+          // v9 adds the public-symbol keep set beside the optional native
+          // shards. The canonical TU still keys source semantics; shard and
+          // keep bytes key the exact merged program object so ABI projections
+          // and single-/multi-TU producers never collide.
+          .update("lib-v9\0")
           .update(cacheTargetIdentity(driver)).update("\0")
           .update(toolchainEnv).update("\0")
           .update(implicitToolchain!).update("\0")
@@ -1639,11 +1710,12 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
           // latter. Archive members also inherit the TU's basename.
           .update(opts.cPath).update("\0")
           .update(resolve(opts.cPath)).update("\0")
-          .update(programBytes)
-          .update("\0program-shards\0");
-        for (const shard of opts.programShards ?? []) {
-          key.update(shard.name).update("\0").update(shard.source).update("\0");
-        }
+          .update(programBytes);
+        updateProgramShardCacheIdentity(
+          key,
+          programShards ?? undefined,
+          programPublicSymbols,
+        );
         const keyHex = key
           .update("\0identity\0")
           .update(identityBytes === null ? "<none>" : "<generated>").update("\0")
@@ -1725,21 +1797,6 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
         cachedProgramBytes === null
           ? opts.cPath
           : join(buildDir, `program${opts.cPath.endsWith(".ll") ? ".ll" : ".c"}`);
-      const shardNames = new Set<string>();
-      const programShardsValid = opts.programShards?.every((shard) => {
-        if (
-          basename(shard.name) !== shard.name || !shard.name.endsWith(".ll") ||
-          shardNames.has(shard.name)
-        ) return false;
-        shardNames.add(shard.name);
-        return true;
-      }) === true;
-      const programShards =
-        opts.cPath.endsWith(".ll") &&
-        programShardsValid && opts.programShards !== undefined && opts.programShards.length > 1 &&
-        opts.programPublicSymbols !== undefined
-          ? opts.programShards
-          : null;
       if (cachedProgramBytes !== null && programShards === null) {
         await writeFile(programSource, cachedProgramBytes);
       }
@@ -1749,7 +1806,7 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
         implicitToolchain !== null && programCompilerInvocation !== null
       ) {
         const programKey = createHash("sha256")
-          .update("lib-program-obj-v1\0")
+          .update("lib-program-obj-v2\0")
           .update(cacheTargetIdentity(driver)).update("\0")
           .update(toolchainEnv).update("\0")
           .update(implicitToolchain).update("\0")
@@ -1762,9 +1819,14 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
           .update(programCompilerArgs.join("\x1f")).update("\0")
           .update(opts.cPath).update("\0")
           .update(resolve(opts.cPath)).update("\0")
-          .update(cachedProgramBytes)
-          .digest("hex");
-        cachedProgramObject = join(root, "program-obj", programKey);
+          .update(cachedProgramBytes);
+        updateProgramShardCacheIdentity(
+          programKey,
+          programShards ?? undefined,
+          programPublicSymbols,
+        );
+        const programKeyHex = programKey.digest("hex");
+        cachedProgramObject = join(root, "program-obj", programKeyHex);
       }
       const stagedProgramObject = join(buildDir, `${stem}.program.o`);
       let programObject: string;
@@ -1824,7 +1886,7 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
           buildDir,
           shardEntries.map((entry) => entry.staged),
           [],
-          opts.programPublicSymbols!,
+          programPublicSymbols!,
           `${stem}.program`,
         );
         // Keep the canonical archive member spelling. The fact that native

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -1372,6 +1372,11 @@ async function ensureTlsArchive(
  * objects apart from executable-lane objects). Persistent builds cache the
  * completed archive by program-TU content and cache runtime objects separately,
  * so an edit recompiles only the changed program object before re-archiving.
+ * Large LLVM dev TUs split further into stable symbol-hash shards: compile
+ * those in parallel, cache each object independently, then relocatably merge
+ * them back into the archive's one canonical program member. A localized edit
+ * recompiles only the changed buckets; exact repeats use the merged-object or
+ * completed-archive tiers and never repeat the merge.
  * The base set narrows from the executable lane's unconditional sources:
  * scr_async.c (fibers, timers, the loop) and scr_child.c drop — the
  * async_free refusal already guarantees nothing references them — and
@@ -1402,6 +1407,14 @@ export interface LibArchiveOptions {
    * spelling. Library assembly uses this for the identity-free projection of
    * a complete caller-visible TU; its bytes drive every native cache key. */
   programSource?: string;
+  /** Optional equivalent LLVM modules for native compilation. The public
+   * `programSource` remains the canonical TU/cache identity; these stable
+   * shards compile independently and are relocatably merged into one program
+   * object before archive assembly. */
+  programShards?: readonly { name: string; source: string }[];
+  /** Canonical externally visible definitions retained while the shard merge
+   * demotes generated cross-shard linkage back to local symbols. */
+  programPublicSymbols?: readonly string[];
   /** Tiny generated C source carrying volatile library identity getters.
    * Its bytes join the complete archive key, but the source itself exists
    * only in the invocation-private build directory and the large program-
@@ -1603,9 +1616,10 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
         const av = await toolVersionOnce(arArgv, toolchainEnv, true);
         archiverVersion = av;
         const key = createHash("sha256")
-          // v7 adds effective compiler-wrapper invocations for the real runtime
-          // and program compile flavors.
-          .update("lib-v7\0")
+          // v8 adds the optional native program-shard set. The canonical TU
+          // still keys source semantics; shard bytes key the exact archive
+          // object layout so single- and multi-TU producers never collide.
+          .update("lib-v8\0")
           .update(cacheTargetIdentity(driver)).update("\0")
           .update(toolchainEnv).update("\0")
           .update(implicitToolchain!).update("\0")
@@ -1626,11 +1640,16 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
           .update(opts.cPath).update("\0")
           .update(resolve(opts.cPath)).update("\0")
           .update(programBytes)
+          .update("\0program-shards\0");
+        for (const shard of opts.programShards ?? []) {
+          key.update(shard.name).update("\0").update(shard.source).update("\0");
+        }
+        const keyHex = key
           .update("\0identity\0")
           .update(identityBytes === null ? "<none>" : "<generated>").update("\0")
           .update(identityBytes ?? Buffer.alloc(0))
           .digest("hex");
-        cachedArchive = join(root, "lib", key);
+        cachedArchive = join(root, "lib", keyHex);
         const tmpOut = privateSiblingPath(opts.outPath, "lib-hit");
         try {
           await mkdir(dirname(opts.outPath), { recursive: true });
@@ -1706,7 +1725,24 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
         cachedProgramBytes === null
           ? opts.cPath
           : join(buildDir, `program${opts.cPath.endsWith(".ll") ? ".ll" : ".c"}`);
-      if (cachedProgramBytes !== null) await writeFile(programSource, cachedProgramBytes);
+      const shardNames = new Set<string>();
+      const programShardsValid = opts.programShards?.every((shard) => {
+        if (
+          basename(shard.name) !== shard.name || !shard.name.endsWith(".ll") ||
+          shardNames.has(shard.name)
+        ) return false;
+        shardNames.add(shard.name);
+        return true;
+      }) === true;
+      const programShards =
+        opts.cPath.endsWith(".ll") &&
+        programShardsValid && opts.programShards !== undefined && opts.programShards.length > 1 &&
+        opts.programPublicSymbols !== undefined
+          ? opts.programShards
+          : null;
+      if (cachedProgramBytes !== null && programShards === null) {
+        await writeFile(programSource, cachedProgramBytes);
+      }
       let cachedProgramObject: string | null = null;
       if (
         root !== null && cachedProgramBytes !== null && compilerVersion !== "" &&
@@ -1737,6 +1773,102 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
         await copyValidCachedFile(cachedProgramObject, stagedProgramObject)
       ) {
         programObject = stagedProgramObject;
+      } else if (programShards !== null) {
+        const shardEntries = programShards.map((shard, index) => {
+          const sourcePath = join(buildDir, shard.name);
+          const staged = join(buildDir, `${stem}.program-${index.toString().padStart(3, "0")}.o`);
+          let cachePath: string | null = null;
+          if (
+            root !== null && compilerVersion !== "" && implicitToolchain !== null &&
+            programCompilerInvocation !== null
+          ) {
+            const key = createHash("sha256")
+              .update("lib-program-shard-v1\0")
+              .update(cacheTargetIdentity(driver)).update("\0")
+              .update(toolchainEnv).update("\0")
+              .update(implicitToolchain).update("\0")
+              .update(programCompilerInvocation).update("\0")
+              .update(opts.cacheIdentity!).update("\0")
+              .update(driver.argv.join("\x1f")).update("\0")
+              .update(compilerVersion).update("\0")
+              .update(runtimeHash).update("\0")
+              .update(programDependencyHash).update("\0")
+              .update(programCompilerArgs.join("\x1f")).update("\0")
+              .update(opts.cPath).update("\0")
+              .update(resolve(opts.cPath)).update("\0")
+              .update(shard.name).update("\0")
+              .update(shard.source)
+              .digest("hex");
+            cachePath = join(root, "program-shard", key);
+          }
+          return { ...shard, sourcePath, staged, cachePath, missed: false };
+        });
+        const shardWidth = Math.min(8, availableParallelism());
+        for (let i = 0; i < shardEntries.length; i += shardWidth) {
+          await Promise.all(shardEntries.slice(i, i + shardWidth).map(async (entry) => {
+            await writeFile(entry.sourcePath, entry.source);
+            if (
+              entry.cachePath !== null &&
+              await copyValidCachedFile(entry.cachePath, entry.staged)
+            ) return;
+            entry.missed = true;
+            await compileOne(entry.sourcePath, basename(entry.staged), opts.cPath);
+          }));
+        }
+        const publishable = shardEntries.filter(
+          (entry) => entry.missed && entry.cachePath !== null,
+        );
+        const mergedProgramObject = await localizeLibraryObjects(
+          driver,
+          arArgv,
+          buildDir,
+          shardEntries.map((entry) => entry.staged),
+          [],
+          opts.programPublicSymbols!,
+          `${stem}.program`,
+        );
+        // Keep the canonical archive member spelling. The fact that native
+        // compilation used shards is an implementation detail; consumers and
+        // deterministic cache tests continue to see `<stem>.program.o`.
+        await rename(mergedProgramObject, stagedProgramObject);
+        programObject = stagedProgramObject;
+        if (cachedProgramObject !== null || publishable.length > 0) {
+          try {
+            const [currentRuntime, currentImplicit, currentInvocation, currentDependencies, currentCompiler] =
+              await Promise.all([
+                runtimeFingerprint(rtDir),
+                implicitToolchainFingerprint(driver, toolchainEnv),
+                effectiveCompilerInvocationFingerprint(
+                  driver,
+                  toolchainEnv,
+                  programCompilerArgs,
+                  programSourceExtension,
+                ),
+                translationUnitDependencyFingerprint(
+                  driver,
+                  cflags,
+                  opts.cPath,
+                  cachedProgramBytes!,
+                  toolchainEnv,
+                ),
+                ccVersionOnce(driver.argv, toolchainEnv, true),
+              ]);
+            if (
+              currentRuntime === runtimeHash && currentImplicit === implicitToolchain &&
+              currentInvocation === programCompilerInvocation &&
+              currentDependencies === programDependencyHash && currentCompiler === compilerVersion
+            ) {
+              await Promise.all([
+                ...(cachedProgramObject === null
+                  ? []
+                  : [publishCachedFile(programObject, cachedProgramObject)]),
+                ...publishable.map((entry) => publishCachedFile(entry.staged, entry.cachePath!)),
+              ]);
+            }
+          } catch {
+            // Best-effort: the merged program object is already valid.
+          }
+        }
       } else {
         programObject = await compileOne(
           programSource,
@@ -2029,13 +2161,16 @@ async function localizeLibraryObjects(
     }
     return combined;
   }
-  await run([arArgv[0] ?? "ar", ...arArgv.slice(1), "rcs", staging, ...supportObjects]);
+  const supportArgs = supportObjects.length === 0 ? [] : [staging];
+  if (supportObjects.length > 0) {
+    await run([arArgv[0] ?? "ar", ...arArgv.slice(1), "rcs", staging, ...supportObjects]);
+  }
   if (platform === "darwin") {
     await writeFile(keepFile, keepSymbols.map((s) => `_${s}\n`).join(""));
-    await run(["ld", "-r", ...rootObjects, staging, "-o", combined, "-exported_symbols_list", keepFile]);
+    await run(["ld", "-r", ...rootObjects, ...supportArgs, "-o", combined, "-exported_symbols_list", keepFile]);
   } else if (platform === "linux" && driver.target === null) {
     await writeFile(keepFile, keepSymbols.map((s) => `${s}\n`).join(""));
-    await run(["ld", "-r", "--force-group-allocation", ...rootObjects, staging, "-o", combined]);
+    await run(["ld", "-r", "--force-group-allocation", ...rootObjects, ...supportArgs, "-o", combined]);
     await run(["objcopy", `--keep-global-symbols=${keepFile}`, combined]);
   } else if (platform === "linux") {
     // Cross ELF: the cross driver's own lld performs the relocatable merge
@@ -2049,7 +2184,7 @@ async function localizeLibraryObjects(
       ...driver.argv.slice(1),
       "-target", driver.zigTarget ?? driver.target!,
       "-nostdlib",
-      "-r", ...rootObjects, staging,
+      "-r", ...rootObjects, ...supportArgs,
       "-o", combined,
     ]);
     try {
@@ -2071,7 +2206,7 @@ async function localizeLibraryObjects(
  * Content-addressed caches that let repeat builds of unchanged programs skip
  * payload code generation/linking — the test lanes' dominant cost. Executable
  * lookups still run lightweight dependency and link-input metadata probes.
- * Three keyspaces under the cache root:
+ * Principal keyspaces under the cache root:
  *
  *   bin/<key>       — whole program binaries. key = sha256(resolved clang
  *                     identity/version, target + compiler/linker environment,
@@ -2100,6 +2235,14 @@ async function localizeLibraryObjects(
  *                     target/flags, gated source set, caller dependency
  *                     identity, TU path, and program-TU bytes.
  *                     Checksum-verified hits skip native code generation and ar.
+ *
+ *   program-obj/<key> — the canonical library program object, after any LLVM
+ *                     shard merge. Exact TU repeats reuse it directly.
+ *
+ *   program-shard/<key> — stable LLVM dev-library buckets keyed by their IR
+ *                     text and complete toolchain/TU identity. Local edits
+ *                     retain every bucket whose definitions/declarations did
+ *                     not change.
  *
  *   obj/<set>/<f>.o — per-flavor runtime objects for cache-miss builds. The
  *                     historical single invocation recompiles every runtime

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -1627,11 +1627,14 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
     }
   }
   let implicitToolchain: string | null = null;
+  let implicitCompileToolchain: string | null = null;
   let runtimeCompilerInvocation: string | null = null;
   let programCompilerInvocation: string | null = null;
   if (persistentDriverCache) {
     try {
-      implicitToolchain = await implicitToolchainFingerprint(driver, toolchainEnv);
+      const fingerprints = await implicitToolchainFingerprints(driver, toolchainEnv);
+      implicitToolchain = fingerprints.complete;
+      implicitCompileToolchain = fingerprints.compile;
     } catch {
       // An identity probe is cache machinery, never a reason a valid native
       // compile should fail. Disable every persistent tier for this invocation.
@@ -1862,14 +1865,21 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
             const staged = join(buildDir, `${stem}.program-${index.toString().padStart(3, "0")}.o`);
             let cachePath: string | null = null;
             if (
-              root !== null && compilerVersion !== "" && implicitToolchain !== null &&
+              root !== null && compilerVersion !== "" && implicitCompileToolchain !== null &&
               programCompilerInvocation !== null
             ) {
               const key = createHash("sha256")
-                .update("lib-program-shard-v1\0")
+                // v2 removes the broad implicit-toolchain fingerprint: it
+                // includes the linker selected by the driver, but raw shard
+                // objects are compile-only outputs. The compile-only toolchain
+                // identity retains compiler/config/header/assembler inputs;
+                // the effective program invocation pins this exact flag lane.
+                // Merge-tool identity belongs only to the merged-object and
+                // completed-archive tiers.
+                .update("lib-program-shard-v2\0")
                 .update(cacheTargetIdentity(driver)).update("\0")
                 .update(toolchainEnv).update("\0")
-                .update(implicitToolchain).update("\0")
+                .update(implicitCompileToolchain).update("\0")
                 .update(programCompilerInvocation).update("\0")
                 .update(opts.cacheIdentity!).update("\0")
                 .update(driver.argv.join("\x1f")).update("\0")
@@ -1917,10 +1927,9 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
           programObject = stagedProgramObject;
           if (cachedProgramObject !== null || publishable.length > 0) {
             try {
-              const [currentRuntime, currentImplicit, currentInvocation, currentDependencies, currentCompiler, currentMerge] =
+              const [currentRuntime, currentInvocation, currentDependencies, currentCompiler] =
                 await Promise.all([
                   runtimeFingerprint(rtDir),
-                  implicitToolchainFingerprint(driver, toolchainEnv),
                   effectiveCompilerInvocationFingerprint(
                     driver,
                     toolchainEnv,
@@ -1935,18 +1944,29 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
                     toolchainEnv,
                   ),
                   ccVersionOnce(driver.argv, toolchainEnv, true),
-                  libraryProgramShardMergeIdentity(driver),
                 ]);
-              if (
-                currentRuntime === runtimeHash && currentImplicit === implicitToolchain &&
+              const shardInputsStillMatch =
+                currentRuntime === runtimeHash &&
                 currentInvocation === programCompilerInvocation &&
-                currentDependencies === programDependencyHash && currentCompiler === compilerVersion &&
-                currentMerge === programShardMergeIdentity
-              ) {
+                currentDependencies === programDependencyHash && currentCompiler === compilerVersion;
+              const currentFingerprints = shardInputsStillMatch
+                ? await implicitToolchainFingerprints(driver, toolchainEnv)
+                : null;
+              const compileInputsStillMatch =
+                shardInputsStillMatch &&
+                currentFingerprints?.compile === implicitCompileToolchain;
+              let mergedInputsStillMatch = false;
+              if (compileInputsStillMatch && cachedProgramObject !== null) {
+                const currentMerge = await libraryProgramShardMergeIdentity(driver).catch(() => null);
+                mergedInputsStillMatch =
+                  currentFingerprints?.complete === implicitToolchain &&
+                  currentMerge === programShardMergeIdentity;
+              }
+              if (compileInputsStillMatch) {
                 await Promise.all([
-                  ...(cachedProgramObject === null
-                    ? []
-                    : [publishCachedFile(programObject, cachedProgramObject)]),
+                  ...(mergedInputsStillMatch
+                    ? [publishCachedFile(programObject, cachedProgramObject!)]
+                    : []),
                   ...publishable.map((entry) => publishCachedFile(entry.staged, entry.cachePath!)),
                 ]);
               }
@@ -2745,6 +2765,14 @@ interface ImplicitToolchainProbe {
   dependencyFingerprint: string;
   invocationPaths: string[];
   tools: { spelling: string; identity: string | null; path: string | null }[];
+  compileToolSpellings: string[];
+}
+
+interface ImplicitToolchainFingerprints {
+  /** Compiler inputs plus assembler identity: safe for compile-only objects. */
+  compile: string;
+  /** The compile identity plus the driver's selected linker identity. */
+  complete: string;
 }
 
 interface ImplicitLinkerProbe {
@@ -3189,10 +3217,10 @@ function translationUnitDependencyFingerprint(
  * change that redirects includes cannot hide behind an unchanged old path
  * list. Dependency discovery must succeed on every cache-enabled invocation;
  * a prior path list cannot reveal a new higher-priority header. */
-async function implicitToolchainFingerprintFresh(
+async function implicitToolchainFingerprintsFresh(
   driver: Pick<CcDriver, "argv" | "targetArgs" | "target">,
   environmentFingerprint: string,
-): Promise<string> {
+): Promise<ImplicitToolchainFingerprints> {
   let probe: ImplicitToolchainProbe;
   const compiler = driver.argv[0] ?? "clang";
   const compilerIdentity = await resolvedToolIdentity(compiler);
@@ -3255,7 +3283,8 @@ async function implicitToolchainFingerprintFresh(
           { cwd: probeDir, maxBuffer: 16 * 1024 * 1024 },
         ),
       ]);
-      const toolSpellings = [linker.stdout.trim(), assembler.stdout.trim()].filter(
+      const assemblerSpelling = assembler.stdout.trim();
+      const toolSpellings = [linker.stdout.trim(), assemblerSpelling].filter(
         (value, index, all) => value !== "" && all.indexOf(value) === index,
       );
       const sourceSet = new Set(sources);
@@ -3286,53 +3315,71 @@ async function implicitToolchainFingerprintFresh(
             };
           }),
         ),
+        compileToolSpellings: assemblerSpelling === "" ? [] : [assemblerSpelling],
       };
     } finally {
       await rm(probeDir, { recursive: true, force: true }).catch(() => undefined);
     }
   }
 
-  const hash = createHash("sha256")
-    .update("implicit-toolchain-v2\0")
-    .update(environmentFingerprint)
-    .update("\0")
-    .update(probe.compilerIdentity)
-    .update("\0")
-    .update(probe.compilerInvocation)
-    .update("\0")
-    .update(driver.argv.join("\x1f"))
-    .update("\0")
-    .update(driver.targetArgs.join("\x1f"))
-    .update("\0")
-    .update(probe.dependencies.join("\x1f"))
-    .update("\0")
-    .update(probe.dependencyFingerprint)
-    .update("\0");
-  for (const tool of probe.tools) {
-    const currentIdentity = await resolvedToolIdentity(tool.spelling);
-    hash
-      .update(tool.spelling)
+  const tools = await Promise.all(probe.tools.map(async (tool) => ({
+    ...tool,
+    currentIdentity: await resolvedToolIdentity(tool.spelling),
+  })));
+  const fingerprint = (
+    domain: string,
+    selectedTools: readonly (typeof tools)[number][],
+  ): string => {
+    const hash = createHash("sha256")
+      .update(domain)
+      .update(environmentFingerprint)
       .update("\0")
-      .update(currentIdentity ?? tool.identity ?? "<unresolved>")
+      .update(probe.compilerIdentity)
+      .update("\0")
+      .update(probe.compilerInvocation)
+      .update("\0")
+      .update(driver.argv.join("\x1f"))
+      .update("\0")
+      .update(driver.targetArgs.join("\x1f"))
+      .update("\0")
+      .update(probe.dependencies.join("\x1f"))
+      .update("\0")
+      .update(probe.dependencyFingerprint)
       .update("\0");
-  }
-  return rememberFingerprintDependencies(
-    hash.digest("hex"),
-    [
-      ...probe.dependencies,
-      ...probe.invocationPaths,
-      ...probe.tools.flatMap((tool) => tool.path === null ? [] : [tool.path]),
-    ],
-    probe.dependencies,
-    probe.dependencyFingerprint,
-  );
+    for (const tool of selectedTools) {
+      hash
+        .update(tool.spelling)
+        .update("\0")
+        .update(tool.currentIdentity ?? tool.identity ?? "<unresolved>")
+        .update("\0");
+    }
+    return rememberFingerprintDependencies(
+      hash.digest("hex"),
+      [
+        ...probe.dependencies,
+        ...probe.invocationPaths,
+        ...selectedTools.flatMap((tool) => tool.path === null ? [] : [tool.path]),
+      ],
+      probe.dependencies,
+      probe.dependencyFingerprint,
+    );
+  };
+  const compileSpellingSet = new Set(probe.compileToolSpellings);
+  return {
+    // Preserve the established complete fingerprint domain and byte stream.
+    complete: fingerprint("implicit-toolchain-v2\0", tools),
+    compile: fingerprint(
+      "implicit-compile-toolchain-v1\0",
+      tools.filter((tool) => compileSpellingSet.has(tool.spelling)),
+    ),
+  };
 }
 
-const stableImplicitToolchainMemos = new Map<string, Promise<string>>();
-function implicitToolchainFingerprint(
+const stableImplicitToolchainMemos = new Map<string, Promise<ImplicitToolchainFingerprints>>();
+function implicitToolchainFingerprints(
   driver: Pick<CcDriver, "argv" | "targetArgs" | "target">,
   environmentFingerprint: string,
-): Promise<string> {
+): Promise<ImplicitToolchainFingerprints> {
   const key = [
     environmentFingerprint,
     driver.argv.join("\x1f"),
@@ -3341,7 +3388,16 @@ function implicitToolchainFingerprint(
     runtimeSrcDir(),
   ].join("\0");
   return stableTestMemo(stableImplicitToolchainMemos, key, () =>
-    implicitToolchainFingerprintFresh(driver, environmentFingerprint),
+    implicitToolchainFingerprintsFresh(driver, environmentFingerprint),
+  );
+}
+
+function implicitToolchainFingerprint(
+  driver: Pick<CcDriver, "argv" | "targetArgs" | "target">,
+  environmentFingerprint: string,
+): Promise<string> {
+  return implicitToolchainFingerprints(driver, environmentFingerprint).then(
+    (fingerprints) => fingerprints.complete,
   );
 }
 

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -1468,6 +1468,7 @@ function updateProgramShardCacheIdentity(
   hash: ReturnType<typeof createHash>,
   shards: readonly { name: string; source: string }[] | undefined,
   publicSymbols: readonly string[] | undefined,
+  mergeIdentity: string | undefined,
 ): void {
   hash.update("\0program-shards\0");
   if (shards === undefined) {
@@ -1485,33 +1486,49 @@ function updateProgramShardCacheIdentity(
     hash.update("<present>\0");
     for (const symbol of publicSymbols) hash.update(symbol).update("\0");
   }
+  hash.update("\0program-shard-merge\0");
+  hash.update(mergeIdentity === undefined ? "<none>\0" : `<present>\0${mergeIdentity}\0`);
 }
 
-/** Whether this target can turn LLVM shard objects back into the canonical
- * program member. Sharding is only a build optimization: a missing host merge
- * tool or an object class the in-process localizers do not support must retain
- * the ordinary single-TU compile instead of making a valid library fail. */
-async function libraryProgramShardMergeAvailable(driver: CcDriver): Promise<boolean> {
+/** Identity of the machinery that turns LLVM shard objects back into the
+ * canonical program member, or null when the target cannot do so. Sharding is
+ * only a build optimization: a missing host tool or unsupported object class
+ * retains the ordinary single-TU compile. The identity joins every cache tier
+ * that contains merged bytes; raw shard-object keys deliberately omit it. */
+async function libraryProgramShardMergeIdentity(driver: CcDriver): Promise<string | null> {
   const platform = targetPlatform(driver);
   // Mach-O merging uses the host's ld64. A Darwin target produced from a
   // non-Darwin host can still compile as one canonical Zig TU, but the host's
   // ELF/COFF linker cannot combine those objects.
   if (platform === "darwin") {
-    return process.platform === "darwin" && await resolvedTool("ld") !== null;
+    if (process.platform !== "darwin") return null;
+    const ld = await resolvedToolIdentity("ld");
+    return ld === null ? null : `program-shard-merge-darwin-v1\0${ld}`;
   }
   if (platform === "linux") {
     if (driver.target === null) {
-      const [ld, objcopy] = await Promise.all([resolvedTool("ld"), resolvedTool("objcopy")]);
-      return ld !== null && objcopy !== null;
+      const [ld, objcopy] = await Promise.all([
+        resolvedToolIdentity("ld"),
+        resolvedToolIdentity("objcopy"),
+      ]);
+      return ld === null || objcopy === null
+        ? null
+        : `program-shard-merge-linux-v1\0${ld}\0${objcopy}`;
     }
     const arch = driver.target.split("-", 1)[0];
-    return arch === "x86_64" || arch === "aarch64";
+    if (arch !== "x86_64" && arch !== "aarch64") return null;
+    const compiler = await resolvedToolIdentity(driver.argv[0] ?? "zig");
+    return compiler === null
+      ? null
+      : `program-shard-merge-cross-elf-v1\0${arch}\0${compiler}`;
   }
   if (platform === "win32") {
     const arch = driver.target?.split("-", 1)[0] ?? process.arch;
-    return arch === "x86_64" || arch === "x64";
+    return arch === "x86_64" || arch === "x64"
+      ? `program-shard-merge-coff-v1\0${arch}`
+      : null;
   }
-  return false;
+  return null;
 }
 
 export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> {
@@ -1532,10 +1549,10 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
     opts.programPublicSymbols !== undefined
       ? opts.programShards
       : null;
-  const programShards =
-    programShardsRequested !== null && await libraryProgramShardMergeAvailable(driver)
-      ? programShardsRequested
-      : null;
+  const programShardMergeIdentity = programShardsRequested === null
+    ? null
+    : await libraryProgramShardMergeIdentity(driver);
+  const programShards = programShardMergeIdentity === null ? null : programShardsRequested;
   const programPublicSymbols = programShards === null ? undefined : opts.programPublicSymbols;
   const sanitize = opts.sanitize ?? false;
   const optimization = opts.optimization ?? "release";
@@ -1686,11 +1703,11 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
         const av = await toolVersionOnce(arArgv, toolchainEnv, true);
         archiverVersion = av;
         const key = createHash("sha256")
-          // v9 adds the public-symbol keep set beside the optional native
-          // shards. The canonical TU still keys source semantics; shard and
-          // keep bytes key the exact merged program object so ABI projections
-          // and single-/multi-TU producers never collide.
-          .update("lib-v9\0")
+          // v10 adds the shard-merge implementation/tool identity. The
+          // canonical TU still keys source semantics; shard, keep, and merge
+          // bytes key the exact merged program object so ABI projections,
+          // tool replacements, and single-/multi-TU producers never collide.
+          .update("lib-v10\0")
           .update(cacheTargetIdentity(driver)).update("\0")
           .update(toolchainEnv).update("\0")
           .update(implicitToolchain!).update("\0")
@@ -1715,6 +1732,7 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
           key,
           programShards ?? undefined,
           programPublicSymbols,
+          programShardMergeIdentity ?? undefined,
         );
         const keyHex = key
           .update("\0identity\0")
@@ -1806,7 +1824,7 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
         implicitToolchain !== null && programCompilerInvocation !== null
       ) {
         const programKey = createHash("sha256")
-          .update("lib-program-obj-v2\0")
+          .update("lib-program-obj-v3\0")
           .update(cacheTargetIdentity(driver)).update("\0")
           .update(toolchainEnv).update("\0")
           .update(implicitToolchain).update("\0")
@@ -1824,112 +1842,130 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
           programKey,
           programShards ?? undefined,
           programPublicSymbols,
+          programShardMergeIdentity ?? undefined,
         );
         const programKeyHex = programKey.digest("hex");
         cachedProgramObject = join(root, "program-obj", programKeyHex);
       }
       const stagedProgramObject = join(buildDir, `${stem}.program.o`);
       let programObject: string;
+      let programShardFallback = false;
       if (
         cachedProgramObject !== null &&
         await copyValidCachedFile(cachedProgramObject, stagedProgramObject)
       ) {
         programObject = stagedProgramObject;
       } else if (programShards !== null) {
-        const shardEntries = programShards.map((shard, index) => {
-          const sourcePath = join(buildDir, shard.name);
-          const staged = join(buildDir, `${stem}.program-${index.toString().padStart(3, "0")}.o`);
-          let cachePath: string | null = null;
-          if (
-            root !== null && compilerVersion !== "" && implicitToolchain !== null &&
-            programCompilerInvocation !== null
-          ) {
-            const key = createHash("sha256")
-              .update("lib-program-shard-v1\0")
-              .update(cacheTargetIdentity(driver)).update("\0")
-              .update(toolchainEnv).update("\0")
-              .update(implicitToolchain).update("\0")
-              .update(programCompilerInvocation).update("\0")
-              .update(opts.cacheIdentity!).update("\0")
-              .update(driver.argv.join("\x1f")).update("\0")
-              .update(compilerVersion).update("\0")
-              .update(runtimeHash).update("\0")
-              .update(programDependencyHash).update("\0")
-              .update(programCompilerArgs.join("\x1f")).update("\0")
-              .update(opts.cPath).update("\0")
-              .update(resolve(opts.cPath)).update("\0")
-              .update(shard.name).update("\0")
-              .update(shard.source)
-              .digest("hex");
-            cachePath = join(root, "program-shard", key);
-          }
-          return { ...shard, sourcePath, staged, cachePath, missed: false };
-        });
-        const shardWidth = Math.min(8, availableParallelism());
-        for (let i = 0; i < shardEntries.length; i += shardWidth) {
-          await Promise.all(shardEntries.slice(i, i + shardWidth).map(async (entry) => {
-            await writeFile(entry.sourcePath, entry.source);
+        try {
+          const shardEntries = programShards.map((shard, index) => {
+            const sourcePath = join(buildDir, shard.name);
+            const staged = join(buildDir, `${stem}.program-${index.toString().padStart(3, "0")}.o`);
+            let cachePath: string | null = null;
             if (
-              entry.cachePath !== null &&
-              await copyValidCachedFile(entry.cachePath, entry.staged)
-            ) return;
-            entry.missed = true;
-            await compileOne(entry.sourcePath, basename(entry.staged), opts.cPath);
-          }));
-        }
-        const publishable = shardEntries.filter(
-          (entry) => entry.missed && entry.cachePath !== null,
-        );
-        const mergedProgramObject = await localizeLibraryObjects(
-          driver,
-          arArgv,
-          buildDir,
-          shardEntries.map((entry) => entry.staged),
-          [],
-          programPublicSymbols!,
-          `${stem}.program`,
-        );
-        // Keep the canonical archive member spelling. The fact that native
-        // compilation used shards is an implementation detail; consumers and
-        // deterministic cache tests continue to see `<stem>.program.o`.
-        await rename(mergedProgramObject, stagedProgramObject);
-        programObject = stagedProgramObject;
-        if (cachedProgramObject !== null || publishable.length > 0) {
-          try {
-            const [currentRuntime, currentImplicit, currentInvocation, currentDependencies, currentCompiler] =
-              await Promise.all([
-                runtimeFingerprint(rtDir),
-                implicitToolchainFingerprint(driver, toolchainEnv),
-                effectiveCompilerInvocationFingerprint(
-                  driver,
-                  toolchainEnv,
-                  programCompilerArgs,
-                  programSourceExtension,
-                ),
-                translationUnitDependencyFingerprint(
-                  driver,
-                  cflags,
-                  opts.cPath,
-                  cachedProgramBytes!,
-                  toolchainEnv,
-                ),
-                ccVersionOnce(driver.argv, toolchainEnv, true),
-              ]);
-            if (
-              currentRuntime === runtimeHash && currentImplicit === implicitToolchain &&
-              currentInvocation === programCompilerInvocation &&
-              currentDependencies === programDependencyHash && currentCompiler === compilerVersion
+              root !== null && compilerVersion !== "" && implicitToolchain !== null &&
+              programCompilerInvocation !== null
             ) {
-              await Promise.all([
-                ...(cachedProgramObject === null
-                  ? []
-                  : [publishCachedFile(programObject, cachedProgramObject)]),
-                ...publishable.map((entry) => publishCachedFile(entry.staged, entry.cachePath!)),
-              ]);
+              const key = createHash("sha256")
+                .update("lib-program-shard-v1\0")
+                .update(cacheTargetIdentity(driver)).update("\0")
+                .update(toolchainEnv).update("\0")
+                .update(implicitToolchain).update("\0")
+                .update(programCompilerInvocation).update("\0")
+                .update(opts.cacheIdentity!).update("\0")
+                .update(driver.argv.join("\x1f")).update("\0")
+                .update(compilerVersion).update("\0")
+                .update(runtimeHash).update("\0")
+                .update(programDependencyHash).update("\0")
+                .update(programCompilerArgs.join("\x1f")).update("\0")
+                .update(opts.cPath).update("\0")
+                .update(resolve(opts.cPath)).update("\0")
+                .update(shard.name).update("\0")
+                .update(shard.source)
+                .digest("hex");
+              cachePath = join(root, "program-shard", key);
             }
-          } catch {
-            // Best-effort: the merged program object is already valid.
+            return { ...shard, sourcePath, staged, cachePath, missed: false };
+          });
+          const shardWidth = Math.min(8, availableParallelism());
+          for (let i = 0; i < shardEntries.length; i += shardWidth) {
+            await Promise.all(shardEntries.slice(i, i + shardWidth).map(async (entry) => {
+              await writeFile(entry.sourcePath, entry.source);
+              if (
+                entry.cachePath !== null &&
+                await copyValidCachedFile(entry.cachePath, entry.staged)
+              ) return;
+              entry.missed = true;
+              await compileOne(entry.sourcePath, basename(entry.staged), opts.cPath);
+            }));
           }
+          const publishable = shardEntries.filter(
+            (entry) => entry.missed && entry.cachePath !== null,
+          );
+          const mergedProgramObject = await localizeLibraryObjects(
+            driver,
+            arArgv,
+            buildDir,
+            shardEntries.map((entry) => entry.staged),
+            [],
+            programPublicSymbols!,
+            `${stem}.program`,
+          );
+          // Keep the canonical archive member spelling. The fact that native
+          // compilation used shards is an implementation detail; consumers and
+          // deterministic cache tests continue to see `<stem>.program.o`.
+          await rename(mergedProgramObject, stagedProgramObject);
+          programObject = stagedProgramObject;
+          if (cachedProgramObject !== null || publishable.length > 0) {
+            try {
+              const [currentRuntime, currentImplicit, currentInvocation, currentDependencies, currentCompiler, currentMerge] =
+                await Promise.all([
+                  runtimeFingerprint(rtDir),
+                  implicitToolchainFingerprint(driver, toolchainEnv),
+                  effectiveCompilerInvocationFingerprint(
+                    driver,
+                    toolchainEnv,
+                    programCompilerArgs,
+                    programSourceExtension,
+                  ),
+                  translationUnitDependencyFingerprint(
+                    driver,
+                    cflags,
+                    opts.cPath,
+                    cachedProgramBytes!,
+                    toolchainEnv,
+                  ),
+                  ccVersionOnce(driver.argv, toolchainEnv, true),
+                  libraryProgramShardMergeIdentity(driver),
+                ]);
+              if (
+                currentRuntime === runtimeHash && currentImplicit === implicitToolchain &&
+                currentInvocation === programCompilerInvocation &&
+                currentDependencies === programDependencyHash && currentCompiler === compilerVersion &&
+                currentMerge === programShardMergeIdentity
+              ) {
+                await Promise.all([
+                  ...(cachedProgramObject === null
+                    ? []
+                    : [publishCachedFile(programObject, cachedProgramObject)]),
+                  ...publishable.map((entry) => publishCachedFile(entry.staged, entry.cachePath!)),
+                ]);
+              }
+            } catch {
+              // Best-effort: the merged program object is already valid.
+            }
+          }
+        } catch {
+          // Sharding is only an optimization. A present but incompatible or
+          // failing merge tool (or a shard-only compiler failure) must not
+          // turn a valid canonical LLVM TU into a failed library build. Do not
+          // publish this retry under shard-derived object/archive cache keys.
+          programShardFallback = true;
+          if (cachedProgramBytes !== null) await writeFile(programSource, cachedProgramBytes);
+          programObject = await compileOne(
+            programSource,
+            `${stem}.program.o`,
+            cachedProgramBytes === null ? undefined : opts.cPath,
+          );
         }
       } else {
         programObject = await compileOne(
@@ -2072,7 +2108,7 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
         compilerVersion !== "" &&
         archiverVersion !== ""
       ) {
-        const [currentRuntime, currentImplicit, currentRuntimeInvocation, currentProgramInvocation, currentProgramDependencies, currentCompiler, currentArchiver] =
+        const [currentRuntime, currentImplicit, currentRuntimeInvocation, currentProgramInvocation, currentProgramDependencies, currentCompiler, currentArchiver, currentProgramShardMerge] =
           await Promise.all([
             runtimeFingerprint(rtDir).catch(() => null),
             implicitToolchainFingerprint(driver, toolchainEnv).catch(() => null),
@@ -2094,16 +2130,21 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
             ).catch(() => null),
             ccVersionOnce(driver.argv, toolchainEnv, true).catch(() => null),
             toolVersionOnce(arArgv, toolchainEnv, true).catch(() => null),
+            programShards === null
+              ? Promise.resolve(null)
+              : libraryProgramShardMergeIdentity(driver).catch(() => null),
           ]);
         runtimeStillMatchesKey =
           cacheInputsStable &&
+          !programShardFallback &&
           currentRuntime === runtimeHash &&
           currentImplicit === implicitToolchain &&
           currentRuntimeInvocation === runtimeCompilerInvocation &&
           currentProgramInvocation === programCompilerInvocation &&
           currentProgramDependencies === programDependencyHash &&
           currentCompiler === compilerVersion &&
-          currentArchiver === archiverVersion;
+          currentArchiver === archiverVersion &&
+          currentProgramShardMerge === programShardMergeIdentity;
       }
       if (cachedArchive !== null && root !== null && runtimeStillMatchesKey) {
         try {

--- a/packages/compiler/src/backend/llvm/split.test.ts
+++ b/packages/compiler/src/backend/llvm/split.test.ts
@@ -1,0 +1,111 @@
+import { execFileSync } from "node:child_process";
+import { mkdtemp, readFile, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterAll, expect, test } from "vitest";
+import { splitLlvmProgram } from "./split.js";
+
+const scratch: string[] = [];
+afterAll(async () => {
+  const { rm } = await import("node:fs/promises");
+  await Promise.all(scratch.map((path) => rm(path, { recursive: true, force: true })));
+});
+
+const SAMPLE = `%Pair = type { i64, i64 }
+declare void @runtime(ptr)
+
+@hidden_value = internal global i64 7
+@public_value = constant i64 11
+
+define internal i64 @left() #0 {
+entry:
+  %v = load i64, ptr @hidden_value
+  ret i64 %v
+}
+
+define internal i64 @right() #0 {
+entry:
+  %v = call i64 @left()
+  ret i64 %v
+}
+
+define i64 @public_entry() #0 {
+entry:
+  %a = call i64 @right()
+  %b = load i64, ptr @public_value
+  %r = add i64 %a, %b
+  ret i64 %r
+}
+
+attributes #0 = { sanitize_address }
+`;
+
+test("splits generated LLVM functions and promotes only private cross-shard definitions", () => {
+  const split = splitLlvmProgram(SAMPLE, { minimumBytes: 0, targetBytes: 64 * 1024 });
+  // The production floor is 64 KiB. Make enough functions to cross it while
+  // retaining the readable SAMPLE assertions below.
+  expect(split).not.toBeNull();
+  expect(splitLlvmProgram(SAMPLE)).toBeNull();
+  const large = SAMPLE.replace(
+    "define i64 @public_entry",
+    `${Array.from({ length: 80 }, (_, i) => `define internal i64 @pad_${i}() #0 {\nentry:\n  ; ${"x".repeat(2048)}\n  ret i64 ${i}\n}\n`).join("\n")}\ndefine i64 @public_entry`,
+  );
+  const actual = splitLlvmProgram(large, { minimumBytes: 0, targetBytes: 64 * 1024 });
+  expect(actual).not.toBeNull();
+  expect(actual!.shards.length).toBeGreaterThan(1);
+  expect(actual!.promotedSymbols).toContain("hidden_value");
+  expect(actual!.promotedSymbols).toContain("left");
+  expect(actual!.promotedSymbols).not.toContain("public_value");
+  expect(actual!.promotedSymbols).not.toContain("public_entry");
+  expect(actual!.publicSymbols).toEqual(["public_value", "public_entry"]);
+  expect(actual!.shards[0]!.name).toBe("program-globals.ll");
+  expect(actual!.shards[0]!.source).toContain("@hidden_value = hidden global i64 7");
+  expect(actual!.shards.slice(1).every((shard) =>
+    shard.source.includes("@hidden_value = external hidden global i64")
+  )).toBe(true);
+  expect(actual!.shards.some((shard) =>
+    !shard.source.includes("define hidden i64 @right() #0") &&
+    shard.source.includes("declare hidden i64 @right() #0")
+  )).toBe(true);
+});
+
+test("thread-local program state conservatively keeps the single-TU path", () => {
+  const tls = SAMPLE.replace(
+    "@hidden_value = internal global i64 7",
+    "@hidden_value = internal thread_local global i64 7",
+  );
+  expect(splitLlvmProgram(tls, { minimumBytes: 0, targetBytes: 64 * 1024 })).toBeNull();
+});
+
+test("every shard compiles and its merged object exposes only canonical public definitions", async () => {
+  const body = Array.from({ length: 120 }, (_, i) =>
+    `define internal i64 @pad_${i}() #0 {\nentry:\n  ; ${"x".repeat(2048)}\n  ret i64 ${i}\n}\n`,
+  ).join("\n");
+  const split = splitLlvmProgram(
+    SAMPLE.replace("define i64 @public_entry", `${body}\ndefine i64 @public_entry`),
+    { minimumBytes: 0, targetBytes: 64 * 1024 },
+  )!;
+  const dir = await mkdtemp(join(tmpdir(), "scriptc-llvm-split-"));
+  scratch.push(dir);
+  const objects: string[] = [];
+  for (const shard of split.shards) {
+    const source = join(dir, shard.name);
+    const object = `${source}.o`;
+    await writeFile(source, shard.source);
+    execFileSync("clang", ["-Wno-override-module", "-c", source, "-o", object]);
+    objects.push(object);
+  }
+  const combined = join(dir, "combined.o");
+  execFileSync("ld", ["-r", ...objects, "-o", combined]);
+  if (process.platform === "linux") {
+    const keep = join(dir, "keep.txt");
+    await writeFile(keep, "public_entry\npublic_value\n");
+    execFileSync("objcopy", [`--keep-global-symbols=${keep}`, combined]);
+  }
+  const globals = execFileSync("nm", ["-g", combined], { encoding: "utf8" });
+  expect(globals).toContain("public_entry");
+  expect(globals).toContain("public_value");
+  expect(globals).not.toContain("hidden_value");
+  expect(globals).not.toContain("left");
+  expect((await readFile(combined)).length).toBeGreaterThan(0);
+});

--- a/packages/compiler/src/backend/llvm/split.ts
+++ b/packages/compiler/src/backend/llvm/split.ts
@@ -1,0 +1,238 @@
+/** Native-library LLVM IR sharding.
+ *
+ * The public `.ll` remains the emitter's single canonical module. Native dev
+ * builds may compile this equivalent set of smaller modules in parallel, then
+ * relocatably merge their objects before archive assembly:
+ *
+ * - the first shard owns every module-scope global and the first function
+ *   group; later shards own only function groups;
+ * - the shared preamble carries types and declarations into every shard;
+ * - generated internal functions/globals are promoted to hidden linkage so
+ *   references can cross object files; the post-compile relocatable link turns
+ *   those hidden definitions back into local symbols on every supported object
+ *   format;
+ * - declarations synthesized from definitions make every shard independently
+ *   valid LLVM IR without changing call signatures.
+ *
+ * The splitter deliberately accepts only the narrow grammar scriptc emits.
+ * An unexpected top-level form returns null and the caller compiles the
+ * canonical TU normally — cache optimization must never become correctness.
+ */
+
+export interface LlvmProgramShard {
+  /** Stable source identity used in object cache keys and diagnostics. */
+  name: string;
+  source: string;
+}
+
+export interface LlvmProgramSplit {
+  shards: LlvmProgramShard[];
+  /** Generated definitions promoted for shard linkage. The relocatable merge
+   * must demote these while retaining the canonical public definitions. */
+  promotedSymbols: string[];
+  /** Canonical non-internal definitions that must stay externally visible
+   * after the shard objects are relocatably merged. */
+  publicSymbols: string[];
+}
+
+export interface LlvmProgramSplitOptions {
+  /** Desired maximum source size per function shard. */
+  targetBytes?: number;
+  /** Inputs smaller than this keep the single-TU path. */
+  minimumBytes?: number;
+}
+
+const DEFAULT_TARGET_BYTES = 2 * 1024 * 1024;
+const DEFAULT_MINIMUM_BYTES = 4 * 1024 * 1024;
+
+interface FunctionDef {
+  source: string;
+  declaration: string;
+  symbol: string;
+  promoted: boolean;
+}
+
+interface GlobalDef {
+  line: string;
+  declaration: string | null;
+  symbol: string;
+  promoted: boolean;
+}
+
+function symbolOf(spelling: string): string | null {
+  const match = /^@([-$._A-Za-z][-$.\w]*)$/.exec(spelling);
+  return match?.[1] ?? null;
+}
+
+function functionDefAt(lines: readonly string[], start: number): { def: FunctionDef; end: number } | null {
+  const header = lines[start]!;
+  const match = /^define\s+(internal\s+)?(.+?)\s+(@[-$._A-Za-z][-$.\w]*)\((.*)\)(.*)\{(?:\s*;.*)?$/.exec(header);
+  if (!match) return null;
+  let end = start + 1;
+  while (end < lines.length && lines[end] !== "}") end++;
+  if (end >= lines.length) return null;
+  const symbol = symbolOf(match[3]!);
+  if (symbol === null) return null;
+  const promoted = match[1] !== undefined;
+  const linkage = promoted ? "hidden " : "";
+  const definitionHeader = promoted ? header.replace(/^define internal /, "define hidden ") : header;
+  const source = [definitionHeader, ...lines.slice(start + 1, end + 1)].join("\n");
+  // Parameter names are legal on declarations. Preserve the emitted text so
+  // attributes, zeroext, and varargs stay byte-exact.
+  const declaration = `declare ${linkage}${match[2]} ${match[3]}(${match[4]})${match[5]}`.trimEnd();
+  return { def: { source, declaration, symbol, promoted }, end };
+}
+
+function globalDef(line: string): GlobalDef | null {
+  const match = /^(@[-$._A-Za-z][-$.\w]*)\s+=\s+(internal\s+)?(thread_local(?:\([^)]*\))?\s+)?(global|constant)\s+(.+)$/.exec(line);
+  if (!match) return null;
+  const symbol = symbolOf(match[1]!);
+  if (symbol === null) return null;
+  const promoted = match[2] !== undefined;
+  const threadLocal = match[3] === undefined ? "" : `${match[3].trim()} `;
+  // The declaration needs only the complete type. Emitted initializers begin
+  // after it; the generated LLVM subset uses first-class scalars/pointers or
+  // balanced aggregate types, so one small scanner is sufficient.
+  const rest = match[5]!;
+  let depth = 0;
+  let quote = false;
+  let typeEnd = -1;
+  for (let i = 0; i < rest.length; i++) {
+    const ch = rest[i]!;
+    if (ch === '"' && rest[i - 1] !== "\\") quote = !quote;
+    if (quote) continue;
+    if (ch === "{" || ch === "[" || ch === "<" || ch === "(") depth++;
+    else if (ch === "}" || ch === "]" || ch === ">" || ch === ")") depth--;
+    else if (ch === " " && depth === 0) {
+      typeEnd = i;
+      break;
+    }
+  }
+  if (typeEnd < 0) return null;
+  const type = rest.slice(0, typeEnd);
+  return {
+    line: promoted ? line.replace(`${match[1]} = internal `, `${match[1]} = hidden `) : line,
+    declaration: `${match[1]} = external ${promoted ? "hidden " : ""}${threadLocal}${match[4]} ${type}`,
+    symbol,
+    promoted,
+  };
+}
+
+function stableBucket(symbol: string, count: number): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < symbol.length; i++) {
+    hash ^= symbol.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  return (hash >>> 0) % count;
+}
+
+function chunksOf(
+  functions: readonly FunctionDef[],
+  targetBytes: number,
+): { bucket: number; functions: FunctionDef[] }[] {
+  const totalBytes = functions.reduce((sum, fn) => sum + Buffer.byteLength(fn.source) + 2, 0);
+  // A power-of-two bucket count changes only when the program crosses a wide
+  // size band. Ordinary edits therefore keep every function in the same
+  // symbol-hash bucket; ceil(total/target) would reshuffle the whole program
+  // whenever a small edit happened to add the next bucket.
+  const required = Math.max(2, Math.ceil(totalBytes / targetBytes));
+  const count = 2 ** Math.ceil(Math.log2(required));
+  const chunks = Array.from({ length: count }, (): FunctionDef[] => []);
+  for (const fn of functions) chunks[stableBucket(fn.symbol, count)]!.push(fn);
+  return chunks.flatMap((chunk, bucket) =>
+    chunk.length === 0 ? [] : [{ bucket, functions: chunk }],
+  );
+}
+
+export function splitLlvmProgram(
+  source: string,
+  options: LlvmProgramSplitOptions = {},
+): LlvmProgramSplit | null {
+  const minimumBytes = options.minimumBytes ?? DEFAULT_MINIMUM_BYTES;
+  if (Buffer.byteLength(source) < minimumBytes) return null;
+  const targetBytes = Math.max(64 * 1024, options.targetBytes ?? DEFAULT_TARGET_BYTES);
+  const lines = source.split("\n");
+  const preamble: string[] = [];
+  const globals: GlobalDef[] = [];
+  const functions: FunctionDef[] = [];
+  const trailer: string[] = [];
+  let sawDefinition = false;
+  let inTrailer = false;
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.startsWith("define ")) {
+      if (inTrailer) return null;
+      const parsed = functionDefAt(lines, i);
+      if (parsed === null) return null;
+      functions.push(parsed.def);
+      sawDefinition = true;
+      i = parsed.end;
+      continue;
+    }
+    if (line.startsWith("@") && line.includes(" = ")) {
+      if (inTrailer) return null;
+      const parsed = globalDef(line);
+      if (parsed === null) {
+        // External declarations are already valid in every shard.
+        if (/^@.+\s+=\s+external\s+/.test(line)) preamble.push(line);
+        else return null;
+      } else {
+        // LLVM textual external TLS declarations compile on Darwin, but GNU
+        // ELF clang emits the cross-shard reference as non-TLS and `ld -r`
+        // correctly refuses the mismatch. Thread-instanced libraries keep
+        // the canonical single-TU path until the producer can preserve TLS
+        // model metadata portably across object formats.
+        if (/\bthread_local(?:\([^)]*\))?\s+global\b/.test(line)) return null;
+        globals.push(parsed);
+        sawDefinition = true;
+      }
+      continue;
+    }
+    if (line.startsWith("attributes ") || line.startsWith("!")) inTrailer = true;
+    if (inTrailer) trailer.push(line);
+    else if (!sawDefinition || line.trim() !== "") preamble.push(line);
+  }
+  if (functions.length < 2) return null;
+  const chunks = chunksOf(functions, targetBytes);
+  if (chunks.length < 2) return null;
+  const globalDecls = globals.flatMap((global) => global.declaration === null ? [] : [global.declaration]);
+  const tail = trailer.length === 0 ? "" : `\n${trailer.join("\n")}`;
+  const functionShards = chunks.map(({ bucket, functions: chunk }) => {
+    const owned = new Set(chunk);
+    const declarations = functions
+      .filter((fn) => !owned.has(fn))
+      .map((fn) => fn.declaration);
+    return {
+      name: `program-f${bucket.toString().padStart(3, "0")}.ll`,
+      source: [
+        [...preamble, ...globalDecls, ...declarations, ""].join("\n"),
+        ...chunk.map((fn) => fn.source),
+        tail,
+      ].join("\n"),
+    };
+  });
+  // Global initializer changes are common (literal text, generated tables)
+  // and should not invalidate an otherwise unrelated function bucket. Keep
+  // all module storage in one dedicated shard that declares every function.
+  const globalShard: LlvmProgramShard = {
+    name: "program-globals.ll",
+    source: [
+      [...preamble, ...functions.map((fn) => fn.declaration), ""].join("\n"),
+      ...globals.map((global) => global.line),
+      tail,
+    ].join("\n"),
+  };
+  const shards = [globalShard, ...functionShards];
+  return {
+    shards,
+    promotedSymbols: [
+      ...globals.filter((global) => global.promoted).map((global) => global.symbol),
+      ...functions.filter((fn) => fn.promoted).map((fn) => fn.symbol),
+    ],
+    publicSymbols: [
+      ...globals.filter((global) => !global.promoted).map((global) => global.symbol),
+      ...functions.filter((fn) => !fn.promoted).map((fn) => fn.symbol),
+    ],
+  };
+}

--- a/packages/compiler/src/backend/object-localize.test.ts
+++ b/packages/compiler/src/backend/object-localize.test.ts
@@ -487,6 +487,35 @@ describe("mergeAndLocalizeCoffObjects", () => {
     expect(byName.has("excluded_unit_ref")).toBe(false);
   });
 
+  test("resolves cross-references between program-shard roots and demotes their private links", () => {
+    const first = buildCoff(
+      [text([{ va: 0, sym: 3, type: 4 }])],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "private_a", section: 1 },
+        { name: "private_b", section: 0 },
+      ],
+    );
+    const second = buildCoff(
+      [text([{ va: 0, sym: 3, type: 4 }])],
+      [
+        { name: ".text", section: 1, storageClass: IMAGE_SYM_CLASS_STATIC, sectionDef: true },
+        { name: "private_b", section: 1 },
+        { name: "private_a", section: 0 },
+        { name: "public_entry", section: 1, value: 4 },
+      ],
+    );
+    const merged = readCoff(
+      mergeAndLocalizeCoffObjects([first, second], [], new Set(["public_entry"])),
+    );
+    const byName = new Map(merged.symbols.map((symbol) => [symbol.name, symbol]));
+    expect(byName.get("private_a")?.storageClass).toBe(IMAGE_SYM_CLASS_STATIC);
+    expect(byName.get("private_b")?.storageClass).toBe(IMAGE_SYM_CLASS_STATIC);
+    expect(byName.get("public_entry")?.storageClass).toBe(IMAGE_SYM_CLASS_EXTERNAL);
+    expect(merged.sections[0]!.relocs[0]!.sym).toBe(byName.get("private_b")!.index);
+    expect(merged.sections[1]!.relocs[0]!.sym).toBe(byName.get("private_a")!.index);
+  });
+
   test("does not pull an alternate definition when a selected object already satisfies the reference", () => {
     // program defines foo and needs bar; the first support member defines
     // bar and calls back into foo. A real archive link stops there. The

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -3,6 +3,7 @@ import { basename, dirname, join, resolve } from "node:path";
 import { buildCacheRoot, CcCompileError, compileC, compileLibArchive, mobileLibraryTarget, mobileTargetRefusal, prepareBuildCacheRoot, pruneBuildCache, resolveCc, targetPlatform } from "./backend/cc.js";
 import { emitModule } from "./backend/emission/emitter.js";
 import { emitLlvmModule, LlvmUnsupportedError } from "./backend/llvm/emitter.js";
+import { splitLlvmProgram } from "./backend/llvm/split.js";
 import { rebaseLibrarySourceComments, replaceLibraryIdentity, stripLibraryIdentity, stripLibrarySourceComments } from "./backend/library-identity.js";
 import { checkerPanicDiag, ffiNativeBuildDiag, libAsyncExportDiag, libAsyncSurfaceDiag, libExportUnresolvedDiag, libGenericExportDiag, libIntBoundaryDiag, libNpmIneligibleDiag, libSidecarDiag, libUnmappableSignatureDiag, iceDiag, isCheckerPanic, LIB_INBOUND_BYTES_TRAP_CODE, LIB_RUNTIME_TRAP_CODES, type ScrDiagnostic } from "./diagnostics/diagnostic.js";
 import { checkLibraryIntegerSlots, classSeed, hasIntSlots, numberCarrierKind, type FnIntSlots, type IntSlotConfig } from "./library/int-infer.js";
@@ -1554,7 +1555,10 @@ async function compileLibraryNative(
   const localizeSymbols = libraryLocalizeSymbols(profile);
   let identityCSource: string | undefined;
   let programSource: string | undefined;
-  if (profile.sidecar !== null || profile.emission === "c") {
+  if (
+    profile.sidecar !== null || profile.emission === "c" ||
+    (profile.emission === "llvm" && profile.optimization === "dev" && !sanitize)
+  ) {
     const publicSource = await readFile(cPath, "utf8");
     programSource = publicSource;
   }
@@ -1576,10 +1580,20 @@ async function compileLibraryNative(
   if (profile.emission === "c") {
     programSource = stripLibrarySourceComments(programSource!, profile.entry);
   }
+  const llvmSplit =
+    profile.emission === "llvm" && profile.optimization === "dev" && !sanitize && programSource !== undefined
+      ? splitLlvmProgram(programSource)
+      : null;
   await compileLibArchive({
     cPath,
     ...(programSource !== undefined ? { programSource } : {}),
     ...(identityCSource !== undefined ? { identityCSource } : {}),
+    ...(llvmSplit !== null
+      ? {
+          programShards: llvmSplit.shards,
+          programPublicSymbols: llvmSplit.publicSymbols,
+        }
+      : {}),
     outPath: archivePath,
     cacheIdentity: "scriptc-generated-library-v1",
     sanitize,


### PR DESCRIPTION
- Split large LLVM dev libraries into stable, parallel compilation shards.
- Cache shard objects independently and merge them into the canonical archive member.
- Preserve public ABI and fall back safely for unsupported or TLS-bearing IR.