### PR TITLE
perf: reduce checker RPC traffic

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -1920,7 +1920,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         }
         // A runtime string whose TYPE pins every possible value to the
         // supported literals — the modes resolve at the call instead.
-        const arms: readonly ts.Type[] = t.isUnionType() ? t.getTypes() : [t];
+        const arms: readonly ts.Type[] = t.isUnionType() ? ts.constituentTypes(t) : [t];
         if (
           arms.length > 0 &&
           arms.every(
@@ -4480,7 +4480,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
       const dflt = { kind: "strLit", value: "utf8", type: STRING, loc } satisfies IrExpr;
       if (!node) return dflt;
       const nodeType = L.typeOf(node);
-      const parts: readonly ts.Type[] = nodeType.isUnionType() ? nodeType.getTypes() : [nodeType];
+      const parts: readonly ts.Type[] = nodeType.isUnionType() ? ts.constituentTypes(nodeType) : [nodeType];
       const supported = parts.every(
         (t) =>
           (t.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void | ts.TypeFlags.Null)) !== 0 ||

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -792,7 +792,7 @@ export interface GenericInstance {
    * instead of the generic supported-types recitation; a no-op for every
    * other unmappable type (the caller's badType reports those). */
   function fenceGenericSignatureResult(L: Lowerer, blame: ts.Node, t: ts.Type): void {
-    const parts = t.isUnionType() ? t.getTypes() : [t];
+    const parts = t.isUnionType() ? ts.constituentTypes(t) : [t];
     if (!parts.some((p) => L.checker.getCallSignatures(p).some((s) => (s.typeParameters?.length ?? 0) > 0))) {
       return;
     }
@@ -1243,8 +1243,8 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
       // unbound type parameter surfaces as a mapping diagnostic later).
       if (declared.isUnionType()) {
         const unitFlags = ts.TypeFlags.Undefined | ts.TypeFlags.Null;
-        const dParts = declared.getTypes().filter((t) => !(t.flags & unitFlags));
-        const iParts: readonly ts.Type[] = inst.isUnionType() ? inst.getTypes().filter((t) => !(t.flags & unitFlags)) : [inst];
+        const dParts = ts.constituentTypes(declared).filter((t) => !(t.flags & unitFlags));
+        const iParts: readonly ts.Type[] = inst.isUnionType() ? ts.constituentTypes(inst).filter((t) => !(t.flags & unitFlags)) : [inst];
         if (dParts.length === 1 && iParts.length === 1) unify(dParts[0]!, iParts[0]!, depth + 1);
         return;
       }
@@ -1643,7 +1643,7 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
         // A `Fn | undefined`-flavored slot: the value can only inhabit the
         // one callable arm — judge by it (the requireExactArityValue union
         // rule).
-        const callable = pinT.getTypes().map((t) => L.checker.getCallSignatures(t)).filter((s) => s.length === 1);
+        const callable = ts.constituentTypes(pinT).map((t) => L.checker.getCallSignatures(t)).filter((s) => s.length === 1);
         if (callable.length === 1) target = callable[0]![0]!;
       }
     }
@@ -1980,6 +1980,16 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
     // the pinned signature over a missing body, which the linker never
     // sees because the poison also fenced the call statement.
     try {
+      // Implicit-any instances lower EAGERLY at the call site so their
+      // inferred return type is available immediately. They therefore do
+      // not pass through emitReachable's queued generic-instance wave,
+      // which normally batches checker work before lowering a body. Prime
+      // this exact committed instance body here; repeated instantiations of
+      // the same declaration find the facade memos warm.
+      L.checker.prefetchRoots([
+        ...info.decl.parameters.flatMap((param) => param.initializer ? [param.initializer] : []),
+        ...(info.decl.body ? [info.decl.body] : []),
+      ]);
       const fn = L.lowerGenericInstance(info, inst);
       L.implicitFns.push(fn);
     } catch (e) {

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -1973,7 +1973,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
           const argIdent = c.arguments[0] as ts.Identifier;
           const sym = L.resolveValueSymbol(argIdent);
           const t = L.checker.getTypeAtLocation(argIdent);
-          const constituents = t.isUnionType() ? t.getTypes() : [];
+          const constituents = t.isUnionType() ? ts.constituentTypes(t) : [];
           const nonArray = constituents.filter((a) => !L.checker.isArrayType(a) && !L.checker.isTupleType(a));
           const mapped = L.mapTypeOf(t);
           const armCount = mapped?.kind === "union" ? L.arrayValueTags(mapped.unionId).length : 0;
@@ -4028,7 +4028,7 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
    * for effect and are not stored. Null for every other target. */
   function settledDropNames(L: Lowerer, tsType: ts.Type): Set<string> | null {
     let names: Set<string> | null = null;
-    const parts: readonly ts.Type[] = tsType.isUnionType() ? tsType.getTypes() : [tsType];
+    const parts: readonly ts.Type[] = tsType.isUnionType() ? ts.constituentTypes(tsType) : [tsType];
     for (const part of parts) {
       const sym = part.getSymbol();
       if (
@@ -4104,7 +4104,7 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
     if (t.isNumberLiteralType()) return String(t.value);
     if (t.isUnionType()) {
       let out: string | null = null;
-      for (const arm of t.getTypes()) {
+      for (const arm of ts.constituentTypes(t)) {
         const s = arm.isStringLiteralType() ? arm.value : arm.isNumberLiteralType() ? String(arm.value) : null;
         if (s === null || (out !== null && s !== out)) return null;
         out = s;
@@ -4480,7 +4480,7 @@ function literalUnionArmOf(
    * types only into their own unit; otherwise the widened IR pair must be
    * equal or width-liftable. */
   const fits = (litT: ts.Type, ftT: ts.Type): boolean => {
-    if (ftT.isUnionType()) return ftT.getTypes().some((a) => fits(litT, a));
+    if (ftT.isUnionType()) return ts.constituentTypes(ftT).some((a) => fits(litT, a));
     if (ftT.isStringLiteralType()) return litT.isStringLiteralType() && litT.value === ftT.value;
     if (ftT.isNumberLiteralType()) return litT.isNumberLiteralType() && litT.value === ftT.value;
     if (ftT.flags & ts.TypeFlags.BooleanLiteral) {
@@ -4496,7 +4496,7 @@ function literalUnionArmOf(
   };
   const armShapeIds = new Set(recordArms.map((a) => a.shapeId));
   const candidates = new Set<string>();
-  for (const member of tsType.getTypes()) {
+  for (const member of ts.constituentTypes(tsType)) {
     const mMapped = L.mapTypeOf(member);
     if (mMapped?.kind !== "record" || !armShapeIds.has(mMapped.shapeId) || candidates.has(mMapped.shapeId)) continue;
     const shape = L.shapes.get(mMapped.shapeId);
@@ -4642,7 +4642,7 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
     // slot's field types (`lanIp: string | null`), which the literal's own
     // type narrows away (a field written as `lanIp: null` types as bare
     // `null`, which maps to nothing on its own).
-    if (tsType.isUnionType() && tsType.getTypes().some((t) => t.getSymbol()?.name === "PromiseLike")) {
+    if (tsType.isUnionType() && ts.constituentTypes(tsType).some((t) => t.getSymbol()?.name === "PromiseLike")) {
       tsType = L.checker.getAwaitedType(tsType) ?? tsType;
     }
     let mapped = L.mapTypeOf(tsType);
@@ -4672,7 +4672,7 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
       if (ctxShape && !ctxShape.indexValue && !ctxShape.tuple) {
         const names = new Set(ctxShape.fields.map((f) => f.name));
         const ctxHasProp = (name: string): boolean => {
-          const members = tsType.isUnionType() ? tsType.getTypes() : [tsType];
+          const members = tsType.isUnionType() ? ts.constituentTypes(tsType) : [tsType];
           return members.some((m) => L.checker.getPropertyOfType(m, name) !== undefined);
         };
         const extraOf = (text: string): boolean => !names.has(text) && !ctxHasProp(text);
@@ -8223,7 +8223,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
     const direct = L.mapTypeOf(t);
     if (rooted(direct)) return direct;
     if (t.isIntersectionType()) {
-      for (const part of t.getTypes()) {
+      for (const part of ts.constituentTypes(t)) {
         const m = L.mapTypeOf(part);
         if (rooted(m)) return m;
       }
@@ -8444,7 +8444,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
       const arm = def.arms[tags[0]!]!;
       // The checker-side arm: the union part whose (widened) mapping IS
       // the proven IR arm — what typeOf answers inside the branch.
-      const parts = valT.isUnionType() ? valT.getTypes() : [valT];
+      const parts = valT.isUnionType() ? ts.constituentTypes(valT) : [valT];
       const tsArm = parts.find((p) => {
         const m = L.mapTypeOf(L.checker.getBaseTypeOfLiteralType(p));
         return m !== null && typeEquals(m, arm);

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -707,7 +707,7 @@ function fenceRequestInitObject(
 ): void {
   const contextual = L.checker.getContextualType(init);
   const contextualArms =
-    contextual?.isUnionType() ? contextual.getTypes() : contextual ? [contextual] : [];
+    contextual?.isUnionType() ? ts.constituentTypes(contextual) : contextual ? [contextual] : [];
   const rows = NODE24_FETCH_COMPAT_PROFILE.inventory.entries.filter((entry) =>
     entry.owner === "RequestInit" && entry.placement === "dictionary"
   );
@@ -1154,7 +1154,7 @@ function fetchElementMemberNames(
   if (key.isStringLiteralType()) return [key.value];
   if (!key.isUnionType()) return null;
   const members: string[] = [];
-  for (const arm of key.getTypes()) {
+  for (const arm of ts.constituentTypes(key)) {
     if (!arm.isStringLiteralType()) return null;
     if (!members.includes(arm.value)) members.push(arm.value);
   }
@@ -3359,7 +3359,7 @@ export function lowerStaticReadableStreamReaderCall(
     const pkg = L.npmPackageOfSymbol(type.getAliasSymbol() ?? type.getSymbol());
     if (pkg) return pkg;
     if (type.isUnionType()) {
-      for (const part of type.getTypes()) {
+      for (const part of ts.constituentTypes(type)) {
         const partPkg = L.npmPackageOf(part);
         if (partPkg) return partPkg;
       }

--- a/packages/compiler/src/frontend/lowering/lower-mixins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-mixins.ts
@@ -502,7 +502,7 @@ function instantiateMixinCall(L: Lowerer, call: ts.CallExpression, shape: MixinF
  * bindings, heritage clauses) participate: they are registered before
  * any body lowers in BOTH passes, so discovery and emit answer alike. */
 export function mixinIntersectionInstanceType(L: Lowerer, widened: ts.Type): IrType | null {
-  const parts = widened.isIntersectionType() ? widened.getTypes() : null;
+  const parts = widened.isIntersectionType() ? ts.constituentTypes(widened) : null;
   if (!parts || L.mixinInstancesByClassNode.size === 0) return null;
   const mixinParts: ts.ClassLikeDeclaration[] = [];
   const plainParts: string[] = [];

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -1981,7 +1981,7 @@ export function isParseArgsDynCheckerType(L: Lowerer, type: ts.Type): boolean {
   function checkerStringSource(L: Lowerer, e: ts.Expression): boolean {
     const stringLike = (t: ts.Type): boolean => {
       if ((t.flags & ts.TypeFlags.StringLike) !== 0) return true;
-      if (t.isUnionType()) return t.getTypes().every(stringLike);
+      if (t.isUnionType()) return ts.constituentTypes(t).every(stringLike);
       return false;
     };
     return stringLike(L.typeOf(e));

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -636,7 +636,7 @@ export function neverTaintedJsType(L: Lowerer, node: ts.Node, t: ts.Type): boole
   if (!isJsSourceFile(node.getSourceFile())) return false;
   const walk = (x: ts.Type, depth: number): boolean => {
     if (depth === 0) return false;
-    if (x.isUnionType()) return x.getTypes().some((a) => walk(a, depth - 1));
+    if (x.isUnionType()) return ts.constituentTypes(x).some((a) => walk(a, depth - 1));
     if (L.checker.isArrayType(x) || L.checker.isTupleType(x)) {
       return L.checker
         .getTypeArguments(x as ts.TypeReference)
@@ -3188,7 +3188,7 @@ export class Lowerer {
     // story through its callable arm. After the package check: a
     // package-declared generic signature stays the package's story.
     {
-      const parts = widened.isUnionType() ? widened.getTypes() : [widened];
+      const parts = widened.isUnionType() ? ts.constituentTypes(widened) : [widened];
       if (
         parts.some((p) =>
           this.checker.getCallSignatures(p).some((s) => (s.typeParameters?.length ?? 0) > 0),
@@ -3576,9 +3576,9 @@ export class Lowerer {
       // when one constituent is; a union is array-proven only when EVERY
       // arm is, so an ordinary `any[] | string` never qualifies.
       if ((part.flags & ts.TypeFlags.Intersection) !== 0) {
-        return (part as ts.UnionOrIntersectionType).getTypes().some(visit);
+        return ts.constituentTypes(part).some(visit);
       }
-      if (part.isUnionType()) return part.getTypes().every(visit);
+      if (part.isUnionType()) return ts.constituentTypes(part).every(visit);
       return false;
     };
     return visit(t);
@@ -6475,7 +6475,7 @@ export class Lowerer {
       } else {
         const t = this.typeOf(d.initializer);
         if (!isUnitOnlyTsType(t)) return null;
-        for (const p of t.isUnionType() ? t.getTypes() : [t]) {
+        for (const p of t.isUnionType() ? ts.constituentTypes(t) : [t]) {
           units.add((p.flags & ts.TypeFlags.Null) !== 0 ? "null" : "undefined");
         }
       }
@@ -7682,7 +7682,7 @@ export class Lowerer {
       }
       if (d && ts.isVariableDeclaration(d) && d.initializer === undefined) {
         const t = this.checker.getTypeOfSymbol(symbol);
-        const parts = t.isUnionType() ? t.getTypes() : [t];
+        const parts = t.isUnionType() ? ts.constituentTypes(t) : [t];
         if (parts.some((p) => this.checker.getCallSignatures(p).some((s) => (s.typeParameters?.length ?? 0) > 0))) {
           this.unsupported(
             "SC1030",

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -138,7 +138,7 @@ function primitiveProtoValueIsIgnored(L: Lowerer, node: ts.Expression): boolean 
     ts.TypeFlags.Void |
     ts.TypeFlags.Never;
   const t = L.typeOf(node);
-  const parts = t.isUnionType() ? t.getTypes() : [t];
+  const parts = t.isUnionType() ? ts.constituentTypes(t) : [t];
   return parts.every((p) => (p.flags & primitive) !== 0);
 }
 

--- a/packages/compiler/src/frontend/program.ts
+++ b/packages/compiler/src/frontend/program.ts
@@ -1120,7 +1120,7 @@ function nonInertTopLevel7(program: ts.Program, sf: ts.SourceFile): ts.Node | nu
    * ToString/ToNumber/ToPrimitive can never reach a user valueOf. */
   const primitiveTyped = (e: ts.Expression): boolean => {
     const t = checker.getTypeAtLocation(e);
-    const parts = t.isUnionType() ? t.getTypes() : [t];
+    const parts = t.isUnionType() ? ts.constituentTypes(t) : [t];
     return parts.every((p) => (p.flags & PRIM) !== 0);
   };
   /** The identifier's symbol lives entirely in declaration files — a

--- a/packages/compiler/src/frontend/ts7/checker.ts
+++ b/packages/compiler/src/frontend/ts7/checker.ts
@@ -27,9 +27,12 @@
  *    type.flags plus the intrinsic-type singletons for the literal kinds
  *    5.9.3 maps to intrinsics (string/number/bigint/boolean literals), with
  *    IPC only for enum-ish and union types. isTupleType answers shape-true
- *    and non-object-false locally and round-trips (memoized) only for
- *    object types. Both verified against the raw checker AND against 5.9.3
- *    by the adapter's suites. */
+ *    and non-object-false locally; isArrayType likewise answers
+ *    non-object-false locally. Both round-trip (memoized) only where object
+ *    identity needs the checker. Immutable union/intersection constituents
+ *    are memoized too because TypeScript 7's Type.getTypes() otherwise
+ *    repeats an IPC request. All paths are verified against the raw checker
+ *    and against 5.9.3 by the adapter's suites. */
 
 import type { Node, SourceFile } from "typescript/unstable/ast";
 import type {
@@ -97,11 +100,31 @@ const PREFETCH_MAX_DEPTH = 512;
  * only 29k ever requested). */
 const TYPE_PREFETCH_KINDS = new Set<SyntaxKind>([
   SyntaxKind.Identifier,
+  SyntaxKind.ThisKeyword,
   SyntaxKind.PropertyAccessExpression,
+  SyntaxKind.ElementAccessExpression,
+  SyntaxKind.CallExpression,
+  SyntaxKind.NewExpression,
   SyntaxKind.ObjectLiteralExpression,
   SyntaxKind.ArrayLiteralExpression,
   SyntaxKind.ConditionalExpression,
 ]);
+
+/** The TypeScript 7 client identity-dedupes immutable types but does not
+ * memoize Type.getTypes(): every union/intersection inspection otherwise
+ * repeats getTypesOfType over IPC. Keep that derived answer beside the
+ * adapter, shared by preflight and lowering regardless of which facade
+ * helper led to the type. */
+const constituentTypesOf = new WeakMap<Type, readonly Type[]>();
+
+export function constituentTypes(type: Type): readonly Type[] {
+  let types = constituentTypesOf.get(type);
+  if (types === undefined) {
+    types = (type as Type & { getTypes(): readonly Type[] | undefined }).getTypes() ?? [];
+    constituentTypesOf.set(type, types);
+  }
+  return types;
+}
 
 /** Function-like declarations whose body is deferred until reachability
  * asks for it. Header prefetch walks their names, type parameters, params,
@@ -656,6 +679,11 @@ export class CheckerFacade {
   }
 
   isArrayType(type: Type): boolean {
+    // Arrays are object types. The raw checker agrees that primitive,
+    // union/intersection, and type-parameter objects themselves are not
+    // arrays (a narrowed array arm arrives as its object type), so avoid a
+    // request for every visibly non-object type just as isTupleType does.
+    if (!(type.flags & TypeFlags.Object)) return false;
     let answer = this.arrayTypeAnswer.get(type);
     if (answer === undefined) {
       answer = this.raw.isArrayType(type);
@@ -729,7 +757,7 @@ export class CheckerFacade {
   private computeAwaitedType(type: Type, depth: number): Type | undefined {
     if (depth > 8) return undefined; // matches 5.9.3's unwrap depth fence
     if (type.isUnionType()) {
-      const arms = type.getTypes();
+      const arms = constituentTypes(type);
       const awaited = arms.map((arm) => this.computeAwaitedType(arm, depth + 1));
       if (awaited.some((arm) => arm === undefined)) return undefined;
       // No arm was a promise: awaiting the union is the union itself

--- a/packages/compiler/src/frontend/types.ts
+++ b/packages/compiler/src/frontend/types.ts
@@ -1025,7 +1025,7 @@ function mapTypeInner(type: ts.Type, ctx: TypeMapperCtx): IrType | null {
   // falls through to the general union branch below, whose per-part
   // recursion re-enters here with the pure enum parts.
   if (flags & ts.TypeFlags.EnumLike) {
-    const parts = widened.isUnionType() ? widened.getTypes() : [widened];
+    const parts = widened.isUnionType() ? ts.constituentTypes(widened) : [widened];
     if (parts.every((p) => p.flags & ts.TypeFlags.EnumLike)) {
       let hasNum = false;
       let hasStr = false;
@@ -1218,7 +1218,7 @@ function mapTypeInner(type: ts.Type, ctx: TypeMapperCtx): IrType | null {
     ]);
     let handle: IrType | null = null;
     let refined = true;
-    for (const part of widened.getTypes()) {
+    for (const part of ts.constituentTypes(widened)) {
       const mapped = mapType(part, ctx);
       if (mapped && HANDLE_KINDS.has(mapped.kind)) {
         if (handle !== null && handle.kind !== mapped.kind) {
@@ -2602,7 +2602,7 @@ function mapTypeInner(type: ts.Type, ctx: TypeMapperCtx): IrType | null {
     const sensitivityAtEntry = contextResolutions;
     try {
       const byKey = new Map<string, IrType>();
-      for (const part of widened.getTypes()) {
+      for (const part of ts.constituentTypes(widened)) {
         // A `void` PART is inhabited only by undefined (`Promise<void> |
         // void` return types, `string | void`): it becomes the undefinedT
         // unit arm, exactly like an undefined part — the value either
@@ -2630,7 +2630,7 @@ function mapTypeInner(type: ts.Type, ctx: TypeMapperCtx): IrType | null {
         if (mapped?.kind === "jsval") return JSVAL;
         if (!mapped) {
           // Before failing the whole union, let a LATER jsval part absorb.
-          for (const rest of widened.getTypes()) {
+          for (const rest of ts.constituentTypes(widened)) {
             if (mapType(rest, ctx)?.kind === "jsval") return JSVAL;
           }
           return null;
@@ -2747,12 +2747,12 @@ function mapNarrowedTypeParam(type: ts.Type, ctx: TypeMapperCtx): IrType | null 
     if (c.flags & (ts.TypeFlags.Undefined | ts.TypeFlags.Void)) return (allowUndefined = true);
     if (c.flags & ts.TypeFlags.Null) return (allowNull = true);
     // A companion UNION (`T & ({} | null)`): each part is an allowance.
-    if (c.isUnionType()) return c.getTypes().every(visitCompanion);
+    if (c.isUnionType()) return ts.constituentTypes(c).every(visitCompanion);
     return false;
   };
   const visitPart = (part: ts.Type): boolean => {
     if (!part.isIntersectionType()) return false;
-    for (const p of part.getTypes()) {
+    for (const p of ts.constituentTypes(part)) {
       if (p.flags & ts.TypeFlags.TypeParameter) {
         if (tp && tp !== p) return false; // two different parameters: not this pattern
         tp = p;
@@ -2762,7 +2762,7 @@ function mapNarrowedTypeParam(type: ts.Type, ctx: TypeMapperCtx): IrType | null 
     }
     return true;
   };
-  const parts: readonly ts.Type[] = type.isUnionType() ? type.getTypes() : [type];
+  const parts: readonly ts.Type[] = type.isUnionType() ? ts.constituentTypes(type) : [type];
   if (!parts.every(visitPart) || !tp) return undefined;
   const bound = resolveTypeParam(tp);
   if (!bound) return null;
@@ -3058,7 +3058,7 @@ export function genResultRecord(
  * a value). */
 export function isUnitOnlyTsType(t: ts.Type): boolean {
   const UNIT = ts.TypeFlags.Undefined | ts.TypeFlags.Void | ts.TypeFlags.Null;
-  const parts: readonly ts.Type[] = t.isUnionType() ? t.getTypes() : [t];
+  const parts: readonly ts.Type[] = t.isUnionType() ? ts.constituentTypes(t) : [t];
   return parts.every((p) => (p.flags & UNIT) !== 0);
 }
 
@@ -3106,7 +3106,7 @@ function mapHybridCallableIntersection(widened: ts.Type, ctx: TypeMapperCtx): Ir
   if (!widened.isIntersectionType()) return null;
   if (checker.getCallSignatures(widened).length !== 1) return null;
   let funcPart: ts.Type | null = null;
-  for (const part of widened.getTypes()) {
+  for (const part of ts.constituentTypes(widened)) {
     if (checker.getCallSignatures(part).length > 0) {
       if (funcPart) return null; // exactly one callable part
       funcPart = part;
@@ -3164,7 +3164,7 @@ function isMappedShape(t: ts.Type): boolean {
 function recordProvenanceOk(t: ts.Type, ctx: TypeMapperCtx): boolean {
   const { checker } = ctx;
   if (t.isIntersectionType()) {
-    return t.getTypes().every(
+    return ts.constituentTypes(t).every(
       (part) => {
         const partSym = part.getSymbol();
         return (part.flags & ts.TypeFlags.Object) !== 0 &&
@@ -3298,7 +3298,7 @@ function mapRecordTypeInner(widened: ts.Type, ctx: TypeMapperCtx): IrType | Reco
     const stringKey = (k: ts.Type): boolean =>
       (k.flags & ts.TypeFlags.String) !== 0 ||
       (k.isIntersectionType() &&
-        k.getTypes().every(
+        ts.constituentTypes(k).every(
           (p) =>
             (p.flags & ts.TypeFlags.String) !== 0 ||
             ((p.flags & ts.TypeFlags.Object) !== 0 &&
@@ -3694,7 +3694,7 @@ export function describeComponentBlocker(widened: ts.Type, ctx: TypeMapperCtx): 
   // arm kind with no union home. Unions have no symbol, so a null answer
   // falls through to the residual fence, never to a false lib claim.
   if (widened.isUnionType()) {
-    const parts = widened.getTypes();
+    const parts = ts.constituentTypes(widened);
     const UNIT = ts.TypeFlags.Undefined | ts.TypeFlags.Void | ts.TypeFlags.Null;
     const dataArms = parts.filter((p) => (p.flags & UNIT) === 0);
     // A union carrying an 'object'/'unknown'-flavored arm rides the

--- a/packages/compiler/test/ts7/facade.test.ts
+++ b/packages/compiler/test/ts7/facade.test.ts
@@ -5,6 +5,7 @@
 
 import { afterAll, expect, test } from "vitest";
 import { lowerToIr } from "../../src/frontend/lowering/lowerer.js";
+import { clearWorkspacePackages, registerWorkspacePackage } from "../../src/frontend/shared.js";
 import { CheckerFacade } from "../../src/frontend/ts7/checker.js";
 import type { Node } from "typescript/unstable/ast";
 import type { Checker, Type } from "typescript/unstable/sync";
@@ -156,6 +157,63 @@ test("isTupleType agrees with the raw checker; only object types round-trip, onc
   const before = counts["isTupleType"] ?? 0;
   for (const t of types) facade.isTupleType(t);
   expect(counts["isTupleType"] ?? 0).toBe(before);
+});
+
+test("isArrayType agrees with the raw checker and skips visibly non-object types", () => {
+  const { facade, counts, w } = build();
+  const raw = w.p7.project.checker;
+  const types = new Set<Type>();
+  for (const node of collectNodes(w)) types.add(facade.getTypeAtLocation(node));
+  expect(types.size).toBeGreaterThan(30);
+
+  let objectTypes = 0;
+  let arrays = 0;
+  for (const type of types) {
+    if (type.flags & ad.TypeFlags.Object) objectTypes++;
+    const viaFacade = facade.isArrayType(type);
+    expect(viaFacade, raw.typeToString(type)).toBe(raw.isArrayType(type));
+    if (viaFacade) arrays++;
+  }
+  expect(arrays).toBeGreaterThan(0);
+  expect(counts["isArrayType"] ?? 0).toBeLessThanOrEqual(objectTypes);
+
+  const before = counts["isArrayType"] ?? 0;
+  for (const type of types) facade.isArrayType(type);
+  expect(counts["isArrayType"] ?? 0).toBe(before);
+});
+
+test("union and intersection constituents are fetched once per immutable type", () => {
+  const { w } = build();
+  const raw = w.p7.project.checker;
+  const calls = new Map<Type, number>();
+  const originals = new Map<Type, () => readonly Type[] | undefined>();
+  const compound = new Set<Type>();
+  for (const node of collectNodes(w)) {
+    const type = raw.getTypeAtLocation(node);
+    if (type === undefined || !(type.isUnionType() || type.isIntersectionType())) continue;
+    compound.add(type);
+  }
+  expect(compound.size).toBeGreaterThan(0);
+  try {
+    for (const type of compound) {
+      const withConstituents = type as Type & { getTypes(): readonly Type[] | undefined };
+      const original = withConstituents.getTypes.bind(withConstituents);
+      originals.set(type, original);
+      withConstituents.getTypes = () => {
+        calls.set(type, (calls.get(type) ?? 0) + 1);
+        return original();
+      };
+    }
+    for (const type of compound) {
+      const first = ad.constituentTypes(type);
+      expect(ad.constituentTypes(type)).toBe(first);
+      expect(calls.get(type)).toBe(1);
+    }
+  } finally {
+    for (const [type, original] of originals) {
+      (type as Type & { getTypes(): readonly Type[] | undefined }).getTypes = original;
+    }
+  }
 });
 
 test("explicit prefetchSourceFile primes hot kinds and direct fallbacks memoize", () => {
@@ -412,6 +470,43 @@ test("class-shape collection batches deferred method default types", () => {
   )).toBe(true);
   expect(typeCalls.some(([arg]) =>
     !Array.isArray(arg) && initializers.includes(arg as never),
+  )).toBe(false);
+});
+
+test("eager npm-static implicit instances batch their committed body", () => {
+  const w = buildTwoWorlds({
+    "eager-implicit.js": `
+function pick(value) {
+  const row = { value };
+  return row.value;
+}
+console.log(pick(42));
+`,
+  }, host);
+  worlds.push(w);
+  const { proxy, calls } = countingChecker(w.p7.project.checker);
+  const facade = new CheckerFacade(proxy, { project: w.p7.project });
+  (w.p7 as unknown as { checkerFacade: CheckerFacade | null }).checkerFacade = facade;
+  const sf = w.p7.getSourceFile(w.files[0]!)!;
+  const fn = sf.statements.find(ad.isFunctionDeclaration)!;
+  const insideBody = (node: Node): boolean =>
+    node.getStart() >= fn.body!.getStart() && node.end <= fn.body!.end;
+
+  // Mark this fixture as an opted-in package file: that is the only gate
+  // separating ordinary JS from npm-static implicit-any monomorphization.
+  registerWorkspacePackage("eager-implicit", w.dir);
+  try {
+    lowerToIr(w.p7, sf, [sf]);
+  } finally {
+    clearWorkspacePackages();
+  }
+
+  const typeCalls = calls["getTypeAtLocation"] ?? [];
+  expect(typeCalls.some(([arg]) =>
+    Array.isArray(arg) && (arg as Node[]).some(insideBody),
+  )).toBe(true);
+  expect(typeCalls.some(([arg]) =>
+    !Array.isArray(arg) && insideBody(arg as Node),
   )).toBe(false);
 });
 


### PR DESCRIPTION
- Batch checker type work for reached call/receiver paths and eager npm-static implicit instances.
- Memoize immutable type constituents and skip array checks for visibly non-object types.