### PR TITLE
fix(compiler): reset module caches between compiles

### DIFF
--- a/packages/compiler/src/backend/cc-cache.test.ts
+++ b/packages/compiler/src/backend/cc-cache.test.ts
@@ -456,6 +456,73 @@ test("implicit dependency seeds include separately compiled vendor system header
   expect(includes).toContain("<stdatomic.h>");
 });
 
+test.skipIf(
+  process.platform === "win32" || clangExecutable === undefined || arExecutable === undefined ||
+  ldExecutable === undefined,
+)(
+  "public native builds re-probe ccache availability after PATH changes",
+  async () => {
+    const dir = await mkdtemp(join(tmpdir(), "scriptc-ccache-reset-"));
+    scratch.push(dir);
+    const binDir = join(dir, "bin");
+    const cacheRoot = join(dir, "cache");
+    const cPath = join(dir, "program.c");
+    const ccacheLog = join(dir, "ccache.log");
+    const oldCacheDir = process.env["SCRIPTC_CACHE_DIR"];
+    const oldNoCache = process.env["SCRIPTC_NO_CACHE"];
+    const oldPath = process.env["PATH"];
+    const oldCcacheLog = process.env["SCRIPTC_TEST_CCACHE_LOG"];
+
+    try {
+      await Promise.all([mkdir(binDir), mkdir(cacheRoot, { mode: 0o700 })]);
+      await Promise.all([
+        symlink(clangExecutable!, join(binDir, "clang")),
+        symlink(arExecutable!, join(binDir, "ar")),
+        symlink(ldExecutable!, join(binDir, "ld")),
+        writeFile(cPath, "int main(void) { return 0; }\n"),
+      ]);
+      process.env["SCRIPTC_CACHE_DIR"] = cacheRoot;
+      process.env["PATH"] = binDir;
+      delete process.env["SCRIPTC_NO_CACHE"];
+
+      await compileC({
+        cPath,
+        outPath: join(dir, "first"),
+        cacheIdentity: TEST_CACHE_IDENTITY,
+        regex: true,
+      });
+
+      await writeFile(
+        join(binDir, "ccache"),
+        `#!/bin/sh
+if [ "$1" = "--version" ]; then exit 0; fi
+printf '%s\n' "$*" >> "$SCRIPTC_TEST_CCACHE_LOG"
+exec "$@"
+`,
+      );
+      await chmod(join(binDir, "ccache"), 0o755);
+      process.env["SCRIPTC_TEST_CCACHE_LOG"] = ccacheLog;
+
+      await compileC({
+        cPath,
+        outPath: join(dir, "second"),
+        cacheIdentity: TEST_CACHE_IDENTITY,
+        dynamic: true,
+      });
+      expect((await readFile(ccacheLog, "utf8")).trim()).not.toBe("");
+    } finally {
+      if (oldCacheDir === undefined) delete process.env["SCRIPTC_CACHE_DIR"];
+      else process.env["SCRIPTC_CACHE_DIR"] = oldCacheDir;
+      if (oldNoCache === undefined) delete process.env["SCRIPTC_NO_CACHE"];
+      else process.env["SCRIPTC_NO_CACHE"] = oldNoCache;
+      if (oldPath === undefined) delete process.env["PATH"];
+      else process.env["PATH"] = oldPath;
+      if (oldCcacheLog === undefined) delete process.env["SCRIPTC_TEST_CCACHE_LOG"];
+      else process.env["SCRIPTC_TEST_CCACHE_LOG"] = oldCcacheLog;
+    }
+  },
+);
+
 test.skipIf(process.platform === "win32")(
   "opaque compiler wrappers bypass persistent caches",
   async () => {

--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -1618,6 +1618,7 @@ async function resolveProgramShardMergeIdentity(driver: CcDriver): Promise<strin
 }
 
 export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> {
+  clearCcCaches();
   const rtDir = runtimeSrcDir();
   const driver = resolveCc();
   const shardNames = new Set<string>();
@@ -3839,6 +3840,14 @@ function implicitLinkerFingerprint(
 }
 
 let ccacheMemo: Promise<boolean> | null = null;
+
+/** Reset process observations whose validity is bounded to one public native
+ * build. A long-lived caller may change PATH or install/remove ccache between
+ * invocations; the next build must probe that environment again. */
+export function clearCcCaches(): void {
+  ccacheMemo = null;
+}
+
 function ccacheAvailable(): Promise<boolean> {
   ccacheMemo ??= execFileAsync("ccache", ["--version"]).then(
     () => true,
@@ -5947,6 +5956,7 @@ async function compileCInternal(
 }
 
 export async function compileC(opts: CcOptions): Promise<void> {
+  clearCcCaches();
   await compileCInternal(opts, false);
 }
 
@@ -5981,6 +5991,7 @@ export function supportedNativeCacheWarmProfiles(
 export async function warmNativeCaches(
   options: WarmNativeCachesOptions = {},
 ): Promise<WarmNativeCachesResult> {
+  clearCcCaches();
   const cacheRoot = cacheRootDir();
   if (cacheRoot === null) {
     throw new Error(

--- a/packages/compiler/src/frontend/resolve.test.ts
+++ b/packages/compiler/src/frontend/resolve.test.ts
@@ -1,0 +1,30 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { expect, test } from "vitest";
+import { clearResolveCaches, projectDtsRuntimeSibling, setProjectRealm } from "./resolve.js";
+
+test("resolver reset clears the active project package realm", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "scriptc-resolve-reset-"));
+  try {
+    const src = join(dir, "src");
+    const declaration = join(src, "value.d.ts");
+    const runtime = join(src, "value.js");
+    await mkdir(src);
+    await Promise.all([
+      writeFile(join(dir, "package.json"), '{"type":"module"}\n'),
+      writeFile(declaration, "export declare const value: number;\n"),
+      writeFile(runtime, "export const value = 1;\n"),
+    ]);
+
+    clearResolveCaches();
+    setProjectRealm(join(src, "main.ts"));
+    expect(projectDtsRuntimeSibling(declaration)).toBe(runtime);
+
+    clearResolveCaches();
+    expect(projectDtsRuntimeSibling(declaration)).toBeNull();
+  } finally {
+    clearResolveCaches();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/compiler/src/frontend/resolve.ts
+++ b/packages/compiler/src/frontend/resolve.ts
@@ -826,11 +826,12 @@ export function resolveTypeDirective(name: string, fromFile: string): string | n
   }
 }
 
-/** Test hook: the package.json cache holds across programs (fine within one
- * compile; a long-lived test process editing fixtures must reset it). */
+/** Resolver metadata and the active project realm are shared within one
+ * compile, never across compiles in a long-lived process. */
 export function clearResolveCaches(): void {
   pkgJsonCache.clear();
   workspaceMembersCache.clear();
+  projectRealmPkgJson = null;
 }
 
 /** True when `path` is under a node_modules directory (the

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -1,6 +1,6 @@
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { basename, dirname, join, resolve } from "node:path";
-import { buildCacheRoot, CcCompileError, compileC, compileLibArchive, executableNativeEnvironmentFingerprint, mobileLibraryTarget, mobileTargetRefusal, prepareBuildCacheRoot, pruneBuildCache, resolveCc, targetPlatform } from "./backend/cc.js";
+import { buildCacheRoot, CcCompileError, clearCcCaches, compileC, compileLibArchive, executableNativeEnvironmentFingerprint, mobileLibraryTarget, mobileTargetRefusal, prepareBuildCacheRoot, pruneBuildCache, resolveCc, targetPlatform } from "./backend/cc.js";
 import { emitModule } from "./backend/emission/emitter.js";
 import { emitLlvmModule, LlvmUnsupportedError } from "./backend/llvm/emitter.js";
 import { splitLlvmLibraryProgram, splitLlvmProgram } from "./backend/llvm/split.js";
@@ -8,12 +8,13 @@ import { rebaseLibrarySourceComments, replaceLibraryIdentity, stripLibraryIdenti
 import { checkerPanicDiag, ffiNativeBuildDiag, libAsyncExportDiag, libAsyncSurfaceDiag, libExportUnresolvedDiag, libGenericExportDiag, libIntBoundaryDiag, libNpmIneligibleDiag, libSidecarDiag, libUnmappableSignatureDiag, iceDiag, isCheckerPanic, LIB_INBOUND_BYTES_TRAP_CODE, LIB_RUNTIME_TRAP_CODES, type ScrDiagnostic } from "./diagnostics/diagnostic.js";
 import { checkLibraryIntegerSlots, classSeed, hasIntSlots, numberCarrierKind, type FnIntSlots, type IntSlotConfig } from "./library/int-infer.js";
 import { loadLibraryProfile, profileRemediation, profileTeaching, type LibraryProfile } from "./library/profile.js";
-import { decorateLibraryRefusals, evaluateLibraryFences } from "./library/fence-eval.js";
+import { clearFenceEvalCaches, decorateLibraryRefusals, evaluateLibraryFences } from "./library/fence-eval.js";
 import { assembleTrapTeaching } from "./library/trap-teaching.js";
 import {
   buildSidecar,
   canonicalModuleGraph,
   canonicalPath,
+  clearSidecarCaches,
   compilerReleaseVersion,
   libraryIdentityHashes,
   updateSidecarIdentity,
@@ -850,7 +851,15 @@ export function analyze(entryPath: string, opts: AnalyzeOptions = {}): AnalyzeRe
 }
 
 /** The whole pipeline: load → preflight → lower → validate → emit C → clang. */
+function clearCompileSessionCaches(): void {
+  clearResolveCaches();
+  clearCcCaches();
+  clearSidecarCaches();
+  clearFenceEvalCaches();
+}
+
 export async function compile(entryPath: string, opts: CompileOptions): Promise<CompileResult> {
+  clearCompileSessionCaches();
   const frontendInputs = new FrontendInputTracker();
   return frontendInputs.run(() => compileTracked(entryPath, opts, frontendInputs));
 }
@@ -1878,6 +1887,7 @@ async function emitSemanticLibraryHit(
 }
 
 export async function compileLibrary(opts: CompileLibraryOptions): Promise<CompileLibraryResult> {
+  clearCompileSessionCaches();
   const frontendInputs = new FrontendInputTracker();
   return frontendInputs.run(() => compileLibraryTracked(opts, frontendInputs));
 }

--- a/packages/compiler/src/library/cache-reset-fixtures/profile.json
+++ b/packages/compiler/src/library/cache-reset-fixtures/profile.json
@@ -1,0 +1,19 @@
+{
+  "profile_format": 1,
+  "name": "cache-reset",
+  "entry": "missing.ts",
+  "emission": "c",
+  "abi": {
+    "prefix": "cr_",
+    "init_symbol": "cr_init",
+    "sink_register_symbol": "cr_set_panic_sink",
+    "collect_symbol": null,
+    "result_reset_symbol": null
+  },
+  "exports": [],
+  "determinism": {
+    "fences": [
+      { "id": "stdlib.math.random" }
+    ]
+  }
+}

--- a/packages/compiler/src/library/cache-reset.test.ts
+++ b/packages/compiler/src/library/cache-reset.test.ts
@@ -1,0 +1,51 @@
+import { join } from "node:path";
+import { afterEach, expect, test, vi } from "vitest";
+import { compileLibrary } from "../index.js";
+import { STATIC_MATH_FNS } from "../frontend/lowering/surfaces.js";
+import { clearFenceEvalCaches, resolveLibraryFences } from "./fence-eval.js";
+import { clearSidecarCaches, compilerReleaseVersion } from "./sidecar.js";
+
+const mockedPackage = vi.hoisted(() => ({ version: null as string | null }));
+vi.mock("node:fs", async () => {
+  const actual = await vi.importActual<typeof import("node:fs")>("node:fs");
+  return {
+    ...actual,
+    readFileSync: (path: Parameters<typeof actual.readFileSync>[0], ...args: unknown[]) => {
+      if (mockedPackage.version !== null && /[\\/]packages[\\/]compiler[\\/]package\.json$/.test(String(path))) {
+        return JSON.stringify({ version: mockedPackage.version });
+      }
+      return Reflect.apply(actual.readFileSync, actual, [path, ...args]);
+    },
+  };
+});
+
+const randomSurface = STATIC_MATH_FNS.random;
+
+afterEach(() => {
+  mockedPackage.version = null;
+  STATIC_MATH_FNS.random = randomSurface;
+  clearSidecarCaches();
+  clearFenceEvalCaches();
+});
+
+test("compileLibrary refreshes release identity and fence taxonomy before profile loading", async () => {
+  const firstVersion = compilerReleaseVersion();
+  const changedVersion = `${firstVersion}-cache-reset-test`;
+  mockedPackage.version = changedVersion;
+
+  const fence = [{ path: "test[0]", id: "stdlib.math.random" }];
+  expect(resolveLibraryFences(fence).ok).toBe(true);
+  // Mutate one taxonomy source after the old view has been memoized. The
+  // profile load below must rebuild it before resolving this static fence.
+  delete STATIC_MATH_FNS.random;
+
+  const result = await compileLibrary({
+    profilePath: join(import.meta.dirname, "cache-reset-fixtures", "profile.json"),
+    outDir: join(import.meta.dirname, "cache-reset-fixtures", "out"),
+  });
+  expect(result.ok).toBe(false);
+  if (result.ok) return;
+  expect(result.diagnostics[0]?.code).toBe("SC4001");
+  expect(result.diagnostics[0]?.message).toContain("names no entry");
+  expect(compilerReleaseVersion()).toBe(changedVersion);
+});

--- a/packages/compiler/src/library/fence-eval.ts
+++ b/packages/compiler/src/library/fence-eval.ts
@@ -126,6 +126,11 @@ interface FenceTaxonomy {
 
 let taxonomy: FenceTaxonomy | null = null;
 
+/** The taxonomy is a compilation-session view of the release manifest. */
+export function clearFenceEvalCaches(): void {
+  taxonomy = null;
+}
+
 function builtinRootId(mod: string): string {
   return `node-builtin.${mod.split("/").join(".")}`;
 }

--- a/packages/compiler/src/library/sidecar.ts
+++ b/packages/compiler/src/library/sidecar.ts
@@ -145,6 +145,12 @@ export interface SidecarDoc {
 
 let releaseVersion: string | null = null;
 
+/** The package version is stable within one compilation, but a long-lived
+ * source/worktree process may observe a release stamp between compilations. */
+export function clearSidecarCaches(): void {
+  releaseVersion = null;
+}
+
 /** The compiler's exact release identifier — the published package
  * version, read once from the compiler package's own package.json (this
  * module lives two levels below the package root in src/ and dist/


### PR DESCRIPTION
- Scope resolver, ccache, release identity, and fence taxonomy memoization to public compile invocations
- Add in-process reuse regressions for project realms, PATH changes, and library metadata