### PR TITLE
chore(compiler): trim internal value exports

### DIFF
--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -816,7 +816,7 @@ export function resolveCc(
 
 /** Musl intentionally has no predefined libc macro. The explicit Zig target
  * is therefore the source of truth for selecting its small runtime shim. */
-export function isMuslTarget(driver: Pick<CcDriver, "target">): boolean {
+function isMuslTarget(driver: Pick<CcDriver, "target">): boolean {
   return driver.target?.includes("linux-musl") ?? false;
 }
 

--- a/packages/compiler/src/backend/emission/emit-async.ts
+++ b/packages/compiler/src/backend/emission/emit-async.ts
@@ -982,7 +982,7 @@ export function emitterInvokeThunkFor(E: CEmitter, cbT: IrType): string {
  * scr_stream_final_done, "d" scr_stream_destroy_done, "t"
  * scr_stream_transform_done, "l" scr_stream_flush_done. Args arrive
  * callee-owned (+1) per the universal convention and are released here. */
-export function streamDoneFnFor(E: CEmitter, kind: "w" | "f" | "d" | "t" | "l", doneT: IrType): string {
+function streamDoneFnFor(E: CEmitter, kind: "w" | "f" | "d" | "t" | "l", doneT: IrType): string {
   if (doneT.kind !== "func") {
     throw new Error("emitter bug: stream done callback not a func (frontend must fence)");
   }

--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -479,7 +479,7 @@ function dynPromiseAdapter(
  * receiver binding. This deliberately small whitelist enables borrowed
  * receivers in typed-array hot loops while side-effecting/calling shapes
  * retain the full snapshot ownership required by JS evaluation order. */
-export function isStableBytesOperand(e: IrExpr, receiverLocalId: string): boolean {
+function isStableBytesOperand(e: IrExpr, receiverLocalId: string): boolean {
   switch (e.kind) {
     case "numLit":
     case "boolLit":

--- a/packages/compiler/src/backend/emission/emit-walkers.ts
+++ b/packages/compiler/src/backend/emission/emit-walkers.ts
@@ -1711,7 +1711,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
    * value, and fulfill dst with it (scr_dyn_new_promise_adapting's
    * callback; rejections never reach an adapter — the runtime copies them
    * raw). Interned per inner typeKey. */
-  export function promiseDynAdapterHelper(E: CEmitter, inner: IrType): string {
+  function promiseDynAdapterHelper(E: CEmitter, inner: IrType): string {
     const key = typeKey(inner);
     const existing = E.promiseDynAdapters.get(key);
     if (existing) return existing;
@@ -1796,7 +1796,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
   }
 
 /** The call thunk for one closure signature (see the block comment). */
-  export function dynFuncThunkHelper(E: CEmitter, t: IrType & { kind: "func" }): string {
+  function dynFuncThunkHelper(E: CEmitter, t: IrType & { kind: "func" }): string {
     const key = typeKey(t);
     const existing = E.dynFuncThunks.get(key);
     if (existing) return existing;
@@ -1894,7 +1894,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
    * function a func-targeted dynCheck wraps a non-identical boxed
    * signature in. caps[0] is an untraced obj-box owning the dyn function
    * value. */
-  export function dynFuncAdapterHelper(E: CEmitter, t: IrType & { kind: "func" }): string {
+  function dynFuncAdapterHelper(E: CEmitter, t: IrType & { kind: "func" }): string {
     const key = typeKey(t);
     const existing = E.dynFuncAdapters.get(key);
     if (existing) return existing;

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -95,7 +95,7 @@ export interface ScopeEntry extends Temp {
   boxed?: boolean;
 }
 
-export function ffiNativeTypeC(
+function ffiNativeTypeC(
   cls: IrFfiCallbackParamClass | IrFfiValueParamClass | IrFfiReturnClass,
 ): string {
   switch (cls) {

--- a/packages/compiler/src/backend/library-identity.ts
+++ b/packages/compiler/src/backend/library-identity.ts
@@ -1,9 +1,9 @@
 export type LibraryEmission = "c" | "llvm";
 
-export const C_LIBRARY_IDENTITY_BEGIN = "/* scriptc-library-identity: begin */";
-export const C_LIBRARY_IDENTITY_END = "/* scriptc-library-identity: end */";
-export const LLVM_LIBRARY_IDENTITY_BEGIN = "; scriptc-library-identity: begin";
-export const LLVM_LIBRARY_IDENTITY_END = "; scriptc-library-identity: end";
+const C_LIBRARY_IDENTITY_BEGIN = "/* scriptc-library-identity: begin */";
+const C_LIBRARY_IDENTITY_END = "/* scriptc-library-identity: end */";
+const LLVM_LIBRARY_IDENTITY_BEGIN = "; scriptc-library-identity: begin";
+const LLVM_LIBRARY_IDENTITY_END = "; scriptc-library-identity: end";
 
 export interface LibraryIdentityValues {
   buildIdSymbol: string;

--- a/packages/compiler/src/backend/llvm/classes.ts
+++ b/packages/compiler/src/backend/llvm/classes.ts
@@ -139,7 +139,7 @@ export function buildClassGraph(mod: IrModule, fnByName: Map<string, IrFunction>
 /** The root's slot list as seen by one class: the implementation the class
  * dispatches to, or null outside the slot's declaring subtree / on a
  * fully-abstract chain (vtEntriesFor, ported). */
-export function vtEntriesFor(meta: LlClassMeta): { slot: LlVtSlot; impl: LlClassMeta | null }[] {
+function vtEntriesFor(meta: LlClassMeta): { slot: LlVtSlot; impl: LlClassMeta | null }[] {
   return meta.root.slots.map((slot) => {
     if (!(slot.declarer.pre <= meta.pre && meta.pre <= slot.declarer.post)) {
       return { slot, impl: null };
@@ -168,7 +168,7 @@ export function classStructSym(className: string): string {
  * struct embeds ScrEmitter's remaining prefix (the registry pointer and
  * the display-name slot) after the vtable word, so an upcast to
  * ScrEmitter* is the usual pointer reinterpret (emit-shapes.ts's rule). */
-export function emitterRooted(meta: LlClassMeta): boolean {
+function emitterRooted(meta: LlClassMeta): boolean {
   return meta.root.def.name === RUNTIME_EMITTER_CLASS;
 }
 
@@ -176,7 +176,7 @@ export function emitterRooted(meta: LlClassMeta): boolean {
  * embeds the FULL ScrStream prefix (registry, display name, state
  * pointer) and its RC/trace helpers delegate the state block to
  * scr_stream_st_* (emit-shapes.ts's streamRooted). */
-export function streamRooted(meta: LlClassMeta): boolean {
+function streamRooted(meta: LlClassMeta): boolean {
   for (let m = meta.base; m; m = m.base) {
     if (RUNTIME_STREAM_CLASSES.has(m.def.name)) return true;
   }

--- a/packages/compiler/src/backend/llvm/dyn.ts
+++ b/packages/compiler/src/backend/llvm/dyn.ts
@@ -32,7 +32,7 @@ import type { WalkerHost } from "./walkers.js";
 
 /** ScrDynKind values (scr_runtime.h). */
 /** ScrDynHandleTag numeric values (scr_runtime.h's enum order). */
-export const DYN_HANDLE_TAG_NUM: Record<string, number> = {
+const DYN_HANDLE_TAG_NUM: Record<string, number> = {
   httpReq: 0,
   httpRes: 1,
   netSocket: 2,

--- a/packages/compiler/src/compat/fetch-profile.ts
+++ b/packages/compiler/src/compat/fetch-profile.ts
@@ -933,12 +933,6 @@ export const NODE24_FETCH_COMPAT_PROFILE = {
   },
 } satisfies FetchCompatProfile;
 
-export const STATIC_REQUEST_INIT_KEYS = new Set(
-  NODE24_FETCH_COMPAT_PROFILE.requestInit.map((entry) =>
-    entry.id.slice("stdlib.fetch.request-init.".length)
-  ),
-);
-
 export const STATIC_RESPONSE_READS = new Set(
   NODE24_FETCH_COMPAT_PROFILE.members.responseReads,
 );

--- a/packages/compiler/src/diagnostics/diagnostic.ts
+++ b/packages/compiler/src/diagnostics/diagnostic.ts
@@ -878,19 +878,6 @@ export function libFenceDiag(
   return diag;
 }
 
-/** SC4006 — island/dynamic machinery on the library path: --dynamic,
- * --npm-static as a FLAG, `any`-typed island surface. Bare npm imports
- * themselves are not this code: an eligible package compiles statically
- * as part of the library graph, an ineligible one refuses SC4013. */
-export function libDynamicDiag(what: string, loc: SrcLoc): ScrDiagnostic {
-  return {
-    code: "SC4006",
-    message: `${what} is not available in library mode — the island engine and embedded npm graphs are executable-lane machinery`,
-    loc,
-    hint: "library artifacts are provable only for the static tier: no engine, no hidden init, no threads",
-  };
-}
-
 /** SC4007 — a mapped export whose signature keeps type parameters: every
  * compiled function is one concrete signature (the SC2005 monomorphization
  * rule, re-anchored at the profile entry). */
@@ -1011,11 +998,6 @@ export const LIB_RUNTIME_TRAP_CODES = [
   "SC4019",
   "SC4025",
 ] as const;
-
-/** SC4025 — the unregistered host-callback trap's code (the runtime
- * family entry above; exported for the resolver that assembles the trap
- * message and the tests that pin it). */
-export const LIB_CALLBACK_UNREGISTERED_TRAP_CODE = "SC4025";
 
 /** SC4024 — a host-callback reference the profile cannot serve. Library
  * mode maps signature-only ambient function declarations onto the

--- a/packages/compiler/src/frontend/input-tracker.ts
+++ b/packages/compiler/src/frontend/input-tracker.ts
@@ -45,7 +45,7 @@ export interface FrontendInputExclusions {
   outputDirectories?: Iterable<string>;
 }
 
-export function frontendSourceDigest(text: string): string {
+function frontendSourceDigest(text: string): string {
   return createHash("sha256").update(text).digest("hex");
 }
 
@@ -117,10 +117,6 @@ export class FrontendInputTracker {
       stable: this.stable,
     };
   }
-}
-
-export function frontendInputTrackingActive(): boolean {
-  return activeTracker.getStore() !== undefined;
 }
 
 function record(probe: FrontendInputProbe): void {

--- a/packages/compiler/src/frontend/lib-contract.ts
+++ b/packages/compiler/src/frontend/lib-contract.ts
@@ -192,7 +192,7 @@ function shapeOfMembers(file: ts.SourceFile, members: readonly ts.Node[], onBad:
 /** The syntactic shape of a type node, over the closed vocabulary the
  * sidecar schema can express. Anything else lands as `unsupported` with
  * the source text preserved for the refusal message. */
-export function typeShape(file: ts.SourceFile, node: ts.TypeNode): ContractTypeShape {
+function typeShape(file: ts.SourceFile, node: ts.TypeNode): ContractTypeShape {
   switch (node.kind) {
     case ts.SyntaxKind.BooleanKeyword:
       return { k: "bool" };

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -277,7 +277,7 @@ function lowerBuiltinOptionalDefault(
    * LOWERS (import.meta has no value representation): it only names the
    * file whose directory anchors the returned require's relative
    * resolution, and every supported spelling names the call's own file. */
-  export function createRequireBaseCallOf(L: Lowerer, expr: ts.Expression): ts.CallExpression | null {
+  function createRequireBaseCallOf(L: Lowerer, expr: ts.Expression): ts.CallExpression | null {
     const e = stripTypeCasts(expr);
     if (!ts.isCallExpression(e) || e.questionDotToken) return null;
     if (!ts.isIdentifier(e.expression)) return null;
@@ -497,7 +497,7 @@ function lowerBuiltinOptionalDefault(
    * alias from the module, or `require("http2").constants` inline. The
    * object itself never materializes; each member read bakes as its
    * literal. */
-  export function builtinConstantsModuleOf(L: Lowerer, node: ts.Expression): string | null {
+  function builtinConstantsModuleOf(L: Lowerer, node: ts.Expression): string | null {
     let module: string | null = null;
     if (ts.isPropertyAccessExpression(node) && !node.questionDotToken) {
       if (node.name.text !== "constants") return null;
@@ -537,7 +537,7 @@ function lowerBuiltinOptionalDefault(
    * value; provenance-checked like console/process, so the bare
    * identifier and the globalThis.performance member both land here and
    * a user's own `performance` binding never does). */
-  export function isPerfHooksPerformanceExpr(L: Lowerer, node: ts.Expression): boolean {
+  function isPerfHooksPerformanceExpr(L: Lowerer, node: ts.Expression): boolean {
     if (L.isStdlibGlobal(node, "performance")) return true;
     if (ts.isIdentifier(node)) {
       const bi = builtinImportOf(L, node);
@@ -5072,7 +5072,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
    * watches one inode), signal, and non-utf8 encodings fence by name;
    * undocumented keys drop like Node. An open watcher keeps the loop
    * alive until watcher.close(). */
-  export function lowerFsWatchCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc): IrExpr {
+  function lowerFsWatchCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc): IrExpr {
     if (expr.arguments.length < 1 || expr.arguments.length > 3 || expr.arguments.some(ts.isSpreadElement)) {
       L.noLowering(
         "fs.watch with this argument shape",
@@ -5494,7 +5494,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
    * member-by-member; the result type must be the interned Dirent record
    * array from types.ts — anything else (encoding: 'buffer', a user alias
    * reshaping Dirent) fences honestly. */
-  export function lowerFsReaddirTypesCall(L: Lowerer, call: ts.CallExpression, loc: SrcLoc): IrExpr {
+  function lowerFsReaddirTypesCall(L: Lowerer, call: ts.CallExpression, loc: SrcLoc): IrExpr {
     const optsNode = call.arguments[1]!;
     if (!ts.isObjectLiteralExpression(optsNode)) {
       L.noLowering(
@@ -5708,7 +5708,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
    * tolerated: @types/node's Dict) — the networkInterfaces verification
    * stance. The default decoder is the one lowered decoder; a custom
    * decodeURIComponent option fences by name. */
-  export function lowerQuerystringParseCall(L: Lowerer, call: ts.CallExpression, loc: SrcLoc): IrExpr {
+  function lowerQuerystringParseCall(L: Lowerer, call: ts.CallExpression, loc: SrcLoc): IrExpr {
     if (call.arguments.length > 4 || call.arguments.some(ts.isSpreadElement)) {
       L.noLowering(`querystring.parse with ${call.arguments.length} arguments`, call);
     }
@@ -5792,7 +5792,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
    * (scr_qs_stringify), so arrays expand to repeated keys and
    * null/undefined values are empty. The default encoder is the one
    * lowered encoder; a custom encodeURIComponent option fences by name. */
-  export function lowerQuerystringStringifyCall(L: Lowerer, call: ts.CallExpression, loc: SrcLoc): IrExpr {
+  function lowerQuerystringStringifyCall(L: Lowerer, call: ts.CallExpression, loc: SrcLoc): IrExpr {
     if (call.arguments.length > 4 || call.arguments.some(ts.isSpreadElement)) {
       L.noLowering(`querystring.stringify with ${call.arguments.length} arguments`, call);
     }
@@ -5856,7 +5856,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     return { kind: "libCall", fn: "qs.stringify", args: [obj, sep, eq], type: STRING, loc };
   }
 
-  export function lowerOsNetworkInterfacesCall(L: Lowerer, call: ts.CallExpression, loc: SrcLoc): IrExpr {
+  function lowerOsNetworkInterfacesCall(L: Lowerer, call: ts.CallExpression, loc: SrcLoc): IrExpr {
     if (call.arguments.length !== 0) {
       L.noLowering(`networkInterfaces with ${call.arguments.length} arguments`, call, "networkInterfaces() takes no arguments");
     }

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -1072,7 +1072,7 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
    * (`const f: (x: number) => number = identity`) reuse one compiled
    * instance. `makeBindings` runs only for a NEW key (binding inference
    * costs checker walks). */
-  export function internGenericInstance(L: Lowerer, blame: ts.Node,
+  function internGenericInstance(L: Lowerer, blame: ts.Node,
     info: GenericFnInfo,
     params: ParamShape[],
     returnType: IrType,
@@ -1129,7 +1129,7 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
    * (`K extends keyof T`) — the parameters whose bound literal is semantic
    * (the body's `o[k]` reads the named field), computed once per info from
    * the declaration's syntax. */
-  export function keyofConstrainedTypeParams(info: GenericFnInfo): Set<ts.Symbol> {
+  function keyofConstrainedTypeParams(info: GenericFnInfo): Set<ts.Symbol> {
     if (info.keyofTps) return info.keyofTps;
     const out = new Set<ts.Symbol>();
     info.decl.typeParameters?.forEach((tpDecl, i) => {
@@ -1175,7 +1175,7 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
    * DEFAULT (`<T = number>`), mapped — the checker already substituted the
    * default into every resolved signature, so this only fills the bindings
    * an instance body's mapType consults. */
-  export function bindDefaultTypeParams(L: Lowerer, typeParams: readonly ts.Symbol[],
+  function bindDefaultTypeParams(L: Lowerer, typeParams: readonly ts.Symbol[],
     typeParamDecls: readonly ts.TypeParameterDeclaration[] | undefined,
     bindings: Map<ts.Symbol, IrType>,
     tsBindings?: Map<ts.Symbol, ts.Type>,): void {
@@ -1197,7 +1197,7 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
    * completed signature a VALUE reference is pinned to (the contextual
    * type's one call signature). Mutates `bindings`; already-bound
    * parameters (explicit type arguments) win. */
-  export function unifySignatureBindings(L: Lowerer, info: GenericFnInfo,
+  function unifySignatureBindings(L: Lowerer, info: GenericFnInfo,
     rsig: ts.Signature,
     bindings: Map<ts.Symbol, IrType>,
     tsBindings?: Map<ts.Symbol, ts.Type>,): void {
@@ -1935,7 +1935,7 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
 /** The all-dyn DEFAULT instance — today's compiled body exactly: what a
    * VALUE reference of an implicit-any function names (indirect calls
    * carry no per-site types to bind). */
-  export function implicitDefaultInstance(L: Lowerer, blame: ts.Node, info: GenericFnInfo): GenericInstance {
+  function implicitDefaultInstance(L: Lowerer, blame: ts.Node, info: GenericFnInfo): GenericInstance {
     const shapes: ParamShape[] = info.decl.parameters.map((param, i) =>
       info.implicitParams![i] ? { type: DYN, mode: "required" as const } : L.paramShape(param),
     );
@@ -2339,7 +2339,7 @@ export function islandPrimitiveExit(L: Lowerer, call: ts.CallExpression, result:
 /** The timer surface's member names — the ambient globals AND the
    * node:timers module's exports (one set: Node's timers module re-exports
    * the globals). */
-  export const TIMER_MODULE_MEMBERS: ReadonlySet<string> = new Set([
+  const TIMER_MODULE_MEMBERS: ReadonlySet<string> = new Set([
     "setTimeout", "clearTimeout", "setInterval", "clearInterval", "setImmediate", "clearImmediate",
   ]);
 
@@ -4538,7 +4538,7 @@ export function lowerCall(L: Lowerer, expr: ts.CallExpression): IrExpr {
    * Answers null when neither lane fits (typed .ts spreads keep
    * completeArgs' rest packing and its fences). JS sources only — the
    * same guard as the over-arity dynCall precedent. */
-  export function lowerSpreadArgsCall(L: Lowerer, expr: ts.CallExpression, callee: IrExpr, loc: SrcLoc): IrExpr | null {
+  function lowerSpreadArgsCall(L: Lowerer, expr: ts.CallExpression, callee: IrExpr, loc: SrcLoc): IrExpr | null {
     if (!isJsSourceFile(expr.getSourceFile())) return null;
     if (!expr.arguments.some((a) => ts.isSpreadElement(a))) return null;
     if (callee.type.kind !== "dyn" && callee.type.kind !== "func" && callee.type.kind !== "jsval") return null;
@@ -4614,7 +4614,7 @@ export function lowerCall(L: Lowerer, expr: ts.CallExpression): IrExpr {
    * (dynRest/islandRest, whose packs are built per-argument): the shapes
    * the runtime-arity lane (lowerSpreadArgsCall) serves. Typed `rest`
    * slots keep completeArgs' same-element spread packing. */
-  export function spreadNeedsRuntimeArity(shapes: readonly ParamShape[], argNodes: readonly ts.Expression[]): boolean {
+  function spreadNeedsRuntimeArity(shapes: readonly ParamShape[], argNodes: readonly ts.Expression[]): boolean {
     const restAt = shapes.findIndex((s) => s.mode === "rest" || s.mode === "dynRest" || s.mode === "islandRest");
     return argNodes.some(
       (a, i) =>
@@ -4777,7 +4777,7 @@ const DYN_PROTO_METHOD_NAMES = new Set([
  * runtime runs the real method for the receiver's kind, throws Node's
  * is-not-a-function where the kind's prototype lacks the name, and
  * fences LOUDLY on real-but-unimplemented pairs. */
-export const DYN_DISPATCH_METHODS = new Set([
+const DYN_DISPATCH_METHODS = new Set([
   "apply", "call",
   "push", "pop", "shift", "unshift", "slice", "at",
   "indexOf", "lastIndexOf", "includes", "join", "concat", "reverse", "sort",
@@ -4992,7 +4992,7 @@ const inliningPredicates = new Set<ts.Symbol>();
    * explicit-radix number form keeps its island lowering (ISLAND_SURFACE);
    * null for other receivers, argument shapes, or non-lib members (a
    * user's own `.toString` takes the ordinary paths). */
-  export function lowerNumberToStringCall(L: Lowerer, call: ts.CallExpression,
+  function lowerNumberToStringCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,): IrExpr | null {
     if (L.chainBlocked(call, access)) return null;
     if (access.name.text !== "toString" || call.arguments.length !== 0) return null;
@@ -5013,7 +5013,7 @@ const inliningPredicates = new Set<ts.Symbol>();
    * unions stay out — `(undefined).toString()` THROWS in JS, and
    * claiming it here would silently print "undefined" instead. Null for
    * other receivers/arms (the narrow-first fences stay). */
-  export function lowerUnionToStringCall(L: Lowerer, call: ts.CallExpression,
+  function lowerUnionToStringCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,): IrExpr | null {
     if (call.questionDotToken || access.questionDotToken) return null;
     if (access.name.text !== "toString" || call.arguments.length !== 0) return null;
@@ -5041,7 +5041,7 @@ const inliningPredicates = new Set<ts.Symbol>();
    * is the USER's symbol, which never lands here). Pure receivers elide
    * evaluation; effectful ones evaluate through an interned identity
    * helper so the receiver's effects keep their place. */
-  export function lowerDefaultToStringCall(L: Lowerer, call: ts.CallExpression,
+  function lowerDefaultToStringCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,): IrExpr | null {
     if (call.questionDotToken || access.questionDotToken) return null;
     if (access.name.text !== "toString" || call.arguments.length !== 0) return null;
@@ -5170,7 +5170,7 @@ const inliningPredicates = new Set<ts.Symbol>();
    *     lowering above) and `charAt(i)` — the two the element hook needs
    *     beyond this file's own claims.
    * Null elsewhere: non-literal keys, other members, other receivers. */
-  export function lowerPrimitiveProtoCall(L: Lowerer, call: ts.CallExpression,
+  function lowerPrimitiveProtoCall(L: Lowerer, call: ts.CallExpression,
     recv: ts.Expression, name: string, memberSym: ts.Symbol | undefined,): IrExpr | null {
     if (call.questionDotToken) return null;
     if (!L.isStdlibSymbol(memberSym)) return null;
@@ -8232,7 +8232,7 @@ export function lowerFunction(L: Lowerer, decl: ts.FunctionDeclaration): IrFunct
 /** Strips the value-preserving wrappers off an expression: parens,
    * non-null assertions, `as`/`satisfies`/angle-bracket casts. What
    * remains is the expression that actually evaluates. */
-  export function stripValueWrappers(e: ts.Expression): ts.Expression {
+  function stripValueWrappers(e: ts.Expression): ts.Expression {
     let v: ts.Expression = e;
     for (;;) {
       if (
@@ -8271,7 +8271,7 @@ export function lowerFunction(L: Lowerer, decl: ts.FunctionDeclaration): IrFunct
    * the value fact alone). Cached per symbol; the pre-seeded null entry
    * guards probe cycles (mutually-assigned bindings resolve link by link,
    * declaration order). */
-  export function nullishValueUnitOf(L: Lowerer, sym: ts.Symbol | null): "null" | "undefined" | null {
+  function nullishValueUnitOf(L: Lowerer, sym: ts.Symbol | null): "null" | "undefined" | null {
     if (!sym) return null;
     const cached = L.nullishBindings.get(sym);
     if (cached !== undefined) return cached;
@@ -8762,7 +8762,7 @@ export function lowerFunction(L: Lowerer, decl: ts.FunctionDeclaration): IrFunct
     "forEach", "keys", "values", "entries", "toString",
   ]);
 
-  export function lowerObjLitGenericMethodCall(L: Lowerer, call: ts.CallExpression,
+  function lowerObjLitGenericMethodCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,): IrExpr | null {
     if (L.chainBlocked(access, call)) return null;
     const name = access.name.text;

--- a/packages/compiler/src/frontend/lowering/lower-classes.ts
+++ b/packages/compiler/src/frontend/lowering/lower-classes.ts
@@ -594,7 +594,7 @@ export const EMITTER_API_MEMBERS: ReadonlySet<string> = new Set([
    * `@dec(...)` evaluates the CALLEE before any argument — and property
    * chains throw at their ROOT (`@instance.decorate` reads `instance`
    * first). */
-  export function ambientDecoratorThrowNameOf(L: Lowerer, dExpr: ts.Expression): string | null {
+  function ambientDecoratorThrowNameOf(L: Lowerer, dExpr: ts.Expression): string | null {
     let e: ts.Expression = dExpr;
     while (ts.isParenthesizedExpression(e)) e = e.expression;
     const target = ts.isCallExpression(e) ? e.expression : e;
@@ -2456,7 +2456,7 @@ export function collectClassShapeInner(L: Lowerer, decl: ts.ClassLikeDeclaration
    * Coverage counts a generic class's statements once: only the FIRST
    * instantiation contributes (the lowerGenericInstance rule). A no-op
    * for ordinary classes. */
-  export function withInstanceBindings<T>(L: Lowerer, info: ClassInfo, fn: () => T): T {
+  function withInstanceBindings<T>(L: Lowerer, info: ClassInfo, fn: () => T): T {
     const gi = info.genericInstance;
     if (!gi) {
       // MIXIN instantiations ride the same mechanism: T (the base
@@ -2735,7 +2735,7 @@ export function collectClassShapeInner(L: Lowerer, decl: ts.ClassLikeDeclaration
    * object, each replacing decorator's non-undefined result feeding the
    * next application; the final value binds the class name (the mutable
    * classval global) when any decorator can replace. */
-  export function lowerClassDecoration(L: Lowerer, info: ClassInfo): IrStmt[] {
+  function lowerClassDecoration(L: Lowerer, info: ClassInfo): IrStmt[] {
     const cd = info.classDecorators;
     if (!cd || cd.poisoned || cd.shapes === undefined || info.decl === null) return [];
     const loc = locOf(info.decl);
@@ -3542,7 +3542,7 @@ export function collectClassShapeInner(L: Lowerer, decl: ts.ClassLikeDeclaration
    * method `name` — overrideBelow's twin: generic methods have no vtable
    * slot, so a call that could reach an override compiles only when the
    * receiver's runtime class is statically exact. */
-  export function genericOverrideBelow(L: Lowerer, info: ClassInfo, name: string): boolean {
+  function genericOverrideBelow(L: Lowerer, info: ClassInfo, name: string): boolean {
     return info.subclasses.some(
       (s) => s.genericMethods?.has(name) === true || genericOverrideBelow(L, s, name),
     );
@@ -4254,7 +4254,7 @@ export function lowerClassMembers(L: Lowerer, info: ClassInfo): IrFunction[] {
    * null when the generic class extends nothing, exactly the source's
    * story (tsc forbids super() there). Ordinary classes answer their base
    * unchanged. */
-  export function superBaseOf(info: ClassInfo): ClassInfo | null {
+  function superBaseOf(info: ClassInfo): ClassInfo | null {
     const b = info.base;
     return b?.generic ? b.base : b;
   }
@@ -4297,7 +4297,7 @@ export function lowerClassMembers(L: Lowerer, info: ClassInfo): IrFunction[] {
    * Each assignment reads the parameter's BODY local (defaults already
    * applied by the declareParams prologue), whose type the collection made
    * the field's type — slot-exact by construction. */
-  export function paramPropInitStmts(L: Lowerer, info: ClassInfo, thisLocal: IrLocal): IrStmt[] {
+  function paramPropInitStmts(L: Lowerer, info: ClassInfo, thisLocal: IrLocal): IrStmt[] {
     const out: IrStmt[] = [];
     const thisType: IrType = { kind: "object", className: info.def.name };
     for (const pp of info.paramProps ?? []) {
@@ -4646,7 +4646,7 @@ export function lowerClassMembers(L: Lowerer, info: ClassInfo): IrFunction[] {
    * super() with default options; passing options through an inherited
    * constructor would need the literal at the new-site to plumb, so it
    * asks for a declared constructor instead). */
-  export function inheritsBuiltinStreamCtor(L: Lowerer, info: ClassInfo): boolean {
+  function inheritsBuiltinStreamCtor(L: Lowerer, info: ClassInfo): boolean {
     for (let c: ClassInfo | null = info; c; c = c.base) {
       if (c.builtinStream) return true;
       if (c.ctor) return false;
@@ -4699,7 +4699,7 @@ function genericNewTarget(L: Lowerer, expr: ts.NewExpression, info: ClassInfo): 
  * the binding never initializes (the %init ReferenceError unwinds first),
  * so `new`, the class as a value, and `extends` all fence — reaching one
  * in compiled code would require executing past the throw. */
-export function fenceDecorationThrows(L: Lowerer, info: ClassInfo, blame: ts.Node): void {
+function fenceDecorationThrows(L: Lowerer, info: ClassInfo, blame: ts.Node): void {
   if (info.decorationThrows === undefined) return;
   L.unsupported(
     "SC1090",
@@ -5730,7 +5730,7 @@ export function lowerNew(L: Lowerer, expr: ts.NewExpression): IrExpr {
  * `time = async <T>(...) => {...}` or `= function g<T>(...) {...}`
  * (parens stripped): bindingGenericFnNodeOf's shape rule, member form.
  * Null when the field isn't that shape. */
-export function genericFieldFnNodeOf(member: ts.PropertyDeclaration): ts.FunctionExpression | ts.ArrowFunction | null {
+function genericFieldFnNodeOf(member: ts.PropertyDeclaration): ts.FunctionExpression | ts.ArrowFunction | null {
   if (member.initializer === undefined) return null;
   let init: ts.Expression = member.initializer;
   while (ts.isParenthesizedExpression(init)) init = init.expression;

--- a/packages/compiler/src/frontend/lowering/lower-comptime.ts
+++ b/packages/compiler/src/frontend/lowering/lower-comptime.ts
@@ -13,11 +13,11 @@ import { PoisonError } from "./lowerer.js";
 /** Wall-clock budget for one comptime callback. Evaluation happens inside
  * the compiler (node:vm), so a runaway loop would hang the BUILD — the vm
  * timeout turns it into a diagnostic instead. */
-export const COMPTIME_TIMEOUT_MS = 2000;
+const COMPTIME_TIMEOUT_MS = 2000;
 
 /** Names a compile-time-computed JS value in a comptime result diagnostic
  * ("expected 'number' at $.t[2], got undefined"). */
-export function describeComptimeValue(v: unknown): string {
+function describeComptimeValue(v: unknown): string {
   if (v === undefined) return "undefined";
   if (v === null) return "null";
   if (Array.isArray(v)) return "an array";

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -636,7 +636,7 @@ function fenceProducedArrayElem(L: Lowerer, node: ts.Node, producer: string, ele
    * visited), elements are read fresh each iteration, callbacks run
    * left-to-right and receive whatever prefix of (element, index, array)
    * they declare. */
-  export function lowerArrayHofCall(L: Lowerer, call: ts.CallExpression,
+  function lowerArrayHofCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,
     method: "map" | "filter" | "forEach",
     elem: IrType,): IrExpr {
@@ -719,7 +719,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
    * combo. Named `%arr.<method>.<n>` ('%' keeps it out of the user
    * namespace); rides `liftedFns` into the module like a lifted lambda (it
    * is a plain function — no captures). */
-  export function arrayHofHelper(L: Lowerer, method: "map" | "filter" | "forEach",
+  function arrayHofHelper(L: Lowerer, method: "map" | "filter" | "forEach",
     elem: IrType,
     fnRet: IrType,
     arity: number,
@@ -916,7 +916,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
    * (pushSpread), then each argument pushes (element) or spreads (array)
    * in order; the receiver and array arguments are only READ. Rides
    * liftedFns like the HOF helpers (a plain function — no captures). */
-  export function arrayConcatHelper(L: Lowerer, elem: IrType, shape: ("e" | "a")[], loc: SrcLoc): string {
+  function arrayConcatHelper(L: Lowerer, elem: IrType, shape: ("e" | "a")[], loc: SrcLoc): string {
     const key = `concat:${typeKey(elem)}:${shape.join("")}`;
     const existing = L.arrHofHelpers.get(key);
     if (existing) return existing;
@@ -966,7 +966,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
    * `arity` is the callback's declared parameter count (1–3): the loop
    * passes the index and the receiver itself after the element when the
    * callback names them, exactly the arguments JS supplies. */
-  export function buildArrayHofFn(L: Lowerer, name: string,
+  function buildArrayHofFn(L: Lowerer, name: string,
     method: "map" | "filter" | "forEach",
     elem: IrType,
     fnRet: IrType,
@@ -1086,7 +1086,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
    * backwards (`i = n - 1; i >= 0; i--`), exactly the es2023 spec's
    * descending index walk. All require a bool-returning callback
    * (JS's ToBoolean of arbitrary predicate results has no lowering). */
-  export function lowerArrayFindLikeCall(L: Lowerer, call: ts.CallExpression,
+  function lowerArrayFindLikeCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,
     method: "find" | "findIndex" | "findLast" | "findLastIndex" | "some" | "every",
     elem: IrType,): IrExpr {
@@ -1347,7 +1347,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
    * which IS map — those calls share map's interned helper. A union return
    * mixing array and non-array arms would need a per-value flatten decision
    * — fenced. */
-  export function lowerArrayFlatMapCall(L: Lowerer, call: ts.CallExpression,
+  function lowerArrayFlatMapCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,
     elem: IrType,): IrExpr {
     const loc = locOf(call);
@@ -1482,7 +1482,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
    * initial value, the element type without one. The callback may declare
    * any prefix of (acc, element, index, array). Without an initial value an
    * empty receiver throws Node's exact TypeError at runtime. */
-  export function lowerArrayReduceCall(L: Lowerer, call: ts.CallExpression,
+  function lowerArrayReduceCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,
     method: "reduce" | "reduceRight",
     elem: IrType,): IrExpr {
@@ -1641,7 +1641,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
    * relational operators. For numbers that default is the notorious string
    * sort ([10, 9, 1] → [1, 10, 9]), deliberately fenced toward an explicit
    * comparator. */
-  export function lowerArraySortCall(L: Lowerer, call: ts.CallExpression,
+  function lowerArraySortCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,
     elem: IrType,
     arrT: IrType & { kind: "array" },): IrExpr {
@@ -2323,7 +2323,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
    * The result is the checker's own `T | undefined` union, the find
    * machinery's wrap rules (an undefined-armed element type passes
    * through). */
-  export function lowerArrayAtCall(L: Lowerer, call: ts.CallExpression,
+  function lowerArrayAtCall(L: Lowerer, call: ts.CallExpression,
     access: ts.PropertyAccessExpression,
     elem: IrType,): IrExpr {
     const loc = locOf(call);
@@ -4033,7 +4033,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
    * desugar substitutes the builtin has/size for the spec's observable
    * calls, which is exact for Sets and wrong for anything else (a Map or
    * a custom { has, size, keys } object fences). */
-  export function lowerSetCombineCall(L: Lowerer, call: ts.CallExpression,
+  function lowerSetCombineCall(L: Lowerer, call: ts.CallExpression,
     name: string,
     receiver: IrExpr,
     setT: IrType & { kind: "set" },): IrExpr {

--- a/packages/compiler/src/frontend/lowering/lower-dgram.ts
+++ b/packages/compiler/src/frontend/lowering/lower-dgram.ts
@@ -18,11 +18,6 @@ const DGRAM_SURFACE_HINT =
   "bind, connect, send, address, close, unref/ref, and on/once of " +
   "message/listening/close/connect/error are the supported dgram.Socket members";
 
-/** The lowered value members of the dgram/dns modules — the surfaces.ts
- * tables' spoke-side twins (call shapes are all special-cased here). */
-export const DGRAM_MODULE_FNS: ReadonlySet<string> = new Set(["createSocket"]);
-export const DNS_MODULE_FNS: ReadonlySet<string> = new Set(["lookup"]);
-
 /** VOID-result socket calls are usable as statements and as concise arrow
  * bodies; anything consuming the result (Node returns `this` where this
  * surface returns void) is fenced — the lower-server stance. */

--- a/packages/compiler/src/frontend/lowering/lower-emitter.ts
+++ b/packages/compiler/src/frontend/lowering/lower-emitter.ts
@@ -1062,7 +1062,7 @@ function isWriteTarget(id: ts.Identifier): boolean {
 }
 
 /** The nearest class at-or-above `info` declaring an emit override. */
-export function emitOverrideAtOrAbove(info: ClassInfo | null | undefined): ClassInfo | null {
+function emitOverrideAtOrAbove(info: ClassInfo | null | undefined): ClassInfo | null {
   for (let c: ClassInfo | null = info ?? null; c; c = c.base) {
     if (c.emitOverride) return c;
   }
@@ -1095,7 +1095,7 @@ function topmostEmitOverridesBelow(info: ClassInfo): ClassInfo[] {
 /** An emit-override class COMPARABLE to `info` (ancestor-or-self or
  * descendant — a dynamic instance under this static type could dispatch
  * through it), or null. The meta-registration fence's test. */
-export function emitOverrideComparable(info: ClassInfo): ClassInfo | null {
+function emitOverrideComparable(info: ClassInfo): ClassInfo | null {
   const above = emitOverrideAtOrAbove(info);
   if (above) return above;
   const below: ClassInfo[] = [];
@@ -1107,7 +1107,7 @@ export function emitOverrideComparable(info: ClassInfo): ClassInfo | null {
  * method on the class (vtable participation — the ABI is `(this, ...tuple)
  * => bool` for every declarer of one event, override-exact by
  * construction) and queues the body for the drive loop's fixpoint. */
-export function ensureEmitSpec(L: Lowerer, info: ClassInfo, event: string, tuple: IrType[]): void {
+function ensureEmitSpec(L: Lowerer, info: ClassInfo, event: string, tuple: IrType[]): void {
   const mName = `emit:${event}`;
   const key = `%${info.def.name}.${mName}`;
   if (L.emitSpecDone.has(key)) return;

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -1946,7 +1946,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
    * array type's role when the caller knows the slot's array type and tsc's
    * API doesn't surface it (a ternary as a SPREAD source — lowerArrayLiteral
    * threads the literal's own type in). */
-  export function lowerTernary(L: Lowerer, expr: ts.ConditionalExpression,
+  function lowerTernary(L: Lowerer, expr: ts.ConditionalExpression,
     expected?: IrType & { kind: "array" },): IrExpr {
     const loc = locOf(expr);
       // `Array.isArray(x) ? x : [x]` over a `T | readonly T[]` union: tsc
@@ -2520,7 +2520,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
    * the same trust-the-checker bet as lowerUnitComparison. Null (fence)
    * when this isn't a null-literal comparison or the operand has no
    * lowering here (dyn/jsval/void). */
-  export function lowerLooseNullCompare(L: Lowerer, expr: ts.BinaryExpression, loc: SrcLoc,): IrExpr | null {
+  function lowerLooseNullCompare(L: Lowerer, expr: ts.BinaryExpression, loc: SrcLoc,): IrExpr | null {
     const negated = expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsToken;
     const unwrap = (e: ts.Expression): ts.Expression =>
       ts.isParenthesizedExpression(e) ? unwrap(e.expression) : e;
@@ -2830,7 +2830,7 @@ export function pureReemittable(e: IrExpr): boolean {
    * lowering's re-dispatch walk past its own step. `f?.()` steps stay out
    * (a call carrying the token has no member step to re-enter — the
    * split-it fence keeps them). */
-  export function chainTailDot(
+  function chainTailDot(
     L: Lowerer,
     expr: ts.Expression,
   ): ts.PropertyAccessExpression | ts.ElementAccessExpression | null {
@@ -2890,7 +2890,7 @@ export function pureReemittable(e: IrExpr): boolean {
    * island ('any') receivers answer their tails through their own
    * undefined-propagating reads and stay out; never-nullish receivers fold
    * at the token's own entry. */
-  export function chainTailClaimed(L: Lowerer, expr: ts.Expression): boolean {
+  function chainTailClaimed(L: Lowerer, expr: ts.Expression): boolean {
     const tail = chainTailDot(L, expr);
     if (!tail) return false;
     const recvT = L.mapTypeOf(L.typeOf(tail.expression));
@@ -2904,7 +2904,7 @@ export function pureReemittable(e: IrExpr): boolean {
    * nullish), so a dyn tail read must answer undefined instead of
    * throwing. Walks the receiver spine only; the argument of the access
    * itself is not part of the guard. */
-  export function chainGuardedByQuestionDot(expr: ts.Expression): boolean {
+  function chainGuardedByQuestionDot(expr: ts.Expression): boolean {
     let cur: ts.Expression = expr;
     for (;;) {
       if (ts.isParenthesizedExpression(cur) || ts.isNonNullExpression(cur)) {
@@ -5967,7 +5967,7 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
    * would capture the value under construction (an RC cycle), and the
    * generic lexical-this walk would silently bind an ENCLOSING method's
    * `this`; the fence names the fix (capture a binding instead). */
-  export function rejectThisInObjectAccessor(L: Lowerer, node: ts.Node): void {
+  function rejectThisInObjectAccessor(L: Lowerer, node: ts.Node): void {
     if (node.kind === ts.SyntaxKind.ThisKeyword) {
       L.unsupported(
         "SC1090",
@@ -6584,7 +6584,7 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
    * exactly the key JS derives; negative/computed keys stay runtime
    * expressions and canonicalize through ensureString instead). Null for
    * everything else. */
-  export function recordKeyLiteralText(node: ts.Expression): string | null {
+  function recordKeyLiteralText(node: ts.Expression): string | null {
     if (ts.isStringLiteral(node)) return node.text;
     if (ts.isNumericLiteral(node)) return String(Number(node.text));
     return null;
@@ -6598,7 +6598,7 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
    * are pure, so the static field read may skip evaluating the key exactly
    * like a syntactic literal. Null anywhere the type keeps more than one
    * key. */
-  export function recordKeyTypeLiteralText(L: Lowerer, node: ts.Expression): string | null {
+  function recordKeyTypeLiteralText(L: Lowerer, node: ts.Expression): string | null {
     if (!ts.isIdentifier(node)) return null;
     let t: ts.Type = L.typeOf(node);
     if (t.flags & ts.TypeFlags.TypeParameter) {
@@ -7362,7 +7362,7 @@ export function lowerPrefixUnary(L: Lowerer, expr: ts.PrefixUnaryExpression): Ir
    * backend reads/writes through the box); record fields and array
    * elements keep the fence in value position (statement-position `obj.f++`
    * still desugars through the compound-field path). */
-  export function lowerIncDec(
+  function lowerIncDec(
     L: Lowerer,
     expr: ts.PrefixUnaryExpression | ts.PostfixUnaryExpression,
     prefix: boolean,
@@ -8468,7 +8468,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
    * maybeNarrow's unionNarrow as usual. Null when neither side is a typeof
    * over a union-typed operand or the literal side isn't a literal (the
    * bare-typeof value form then composes with strEq for pure operands). */
-  export function lowerUnionTypeofTest(L: Lowerer, expr: ts.BinaryExpression, loc: SrcLoc): IrExpr | null {
+  function lowerUnionTypeofTest(L: Lowerer, expr: ts.BinaryExpression, loc: SrcLoc): IrExpr | null {
     const negated = expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken;
     for (const [a, b] of [
       [expr.left, expr.right],
@@ -8522,7 +8522,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
    * fence — an object-narrowed `unknown` read has no lowering anyway (a
    * checked cast `v as T` is the supported extraction). Null when neither
    * side is a typeof over a dyn-typed operand (not this pattern). */
-  export function lowerDynTypeofTest(L: Lowerer, expr: ts.BinaryExpression, loc: SrcLoc): IrExpr | null {
+  function lowerDynTypeofTest(L: Lowerer, expr: ts.BinaryExpression, loc: SrcLoc): IrExpr | null {
     const negated = expr.operatorToken.kind === ts.SyntaxKind.ExclamationEqualsEqualsToken;
     for (const [a, b] of [
       [expr.left, expr.right],
@@ -8651,7 +8651,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
    * CJS model types the read off the replacement — identity-blind). Null
    * everywhere else: no replacement, a real attachment of this name, a
    * shadowing binding named `exports`, or write position. */
-  export function lowerReplacedExportsRead(L: Lowerer, expr: ts.PropertyAccessExpression): IrExpr | null {
+  function lowerReplacedExportsRead(L: Lowerer, expr: ts.PropertyAccessExpression): IrExpr | null {
     if (expr.questionDotToken) return null;
     const recv = expr.expression;
     if (!ts.isIdentifier(recv) || recv.text !== "exports") return null;
@@ -8684,7 +8684,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
    * exactly. Null when the identifier doesn't resolve to such a property
    * (or it has no getter: a setter-only read answers undefined in Node —
    * rare enough to keep fenced). */
-  export function cjsExportAccessorRead(L: Lowerer, ident: ts.Identifier): IrExpr | null {
+  function cjsExportAccessorRead(L: Lowerer, ident: ts.Identifier): IrExpr | null {
     const symbol = L.resolveValueSymbol(ident);
     const getter = symbol ? L.checker.declarationsOf(symbol).find(ts.isGetAccessorDeclaration) : undefined;
     if (!getter) return null;
@@ -8718,7 +8718,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
    * expression's `this` is its own). Null everywhere else — non-getter
    * siblings and absent names keep their per-site fences (none of the
    * probed suite shapes read them). */
-  export function lowerCjsExportTableThisMember(L: Lowerer, expr: ts.PropertyAccessExpression): IrExpr | null {
+  function lowerCjsExportTableThisMember(L: Lowerer, expr: ts.PropertyAccessExpression): IrExpr | null {
     if (expr.expression.kind !== ts.SyntaxKind.ThisKeyword || expr.questionDotToken) return null;
     if (!isJsSourceFile(expr.getSourceFile())) return null;
     // The enclosing accessor, crossing only arrow boundaries (arrows
@@ -9251,7 +9251,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
    * idiom over multiple shapes), index-signature keys, class instances,
    * and dyn/unknown stay fenced. Keys are literal strings — a computed key
    * over a shape would need the runtime key table. */
-  export function lowerInExpression(L: Lowerer, expr: ts.BinaryExpression, loc: SrcLoc): IrExpr {
+  function lowerInExpression(L: Lowerer, expr: ts.BinaryExpression, loc: SrcLoc): IrExpr {
     // `#name in obj` — the ergonomic brand check (ES2022) — resolves
     // before any string-key machinery: the left operand is a private
     // NAME, not a value.
@@ -9635,7 +9635,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
    * only needs to track escapes, character classes, and `(` kinds; tsc
    * has already syntax-checked the literal, so a malformed pattern here
    * answers null and the engine's lazy compile reports it. */
-  export function namedCaptureGroupsOfPattern(pattern: string): { name: string; index: number }[] | null {
+  function namedCaptureGroupsOfPattern(pattern: string): { name: string; index: number }[] | null {
     const groups: { name: string; index: number }[] = [];
     let captureIndex = 0;
     let inClass = false;
@@ -9687,7 +9687,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
    * `const regexp = /(?<m>\d+)/` shape), or `new RegExp("...")` over a
    * string literal (the cooked text IS the pattern). Null when the regex
    * only exists at runtime — .groups consumers fence there. */
-  export function staticRegexPatternOf(L: Lowerer, e: ts.Expression): string | null {
+  function staticRegexPatternOf(L: Lowerer, e: ts.Expression): string | null {
     let expr = e;
     for (;;) {
       if (ts.isParenthesizedExpression(expr) || ts.isNonNullExpression(expr)) {
@@ -9850,7 +9850,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
    * prefix (the Object.groupBy stance, ledgered). Null when the receiver
    * isn't a match slice or the regex isn't traceable — the caller's
    * member fence (with the groups hint) names the gap. */
-  export function lowerMatchGroupsRead(L: Lowerer, expr: ts.PropertyAccessExpression): IrExpr | null {
+  function lowerMatchGroupsRead(L: Lowerer, expr: ts.PropertyAccessExpression): IrExpr | null {
     if (expr.name.text !== "groups" || expr.questionDotToken !== undefined) return null;
     const loc = locOf(expr);
     const strArr = arrayOf(STRING);
@@ -10496,7 +10496,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
 
 /** `obj[k]` as an assignable field target — the symbol-keyed twin of
    * fieldTarget's class branch (the receiver lowers here, exactly once). */
-  export function symbolFieldTarget(L: Lowerer, expr: ts.ElementAccessExpression): FieldTarget | null {
+  function symbolFieldTarget(L: Lowerer, expr: ts.ElementAccessExpression): FieldTarget | null {
     const info = symbolFieldInfo(L, expr);
     if (!info) return null;
     const obj = L.lowerExpr(expr.expression);
@@ -10907,7 +10907,7 @@ function lowerStreamObjectProperty(L: Lowerer, expr: ts.PropertyAccessExpression
  * `Number(s)` lowering emits), Boolean the emptiness test. Interning makes
  * every reference the SAME immortal closure, so `opt.type === String`
  * compares like JS function identity. */
-export function primitiveCtorClosure(
+function primitiveCtorClosure(
   L: Lowerer,
   name: "String" | "Number" | "Boolean",
   loc: SrcLoc,

--- a/packages/compiler/src/frontend/lowering/lower-inspect.ts
+++ b/packages/compiler/src/frontend/lowering/lower-inspect.ts
@@ -60,7 +60,7 @@ function concatAll(parts: IrExpr[], loc: SrcLoc): IrExpr {
 /** strEscape's quote ladder over a COMPILE-TIME string (record field
  * names, format-string chunks never pass through here — only keys).
  * Mirrors scr_inspect.c's insp_quote_into byte-for-byte. */
-export function inspectQuote(s: string): string {
+function inspectQuote(s: string): string {
   const hasSingle = s.includes("'");
   const quote = !hasSingle ? "'" : !s.includes('"') ? '"' : !s.includes("`") && !s.includes("${") ? "`" : "'";
   let body = "";
@@ -778,7 +778,7 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
  * exactly as inspect at the given depth. Unions dispatch per arm AT
  * RUNTIME through an interned helper, so a string arm stays verbatim
  * while its sibling arms inspect. Callers check inspectSupport first. */
-export function formatValueExpr(L: Lowerer, t: IrType, value: IrExpr, depth: number, loc: SrcLoc): IrExpr {
+function formatValueExpr(L: Lowerer, t: IrType, value: IrExpr, depth: number, loc: SrcLoc): IrExpr {
   switch (t.kind) {
     case "string":
       return value;

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -3095,7 +3095,7 @@ export function lowerStaticReadableStreamReaderCall(
    * are admitted; engine property names have no identifier restriction. Plain
    * spreads copy through the engine's CopyDataProperties operation in
    * source order, including nested RequestInit/header dictionaries. */
-  export function lowerIslandObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression): IrExpr {
+  function lowerIslandObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression): IrExpr {
     const loc = locOf(expr);
     let args: IrExpr[] = [];
     let acc: IrExpr | null = null;

--- a/packages/compiler/src/frontend/lowering/lower-mixins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-mixins.ts
@@ -226,7 +226,7 @@ export function mixinFnOfCallee(L: Lowerer, callee: ts.Expression): MixinFnShape
 
 /** The arrow/function-expression initializer of a CONST binding — the
  * value-binding spelling of a mixin function declaration. */
-export function mixinFnNodeOfBinding(
+function mixinFnNodeOfBinding(
   decl: ts.VariableDeclaration,
 ): ts.ArrowFunction | ts.FunctionExpression | null {
   if (!ts.isIdentifier(decl.name) || decl.initializer === undefined) return null;

--- a/packages/compiler/src/frontend/lowering/lower-modules.ts
+++ b/packages/compiler/src/frontend/lowering/lower-modules.ts
@@ -71,7 +71,7 @@ export interface FileParts {
    * that is not JSON and not CommonJS-flavored (a CJS namespace is built
    * from module.exports through Node's lexer — a different surface with no
    * static story here). Null for everything else. */
-  export function dynamicImportProgramTargetOf(
+  function dynamicImportProgramTargetOf(
     program: ts.Program,
     sf: ts.SourceFile,
     spec: string,

--- a/packages/compiler/src/frontend/lowering/lower-namespaces.ts
+++ b/packages/compiler/src/frontend/lowering/lower-namespaces.ts
@@ -47,7 +47,7 @@ import { F64, IrExpr, IrStmt, IrType, STRING } from "../../ir/nodes.js";
  * ambient (`declare namespace/module`, `declare global`, string-named
  * modules — .d.ts surface or user-file declares) or a non-instantiated
  * body (only type-world statements inside). */
-export function nsZeroRuntime(decl: ts.ModuleDeclaration): boolean {
+function nsZeroRuntime(decl: ts.ModuleDeclaration): boolean {
   if (isAmbientModuleDecl(decl)) return true;
   if (!ts.isIdentifier(decl.name)) return true; // string-named: ambient by grammar
   return nsTypeOnlyBody(decl);
@@ -55,7 +55,7 @@ export function nsZeroRuntime(decl: ts.ModuleDeclaration): boolean {
 
 /** Ambient module declaration: carries `declare` itself, sits in an
  * ambient ancestor, or is the `declare global` augmentation. */
-export function isAmbientModuleDecl(decl: ts.ModuleDeclaration): boolean {
+function isAmbientModuleDecl(decl: ts.ModuleDeclaration): boolean {
   if (decl.flags & ts.NodeFlags.Ambient) return true;
   for (let p: ts.Node | undefined = decl; p !== undefined && !ts.isSourceFile(p); p = p.parent) {
     if (ts.isModuleDeclaration(p)) {
@@ -89,7 +89,7 @@ function nsTypeOnlyBody(decl: ts.ModuleDeclaration): boolean {
  * declaration's block flattened (the object exists once a block ran;
  * merged ambient declarations don't subtract), "typeOnly"/"ambient" when
  * none did. Null for non-namespace symbols. */
-export function nsSymbolRuntimeKind(L: Lowerer, sym: ts.Symbol): "instantiated" | "typeOnly" | "ambient" | null {
+function nsSymbolRuntimeKind(L: Lowerer, sym: ts.Symbol): "instantiated" | "typeOnly" | "ambient" | null {
   if (!(sym.flags & (ts.SymbolFlags.ValueModule | ts.SymbolFlags.NamespaceModule))) return null;
   let sawTypeOnly = false;
   let sawNamespace = false;
@@ -181,7 +181,7 @@ export function nsPathPrefix(node: ts.Node, modifierDecl?: ts.Node): string {
  * non-instantiated one, whose only value members are import= aliases), or
  * null. The walk stops at class/function boundaries: a static member of a
  * class INSIDE a namespace is the class's business, not the namespace's. */
-export function nsBlockKindOfSymbol(L: Lowerer, sym: ts.Symbol): "flattened" | "typeOnly" | null {
+function nsBlockKindOfSymbol(L: Lowerer, sym: ts.Symbol): "flattened" | "typeOnly" | null {
   for (const d of L.checker.declarationsOf(sym)) {
     // TYPE declarations don't make a member a namespace VALUE: a class
     // static `C.B` whose name also carries `namespace C { export
@@ -219,7 +219,7 @@ export function nsBlockKindOfSymbol(L: Lowerer, sym: ts.Symbol): "flattened" | "
  * Builtin/stdlib module namespaces (string-named ambient modules in
  * .d.ts files) and npm packages answer null — their own chokepoints and
  * fences keep ownership. */
-export function moduleNsSourceFileOf(L: Lowerer, e: ts.Expression): ts.SourceFile | null {
+function moduleNsSourceFileOf(L: Lowerer, e: ts.Expression): ts.SourceFile | null {
   let sym: ts.Symbol | undefined;
   if (ts.isIdentifier(e)) {
     sym = L.checker.getSymbolAtLocation(e);

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -27,15 +27,6 @@ import {
 } from "./surfaces.js";
 import { conditionalSpreadOf } from "./lower-exprs.js";
 
-/** The lowered value members of the net module — the surfaces.ts table's
- * spoke-side twin (the call SHAPES are all special-cased here, so the
- * entries carry no param/result rows). */
-export const NET_MODULE_FNS: ReadonlySet<string> = new Set([
-  "createServer",
-  "connect",
-  "createConnection",
-]);
-
 const NARROW_DATA_HINT =
   'write/end take one string or one Uint8Array/Buffer value (narrow unions first)';
 
@@ -4333,7 +4324,7 @@ export function lowerSocketInstanceOf(L: Lowerer, expr: ts.BinaryExpression, loc
 
 /** True when `node` reads `.headers` off an IncomingMessage — the
  * receiver shape of both header-read forms. */
-export function isHttpReqHeaders(L: Lowerer, node: ts.Expression): boolean {
+function isHttpReqHeaders(L: Lowerer, node: ts.Expression): boolean {
   return (
     ts.isPropertyAccessExpression(node) &&
     !node.questionDotToken &&

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -437,7 +437,7 @@ export function provenanceElidedConstDecl(L: Lowerer, decl: ts.VariableDeclarati
    * a loop re-ASSIGNS the one binding per pass and never resets it — the
    * classic capture semantics fall out: closures made in a loop share the
    * single boxed binding, where `let` gets a fresh box per iteration. */
-  export function hoistVarBinding(L: Lowerer, symbol: ts.Symbol, nameNode: ts.Identifier): IrLocal {
+  function hoistVarBinding(L: Lowerer, symbol: ts.Symbol, nameNode: ts.Identifier): IrLocal {
     const existing = L.hoistedVars.get(symbol);
     if (existing) return existing;
     // The parameter merge: the symbol already binds a function-root local.
@@ -625,7 +625,7 @@ export function provenanceElidedConstDecl(L: Lowerer, decl: ts.VariableDeclarati
    * after consuming them: an unused label costs nothing, and a labeled
    * jump naming one fences by name at the jump site instead of compiling
    * against the wrong target. */
-  export function lowerLabeled(L: Lowerer, stmt: ts.LabeledStatement): IrStmt | IrStmt[] | null {
+  function lowerLabeled(L: Lowerer, stmt: ts.LabeledStatement): IrStmt | IrStmt[] | null {
     const labels: string[] = [];
     let inner: ts.Statement = stmt;
     while (ts.isLabeledStatement(inner)) {
@@ -1959,7 +1959,7 @@ export function isParseArgsDynCheckerType(L: Lowerer, type: ts.Type): boolean {
    * source's field under exactly that name, and pure keys make skipping
    * the evaluation exact). Null for runtime-valued keys — the callers
    * fence, or route island sources to the engine pattern. */
-  export function patternKeyNameOf(L: Lowerer, prop: ts.PropertyName): string | null {
+  function patternKeyNameOf(L: Lowerer, prop: ts.PropertyName): string | null {
     if (ts.isIdentifier(prop) || ts.isPrivateIdentifier(prop)) return prop.text;
     if (ts.isComputedPropertyName(prop)) return L.foldedStringKeyOf(prop.expression);
     // A numeric-literal key spells JS's canonical ToPropertyKey form
@@ -2636,7 +2636,7 @@ export function isParseArgsDynCheckerType(L: Lowerer, type: ts.Type): boolean {
    * Null when any element has no engine form (computed keys — a compiled
    * expression the pattern text cannot carry — or untransportable
    * defaults). */
-  export function enginePatternSpec(L: Lowerer, pattern: ts.ArrayBindingPattern | ts.ObjectBindingPattern,
+  function enginePatternSpec(L: Lowerer, pattern: ts.ArrayBindingPattern | ts.ObjectBindingPattern,
   ): { text: string; binds: ts.Identifier[]; extras: ts.Expression[] } | null {
     const binds: ts.Identifier[] = [];
     const extras: ts.Expression[] = [];
@@ -3583,7 +3583,7 @@ export function lowerVarDecl(L: Lowerer, decl: ts.VariableDeclaration, isLet: bo
    *   the chain's final else reproduces that as long as its body exits or
    *   is last).
    * Case bodies share ONE lexical scope, exactly like the real switch. */
-  export function lowerUnionSwitch(L: Lowerer, stmt: ts.SwitchStatement, disc: IrExpr): IrStmt {
+  function lowerUnionSwitch(L: Lowerer, stmt: ts.SwitchStatement, disc: IrExpr): IrStmt {
     const loc = locOf(stmt);
     if (disc.type.kind !== "union") throw new Error("lowerer bug: non-union disc");
     const unionType = disc.type;
@@ -6558,7 +6558,7 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
 /** A DIRECT `s.matchAll(re)` call: a stdlib matchAll property call on a
    * string-typed receiver with one regex-typed argument (parens stripped).
    * The shape the companion-index machinery serves. */
-  export function directMatchAllCallOf(L: Lowerer, e: ts.Expression): ts.CallExpression | null {
+  function directMatchAllCallOf(L: Lowerer, e: ts.Expression): ts.CallExpression | null {
     let src = e;
     while (ts.isParenthesizedExpression(src)) src = src.expression;
     if (
@@ -7213,7 +7213,7 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
    * local, `var` assigns the hoisted shared slot, a pre-declared
    * identifier target assigns per pass; destructuring heads are tsc
    * errors. */
-  export function lowerForIn(L: Lowerer, stmt: ts.ForInStatement): IrStmt {
+  function lowerForIn(L: Lowerer, stmt: ts.ForInStatement): IrStmt {
     const labels = L.takeLabels();
     const loc = locOf(stmt);
     if (stdlibGlobalNameOf(L, stmt.expression) === "globalThis") {

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -154,7 +154,7 @@ export function own<T>(table: Record<string, T | undefined>, key: string): T | u
 /** Sentinel binding key for `this` (which has no ts.Symbol): a stable
  * object identity used in the same scope/capture maps as real symbols, so
  * arrows capturing `this` ride the ordinary capture machinery. */
-export const THIS_BINDING = { escapedName: "%this" } as unknown as ts.Symbol;
+const THIS_BINDING = { escapedName: "%this" } as unknown as ts.Symbol;
 
 /* ── the island boundary, in one voice ────────────────────────────────
  * Whether a value can cross between the static world and the island is
@@ -250,7 +250,7 @@ export interface LowerStats {
  * visit; descending would attribute a nested island statement to every
  * enclosing construct too). The top-level statement object itself is
  * always visited. */
-export const IR_STMT_KINDS = new Set([
+const IR_STMT_KINDS = new Set([
   "varDecl", "assign", "exprStmt", "if", "while", "doWhile", "switch",
   "arraySet", "forOf", "return", "fieldSet", "recordSet", "break",
   "continue", "block", "tryCatch", "throw", "rethrow", "runtimeFence",

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -433,9 +433,9 @@ export interface IslandFnEntry {
   ret: IrType;
 }
 
-export const ISL_N1: IslandFnEntry = { args: [F64], ret: F64 };
+const ISL_N1: IslandFnEntry = { args: [F64], ret: F64 };
 
-export const ISL_N2: IslandFnEntry = { args: [F64, F64], ret: F64 };
+const ISL_N2: IslandFnEntry = { args: [F64, F64], ret: F64 };
 
 export const boundaryIntoIslandMsg = (typeName: string): string =>
   `passing a value of type '${typeName}' into dynamically-executed ('any'-typed) code ` +
@@ -782,7 +782,7 @@ export const BUILTIN_MODULE_FNS: Record<string, Record<string, BuiltinModuleFn |
   // node:net and node:http lower ENTIRELY through the server spoke
   // (lower-server.ts — every call shape is special-cased: closures, the
   // optional connect host, writeHead's literal headers); the member list
-  // is NET_MODULE_FNS there. The modules still need keys here so future
+  // is the lower-server dispatch there. The modules still need keys here so future
   // table entries have a home, and so the "recognized module, unlowered
   // member" fence wording applies.
   net: {
@@ -1140,7 +1140,7 @@ const URL_WIN32_MODULE_FNS: Record<string, BuiltinModuleFn | undefined> = {
  * TARGET: a win32 triple compiles Node-on-Windows semantics — `path` is
  * path.win32 and url's bridge takes the win32 flavors. Fence wording is
  * unaffected — callers keep naming the module the source spelled. */
-export function builtinModuleFnsOf(L: Lowerer, module: string): Record<string, BuiltinModuleFn | undefined> | undefined {
+function builtinModuleFnsOf(L: Lowerer, module: string): Record<string, BuiltinModuleFn | undefined> | undefined {
   if (L.targetPlatform === "win32") {
     if (module === "path") return BUILTIN_MODULE_FNS["path/win32"];
     if (module === "url") return URL_WIN32_MODULE_FNS;
@@ -1199,7 +1199,7 @@ export function builtinConstLit(value: string | number | boolean, loc: { file: s
  * Node ships one frozen singleton; each read here mints a fresh string
  * array — a divergence only mutation could observe, and mutating Node's
  * frozen array throws anyway. */
-export const NODE_BUILTIN_MODULES_V24: readonly string[] = [
+const NODE_BUILTIN_MODULES_V24: readonly string[] = [
   "_http_agent", "_http_client", "_http_common", "_http_incoming",
   "_http_outgoing", "_http_server", "_stream_duplex", "_stream_passthrough",
   "_stream_readable", "_stream_transform", "_stream_wrap", "_stream_writable",
@@ -1233,7 +1233,7 @@ export function builtinModulesArrayLit(loc: { file: string; start: number; end: 
 /** Member-specific hints for RECOGNIZED builtin modules whose member has
  * no lowering. deflateSync/inflateSync lower now (Buffers are real);
  * the rest of the zlib surface points at the lowered pair. */
-export const ZLIB_HINT =
+const ZLIB_HINT =
   "deflateSync and inflateSync are the lowered zlib surface";
 
 /** The loose-equality quartet's shared hint: == coercion has no lowering

--- a/packages/compiler/src/frontend/npm-static.ts
+++ b/packages/compiler/src/frontend/npm-static.ts
@@ -82,10 +82,6 @@ export function npmStaticActive(): boolean {
   return activePackages.size > 0;
 }
 
-export function npmStaticPackages(): ReadonlySet<string> {
-  return activePackages;
-}
-
 export function isNpmStaticPackage(name: string | null): boolean {
   return name !== null && activePackages.has(name);
 }
@@ -242,7 +238,7 @@ export function npmStaticTransformPkgJson(pkg: Record<string, unknown>): void {
 /** npmStaticTransformPkgJson over a package.json TEXT (the fs shadow's
  * form). Malformed documents pass through untouched — resolution reports
  * them exactly as it always did. */
-export function npmStaticTransformPkgJsonText(text: string): string {
+function npmStaticTransformPkgJsonText(text: string): string {
   let doc: unknown;
   try {
     doc = JSON.parse(text);
@@ -423,13 +419,13 @@ const TRANSFORM_MARKERS = ["__webpack_require__"];
 /** Unminified-JS heuristic over an entry source: at least two lines and
  * an average line length under 200 characters (minified dists are one
  * enormous line; readable code averages well under 100). */
-export function looksUnminified(source: string): boolean {
+function looksUnminified(source: string): boolean {
   const lines = source.split("\n");
   if (lines.length < 2) return false;
   return source.length / lines.length <= 200;
 }
 
-export function hasTransformMarkers(source: string): boolean {
+function hasTransformMarkers(source: string): boolean {
   return TRANSFORM_MARKERS.some((m) => source.includes(m));
 }
 

--- a/packages/compiler/src/frontend/npm.ts
+++ b/packages/compiler/src/frontend/npm.ts
@@ -135,7 +135,7 @@ export interface EmbeddedModule {
  * guard). Export names that aren't identifiers ("dash-name") use string
  * ModuleExportNames — every name does, uniformly; the locals are e0, e1, …
  * temps. */
-export function cjsEsmFacadeSource(key: string, names: readonly string[]): string {
+function cjsEsmFacadeSource(key: string, names: readonly string[]): string {
   const uniq = [...new Set(names)].filter((n) => n !== "default" && n !== "module.exports");
   const parts = [
     `const m=globalThis.__scr_require(${JSON.stringify(key)});`,
@@ -1796,13 +1796,4 @@ export class NpmGraphBuilder {
       }
     }
   }
-}
-
-/** One-call convenience over NpmGraphBuilder. */
-export function buildNpmRuntimeGraph(
-  imports: readonly { fromFile: string; specifier: string }[],
-): NpmRuntimeGraph {
-  const b = new NpmGraphBuilder();
-  for (const i of imports) b.addImport(i.fromFile, i.specifier);
-  return b.finish();
 }

--- a/packages/compiler/src/frontend/provenance-registry.ts
+++ b/packages/compiler/src/frontend/provenance-registry.ts
@@ -105,15 +105,6 @@ export function isProvenanceSourceFile(fileName: string): boolean {
   return false;
 }
 
-/** The registered package owning `fileName`, or null. */
-export function provenancePackageOfFile(fileName: string): ProvenancePackageSource | null {
-  if (state === null) return null;
-  for (let i = 0; i < state.packageDirs.length; i++) {
-    if (fileName.startsWith(state.packageDirs[i]!)) return state.sources.packages[i]!;
-  }
-  return null;
-}
-
 /** tsconfig "paths" for the registered entries — loadProgram feeds these
  * to tsgo so the checker resolves registered bare specifiers to the same
  * source files the preflight resolver answers. */

--- a/packages/compiler/src/frontend/ts7/world-check.ts
+++ b/packages/compiler/src/frontend/ts7/world-check.ts
@@ -20,7 +20,7 @@
 import type ts5 from "typescript5";
 import type * as ts7 from "./adapter.js";
 
-export function assertWorldsAreDisjoint(
+function assertWorldsAreDisjoint(
   node5: ts5.Node,
   node7: ts7.Node,
   file5: ts5.SourceFile,
@@ -42,3 +42,5 @@ export function assertWorldsAreDisjoint(
   const _f: ts5.SyntaxKind = kind7;
   void [_a, _b, _c, _d, _e, _f];
 }
+
+void assertWorldsAreDisjoint;

--- a/packages/compiler/src/frontend/types.ts
+++ b/packages/compiler/src/frontend/types.ts
@@ -551,7 +551,7 @@ export function formatIrType(t: IrType, shapes: ShapeRegistry, unions: UnionRegi
  * first in ascending numeric order, everything else follows in the given
  * (insertion/declaration) order. This is JS's enumeration order for the
  * objects records model — Object.keys, JSON.stringify, spread, inspect. */
-export function esOwnKeyOrder(names: string[]): string[] {
+function esOwnKeyOrder(names: string[]): string[] {
   const isArrayIndex = (name: string): boolean => {
     const n = Number(name);
     return Number.isInteger(n) && n >= 0 && n < 4294967295 && String(n) === name;
@@ -3578,7 +3578,7 @@ const STDLIB_CONTAINERS: Record<string, { role: (i: number) => string }> = {
  * machinery), promises, regexes, generators, handles, nested unions —
  * would DEGRADE (identity, methods, dispatch) riding dyn, so those arms
  * keep their existing homes and fences. */
-export function dynSubsumableUnionArm(arm: IrType, ctx: TypeMapperCtx): boolean {
+function dynSubsumableUnionArm(arm: IrType, ctx: TypeMapperCtx): boolean {
   switch (arm.kind) {
     case "dyn":
     case "f64":

--- a/packages/compiler/src/library/int-infer.ts
+++ b/packages/compiler/src/library/int-infer.ts
@@ -106,7 +106,7 @@ export interface AbsVal {
 
 const normZero = (x: number): number => (Object.is(x, -0) ? 0 : x);
 
-export function absVal(lo: number, hi: number, whole: boolean, maybeNaN: boolean, spelling?: string): AbsVal {
+function absVal(lo: number, hi: number, whole: boolean, maybeNaN: boolean, spelling?: string): AbsVal {
   lo = normZero(lo);
   hi = normZero(hi);
   // Infinities are not integers: a set with a non-finite bound may
@@ -118,22 +118,22 @@ export function absVal(lo: number, hi: number, whole: boolean, maybeNaN: boolean
 }
 
 /** Any f64 a caller could pass — unbounded, not whole, NaN included. */
-export const TOP: AbsVal = { lo: -Infinity, hi: Infinity, whole: false, maybeNaN: true };
+const TOP: AbsVal = { lo: -Infinity, hi: Infinity, whole: false, maybeNaN: true };
 /** The empty set (unreachable): lo > hi and no NaN. */
-export const BOTTOM: AbsVal = { lo: Infinity, hi: -Infinity, whole: true, maybeNaN: false };
+const BOTTOM: AbsVal = { lo: Infinity, hi: -Infinity, whole: true, maybeNaN: false };
 
-export const isBottom = (v: AbsVal): boolean => v.lo > v.hi && !v.maybeNaN;
-export const isSingleton = (v: AbsVal): boolean => v.lo === v.hi && !v.maybeNaN;
+const isBottom = (v: AbsVal): boolean => v.lo > v.hi && !v.maybeNaN;
+const isSingleton = (v: AbsVal): boolean => v.lo === v.hi && !v.maybeNaN;
 const hasNumeric = (v: AbsVal): boolean => v.lo <= v.hi;
 
-export function constVal(value: number, spelling?: string): AbsVal {
+function constVal(value: number, spelling?: string): AbsVal {
   if (Number.isNaN(value)) return { lo: Infinity, hi: -Infinity, whole: false, maybeNaN: true };
   return absVal(value, value, Number.isInteger(value), false, spelling);
 }
 
 /** Least upper bound: interval hull, wholeness/NaN pessimism, spelling
  * kept only when both sides carry the same one. */
-export function join(a: AbsVal, b: AbsVal): AbsVal {
+function join(a: AbsVal, b: AbsVal): AbsVal {
   if (isBottom(a)) return b;
   if (isBottom(b)) return a;
   const numA = hasNumeric(a);
@@ -145,7 +145,7 @@ export function join(a: AbsVal, b: AbsVal): AbsVal {
   return absVal(lo, hi, whole, a.maybeNaN || b.maybeNaN, spelling);
 }
 
-export function sameVal(a: AbsVal, b: AbsVal): boolean {
+function sameVal(a: AbsVal, b: AbsVal): boolean {
   return a.lo === b.lo && a.hi === b.hi && a.whole === b.whole && a.maybeNaN === b.maybeNaN && a.spelling === b.spelling;
 }
 
@@ -157,7 +157,7 @@ export function sameVal(a: AbsVal, b: AbsVal): boolean {
 const WIDEN_THRESHOLDS = [0, 2 ** 31 - 1, 2 ** 32 - 1, SAFE_MAX, Infinity];
 const WIDEN_THRESHOLDS_NEG = [0, -(2 ** 31), SAFE_MIN, -Infinity];
 
-export function widen(prev: AbsVal, next: AbsVal): AbsVal {
+function widen(prev: AbsVal, next: AbsVal): AbsVal {
   if (isBottom(prev)) return next;
   let lo = next.lo;
   let hi = next.hi;
@@ -277,17 +277,17 @@ function transferBitwise(op: IrNumBinOp, a: AbsVal, b: AbsVal): AbsVal {
 }
 
 /** JS `~`: ToInt32, complement — whole, int32 range, whatever the input. */
-export function transferBitNot(a: AbsVal): AbsVal {
+function transferBitNot(a: AbsVal): AbsVal {
   if (isSingleton(a)) return constVal(~a.lo);
   return absVal(-(2 ** 31), 2 ** 31 - 1, true, false);
 }
 
-export function transferNeg(a: AbsVal): AbsVal {
+function transferNeg(a: AbsVal): AbsVal {
   if (!hasNumeric(a)) return { ...BOTTOM, maybeNaN: a.maybeNaN };
   return absVal(-a.hi, -a.lo, a.whole, a.maybeNaN);
 }
 
-export function transferBin(op: IrNumBinOp, a: AbsVal, b: AbsVal): AbsVal {
+function transferBin(op: IrNumBinOp, a: AbsVal, b: AbsVal): AbsVal {
   switch (op) {
     case "+": return transferAdd(a, b);
     case "-": return transferSub(a, b);
@@ -307,20 +307,20 @@ export function transferBin(op: IrNumBinOp, a: AbsVal, b: AbsVal): AbsVal {
  * input maps to a whole output, so these discharge the WHOLENESS
  * obligation. They do not discharge range (an unbounded input stays
  * unbounded) or NaN (Math.trunc(NaN) is NaN — maybeNaN propagates). */
-export function transferMathRound(fn: "trunc" | "floor" | "ceil" | "round", a: AbsVal): AbsVal {
+function transferMathRound(fn: "trunc" | "floor" | "ceil" | "round", a: AbsVal): AbsVal {
   if (!hasNumeric(a)) return { ...BOTTOM, maybeNaN: a.maybeNaN };
   const f = fn === "trunc" ? Math.trunc : fn === "floor" ? Math.floor : fn === "ceil" ? Math.ceil : Math.round;
   return absVal(f(a.lo), f(a.hi), true, a.maybeNaN);
 }
 
-export function transferAbs(a: AbsVal): AbsVal {
+function transferAbs(a: AbsVal): AbsVal {
   if (!hasNumeric(a)) return { ...BOTTOM, maybeNaN: a.maybeNaN };
   const lo = a.lo <= 0 && a.hi >= 0 ? 0 : Math.min(Math.abs(a.lo), Math.abs(a.hi));
   return absVal(lo, Math.max(Math.abs(a.lo), Math.abs(a.hi)), a.whole, a.maybeNaN);
 }
 
 /** Math.min/max propagate NaN from ANY argument, exactly as JS does. */
-export function transferMinMax(fn: "min" | "max", args: AbsVal[]): AbsVal {
+function transferMinMax(fn: "min" | "max", args: AbsVal[]): AbsVal {
   const maybeNaN = args.some((v) => v.maybeNaN);
   if (args.some((v) => !hasNumeric(v))) return { ...BOTTOM, maybeNaN };
   const lo = fn === "min" ? Math.min(...args.map((v) => v.lo)) : Math.max(...args.map((v) => v.lo));
@@ -354,7 +354,7 @@ export interface IntVerdict {
 /** Does an integer literal's source spelling survive the trip through
  * f64? Parse, convert, format back, compare (numeric separators were
  * stripped by the frontend — they are spelling sugar, not value). */
-export function spellingRoundTrips(spelling: string): boolean {
+function spellingRoundTrips(spelling: string): boolean {
   return String(Number(spelling)) === spelling;
 }
 
@@ -363,7 +363,7 @@ export function spellingRoundTrips(spelling: string): boolean {
  * fractional wholeness — the FIRST failure names the refusal (a value
  * both fractional and out of range hears about the more fundamental
  * problem). */
-export function checkBoundary(v: AbsVal, path: string, cls: IntClass, loc: SrcLoc): IntVerdict {
+function checkBoundary(v: AbsVal, path: string, cls: IntClass, loc: SrcLoc): IntVerdict {
   // Representability first: the author wrote a number the program never held.
   if (v.spelling !== undefined && !spellingRoundTrips(v.spelling)) {
     return {

--- a/packages/compiler/src/library/profile.ts
+++ b/packages/compiler/src/library/profile.ts
@@ -261,8 +261,7 @@ export const LIB_PARAM_CLASSES = ["f64", "bool", "string", "bytes", "u8", "u32",
 export const LIB_RETURN_CLASSES = ["f64", "bool", "string", "bytes", "void", "i64", "u64"] as const;
 
 /** Ask 4's declared integer classes (the prove-or-refuse pair). */
-export const LIB_INT_CLASSES = ["i64", "u64"] as const;
-export type LibIntClass = (typeof LIB_INT_CLASSES)[number];
+export type LibIntClass = "i64" | "u64";
 
 export type LibParamClass = (typeof LIB_PARAM_CLASSES)[number];
 export type LibReturnClass = (typeof LIB_RETURN_CLASSES)[number];
@@ -274,15 +273,15 @@ export type LibReturnClass = (typeof LIB_RETURN_CLASSES)[number];
  * declared integer classes stay export-map surface: an outbound i64/u64
  * demands the prove-or-refuse machinery, which is scoped to export
  * returns today. */
-export const LIB_CALLBACK_PARAM_CLASSES = ["f64", "bool", "string", "bytes", "u8", "u32", "i32"] as const;
+const LIB_CALLBACK_PARAM_CLASSES = ["f64", "bool", "string", "bytes", "u8", "u32", "i32"] as const;
 /** Marshalling classes legal in a CALLBACK RETURN position (inbound: host
  * → compiled code). Scalars only — every conversion to f64 is exact by
  * construction; a buffer return would need an ownership contract the mode
  * does not define (the FFI format-1 ruling). */
-export const LIB_CALLBACK_RETURN_CLASSES = ["f64", "bool", "u8", "u32", "i32", "void"] as const;
+const LIB_CALLBACK_RETURN_CLASSES = ["f64", "bool", "u8", "u32", "i32", "void"] as const;
 /** The runtime's fixed channel-slot capacity (scr_library.c's
  * SCR_LIB_MAX_CALLBACKS — keep the two in step). */
-export const LIB_MAX_CALLBACKS = 32;
+const LIB_MAX_CALLBACKS = 32;
 
 export type LibCallbackParamClass = (typeof LIB_CALLBACK_PARAM_CLASSES)[number];
 export type LibCallbackReturnClass = (typeof LIB_CALLBACK_RETURN_CLASSES)[number];


### PR DESCRIPTION
- Make file-local compiler helpers private across frontend and backend modules
- Remove dead declarations exposed by the tighter module boundaries
- Preserve tested IR deserialization and generated manifest dependencies