### PR TITLE
fix(compiler): adopt tsconfig paths/baseUrl for the ts7 checker

### DIFF
--- a/packages/compiler/src/frontend/program.ts
+++ b/packages/compiler/src/frontend/program.ts
@@ -40,7 +40,7 @@
  *    that path (no snapshot pins it). */
 
 import { builtinModules } from "node:module";
-import { dirname, resolve } from "node:path";
+import { dirname, isAbsolute, join, resolve } from "node:path";
 import * as ts from "./ts7/adapter.js";
 import type { ScrDiagnostic } from "../diagnostics/diagnostic.js";
 import {
@@ -167,6 +167,36 @@ function adoptProjectConfig7(
   for (const key of ADOPTED_OPTIONS) {
     const value = parsed.options[key];
     if (value !== undefined) adopted[key] = value;
+  }
+  // `paths` is a real, well-supported tsgo checker option, but `baseUrl`
+  // itself is not — tsgo rejects it outright ("Option 'baseUrl' has been
+  // removed. Please remove it from your configuration. Use '"paths": {"*":
+  // ["./*"]}' instead."), so it never joins `adopted` on its own. The
+  // synthesized virtual tsconfig (ts7/program.ts) is also written BESIDE THE
+  // ENTRY FILE, not beside this real tsconfig.json, so relative `paths`
+  // targets can't simply pass through either: they're resolved to absolute
+  // paths here, against the real config's resolved `baseUrl` (tsgo's own
+  // parser already makes that absolute — hence the isAbsolute guard rather
+  // than a bare join) or, absent one, the config's own directory (tsc's
+  // default), or tsgo resolves them against the wrong base entirely.
+  const rawPaths = parsed.options["paths"];
+  if (rawPaths !== undefined && typeof rawPaths === "object" && rawPaths !== null) {
+    const configDir = dirname(configFile);
+    const rawBaseUrl = parsed.options["baseUrl"];
+    const base =
+      typeof rawBaseUrl !== "string"
+        ? configDir
+        : isAbsolute(rawBaseUrl)
+          ? rawBaseUrl
+          : join(configDir, rawBaseUrl);
+    const abs = (p: string): string => (isAbsolute(p) ? p : join(base, p));
+    const paths: Record<string, string[]> = {};
+    for (const [key, value] of Object.entries(rawPaths as Record<string, unknown>)) {
+      if (Array.isArray(value)) {
+        paths[key] = value.filter((v): v is string => typeof v === "string").map(abs);
+      }
+    }
+    adopted["paths"] = paths;
   }
   const nullChecks = adopted["strictNullChecks"] ?? adopted["strict"] ?? false;
   if (nullChecks !== true) {

--- a/packages/compiler/test/ts7/program.test.ts
+++ b/packages/compiler/test/ts7/program.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "vitest";
@@ -62,6 +62,35 @@ console.log(required.value);
     expect(checkPreflight(load).map((diag) => diag.code)).toContain("SC1013");
     expect(calls.some(([arg]) => Array.isArray(arg) && arg.length > 24)).toBe(true);
     expect(calls.some(([arg]) => !Array.isArray(arg))).toBe(false);
+  } finally {
+    load.dispose();
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("adopts tsconfig paths/baseUrl so tsgo resolves aliased imports", () => {
+  const tempRoot = process.platform === "win32" ? tmpdir() : "/tmp";
+  const dir = mkdtempSync(join(tempRoot, "scriptc-preflight-paths-"));
+  writeFileSync(
+    join(dir, "tsconfig.json"),
+    JSON.stringify({
+      compilerOptions: { strictNullChecks: true, baseUrl: ".", paths: { "@/*": ["./src/*"] } },
+    }),
+  );
+  const srcDir = join(dir, "src");
+  mkdirSync(srcDir);
+  writeFileSync(join(dir, "entry.ts"), `import { value } from "@/dep";\nconsole.log(value);\n`);
+  writeFileSync(join(srcDir, "dep.ts"), "export const value = 1;\n");
+  const entry = join(dir, "entry.ts");
+
+  const load = loadProgram(entry);
+  try {
+    // Before the fix, tsgo never learns about `paths`/`baseUrl` and reports
+    // SC0001 "Cannot find module '@/dep'". SC1010 (own resolver has no
+    // opinion on bare-specifier aliases outside npm/imports-field) is a
+    // separate, pre-existing limitation and is unaffected by this fix.
+    const codes = checkPreflight(load).map((diag) => diag.code);
+    expect(codes).not.toContain("SC0001");
   } finally {
     load.dispose();
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Problem

Any project whose tsconfig uses `paths` aliases (e.g. `"@/*": ["./src/*"]`) fails type-checking with:

```
error SC0001: Cannot find module '@/foo' or its corresponding type declarations.
```

even though the underlying checker (tsgo, TypeScript 7 native) fully supports `paths`/`baseUrl` natively.

## Root cause

Type-checking is driven by a spawned `tsgo` process against a synthesized in-memory virtual tsconfig, built in `packages/compiler/src/frontend/program.ts`'s `adoptProjectConfig7()`. That function only copies a small strictness-flag allowlist (`ADOPTED_OPTIONS`) from the project's real `tsconfig.json` into the options handed to tsgo — `paths` and `baseUrl` are silently dropped, so tsgo never learns about the aliases and fails to resolve them.

## Fix

`adoptProjectConfig7()` now also adopts `paths`, resolving relative targets to absolute paths against the real config's directory (or its `baseUrl`, when set), since the virtual tsconfig fed to tsgo is written beside the entry file rather than beside the real `tsconfig.json` — passing relative targets through unresolved would make tsgo resolve them against the wrong base.

`baseUrl` itself is intentionally *not* forwarded: tsgo rejects it outright as a removed option ("Option 'baseUrl' has been removed... Use `"paths": {"*": ["./*"]}` instead."). Resolving `paths` targets to absolute paths up front makes forwarding `baseUrl` unnecessary.

## Verification

- `packages/compiler`: `node node_modules/typescript5/bin/tsc -p tsconfig.json` — 0 errors.
- Added a regression test in `packages/compiler/test/ts7/program.test.ts` covering `adoptProjectConfig7` via `loadProgram`/`checkPreflight`: builds a temp project with a `paths` alias (`@/*` → `./src/*`) and an aliased import, and asserts `SC0001` no longer appears in the preflight diagnostics. Confirmed the test reproduces the original bug (fails with the exact `SC0001` message above) against the unpatched code, and passes with the fix.
- Ran the full existing `packages/compiler/test/ts7` suite; no new failures introduced (two pre-existing Windows path-separator test failures on this platform predate this change, verified against a clean checkout).