### PR TITLE
perf: lazy-load the compiler from the CLI

### DIFF
--- a/packages/cli/src/bootstrap.ts
+++ b/packages/cli/src/bootstrap.ts
@@ -1,6 +1,13 @@
 #!/usr/bin/env node
 
+import { spawn } from "node:child_process";
+import { readFile, rm } from "node:fs/promises";
 import { enableCompileCache } from "node:module";
+import { arch } from "node:process";
+import { basename, dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parseArgs } from "node:util";
+import { CLI_OPTIONS, USAGE } from "./usage.js";
 
 // Node 24 can persist V8's compiled module bytecode. scriptc's CLI imports
 // the compiler and its lowering/backend graph before handling any command, so
@@ -13,4 +20,123 @@ try {
   // must never prevent the compiler from running.
 }
 
-await import("./main.js");
+function packageVersion(): string {
+  const here = dirname(fileURLToPath(import.meta.url));
+  try {
+    return (JSON.parse(requireText(join(here, "..", "package.json"))) as { version?: string }).version ?? "unknown";
+  } catch {
+    return "unknown";
+  }
+}
+
+function requireText(path: string): string {
+  // This tiny synchronous read keeps --version free of the compiler graph and
+  // preserves the package manifest as the one release-version authority.
+  const { readFileSync } = process.getBuiltinModule("node:fs") as typeof import("node:fs");
+  return readFileSync(path, "utf8");
+}
+
+async function tryFastPath(): Promise<number | null> {
+  let parsed: ReturnType<typeof parseArgs<{ options: typeof CLI_OPTIONS; allowPositionals: true; allowNegative: true }>>;
+  try {
+    parsed = parseArgs({ options: CLI_OPTIONS, allowPositionals: true, allowNegative: true });
+  } catch {
+    return null; // main owns exact user-error wording
+  }
+  const { values, positionals } = parsed;
+  if (values.version) {
+    process.stdout.write(`${packageVersion()}\n`);
+    return 0;
+  }
+  if (values.help || positionals.length === 0) {
+    process.stdout.write(USAGE);
+    return values.help ? 0 : 1;
+  }
+  const [command, inputArg] = positionals;
+  if (
+    (command !== "build" && command !== "run") || inputArg === undefined ||
+    values.lib || values["from-c"] || values["provenance-sources"] ||
+    (values["external-types"] ?? []).length > 0
+  ) return null;
+  const backend = values.backend;
+  if (backend !== undefined && backend !== "c" && backend !== "llvm") return null;
+  const npmRaw = (values["npm-static"] ?? [])
+    .flatMap((value) => value.split(","))
+    .map((value) => value.trim())
+    .filter((value) => value !== "");
+  let npmStatic: string[] | "auto" | null = null;
+  if (npmRaw.includes("auto")) {
+    if (npmRaw.length !== 1) return null;
+    npmStatic = "auto";
+  } else if (npmRaw.length > 0) {
+    npmStatic = npmRaw;
+  }
+
+  let startup: typeof import("@scriptc/compiler/startup-cache");
+  let driver: ReturnType<typeof import("@scriptc/compiler/startup-cache")["resolveCc"]>;
+  try {
+    startup = await import("@scriptc/compiler/startup-cache");
+    driver = startup.resolveCc();
+  } catch {
+    return null;
+  }
+  const buildPlatform = startup.targetPlatform(driver);
+  if (command === "run" && buildPlatform === "wasi") return null;
+  const input = resolve(inputArg);
+  const outDir = values.out ? dirname(resolve(values.out)) : join(dirname(input), ".scriptc");
+  const stem = basename(input).replace(/\.(ts|js|mjs|cjs|c|ll)$/, "");
+  const defaultName = buildPlatform === "win32"
+    ? `${stem}.exe`
+    : buildPlatform === "wasi"
+      ? `${stem}.wasm`
+      : stem;
+  const outPath = values.out ? resolve(values.out) : join(outDir, defaultName);
+  const ffiPath = values.ffi === undefined ? null : resolve(values.ffi);
+  const ffiBytes = ffiPath === null ? null : await readFile(ffiPath).catch(() => null);
+  if (ffiPath !== null && ffiBytes === null) return null;
+  const root = await startup.prepareBuildCacheRoot(startup.resolveBuildCacheRoot());
+  const nativeEnvironment = await startup.executableNativeEnvironmentFingerprint().catch(() => null);
+  if (nativeEnvironment === null) return null;
+  const hit = await startup.readRoutedExecutableCache(root, {
+    entryPath: input,
+    outDir,
+    outPath,
+    emitIr: values["emit-ir"],
+    sanitize: values.sanitize,
+    dynamic: values.dynamic,
+    backend: backend ?? "auto",
+    npmStatic,
+    ffiProfile: ffiPath === null ? null : { path: ffiPath, bytes: ffiBytes! },
+    target: `${process.env["SCRIPTC_TARGET"] ?? "native"}:${buildPlatform}:${arch}`,
+    compiler: [process.env["SCRIPTC_CC"] ?? "clang"],
+    nativeEnvironment,
+    nodeVersion: process.version,
+  });
+  if (hit === null) return null;
+  if (hit.native.llvmRefusal !== undefined) {
+    process.stderr.write(`scriptc: backend c (llvm refused: ${hit.native.llvmRefusal})\n`);
+  }
+  if (!values["keep-c"]) await rm(hit.cPath, { force: true });
+  if (command === "build") {
+    process.stdout.write(`${outPath}\n`);
+    return 0;
+  }
+  return new Promise<number>((resolveExit) => {
+    const child = spawn(outPath, [], { stdio: "inherit" });
+    child.on("exit", (code, signal) => {
+      if (signal) {
+        process.stderr.write(`scriptc: program killed by ${signal}\n`);
+        resolveExit(1);
+      } else {
+        resolveExit(code ?? 0);
+      }
+    });
+  });
+}
+
+const fastExit = await tryFastPath();
+if (fastExit === null) {
+  await import("./main.js");
+} else {
+  process.exitCode = fastExit;
+}

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -5,65 +5,7 @@ import { fileURLToPath } from "node:url";
 import { parseArgs } from "node:util";
 import { analyze, buildTargetPlatform, compile, compileC, compileLibrary, isExactExternalTypeSpecifier, renderAll, renderCoverage, resolveProvenanceSources, setProvenanceSources } from "@scriptc/compiler";
 import { defaultExecutableName } from "./paths.js";
