### PR TITLE
Consolidate runtime RC symbol dispatch

### DIFF
--- a/packages/compiler/src/backend/emission/emit-types.test.ts
+++ b/packages/compiler/src/backend/emission/emit-types.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "vitest";
+import { RUNTIME_EMITTER_CLASS } from "../../ir/nodes.js";
+import { releaseCallC, retainCallC, vAdapters } from "./emit-types.js";
+
+describe("runtime RC symbols", () => {
+  test("derives typed and adapter symbols from the shared stems", () => {
+    expect(retainCallC({ kind: "child" }, "x")).toBe("scr_child_retain(x)");
+    expect(releaseCallC({ kind: "netSocket" }, "x")).toBe("scr_net_sock_release(x)");
+    expect(vAdapters({ kind: "http2Session" })).toEqual({
+      retain: "scr_http2_session_retain_v",
+      release: "scr_http2_session_release_v",
+    });
+  });
+
+  test("keeps runtime and emitted object families distinct", () => {
+    expect(vAdapters({ kind: "object", className: RUNTIME_EMITTER_CLASS })).toEqual({
+      retain: "scr_emitter_retain_v",
+      release: "scr_emitter_release_v",
+    });
+    expect(retainCallC({ kind: "object", className: "Widget" }, "x")).toBe("sc_retain_Widget(x)");
+    expect(vAdapters({ kind: "record", shapeId: "r0" })).toEqual({
+      retain: "sc_rretain_r0_v",
+      release: "sc_rrelease_r0_v",
+    });
+  });
+});

--- a/packages/compiler/src/backend/emission/emit-types.ts
+++ b/packages/compiler/src/backend/emission/emit-types.ts
@@ -5,7 +5,7 @@ import { InternalCompilerError } from "../../errors.js";
  * functions of IrType/values — every emission module leans on these, so they
  * live in ONE place with no emitter state. */
 import type { IrType } from "../../ir/nodes.js";
-import { RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES } from "../../ir/nodes.js";
+import { runtimeRcStem, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES } from "../../ir/nodes.js";
 import {
   mangleClassRelease,
   mangleClassRetain,
@@ -129,80 +129,13 @@ export function cType(t: IrType): string {
 
 /** The retain call (+1, returns the value) for one refcounted type. */
 export function retainCallC(type: IrType, expr: string): string {
+  const stem = runtimeRcStem(type);
+  if (stem !== null) return `${stem}_retain(${expr})`;
   switch (type.kind) {
-    case "string":
-      return `scr_str_retain(${expr})`;
-    case "array":
-      return `scr_arr_retain(${expr})`;
-    case "map":
-    case "set":
-      return `scr_map_retain(${expr})`;
-    case "regex":
-      return `scr_regex_retain(${expr})`;
-    case "bytes":
-      return `scr_bytes_retain(${expr})`;
-    case "url":
-      return `scr_url_retain(${expr})`;
-    case "searchParams":
-      return `scr_sp_retain(${expr})`;
-    case "symbol":
-      return `scr_sym_retain(${expr})`;
-    case "stats":
-      return `scr_stats_retain(${expr})`;
-    case "fileHandle":
-      return `scr_file_handle_retain(${expr})`;
-    case "spawnRes":
-      return `scr_spawn_res_retain(${expr})`;
-    case "child":
-      return `scr_child_retain(${expr})`;
-    case "netServer":
-      return `scr_net_server_retain(${expr})`;
-    case "netSocket":
-      return `scr_net_sock_retain(${expr})`;
-    case "http2Session":
-      return `scr_http2_session_retain(${expr})`;
-    case "http2Stream":
-      return `scr_http2_stream_retain(${expr})`;
-    case "dgramSocket":
-      return `scr_dgram_retain(${expr})`;
-    case "testCtx":
-      return `scr_testctx_retain(${expr})`;
-    case "httpReq":
-      return `scr_http_req_retain(${expr})`;
-    case "httpRes":
-      return `scr_http_res_retain(${expr})`;
-    case "httpClientReq":
-      return `scr_http_client_retain(${expr})`;
-    case "secureCtx":
-      return `scr_secure_ctx_retain(${expr})`;
-    case "fsWatcher":
-      return `scr_watcher_retain(${expr})`;
-    case "childStream":
-      return `scr_child_stream_retain(${expr})`;
-    case "func":
-      return `scr_closure_retain(${expr})`;
-    case "classval":
-      // A no-op on the immortal static — kept for ownership uniformity.
-      return `scr_classobj_retain(${expr})`;
     case "object":
-      if (RUNTIME_ERROR_CLASSES.has(type.className)) return `scr_error_retain(${expr})`;
-      if (type.className === RUNTIME_EMITTER_CLASS) return `scr_emitter_retain(${expr})`;
-      if (RUNTIME_STREAM_CLASSES.has(type.className)) return `scr_stream_retain(${expr})`;
       return `${mangleClassRetain(type.className)}(${expr})`;
     case "record":
       return `${mangleRecordRetain(type.shapeId)}(${expr})`;
-    case "promise":
-      return `scr_promise_retain(${expr})`;
-    case "generator":
-      return `scr_gen_retain(${expr})`;
-    case "union":
-      return `scr_union_retain(${expr})`;
-    case "dyn":
-      return `scr_dyn_retain(${expr})`;
-    case "jsval":
-      return `scr_jsval_retain(${expr})`;
-    case "caught":
-      return `scr_caught_retain(${expr})`;
     default:
       throw new InternalCompilerError(`emitter bug: retain of non-refcounted type ${type.kind}`);
   }
@@ -210,79 +143,13 @@ export function retainCallC(type: IrType, expr: string): string {
 
 /** The release call for one owned refcounted value (all NULL-tolerant). */
 export function releaseCallC(type: IrType, expr: string): string {
+  const stem = runtimeRcStem(type);
+  if (stem !== null) return `${stem}_release(${expr})`;
   switch (type.kind) {
-    case "string":
-      return `scr_str_release(${expr})`;
-    case "array":
-      return `scr_arr_release(${expr})`;
-    case "map":
-    case "set":
-      return `scr_map_release(${expr})`;
-    case "regex":
-      return `scr_regex_release(${expr})`;
-    case "bytes":
-      return `scr_bytes_release(${expr})`;
-    case "url":
-      return `scr_url_release(${expr})`;
-    case "searchParams":
-      return `scr_sp_release(${expr})`;
-    case "symbol":
-      return `scr_sym_release(${expr})`;
-    case "stats":
-      return `scr_stats_release(${expr})`;
-    case "fileHandle":
-      return `scr_file_handle_release(${expr})`;
-    case "spawnRes":
-      return `scr_spawn_res_release(${expr})`;
-    case "child":
-      return `scr_child_release(${expr})`;
-    case "netServer":
-      return `scr_net_server_release(${expr})`;
-    case "netSocket":
-      return `scr_net_sock_release(${expr})`;
-    case "http2Session":
-      return `scr_http2_session_release(${expr})`;
-    case "http2Stream":
-      return `scr_http2_stream_release(${expr})`;
-    case "dgramSocket":
-      return `scr_dgram_release(${expr})`;
-    case "testCtx":
-      return `scr_testctx_release(${expr})`;
-    case "httpReq":
-      return `scr_http_req_release(${expr})`;
-    case "httpRes":
-      return `scr_http_res_release(${expr})`;
-    case "httpClientReq":
-      return `scr_http_client_release(${expr})`;
-    case "secureCtx":
-      return `scr_secure_ctx_release(${expr})`;
-    case "fsWatcher":
-      return `scr_watcher_release(${expr})`;
-    case "childStream":
-      return `scr_child_stream_release(${expr})`;
-    case "func":
-      return `scr_closure_release(${expr})`;
-    case "classval":
-      return `scr_classobj_release(${expr})`;
     case "object":
-      if (RUNTIME_ERROR_CLASSES.has(type.className)) return `scr_error_release(${expr})`;
-      if (type.className === RUNTIME_EMITTER_CLASS) return `scr_emitter_release(${expr})`;
-      if (RUNTIME_STREAM_CLASSES.has(type.className)) return `scr_stream_release(${expr})`;
       return `${mangleClassRelease(type.className)}(${expr})`;
     case "record":
       return `${mangleRecordRelease(type.shapeId)}(${expr})`;
-    case "promise":
-      return `scr_promise_release(${expr})`;
-    case "generator":
-      return `scr_gen_release(${expr})`;
-    case "union":
-      return `scr_union_release(${expr})`;
-    case "dyn":
-      return `scr_dyn_release(${expr})`;
-    case "jsval":
-      return `scr_jsval_release(${expr})`;
-    case "caught":
-      return `scr_caught_release(${expr})`;
     default:
       throw new InternalCompilerError(`emitter bug: release of non-refcounted type ${type.kind}`);
   }
@@ -368,85 +235,15 @@ export function boxKindC(t: IrType): string {
  * emitted per-shape adapters; everything else has runtime-provided ones.
  * Bare symbol names — call sites prefix `&` where a fn ptr is passed. */
 export function vAdapters(t: IrType): { retain: string; release: string } {
+  const stem = runtimeRcStem(t);
+  if (stem !== null && t.kind !== "caught") {
+    return { retain: `${stem}_retain_v`, release: `${stem}_release_v` };
+  }
   switch (t.kind) {
-    case "string":
-      return { retain: "scr_str_retain_v", release: "scr_str_release_v" };
-    case "array":
-      return { retain: "scr_arr_retain_v", release: "scr_arr_release_v" };
-    case "map":
-    case "set":
-      return { retain: "scr_map_retain_v", release: "scr_map_release_v" };
-    case "regex":
-      return { retain: "scr_regex_retain_v", release: "scr_regex_release_v" };
-    case "bytes":
-      return { retain: "scr_bytes_retain_v", release: "scr_bytes_release_v" };
-    case "url":
-      return { retain: "scr_url_retain_v", release: "scr_url_release_v" };
-    case "searchParams":
-      return { retain: "scr_sp_retain_v", release: "scr_sp_release_v" };
-    case "symbol":
-      return { retain: "scr_sym_retain_v", release: "scr_sym_release_v" };
-    case "stats":
-      return { retain: "scr_stats_retain_v", release: "scr_stats_release_v" };
-    case "fileHandle":
-      return { retain: "scr_file_handle_retain_v", release: "scr_file_handle_release_v" };
-    case "spawnRes":
-      return { retain: "scr_spawn_res_retain_v", release: "scr_spawn_res_release_v" };
-    case "child":
-      return { retain: "scr_child_retain_v", release: "scr_child_release_v" };
-    case "netServer":
-      return { retain: "scr_net_server_retain_v", release: "scr_net_server_release_v" };
-    case "netSocket":
-      return { retain: "scr_net_sock_retain_v", release: "scr_net_sock_release_v" };
-    case "http2Session":
-      return { retain: "scr_http2_session_retain_v", release: "scr_http2_session_release_v" };
-    case "http2Stream":
-      return { retain: "scr_http2_stream_retain_v", release: "scr_http2_stream_release_v" };
-    case "dgramSocket":
-      return { retain: "scr_dgram_retain_v", release: "scr_dgram_release_v" };
-    case "testCtx":
-      return { retain: "scr_testctx_retain_v", release: "scr_testctx_release_v" };
-    case "httpReq":
-      return { retain: "scr_http_req_retain_v", release: "scr_http_req_release_v" };
-    case "httpRes":
-      return { retain: "scr_http_res_retain_v", release: "scr_http_res_release_v" };
-    case "httpClientReq":
-      return { retain: "scr_http_client_retain_v", release: "scr_http_client_release_v" };
-    case "secureCtx":
-      return { retain: "scr_secure_ctx_retain_v", release: "scr_secure_ctx_release_v" };
-    case "fsWatcher":
-      return { retain: "scr_watcher_retain_v", release: "scr_watcher_release_v" };
-    case "childStream":
-      return { retain: "scr_child_stream_retain_v", release: "scr_child_stream_release_v" };
-    case "func":
-      return { retain: "scr_closure_retain_v", release: "scr_closure_release_v" };
-    case "classval":
-      // No-ops on the immortal class object; the container machinery
-      // stays uniform.
-      return { retain: "scr_classobj_retain_v", release: "scr_classobj_release_v" };
-    case "union":
-      return { retain: "scr_union_retain_v", release: "scr_union_release_v" };
     case "object":
-      if (RUNTIME_ERROR_CLASSES.has(t.className)) {
-        return { retain: "scr_error_retain_v", release: "scr_error_release_v" };
-      }
-      if (t.className === RUNTIME_EMITTER_CLASS) {
-        return { retain: "scr_emitter_retain_v", release: "scr_emitter_release_v" };
-      }
-      if (RUNTIME_STREAM_CLASSES.has(t.className)) {
-        return { retain: "scr_stream_retain_v", release: "scr_stream_release_v" };
-      }
       return { retain: `${mangleClassRetain(t.className)}_v`, release: `${mangleClassRelease(t.className)}_v` };
     case "record":
       return { retain: `${mangleRecordRetain(t.shapeId)}_v`, release: `${mangleRecordRelease(t.shapeId)}_v` };
-    case "promise":
-      return { retain: "scr_promise_retain_v", release: "scr_promise_release_v" };
-    case "generator":
-      return { retain: "scr_gen_retain_v", release: "scr_gen_release_v" };
-    case "dyn":
-      return { retain: "scr_dyn_retain_v", release: "scr_dyn_release_v" };
-    case "jsval":
-      return { retain: "scr_jsval_retain_v", release: "scr_jsval_release_v" };
     default:
       throw new InternalCompilerError(`emitter bug: no RC adapters for ${t.kind}`);
   }

--- a/packages/compiler/src/backend/llvm/shapes.test.ts
+++ b/packages/compiler/src/backend/llvm/shapes.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "vitest";
+import { RUNTIME_EMITTER_CLASS } from "../../ir/nodes.js";
+import { releaseSym, type ShapeHost, vAdapters } from "./shapes.js";
+
+function declarationHost(): { host: ShapeHost; declarations: string[] } {
+  const declarations: string[] = [];
+  const host: ShapeHost = {
+    declare(decl) { declarations.push(decl); },
+    needOom() {},
+    sizeType: "i64",
+    cycleColorOffset: 0,
+    tracedShapes: new Set(),
+    tracedUnions: new Set(),
+    recordsById: new Map(),
+    recordCloneShapes: new Set(),
+  };
+  return { host, declarations };
+}
+
+describe("LLVM runtime RC symbols", () => {
+  test("derives adapter declarations from the shared stems", () => {
+    const { host, declarations } = declarationHost();
+    expect(vAdapters(host, { kind: "netSocket" })).toEqual({
+      retain: "@scr_net_sock_retain_v",
+      release: "@scr_net_sock_release_v",
+    });
+    expect(declarations).toEqual([
+      "declare ptr @scr_net_sock_retain_v(ptr)",
+      "declare void @scr_net_sock_release_v(ptr)",
+    ]);
+  });
+
+  test("uses typed releases and preserves ABI exceptions", () => {
+    const { host, declarations } = declarationHost();
+    expect(releaseSym(host, { kind: "url" })).toBe("@scr_url_release");
+    expect(releaseSym(host, { kind: "classval", className: "Widget" })).toBe("@scr_classobj_release_v");
+    expect(vAdapters(host, { kind: "caught" })).toEqual({
+      retain: "@scr_caught_retain",
+      release: "@scr_caught_release",
+    });
+    expect(declarations).toContain("declare void @scr_url_release(ptr)");
+  });
+
+  test("keeps runtime and emitted object families distinct", () => {
+    const { host } = declarationHost();
+    expect(vAdapters(host, { kind: "object", className: RUNTIME_EMITTER_CLASS })).toEqual({
+      retain: "@scr_emitter_retain_v",
+      release: "@scr_emitter_release_v",
+    });
+    expect(vAdapters(host, { kind: "object", className: "Widget" })).toEqual({
+      retain: "@sc_retain_Widget",
+      release: "@sc_release_Widget",
+    });
+  });
+});

--- a/packages/compiler/src/backend/llvm/shapes.ts
+++ b/packages/compiler/src/backend/llvm/shapes.ts
@@ -11,7 +11,7 @@
  * Anything outside the tier refuses loudly (LlvmUnsupportedError naming
  * the type kind) — the tables never guess. */
 import type { IrModule, IrRecordShape, IrType } from "../../ir/nodes.js";
-import { funcOf, isRefCounted, mapOf, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, VOID } from "../../ir/nodes.js";
+import { funcOf, isRefCounted, mapOf, runtimeRcStem, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, VOID } from "../../ir/nodes.js";
 import {
   mangleClassRelease,
   mangleClassRetain,
@@ -152,166 +152,24 @@ export function computeTraced(mod: IrModule): { shapes: Set<string>; unions: Set
  * use their emitted per-shape helpers, whose signatures are already
  * `_v`-shaped. */
 export function vAdapters(host: ShapeHost, t: IrType): { retain: string; release: string } {
+  const stem = runtimeRcStem(t);
+  if (stem !== null) {
+    // Catch-binding snapshots have typed ptr-shaped entry points but no
+    // separate `_v` wrappers; every other runtime family is uniform.
+    const suffix = t.kind === "caught" ? "" : "_v";
+    const retain = `@${stem}_retain${suffix}`;
+    const release = `@${stem}_release${suffix}`;
+    host.declare(`declare ptr ${retain}(ptr)`);
+    host.declare(`declare void ${release}(ptr)`);
+    return { retain, release };
+  }
   switch (t.kind) {
-    case "caught":
-      // Catch-binding snapshot boxes (ScrCaught): the runtime pair is
-      // already `_v`-shaped. Caught values never enter containers — these
-      // arms serve retainSym/releaseSym only.
-      host.declare(`declare ptr @scr_caught_retain(ptr)`);
-      host.declare(`declare void @scr_caught_release(ptr)`);
-      return { retain: "@scr_caught_retain", release: "@scr_caught_release" };
-    case "string":
-      host.declare(`declare ptr @scr_str_retain_v(ptr)`);
-      host.declare(`declare void @scr_str_release_v(ptr)`);
-      return { retain: "@scr_str_retain_v", release: "@scr_str_release_v" };
-    case "array":
-      host.declare(`declare ptr @scr_arr_retain_v(ptr)`);
-      host.declare(`declare void @scr_arr_release_v(ptr)`);
-      return { retain: "@scr_arr_retain_v", release: "@scr_arr_release_v" };
-    case "map":
-    case "set":
-      host.declare(`declare ptr @scr_map_retain_v(ptr)`);
-      host.declare(`declare void @scr_map_release_v(ptr)`);
-      return { retain: "@scr_map_retain_v", release: "@scr_map_release_v" };
-    case "union":
-      host.declare(`declare ptr @scr_union_retain_v(ptr)`);
-      host.declare(`declare void @scr_union_release_v(ptr)`);
-      return { retain: "@scr_union_retain_v", release: "@scr_union_release_v" };
-    case "promise":
-      host.declare(`declare ptr @scr_promise_retain_v(ptr)`);
-      host.declare(`declare void @scr_promise_release_v(ptr)`);
-      return { retain: "@scr_promise_retain_v", release: "@scr_promise_release_v" };
-    case "bytes":
-      host.declare(`declare ptr @scr_bytes_retain_v(ptr)`);
-      host.declare(`declare void @scr_bytes_release_v(ptr)`);
-      return { retain: "@scr_bytes_retain_v", release: "@scr_bytes_release_v" };
-    case "url":
-      host.declare(`declare ptr @scr_url_retain_v(ptr)`);
-      host.declare(`declare void @scr_url_release_v(ptr)`);
-      return { retain: "@scr_url_retain_v", release: "@scr_url_release_v" };
-    case "searchParams":
-      host.declare(`declare ptr @scr_sp_retain_v(ptr)`);
-      host.declare(`declare void @scr_sp_release_v(ptr)`);
-      return { retain: "@scr_sp_retain_v", release: "@scr_sp_release_v" };
-    case "stats":
-      host.declare(`declare ptr @scr_stats_retain_v(ptr)`);
-      host.declare(`declare void @scr_stats_release_v(ptr)`);
-      return { retain: "@scr_stats_retain_v", release: "@scr_stats_release_v" };
-    case "fileHandle":
-      host.declare(`declare ptr @scr_file_handle_retain_v(ptr)`);
-      host.declare(`declare void @scr_file_handle_release_v(ptr)`);
-      return { retain: "@scr_file_handle_retain_v", release: "@scr_file_handle_release_v" };
-    case "spawnRes":
-      host.declare(`declare ptr @scr_spawn_res_retain_v(ptr)`);
-      host.declare(`declare void @scr_spawn_res_release_v(ptr)`);
-      return { retain: "@scr_spawn_res_retain_v", release: "@scr_spawn_res_release_v" };
-    case "child":
-      host.declare(`declare ptr @scr_child_retain_v(ptr)`);
-      host.declare(`declare void @scr_child_release_v(ptr)`);
-      return { retain: "@scr_child_retain_v", release: "@scr_child_release_v" };
-    case "childStream":
-      host.declare(`declare ptr @scr_child_stream_retain_v(ptr)`);
-      host.declare(`declare void @scr_child_stream_release_v(ptr)`);
-      return { retain: "@scr_child_stream_retain_v", release: "@scr_child_stream_release_v" };
-    case "generator":
-      host.declare(`declare ptr @scr_gen_retain_v(ptr)`);
-      host.declare(`declare void @scr_gen_release_v(ptr)`);
-      return { retain: "@scr_gen_retain_v", release: "@scr_gen_release_v" };
-    case "func":
-      host.declare(`declare ptr @scr_closure_retain_v(ptr)`);
-      host.declare(`declare void @scr_closure_release_v(ptr)`);
-      return { retain: "@scr_closure_retain_v", release: "@scr_closure_release_v" };
-    case "symbol":
-      host.declare(`declare ptr @scr_sym_retain_v(ptr)`);
-      host.declare(`declare void @scr_sym_release_v(ptr)`);
-      return { retain: "@scr_sym_retain_v", release: "@scr_sym_release_v" };
-    case "regex":
-      host.declare(`declare ptr @scr_regex_retain_v(ptr)`);
-      host.declare(`declare void @scr_regex_release_v(ptr)`);
-      return { retain: "@scr_regex_retain_v", release: "@scr_regex_release_v" };
     case "record":
       return { retain: `@${mangleRecordRetain(t.shapeId)}`, release: `@${mangleRecordRelease(t.shapeId)}` };
     case "object":
-      if (RUNTIME_ERROR_CLASSES.has(t.className)) {
-        host.declare(`declare ptr @scr_error_retain_v(ptr)`);
-        host.declare(`declare void @scr_error_release_v(ptr)`);
-        return { retain: "@scr_error_retain_v", release: "@scr_error_release_v" };
-      }
-      if (t.className === RUNTIME_EMITTER_CLASS) {
-        // Bare EventEmitter instances: the runtime's `_v` pair (release
-        // dispatches through the stamped vtable, so a base-typed release
-        // tears down a user subclass too).
-        host.declare(`declare ptr @scr_emitter_retain_v(ptr)`);
-        host.declare(`declare void @scr_emitter_release_v(ptr)`);
-        return { retain: "@scr_emitter_retain_v", release: "@scr_emitter_release_v" };
-      }
-      if (RUNTIME_STREAM_CLASSES.has(t.className)) {
-        // The five runtime stream classes share ONE runtime layout; the
-        // `_v` pair dispatches teardown through the stamped vtable.
-        host.declare(`declare ptr @scr_stream_retain_v(ptr)`);
-        host.declare(`declare void @scr_stream_release_v(ptr)`);
-        return { retain: "@scr_stream_retain_v", release: "@scr_stream_release_v" };
-      }
       // Emitted per-class helpers are already `_v`-shaped (ptr → ptr /
       // ptr → void), so the same symbols serve as container entry points.
       return { retain: `@${mangleClassRetain(t.className)}`, release: `@${mangleClassRelease(t.className)}` };
-    case "classval":
-      // No-ops on the immortal class object; container machinery uniform.
-      host.declare(`declare ptr @scr_classobj_retain_v(ptr)`);
-      host.declare(`declare void @scr_classobj_release_v(ptr)`);
-      return { retain: "@scr_classobj_retain_v", release: "@scr_classobj_release_v" };
-    case "fsWatcher":
-      // fs.watch handles (ScrWatcher): the runtime's `_v` pair; no trace
-      // (listeners drop at close — never part of a lasting cycle).
-      host.declare(`declare ptr @scr_watcher_retain_v(ptr)`);
-      host.declare(`declare void @scr_watcher_release_v(ptr)`);
-      return { retain: "@scr_watcher_retain_v", release: "@scr_watcher_release_v" };
-    case "netServer":
-      host.declare(`declare ptr @scr_net_server_retain_v(ptr)`);
-      host.declare(`declare void @scr_net_server_release_v(ptr)`);
-      return { retain: "@scr_net_server_retain_v", release: "@scr_net_server_release_v" };
-    case "netSocket":
-      host.declare(`declare ptr @scr_net_sock_retain_v(ptr)`);
-      host.declare(`declare void @scr_net_sock_release_v(ptr)`);
-      return { retain: "@scr_net_sock_retain_v", release: "@scr_net_sock_release_v" };
-    case "dgramSocket":
-      host.declare(`declare ptr @scr_dgram_retain_v(ptr)`);
-      host.declare(`declare void @scr_dgram_release_v(ptr)`);
-      return { retain: "@scr_dgram_retain_v", release: "@scr_dgram_release_v" };
-    case "httpReq":
-      host.declare(`declare ptr @scr_http_req_retain_v(ptr)`);
-      host.declare(`declare void @scr_http_req_release_v(ptr)`);
-      return { retain: "@scr_http_req_retain_v", release: "@scr_http_req_release_v" };
-    case "httpRes":
-      host.declare(`declare ptr @scr_http_res_retain_v(ptr)`);
-      host.declare(`declare void @scr_http_res_release_v(ptr)`);
-      return { retain: "@scr_http_res_retain_v", release: "@scr_http_res_release_v" };
-    case "httpClientReq":
-      host.declare(`declare ptr @scr_http_client_retain_v(ptr)`);
-      host.declare(`declare void @scr_http_client_release_v(ptr)`);
-      return { retain: "@scr_http_client_retain_v", release: "@scr_http_client_release_v" };
-    case "secureCtx":
-      host.declare(`declare ptr @scr_secure_ctx_retain_v(ptr)`);
-      host.declare(`declare void @scr_secure_ctx_release_v(ptr)`);
-      return { retain: "@scr_secure_ctx_retain_v", release: "@scr_secure_ctx_release_v" };
-    case "testCtx":
-      host.declare(`declare ptr @scr_testctx_retain_v(ptr)`);
-      host.declare(`declare void @scr_testctx_release_v(ptr)`);
-      return { retain: "@scr_testctx_retain_v", release: "@scr_testctx_release_v" };
-    case "jsval":
-      // Island handles (the --dynamic engine boundary): the runtime's
-      // `_v` pair; UNTRACED (engine values never join static cycles).
-      host.declare(`declare ptr @scr_jsval_retain_v(ptr)`);
-      host.declare(`declare void @scr_jsval_release_v(ptr)`);
-      return { retain: "@scr_jsval_retain_v", release: "@scr_jsval_release_v" };
-    case "dyn":
-      // dyn values (the `unknown` boundary): the runtime's `_v` pair —
-      // scr_dyn_retain is a header inline, so the `_v` symbols serve both
-      // roles. UNTRACED (the dyn→closure stance: cycles through dyn are
-      // never collected, SEMANTICS.md) — traceAdapter answers null.
-      host.declare(`declare ptr @scr_dyn_retain_v(ptr)`);
-      host.declare(`declare void @scr_dyn_release_v(ptr)`);
-      return { retain: "@scr_dyn_retain_v", release: "@scr_dyn_release_v" };
     default:
       throw new LlvmUnsupportedError(`rc:${t.kind}`);
   }
@@ -327,101 +185,20 @@ export function retainSym(host: ShapeHost, t: IrType): string {
  * typed releases are external symbols, so the direct (non-`_v`) entry
  * points serve where one exists; records use their emitted helper. */
 export function releaseSym(host: ShapeHost, t: IrType): string {
+  const stem = runtimeRcStem(t);
+  if (stem !== null) {
+    // scr_classobj_release is header-inline only; LLVM calls its exported
+    // `_v` wrapper. Every other runtime family exports the typed release.
+    const suffix = t.kind === "classval" ? "_release_v" : "_release";
+    const release = `@${stem}${suffix}`;
+    host.declare(`declare void ${release}(ptr)`);
+    return release;
+  }
   switch (t.kind) {
-    case "caught":
-      host.declare(`declare void @scr_caught_release(ptr)`);
-      return "@scr_caught_release";
-    case "string":
-      host.declare(`declare void @scr_str_release(ptr)`);
-      return "@scr_str_release";
-    case "array":
-      host.declare(`declare void @scr_arr_release(ptr)`);
-      return "@scr_arr_release";
-    case "map":
-    case "set":
-      host.declare(`declare void @scr_map_release(ptr)`);
-      return "@scr_map_release";
-    case "union":
-      host.declare(`declare void @scr_union_release(ptr)`);
-      return "@scr_union_release";
-    case "promise":
-      host.declare(`declare void @scr_promise_release(ptr)`);
-      return "@scr_promise_release";
-    case "bytes":
-      host.declare(`declare void @scr_bytes_release(ptr)`);
-      return "@scr_bytes_release";
-    case "url":
-      host.declare(`declare void @scr_url_release_v(ptr)`);
-      return "@scr_url_release_v";
-    case "searchParams":
-      host.declare(`declare void @scr_sp_release_v(ptr)`);
-      return "@scr_sp_release_v";
-    case "stats":
-      host.declare(`declare void @scr_stats_release_v(ptr)`);
-      return "@scr_stats_release_v";
-    case "fileHandle":
-      host.declare(`declare void @scr_file_handle_release_v(ptr)`);
-      return "@scr_file_handle_release_v";
-    case "spawnRes":
-      host.declare(`declare void @scr_spawn_res_release_v(ptr)`);
-      return "@scr_spawn_res_release_v";
-    case "child":
-      host.declare(`declare void @scr_child_release_v(ptr)`);
-      return "@scr_child_release_v";
-    case "childStream":
-      host.declare(`declare void @scr_child_stream_release_v(ptr)`);
-      return "@scr_child_stream_release_v";
-    case "generator":
-      host.declare(`declare void @scr_gen_release(ptr)`);
-      return "@scr_gen_release";
-    case "func":
-      host.declare(`declare void @scr_closure_release(ptr)`);
-      return "@scr_closure_release";
-    case "symbol":
-      host.declare(`declare void @scr_sym_release(ptr)`);
-      return "@scr_sym_release";
-    case "regex":
-      host.declare(`declare void @scr_regex_release(ptr)`);
-      return "@scr_regex_release";
     case "record":
       return `@${mangleRecordRelease(t.shapeId)}`;
     case "object":
-      if (RUNTIME_ERROR_CLASSES.has(t.className)) {
-        host.declare(`declare void @scr_error_release_v(ptr)`);
-        return "@scr_error_release_v";
-      }
-      if (t.className === RUNTIME_EMITTER_CLASS) {
-        host.declare(`declare void @scr_emitter_release_v(ptr)`);
-        return "@scr_emitter_release_v";
-      }
-      if (RUNTIME_STREAM_CLASSES.has(t.className)) {
-        host.declare(`declare void @scr_stream_release_v(ptr)`);
-        return "@scr_stream_release_v";
-      }
       return `@${mangleClassRelease(t.className)}`;
-    case "classval":
-      host.declare(`declare void @scr_classobj_release_v(ptr)`);
-      return "@scr_classobj_release_v";
-    case "fsWatcher":
-      host.declare(`declare void @scr_watcher_release_v(ptr)`);
-      return "@scr_watcher_release_v";
-    case "netServer":
-    case "netSocket":
-    case "dgramSocket":
-    case "httpReq":
-    case "httpRes":
-    case "httpClientReq":
-    case "secureCtx":
-    case "testCtx":
-      // The handle kinds share their `_v` pair for both roles.
-      return vAdapters(host, t).release;
-    case "jsval":
-      host.declare(`declare void @scr_jsval_release_v(ptr)`);
-      return "@scr_jsval_release_v";
-    case "dyn":
-      // scr_dyn_release releases the tree recursively; NULL-tolerant.
-      host.declare(`declare void @scr_dyn_release(ptr)`);
-      return "@scr_dyn_release";
     default:
       throw new LlvmUnsupportedError(`rc:${t.kind}`);
   }

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -312,6 +312,68 @@ export type IrType =
   | { kind: "nullT" }
   | { kind: "void" }; // return position only
 
+/** Runtime RC symbol stem for each IR type kind. An empty stem means the
+ * kind is scalar/unit or uses an emitted per-shape helper (object/record).
+ * Keeping this exhaustive makes a new runtime handle kind a compile error
+ * until its one retain/release family is named here. */
+export const RUNTIME_RC_STEMS: Record<IrType["kind"], string> = {
+  f64: "",
+  date: "",
+  string: "scr_str",
+  bool: "",
+  array: "scr_arr",
+  map: "scr_map",
+  set: "scr_map",
+  regex: "scr_regex",
+  bytes: "scr_bytes",
+  url: "scr_url",
+  searchParams: "scr_sp",
+  symbol: "scr_sym",
+  stats: "scr_stats",
+  fileHandle: "scr_file_handle",
+  spawnRes: "scr_spawn_res",
+  child: "scr_child",
+  netServer: "scr_net_server",
+  netSocket: "scr_net_sock",
+  http2Session: "scr_http2_session",
+  http2Stream: "scr_http2_stream",
+  dgramSocket: "scr_dgram",
+  testCtx: "scr_testctx",
+  httpReq: "scr_http_req",
+  httpRes: "scr_http_res",
+  httpClientReq: "scr_http_client",
+  childStream: "scr_child_stream",
+  procStream: "",
+  fsWatcher: "scr_watcher",
+  secureCtx: "scr_secure_ctx",
+  func: "scr_closure",
+  object: "",
+  classval: "scr_classobj",
+  record: "",
+  union: "scr_union",
+  dyn: "scr_dyn",
+  jsval: "scr_jsval",
+  caught: "scr_caught",
+  promise: "scr_promise",
+  generator: "scr_gen",
+  undefinedT: "",
+  nullT: "",
+  void: "",
+};
+
+/** The runtime-provided RC family for a type, or null when the backend must
+ * use an emitted class/record helper (or the type is not refcounted). */
+export function runtimeRcStem(t: IrType): string | null {
+  if (t.kind === "object") {
+    if (RUNTIME_ERROR_CLASSES.has(t.className)) return "scr_error";
+    if (t.className === RUNTIME_EMITTER_CLASS) return "scr_emitter";
+    if (RUNTIME_STREAM_CLASSES.has(t.className)) return "scr_stream";
+    return null;
+  }
+  const stem = RUNTIME_RC_STEMS[t.kind];
+  return stem === "" ? null : stem;
+}
+
 /** The ref kinds whose values are JS OBJECTS for truthiness: always true
  * ([] and {} included) — toBool accepts them (the operand still evaluates;
  * the test is constant), and per-union truthiness helpers answer their
@@ -647,76 +709,7 @@ export function typeEquals(a: IrType, b: IrType): boolean {
  * this — adding a refcounted kind must not grow new per-kind checks outside
  * the type-directed helpers. */
 export function isRefCounted(t: IrType): boolean {
-  return (
-    t.kind === "string" ||
-    t.kind === "array" ||
-    t.kind === "map" ||
-    t.kind === "set" ||
-    // Every regex value is an immortal interned literal today, so its
-    // retains/releases are no-ops — riding the uniform machinery anyway
-    // means dynamic construction can arrive without a redesign.
-    t.kind === "regex" ||
-    // URL, Stats, and spawnSync-result instances are ordinary refcounted
-    // heap values (immutable, no cycles — strings/scalars inside only).
-    t.kind === "url" ||
-    // URLSearchParams lists are ordinary refcounted heap values (strings
-    // plus at most the owning-URL edge — no cycles).
-    t.kind === "searchParams" ||
-    // Symbols are the same story: immutable identity values holding at
-    // most two strings.
-    t.kind === "symbol" ||
-    t.kind === "stats" ||
-    t.kind === "fileHandle" ||
-    t.kind === "spawnRes" ||
-    t.kind === "child" ||
-    // net handles are refcounted like child (listeners drop at settle,
-    // so lean allocation — see the IrType comment).
-    t.kind === "netServer" ||
-    t.kind === "netSocket" ||
-    // h2 sessions/streams are refcounted like the net pair (listeners
-    // drop at settlement; the session→stream↔session cycle breaks there).
-    t.kind === "http2Session" ||
-    t.kind === "http2Stream" ||
-    t.kind === "dgramSocket" ||
-    // TestContext handles are refcounted like dgramSocket (the runner
-    // tree owns children; no cycles through the handle).
-    t.kind === "testCtx" ||
-    t.kind === "httpReq" ||
-    t.kind === "httpRes" ||
-    t.kind === "httpClientReq" ||
-    // SecureContext handles are refcounted like url/stats (immutable, no
-    // cycles — parsed cert/key material inside only).
-    t.kind === "secureCtx" ||
-    // FSWatcher handles are refcounted like child (listeners drop at
-    // close, so lean allocation — see the IrType comment).
-    t.kind === "fsWatcher" ||
-    // Child-output streams are refcounted like child (listeners drop at
-    // EOF — see the IrType comment).
-    t.kind === "childStream" ||
-    // Typed arrays / Buffers are ordinary refcounted heap values (mutable,
-    // no cycles — raw bytes inside only).
-    t.kind === "bytes" ||
-    t.kind === "func" ||
-    t.kind === "object" ||
-    // Every class object is an immortal emitted static, so its
-    // retains/releases are no-ops — riding the uniform machinery (the
-    // regex-literal stance) keeps every container and box path unchanged.
-    t.kind === "classval" ||
-    t.kind === "record" ||
-    // The union CONTAINER is heap/refcounted regardless of which arm it
-    // holds (uniform representation keeps the RC discipline simple).
-    t.kind === "union" ||
-    t.kind === "promise" ||
-    // A generator object is a refcounted handle over its paused fiber and
-    // typed channel slots (ScrGen — lean allocation, no cycle header).
-    t.kind === "generator" ||
-    // A dyn value is a refcounted JSON dyn tree (ScrDyn).
-    t.kind === "dyn" ||
-    // An island value is a refcounted cell owning one engine value.
-    t.kind === "jsval" ||
-    // A catch binding is a refcounted snapshot box (ScrCaught).
-    t.kind === "caught"
-  );
+  return RUNTIME_RC_STEMS[t.kind] !== "" || t.kind === "object" || t.kind === "record";
 }
 
 /* ── module ────────────────────────────────────────────────────────────── */


### PR DESCRIPTION
- Define one exhaustive IR runtime RC stem table shared by refcount detection and both backends.
- Derive C and LLVM retain/release symbols while preserving shape-specific and ABI exceptions.
- Add focused coverage for runtime, object, record, and LLVM declaration paths.