-
-const USAGE = `scriptc — TypeScript/JavaScript to native and WebAssembly executables (experimental)
-
-Usage:
-  scriptc build <file.ts|.js> [options]     compile to an executable target artifact
-  scriptc run <file.ts|.js> [options]       compile and run
-  scriptc coverage <file.ts|.js>            how much compiles statically, and why not
-  scriptc coverage <file.ts|.js> --dynamic  what a --dynamic build compiles, and what still blocks it
-  scriptc coverage <file.ts|.js> --external-types <specifier=file.d.ts>
-                                            type-resolve an embedder-provided module for analysis
-  scriptc build --lib --profile <p.json>    library mode: compile the profile's entry
-                                            module to a linkable static archive
-                                            (<name>.lib.a) exporting the
-                                            profile-declared C symbols; a profile
-                                            with a sidecar section also gets the
-                                            contract sidecar JSON beside the archive
-
-Options:
-  -o, --out <path>   output path (default: .scriptc/<name>[.exe|.wasm])
-      --backend <b>  code generator. llvm is the default and the output that
-                     ships; c emits readable C for inspecting what the
-                     compiler produced, and program behavior is identical
-                     either way. On native targets, a program outside the LLVM tier still
-                     builds — the default lane emits C for it and a one-line
-                     stderr note names the construct — while an explicit
-                     --backend llvm fails with that construct named
-                     wasm32-wasi is LLVM-only unless --backend c is explicit;
-                     its C inspection lane accepts async-free programs only
-      --from-c       treat input as a C (or .ll) file (toolchain plumbing/debugging)
-      --keep-c       keep the generated program TU next to the executable
-                     (default; the .ll — or the .c under --backend=c or
-                     when the build fell back)
-      --no-keep-c    delete the generated program TU after compiling
-      --emit-ir      also write the IR as JSON next to the executable
-      --sanitize     build with ASan + runtime RC audit
-      --dynamic      embed the dynamic engine (adds ~620KB; static stays the default)
-      --ffi <file>   bind signature-only TypeScript declarations to native
-                     C symbols and link the manifest's archives/libraries
-      --npm-static <pkg[,pkg…]|auto>
-                     compile the named npm packages' shipped JS statically as
-                     program modules (repeatable; "auto" opts in every eligible
-                     direct import: own .d.ts, unminified JS, no build-transform
-                     markers). A package preflight refuses falls back to the
-                     island (--dynamic) with a coverage-report note — opt-in,
-                     experimental
-      --provenance-sources
-                     EXPERIMENTAL: compile npm dependencies from their
-                     provenance-attested SOURCE (fetched at the attested
-                     commit) as static program modules; packages without a
-                     usable attestation keep the island path (a note, never
-                     a failure)
-      --external-types <specifier=file.d.ts>
-                     coverage only: map an exact bare module specifier to a
-                     local declaration file. The declaration supplies types
-                     for analysis; the host module remains an explicit
-                     external-boundary blocker (repeatable)
-  -h, --help         show this help
-  -v, --version      print the version
-`;
+import { CLI_OPTIONS, USAGE } from "./usage.js";
 
 /** The version of the installed package. Read from the manifest rather than
  * baked in by the build, so a stamped release and a source checkout answer
@@ -109,26 +51,6 @@ function parseCli(): ReturnType<typeof parseArgs<{ options: typeof CLI_OPTIONS; 
     fail(`scriptc: ${msg}\n\n${USAGE}`);
   }
 }
-
-const CLI_OPTIONS = {
-  out: { type: "string", short: "o" },
-  // No parseArgs default: unset means the compiler's default lane
-  // (LLVM with the transparent C fallback); an explicit value pins.
-  backend: { type: "string" },
-  "from-c": { type: "boolean", default: false },
-  "keep-c": { type: "boolean", default: true },
-  "emit-ir": { type: "boolean", default: false },
-  sanitize: { type: "boolean", default: false },
-  dynamic: { type: "boolean", default: false },
-  ffi: { type: "string" },
-  "npm-static": { type: "string", multiple: true },
-  "provenance-sources": { type: "boolean", default: false },
-  "external-types": { type: "string", multiple: true },
-  lib: { type: "boolean", default: false },
-  profile: { type: "string" },
-  help: { type: "boolean", short: "h", default: false },
-  version: { type: "boolean", short: "v", default: false },
-} as const;
 
 async function main(): Promise<number> {
   const { values, positionals } = parseCli();

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -1,0 +1,76 @@
+export const USAGE = `scriptc — TypeScript/JavaScript to native and WebAssembly executables (experimental)
+
+Usage:
+  scriptc build <file.ts|.js> [options]     compile to an executable target artifact
+  scriptc run <file.ts|.js> [options]       compile and run
+  scriptc coverage <file.ts|.js>            how much compiles statically, and why not
+  scriptc coverage <file.ts|.js> --dynamic  what a --dynamic build compiles, and what still blocks it
+  scriptc coverage <file.ts|.js> --external-types <specifier=file.d.ts>
+                                            type-resolve an embedder-provided module for analysis
+  scriptc build --lib --profile <p.json>    library mode: compile the profile's entry
+                                            module to a linkable static archive
+                                            (<name>.lib.a) exporting the
+                                            profile-declared C symbols; a profile
+                                            with a sidecar section also gets the
+                                            contract sidecar JSON beside the archive
+
+Options:
+  -o, --out <path>   output path (default: .scriptc/<name>[.exe|.wasm])
+      --backend <b>  code generator. llvm is the default and the output that
+                     ships; c emits readable C for inspecting what the
+                     compiler produced, and program behavior is identical
+                     either way. On native targets, a program outside the LLVM tier still
+                     builds — the default lane emits C for it and a one-line
+                     stderr note names the construct — while an explicit
+                     --backend llvm fails with that construct named
+                     wasm32-wasi is LLVM-only unless --backend c is explicit;
+                     its C inspection lane accepts async-free programs only
+      --from-c       treat input as a C (or .ll) file (toolchain plumbing/debugging)
+      --keep-c       keep the generated program TU next to the executable
+                     (default; the .ll — or the .c under --backend=c or
+                     when the build fell back)
+      --no-keep-c    delete the generated program TU after compiling
+      --emit-ir      also write the IR as JSON next to the executable
+      --sanitize     build with ASan + runtime RC audit
+      --dynamic      embed the dynamic engine (adds ~620KB; static stays the default)
+      --ffi <file>   bind signature-only TypeScript declarations to native
+                     C symbols and link the manifest's archives/libraries
+      --npm-static <pkg[,pkg…]|auto>
+                     compile the named npm packages' shipped JS statically as
+                     program modules (repeatable; "auto" opts in every eligible
+                     direct import: own .d.ts, unminified JS, no build-transform
+                     markers). A package preflight refuses falls back to the
+                     island (--dynamic) with a coverage-report note — opt-in,
+                     experimental
+      --provenance-sources
+                     EXPERIMENTAL: compile npm dependencies from their
+                     provenance-attested SOURCE (fetched at the attested
+                     commit) as static program modules; packages without a
+                     usable attestation keep the island path (a note, never
+                     a failure)
+      --external-types <specifier=file.d.ts>
+                     coverage only: map an exact bare module specifier to a
+                     local declaration file. The declaration supplies types
+                     for analysis; the host module remains an explicit
+                     external-boundary blocker (repeatable)
+  -h, --help         show this help
+  -v, --version      print the version
+`;
+
+export const CLI_OPTIONS = {
+  out: { type: "string", short: "o" },
+  backend: { type: "string" },
+  "from-c": { type: "boolean", default: false },
+  "keep-c": { type: "boolean", default: true },
+  "emit-ir": { type: "boolean", default: false },
+  sanitize: { type: "boolean", default: false },
+  dynamic: { type: "boolean", default: false },
+  ffi: { type: "string" },
+  "npm-static": { type: "string", multiple: true },
+  "provenance-sources": { type: "boolean", default: false },
+  "external-types": { type: "string", multiple: true },
+  lib: { type: "boolean", default: false },
+  profile: { type: "string" },
+  help: { type: "boolean", short: "h", default: false },
+  version: { type: "boolean", short: "v", default: false },
+} as const;

--- a/packages/cli/test/bootstrap.test.ts
+++ b/packages/cli/test/bootstrap.test.ts
@@ -1,0 +1,59 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+import { expect, test } from "vitest";
+
+const execFileAsync = promisify(execFile);
+const repoRoot = join(import.meta.dirname, "../../..");
+const bootstrap = join(repoRoot, "packages/cli/dist/bootstrap.js");
+
+test("bootstrap serves version and help without loading the compiler graph", async () => {
+  const preloadDir = await mkdtemp(join(tmpdir(), "scriptc-bootstrap-preload-"));
+  const preload = join(preloadDir, "preload.mjs");
+  try {
+    await writeFile(preload, [
+      "import { registerHooks } from 'node:module';",
+      "registerHooks({ load(url, context, nextLoad) {",
+      "  if (url.includes('/packages/compiler/dist/index.js')) throw new Error('compiler graph loaded');",
+      "  return nextLoad(url, context);",
+      "}});",
+      "",
+    ].join("\n"));
+    const version = await execFileAsync(process.execPath, ["--import", preload, bootstrap, "--version"]);
+    expect(version.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
+    const help = await execFileAsync(process.execPath, ["--import", preload, bootstrap, "--help"]);
+    expect(help.stdout).toContain("scriptc build <file.ts|.js>");
+  } finally {
+    await rm(preloadDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+});
+
+test("bootstrap exact builds use the routed cache and source edits fall through", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "scriptc-bootstrap-cache-"));
+  const cacheRoot = join(dir, "cache");
+  const entry = join(dir, "main.ts");
+  const outPath = join(dir, process.platform === "win32" ? "program.exe" : "program");
+  const env = { ...process.env, SCRIPTC_CACHE_DIR: cacheRoot, SCRIPTC_TIMING: "1" };
+  const build = (): Promise<{ stderr: string }> =>
+    execFileAsync(process.execPath, [bootstrap, "build", entry, "-o", outPath], {
+      env,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+  try {
+    await mkdir(cacheRoot, { mode: 0o700 });
+    await writeFile(entry, 'console.log("one");\n');
+    expect((await build()).stderr).toContain("scriptc lowering");
+    expect((await build()).stderr).not.toContain("scriptc lowering");
+    expect((await execFileAsync(outPath)).stdout).toBe("one\n");
+
+    await writeFile(entry, 'console.log("two");\n');
+    expect((await build()).stderr).toContain("scriptc lowering");
+    expect((await build()).stderr).not.toContain("scriptc lowering");
+    expect((await execFileAsync(outPath)).stdout).toBe("two\n");
+    expect(await readFile(join(dir, "main.ll"), "utf8")).toContain("two");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}, 120_000);

--- a/packages/cli/test/bootstrap.test.ts
+++ b/packages/cli/test/bootstrap.test.ts
@@ -35,18 +35,46 @@ test("bootstrap exact builds use the routed cache and source edits fall through"
   const cacheRoot = join(dir, "cache");
   const entry = join(dir, "main.ts");
   const outPath = join(dir, process.platform === "win32" ? "program.exe" : "program");
+  const preload = join(dir, "reject-full-compiler.mjs");
   const env = { ...process.env, SCRIPTC_CACHE_DIR: cacheRoot, SCRIPTC_TIMING: "1" };
-  const build = (): Promise<{ stderr: string }> =>
-    execFileAsync(process.execPath, [bootstrap, "build", entry, "-o", outPath], {
+  const build = (rejectFullCompiler = false): Promise<{ stderr: string }> =>
+    execFileAsync(process.execPath, [
+      ...(rejectFullCompiler ? ["--import", preload] : []),
+      bootstrap,
+      "build",
+      entry,
+      "-o",
+      outPath,
+    ], {
       env,
       maxBuffer: 4 * 1024 * 1024,
     });
   try {
     await mkdir(cacheRoot, { mode: 0o700 });
-    await writeFile(entry, 'console.log("one");\n');
+    await Promise.all([
+      writeFile(entry, 'console.log("one");\n'),
+      writeFile(preload, [
+        "import { registerHooks } from 'node:module';",
+        "registerHooks({ load(url, context, nextLoad) {",
+        "  if (url.includes('/packages/compiler/dist/index.js')) throw new Error('compiler graph loaded');",
+        "  return nextLoad(url, context);",
+        "}});",
+        "",
+      ].join("\n")),
+    ]);
     expect((await build()).stderr).toContain("scriptc lowering");
     expect((await build()).stderr).not.toContain("scriptc lowering");
     expect((await execFileAsync(outPath)).stdout).toBe("one\n");
+
+    // Route metadata can be evicted independently of the executable payload.
+    // One full-compiler fallback must repair it so the following invocation is
+    // once again able to run with the package root import forbidden.
+    await Promise.all([
+      rm(join(cacheRoot, "early-exe-route"), { recursive: true, force: true }),
+      rm(join(cacheRoot, "early-exe-implementation"), { recursive: true, force: true }),
+    ]);
+    expect((await build()).stderr).not.toContain("scriptc lowering");
+    await expect(build(true)).resolves.toMatchObject({ stderr: "" });
 
     await writeFile(entry, 'console.log("two");\n');
     expect((await build()).stderr).toContain("scriptc lowering");

--- a/packages/compiler/package.json
+++ b/packages/compiler/package.json
@@ -14,6 +14,7 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./startup-cache": "./dist/startup-cache.js",
     "./scriptc.d.ts": "./ambient/scriptc.d.ts",
     "./scriptc-overrides.d.ts": "./ambient/scriptc-overrides.d.ts",
     "./scriptc-node-fallback.d.ts": "./ambient/scriptc-node-fallback.d.ts",

--- a/packages/compiler/src/executable/early-cache.test.ts
+++ b/packages/compiler/src/executable/early-cache.test.ts
@@ -7,6 +7,7 @@ import { nativeArtifactDependenciesStillMatch } from "../backend/cc.js";
 import {
   publishEarlyExecutableCache,
   readEarlyExecutableCache,
+  readRoutedExecutableCache,
   type EarlyExecutableCacheOptions,
   type EarlyExecutableNativeFeatures,
 } from "./early-cache.js";
@@ -88,7 +89,8 @@ async function fixture(): Promise<{
       compiler: ["clang"],
       nativeEnvironment: "test-native-environment",
       nodeVersion: "v24-test",
-      implementation: "test-implementation",
+      implementation: "a".repeat(64),
+      implementationDependencies: [],
     },
   };
 }
@@ -237,6 +239,85 @@ test("early executable cache restores a validated final binary", async () => {
   const staleNative = await readEarlyExecutableCache(f.root, f.options);
   expect(staleNative?.executableRestored).toBe(false);
   expect(await readFile(f.options.outPath, "utf8")).toBe("keep-current\n");
+});
+
+test("routed executable hits require an unchanged compiler implementation proof", async () => {
+  const f = await fixture();
+  const dependency = join(f.options.outDir, "compiler-file.js");
+  const nativeDependency = join(f.options.outDir, "native-tool");
+  await Promise.all([
+    writeFile(dependency, "compiler-v1\n"),
+    writeFile(nativeDependency, "tool-v1\n"),
+    writeFile(f.options.outPath, "native-v1\n"),
+  ]);
+  const [implementationInfo, nativeInfo] = await Promise.all([
+    stat(dependency),
+    stat(nativeDependency),
+  ]);
+  f.options.implementationDependencies = [{
+    path: dependency,
+    kind: "file",
+    dev: implementationInfo.dev,
+    ino: implementationInfo.ino,
+    size: implementationInfo.size,
+    mtimeMs: implementationInfo.mtimeMs,
+    ctimeMs: implementationInfo.ctimeMs,
+  }];
+  const tracker = new FrontendInputTracker();
+  tracker.run(() => trackedReadFile(f.source));
+  await publishEarlyExecutableCache(f.root, f.options, {
+    cPath: f.cPath,
+    irPath: f.irPath,
+    native,
+    executableRestored: true,
+    nativeDependencies: [{
+      path: nativeDependency,
+      kind: "file",
+      dev: nativeInfo.dev,
+      ino: nativeInfo.ino,
+      size: nativeInfo.size,
+      mtimeMs: nativeInfo.mtimeMs,
+      ctimeMs: nativeInfo.ctimeMs,
+    }],
+    frontend: tracker.snapshot(),
+  });
+  const route = { ...f.options };
+  delete (route as Partial<EarlyExecutableCacheOptions>).implementation;
+  delete (route as Partial<EarlyExecutableCacheOptions>).implementationDependencies;
+  const routeDirectory = join(f.root, "early-exe-route");
+  const [routeName] = await readdir(routeDirectory);
+  const routePath = join(routeDirectory, routeName!);
+  const proofInstallDirectory = join(f.root, "early-exe-implementation");
+  const [proofInstall] = await readdir(proofInstallDirectory);
+  const proofPath = join(proofInstallDirectory, proofInstall!, f.options.implementation);
+  const old = new Date("2000-01-01T00:00:00.000Z");
+  await Promise.all([routePath, proofPath].map((path) => utimes(path, old, old)));
+  expect(await readRoutedExecutableCache(f.root, route)).not.toBeNull();
+  for (const path of [routePath, proofPath]) {
+    expect((await stat(path)).mtimeMs).toBeGreaterThan(old.getTime());
+  }
+
+  // Publishing the same route again must replace its metadata on every
+  // platform (notably Windows, whose rename does not overwrite files).
+  await publishEarlyExecutableCache(f.root, f.options, {
+    cPath: f.cPath,
+    irPath: f.irPath,
+    native,
+    executableRestored: true,
+    nativeDependencies: [{
+      path: nativeDependency,
+      kind: "file",
+      dev: nativeInfo.dev,
+      ino: nativeInfo.ino,
+      size: nativeInfo.size,
+      mtimeMs: nativeInfo.mtimeMs,
+      ctimeMs: nativeInfo.ctimeMs,
+    }],
+    frontend: tracker.snapshot(),
+  });
+  expect(await readRoutedExecutableCache(f.root, route)).not.toBeNull();
+  await writeFile(dependency, "compiler-v2\n");
+  expect(await readRoutedExecutableCache(f.root, route)).toBeNull();
 });
 
 test("native dependency validation rejects malformed cache data", async () => {

--- a/packages/compiler/src/executable/early-cache.ts
+++ b/packages/compiler/src/executable/early-cache.ts
@@ -507,6 +507,55 @@ export async function readRoutedExecutableCache(
   }
 }
 
+/** Publish the lightweight lookup metadata for an already-validated payload.
+ * Full-compiler cache hits call this as a repair path: route/proof files can be
+ * evicted independently of the larger executable entry, and one fallback
+ * lookup should make later CLI invocations lightweight again. */
+export async function publishEarlyExecutableRoute(
+  root: string | null,
+  options: EarlyExecutableCacheOptions,
+): Promise<void> {
+  if (root === null) return;
+  const proofDestination = implementationProofPath(root, options.implementation);
+  const proofUnsigned: Omit<EarlyExecutableImplementationProof, "integrity"> = {
+    version: 1,
+    implementation: options.implementation,
+    dependencies: options.implementationDependencies,
+  };
+  const proof: EarlyExecutableImplementationProof = {
+    ...proofUnsigned,
+    integrity: implementationProofIntegrity(proofUnsigned),
+  };
+  await mkdir(dirname(proofDestination), { recursive: true, mode: 0o700 });
+  const proofTmp = `${proofDestination}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    await writeFile(proofTmp, `${JSON.stringify(proof)}\n`, { mode: 0o600 });
+    await installCacheMetadata(proofTmp, proofDestination);
+  } finally {
+    await rm(proofTmp, { force: true }).catch(() => undefined);
+  }
+
+  const routeOptions: EarlyExecutableRouteOptions = options;
+  const routeDestination = routePath(root, routeOptions);
+  const routeUnsigned: Omit<EarlyExecutableRouteStamp, "integrity"> = {
+    version: 1,
+    key: cacheKey(options),
+    implementation: options.implementation,
+  };
+  const route: EarlyExecutableRouteStamp = {
+    ...routeUnsigned,
+    integrity: routeIntegrity(routeUnsigned),
+  };
+  await mkdir(dirname(routeDestination), { recursive: true, mode: 0o700 });
+  const routeTmp = `${routeDestination}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+  try {
+    await writeFile(routeTmp, `${JSON.stringify(route)}\n`, { mode: 0o600 });
+    await installCacheMetadata(routeTmp, routeDestination);
+  } finally {
+    await rm(routeTmp, { force: true }).catch(() => undefined);
+  }
+}
+
 export async function publishEarlyExecutableCache(
   root: string | null,
   options: EarlyExecutableCacheOptions,
@@ -565,57 +614,7 @@ export async function publishEarlyExecutableCache(
     if (ir !== null) await install(ir.name);
     if (executable !== null) await install(executable.name);
     await install("stamp.json");
-    const routeOptions: EarlyExecutableRouteOptions = {
-      entryPath: options.entryPath,
-      outDir: options.outDir,
-      outPath: options.outPath,
-      emitIr: options.emitIr,
-      sanitize: options.sanitize,
-      dynamic: options.dynamic,
-      backend: options.backend,
-      npmStatic: options.npmStatic,
-      ffiProfile: options.ffiProfile,
-      target: options.target,
-      compiler: options.compiler,
-      nativeEnvironment: options.nativeEnvironment,
-      nodeVersion: options.nodeVersion,
-    };
-    const proofDestination = implementationProofPath(root, options.implementation);
-    const proofUnsigned: Omit<EarlyExecutableImplementationProof, "integrity"> = {
-      version: 1,
-      implementation: options.implementation,
-      dependencies: options.implementationDependencies,
-    };
-    const proof: EarlyExecutableImplementationProof = {
-      ...proofUnsigned,
-      integrity: implementationProofIntegrity(proofUnsigned),
-    };
-    await mkdir(dirname(proofDestination), { recursive: true, mode: 0o700 });
-    const proofTmp = `${proofDestination}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
-    try {
-      await writeFile(proofTmp, `${JSON.stringify(proof)}\n`, { mode: 0o600 });
-      await installCacheMetadata(proofTmp, proofDestination);
-    } finally {
-      await rm(proofTmp, { force: true }).catch(() => undefined);
-    }
-    const routeDestination = routePath(root, routeOptions);
-    const routeUnsigned: Omit<EarlyExecutableRouteStamp, "integrity"> = {
-      version: 1,
-      key: cacheKey(options),
-      implementation: options.implementation,
-    };
-    const route: EarlyExecutableRouteStamp = {
-      ...routeUnsigned,
-      integrity: routeIntegrity(routeUnsigned),
-    };
-    await mkdir(dirname(routeDestination), { recursive: true, mode: 0o700 });
-    const routeTmp = `${routeDestination}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
-    try {
-      await writeFile(routeTmp, `${JSON.stringify(route)}\n`, { mode: 0o600 });
-      await installCacheMetadata(routeTmp, routeDestination);
-    } finally {
-      await rm(routeTmp, { force: true }).catch(() => undefined);
-    }
+    await publishEarlyExecutableRoute(root, options);
   } finally {
     await rm(stage, { recursive: true, force: true }).catch(() => undefined);
   }

--- a/packages/compiler/src/executable/early-cache.ts
+++ b/packages/compiler/src/executable/early-cache.ts
@@ -5,6 +5,8 @@ import type { FrontendInputSnapshot } from "../frontend/input-tracker.js";
 import { frontendInputsStillMatch, validFrontendInputSnapshot } from "../frontend/input-tracker.js";
 import { compilerReleaseVersion } from "../library/sidecar.js";
 import { nativeArtifactDependenciesStillMatch, type NativeArtifactDependency } from "../backend/cc.js";
+import type { CompilerImplementationDependency } from "../library/implementation-identity.js";
+import { compilerImplementationDependenciesStillMatch, compilerImplementationRoot } from "../library/implementation-identity.js";
 
 interface CachedExecutableFile {
   name: string;
@@ -76,6 +78,26 @@ export interface EarlyExecutableCacheOptions {
   nativeEnvironment: string;
   nodeVersion: string;
   implementation: string;
+  implementationDependencies: CompilerImplementationDependency[];
+}
+
+export type EarlyExecutableRouteOptions = Omit<
+  EarlyExecutableCacheOptions,
+  "implementation" | "implementationDependencies"
+>;
+
+interface EarlyExecutableRouteStamp {
+  version: 1;
+  key: string;
+  implementation: string;
+  integrity: string;
+}
+
+interface EarlyExecutableImplementationProof {
+  version: 1;
+  implementation: string;
+  dependencies: CompilerImplementationDependency[];
+  integrity: string;
 }
 
 export interface EarlyExecutableCacheHit {
@@ -165,6 +187,75 @@ function cacheKey(options: EarlyExecutableCacheOptions): string {
       .update(options.ffiProfile.bytes);
   }
   return hash.digest("hex");
+}
+
+function routeKey(options: EarlyExecutableRouteOptions): string {
+  const hash = createHash("sha256")
+    .update("early-executable-route-v1\0")
+    .update(compilerReleaseVersion()).update("\0")
+    .update(compilerImplementationRoot()).update("\0")
+    .update(resolve(options.entryPath)).update("\0")
+    .update(resolve(options.outDir)).update("\0")
+    .update(resolve(options.outPath)).update("\0")
+    .update(options.emitIr ? "emit-ir" : "no-ir").update("\0")
+    .update(options.sanitize ? "sanitize" : "plain").update("\0")
+    .update(options.dynamic ? "dynamic" : "static").update("\0")
+    .update(options.backend).update("\0")
+    .update(options.npmStatic === null
+      ? "<npm-static-off>"
+      : options.npmStatic === "auto"
+        ? "<npm-static-auto>"
+        : JSON.stringify(options.npmStatic)).update("\0")
+    .update(options.target).update("\0")
+    .update(options.compiler.join("\x1f")).update("\0")
+    .update(options.nativeEnvironment).update("\0")
+    .update(options.nodeVersion).update("\0");
+  if (options.ffiProfile === null) {
+    hash.update("<ffi-off>");
+  } else {
+    hash
+      .update(resolve(options.ffiProfile.path)).update("\0")
+      .update(options.ffiProfile.bytes);
+  }
+  return hash.digest("hex");
+}
+
+function routePath(root: string, options: EarlyExecutableRouteOptions): string {
+  return join(root, "early-exe-route", routeKey(options));
+}
+
+function routeIntegrity(stamp: Omit<EarlyExecutableRouteStamp, "integrity">): string {
+  return createHash("sha256")
+    .update("early-executable-route-stamp-v1\0")
+    .update(JSON.stringify(stamp))
+    .digest("hex");
+}
+
+function implementationProofPath(root: string, implementation: string): string {
+  const install = createHash("sha256")
+    .update("early-executable-install-v1\0")
+    .update(compilerImplementationRoot())
+    .digest("hex");
+  return join(root, "early-exe-implementation", install, implementation);
+}
+
+function implementationProofIntegrity(
+  proof: Omit<EarlyExecutableImplementationProof, "integrity">,
+): string {
+  return createHash("sha256")
+    .update("early-executable-implementation-proof-v1\0")
+    .update(JSON.stringify(proof))
+    .digest("hex");
+}
+
+async function installCacheMetadata(source: string, destination: string): Promise<void> {
+  await rename(source, destination).catch(async () => {
+    // Windows does not replace an existing destination with rename(). Route
+    // and implementation-proof files are republished on every full compile,
+    // so use the same replacement fallback as the payload cache below.
+    await rm(destination, { force: true });
+    await rename(source, destination);
+  });
 }
 
 function stampPath(root: string, options: EarlyExecutableCacheOptions): string {
@@ -368,6 +459,54 @@ export async function readEarlyExecutableCache(
   }
 }
 
+/** Follow the exact-invocation route without hashing/importing the complete
+ * compiler package. The full compiler publishes a content digest plus a
+ * metadata replay proof; any implementation change turns this into a miss. */
+export async function readRoutedExecutableCache(
+  root: string | null,
+  options: EarlyExecutableRouteOptions,
+): Promise<EarlyExecutableCacheHit | null> {
+  if (root === null) return null;
+  try {
+    const routeFile = routePath(root, options);
+    const route = JSON.parse(
+      await readFile(routeFile, "utf8"),
+    ) as EarlyExecutableRouteStamp;
+    const { integrity, ...unsigned } = route;
+    if (
+      route.version !== 1 ||
+      !/^[0-9a-f]{64}$/.test(route.key) ||
+      !/^[0-9a-f]{64}$/.test(route.implementation) ||
+      routeIntegrity(unsigned) !== integrity
+    ) return null;
+    const proofFile = implementationProofPath(root, route.implementation);
+    const proof = JSON.parse(await readFile(proofFile, "utf8")) as EarlyExecutableImplementationProof;
+    const { integrity: proofIntegrity, ...proofUnsigned } = proof;
+    if (
+      proof.version !== 1 || proof.implementation !== route.implementation ||
+      !Array.isArray(proof.dependencies) ||
+      implementationProofIntegrity(proofUnsigned) !== proofIntegrity ||
+      !(await compilerImplementationDependenciesStillMatch(proof.dependencies))
+    ) return null;
+    const complete: EarlyExecutableCacheOptions = {
+      ...options,
+      implementation: route.implementation,
+      implementationDependencies: proof.dependencies,
+    };
+    if (cacheKey(complete) !== route.key) return null;
+    const hit = await readEarlyExecutableCache(root, complete);
+    if (hit?.executableRestored !== true) return null;
+    const now = new Date();
+    await Promise.all([
+      routeFile,
+      proofFile,
+    ].map((cachePath) => utimes(cachePath, now, now).catch(() => undefined)));
+    return hit;
+  } catch {
+    return null;
+  }
+}
+
 export async function publishEarlyExecutableCache(
   root: string | null,
   options: EarlyExecutableCacheOptions,
@@ -426,6 +565,57 @@ export async function publishEarlyExecutableCache(
     if (ir !== null) await install(ir.name);
     if (executable !== null) await install(executable.name);
     await install("stamp.json");
+    const routeOptions: EarlyExecutableRouteOptions = {
+      entryPath: options.entryPath,
+      outDir: options.outDir,
+      outPath: options.outPath,
+      emitIr: options.emitIr,
+      sanitize: options.sanitize,
+      dynamic: options.dynamic,
+      backend: options.backend,
+      npmStatic: options.npmStatic,
+      ffiProfile: options.ffiProfile,
+      target: options.target,
+      compiler: options.compiler,
+      nativeEnvironment: options.nativeEnvironment,
+      nodeVersion: options.nodeVersion,
+    };
+    const proofDestination = implementationProofPath(root, options.implementation);
+    const proofUnsigned: Omit<EarlyExecutableImplementationProof, "integrity"> = {
+      version: 1,
+      implementation: options.implementation,
+      dependencies: options.implementationDependencies,
+    };
+    const proof: EarlyExecutableImplementationProof = {
+      ...proofUnsigned,
+      integrity: implementationProofIntegrity(proofUnsigned),
+    };
+    await mkdir(dirname(proofDestination), { recursive: true, mode: 0o700 });
+    const proofTmp = `${proofDestination}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+    try {
+      await writeFile(proofTmp, `${JSON.stringify(proof)}\n`, { mode: 0o600 });
+      await installCacheMetadata(proofTmp, proofDestination);
+    } finally {
+      await rm(proofTmp, { force: true }).catch(() => undefined);
+    }
+    const routeDestination = routePath(root, routeOptions);
+    const routeUnsigned: Omit<EarlyExecutableRouteStamp, "integrity"> = {
+      version: 1,
+      key: cacheKey(options),
+      implementation: options.implementation,
+    };
+    const route: EarlyExecutableRouteStamp = {
+      ...routeUnsigned,
+      integrity: routeIntegrity(routeUnsigned),
+    };
+    await mkdir(dirname(routeDestination), { recursive: true, mode: 0o700 });
+    const routeTmp = `${routeDestination}.tmp-${process.pid}-${Math.random().toString(36).slice(2)}`;
+    try {
+      await writeFile(routeTmp, `${JSON.stringify(route)}\n`, { mode: 0o600 });
+      await installCacheMetadata(routeTmp, routeDestination);
+    } finally {
+      await rm(routeTmp, { force: true }).catch(() => undefined);
+    }
   } finally {
     await rm(stage, { recursive: true, force: true }).catch(() => undefined);
   }

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -39,7 +39,7 @@ import { hasForeignFfiCallback } from "./backend/ffi-callbacks.js";
 import { FrontendInputTracker, trackedReadFile } from "./frontend/input-tracker.js";
 import { libraryFrontendImplementationFingerprint, publishEarlyLibraryCache, readEarlyLibraryCache, readSemanticLibraryCache, type EarlyLibraryCacheOptions, type EarlyLibraryCachePublish, type EarlyLibraryNativeFeatures, type SemanticLibraryCacheHit } from "./library/early-cache.js";
 import { createSourceLineRebaser } from "./library/semantic-source.js";
-import { publishEarlyExecutableCache, readEarlyExecutableCache, type EarlyExecutableCacheOptions, type EarlyExecutableNativeFeatures } from "./executable/early-cache.js";
+import { publishEarlyExecutableCache, publishEarlyExecutableRoute, readEarlyExecutableCache, type EarlyExecutableCacheOptions, type EarlyExecutableNativeFeatures } from "./executable/early-cache.js";
 import { compilerImplementationIdentity } from "./library/implementation-identity.js";
 
 export const VERSION = "0.0.1";
@@ -1012,6 +1012,10 @@ async function compileTracked(
   };
   const earlyHit = await readEarlyExecutableCache(cacheRoot, earlyCacheOptions);
   if (earlyHit !== null) {
+    // Route/proof metadata is independently evictable. A full-compiler
+    // fallback that still finds the validated payload repairs that lightweight
+    // index so the next identical CLI invocation can avoid this module graph.
+    await publishEarlyExecutableRoute(cacheRoot, earlyCacheOptions).catch(() => undefined);
     if (earlyHit.executableRestored) {
       await pruneBuildCache(cacheRoot);
       return {

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -40,6 +40,7 @@ import { FrontendInputTracker, trackedReadFile } from "./frontend/input-tracker.
 import { libraryFrontendImplementationFingerprint, publishEarlyLibraryCache, readEarlyLibraryCache, readSemanticLibraryCache, type EarlyLibraryCacheOptions, type EarlyLibraryCachePublish, type EarlyLibraryNativeFeatures, type SemanticLibraryCacheHit } from "./library/early-cache.js";
 import { createSourceLineRebaser } from "./library/semantic-source.js";
 import { publishEarlyExecutableCache, readEarlyExecutableCache, type EarlyExecutableCacheOptions, type EarlyExecutableNativeFeatures } from "./executable/early-cache.js";
+import { compilerImplementationIdentity } from "./library/implementation-identity.js";
 
 export const VERSION = "0.0.1";
 
@@ -988,6 +989,7 @@ async function compileTracked(
   const cacheRoot = provenanceSources() === null
     ? await prepareBuildCacheRoot(buildCacheRoot())
     : null;
+  const implementation = await compilerImplementationIdentity();
   const earlyCacheOptions: EarlyExecutableCacheOptions = {
     entryPath,
     outDir: opts.outDir,
@@ -1005,7 +1007,8 @@ async function compileTracked(
     compiler: [process.env["SCRIPTC_CC"] ?? "clang"],
     nativeEnvironment: await executableNativeEnvironmentFingerprint(),
     nodeVersion: process.version,
-    implementation: await libraryFrontendImplementationFingerprint(),
+    implementation: implementation.digest,
+    implementationDependencies: implementation.dependencies,
   };
   const earlyHit = await readEarlyExecutableCache(cacheRoot, earlyCacheOptions);
   if (earlyHit !== null) {

--- a/packages/compiler/src/library/early-cache.ts
+++ b/packages/compiler/src/library/early-cache.ts
@@ -1,7 +1,6 @@
 import { createHash } from "node:crypto";
-import { chmod, copyFile, mkdir, readFile, readdir, rename, rm, utimes, writeFile } from "node:fs/promises";
-import { basename, dirname, join, relative, resolve } from "node:path";
-import { fileURLToPath } from "node:url";
+import { chmod, copyFile, mkdir, readFile, rename, rm, utimes, writeFile } from "node:fs/promises";
+import { basename, dirname, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import { deserialize as deserializeV8, serialize as serializeV8 } from "node:v8";
 import { gzip, gunzip } from "node:zlib";
@@ -10,6 +9,7 @@ import type { IrModule } from "../ir/nodes.js";
 import { IR_VERSION } from "../ir/serialize.js";
 import { frontendInputsSemanticallyMatch, frontendInputsStillMatch, validFrontendInputSnapshot, type FrontendInputExclusions, type FrontendInputSnapshot } from "../frontend/input-tracker.js";
 import { rebaseSourceLocations, semanticallyEqualSource, sourceLineRebaseIsIdentity } from "./semantic-source.js";
+import { compilerImplementationIdentity } from "./implementation-identity.js";
 
 const gzipAsync = promisify(gzip);
 const gunzipAsync = promisify(gunzip);
@@ -150,24 +150,7 @@ function cacheKey(options: EarlyLibraryCacheOptions): string {
  * mixed installs without hashing the TypeScript source tree beside it.
  */
 export async function libraryFrontendImplementationFingerprint(): Promise<string> {
-  const moduleDir = dirname(fileURLToPath(import.meta.url));
-  const implementationRoot = resolve(moduleDir, "..", "..");
-  const files: string[] = [];
-  const walk = async (directory: string): Promise<void> => {
-    const entries = await readdir(directory, { withFileTypes: true });
-    entries.sort((a, b) => a.name.localeCompare(b.name));
-    for (const entry of entries) {
-      const path = join(directory, entry.name);
-      if (entry.isDirectory()) await walk(path);
-      else if (entry.isFile()) files.push(path);
-    }
-  };
-  await walk(implementationRoot);
-  const hash = createHash("sha256").update("scriptc-frontend-implementation-v1\0");
-  for (const file of files) {
-    hash.update(relative(implementationRoot, file)).update("\0").update(await readFile(file)).update("\0");
-  }
-  return hash.digest("hex");
+  return (await compilerImplementationIdentity(false)).digest;
 }
 
 function stampPath(root: string, options: EarlyLibraryCacheOptions): string {

--- a/packages/compiler/src/library/implementation-identity.ts
+++ b/packages/compiler/src/library/implementation-identity.ts
@@ -1,0 +1,104 @@
+import { createHash } from "node:crypto";
+import { lstat, readFile, readdir } from "node:fs/promises";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+export interface CompilerImplementationDependency {
+  path: string;
+  kind: "file" | "directory";
+  dev: number;
+  ino: number;
+  size: number;
+  mtimeMs: number;
+  ctimeMs: number;
+}
+
+export interface CompilerImplementationIdentity {
+  digest: string;
+  dependencies: CompilerImplementationDependency[];
+}
+
+/** The installed compiler package whose bytes define frontend identity. The
+ * startup route also uses this location to keep metadata proofs from two
+ * source checkouts sharing a cache root from standing in for one another. */
+export function compilerImplementationRoot(): string {
+  const moduleDir = dirname(fileURLToPath(import.meta.url));
+  return resolve(moduleDir, "..", "..");
+}
+
+function dependency(
+  path: string,
+  info: Awaited<ReturnType<typeof lstat>>,
+): CompilerImplementationDependency | null {
+  const kind = info.isFile() ? "file" : info.isDirectory() ? "directory" : null;
+  return kind === null
+    ? null
+    : {
+        path,
+        kind,
+        dev: Number(info.dev),
+        ino: Number(info.ino),
+        size: Number(info.size),
+        mtimeMs: Number(info.mtimeMs),
+        ctimeMs: Number(info.ctimeMs),
+      };
+}
+
+/** Content identity plus a cheap replay proof for the compiler package that
+ * produced an early frontend artifact. Full compiles hash every byte before
+ * publication; the CLI fast path validates the captured inode/time/size
+ * metadata and loads the large compiler graph only when anything changed. */
+export async function compilerImplementationIdentity(
+  captureDependencies = true,
+): Promise<CompilerImplementationIdentity> {
+  const implementationRoot = compilerImplementationRoot();
+  const files: string[] = [];
+  const dependencies: CompilerImplementationDependency[] = [];
+  const walk = async (directory: string): Promise<void> => {
+    const directoryInfo = dependency(directory, await lstat(directory));
+    if (captureDependencies && directoryInfo !== null) dependencies.push(directoryInfo);
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((a, b) => a.name.localeCompare(b.name));
+    for (const entry of entries) {
+      const path = join(directory, entry.name);
+      if (entry.isDirectory()) {
+        await walk(path);
+      } else if (entry.isFile()) {
+        files.push(path);
+        const fileInfo = dependency(path, await lstat(path));
+        if (captureDependencies && fileInfo !== null) dependencies.push(fileInfo);
+      }
+    }
+  };
+  await walk(implementationRoot);
+  // Keep the v1 digest byte-identical: dependency metadata augments replay
+  // validation without invalidating every existing library/executable entry.
+  const hash = createHash("sha256").update("scriptc-frontend-implementation-v1\0");
+  for (const file of files) {
+    hash.update(relative(implementationRoot, file)).update("\0").update(await readFile(file)).update("\0");
+  }
+  return { digest: hash.digest("hex"), dependencies };
+}
+
+function validDependency(value: unknown): value is CompilerImplementationDependency {
+  if (value === null || typeof value !== "object") return false;
+  const item = value as Partial<CompilerImplementationDependency>;
+  return typeof item.path === "string" &&
+    (item.kind === "file" || item.kind === "directory") &&
+    typeof item.dev === "number" && typeof item.ino === "number" &&
+    typeof item.size === "number" && typeof item.mtimeMs === "number" &&
+    typeof item.ctimeMs === "number";
+}
+
+export async function compilerImplementationDependenciesStillMatch(
+  dependencies: readonly CompilerImplementationDependency[],
+): Promise<boolean> {
+  if (!Array.isArray(dependencies) || !dependencies.every(validDependency)) return false;
+  const current = await Promise.all(dependencies.map(async (expected) => {
+    const info = await lstat(expected.path).catch(() => null);
+    if (info === null) return false;
+    const observed = dependency(expected.path, info);
+    return observed !== null && JSON.stringify(observed) === JSON.stringify(expected);
+  }));
+  return current.every(Boolean);
+}

--- a/packages/compiler/src/startup-cache.ts
+++ b/packages/compiler/src/startup-cache.ts
@@ -1,0 +1,12 @@
+/** Small CLI-startup surface. Importing the package root eagerly loads the
+ * full lowering/emitter graph; exact builds need only these cache/native
+ * identity primitives before deciding whether that graph is necessary. */
+export { readRoutedExecutableCache } from "./executable/early-cache.js";
+export type { EarlyExecutableRouteOptions } from "./executable/early-cache.js";
+export {
+  executableNativeEnvironmentFingerprint,
+  prepareBuildCacheRoot,
+  resolveBuildCacheRoot,
+  resolveCc,
+  targetPlatform,
+} from "./backend/cc.js";


### PR DESCRIPTION
- Serve help and version from a lightweight bootstrap and route exact executable cache hits before loading the compiler graph.
- Validate routed hits against compiler, frontend, toolchain, and native dependency proofs with portable cache publication.