### PR TITLE
refactor(compiler): centralize pointer kind sets

### DIFF
--- a/packages/compiler/src/backend/emission/emit-types.ts
+++ b/packages/compiler/src/backend/emission/emit-types.ts
@@ -5,7 +5,7 @@ import { InternalCompilerError } from "../../errors.js";
  * functions of IrType/values — every emission module leans on these, so they
  * live in ONE place with no emitter state. */
 import type { IrType } from "../../ir/nodes.js";
-import { runtimeRcStem, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES } from "../../ir/nodes.js";
+import { POINTER_KINDS, type PointerKind, runtimeRcStem, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES } from "../../ir/nodes.js";
 import {
   mangleClassRelease,
   mangleClassRetain,
@@ -14,6 +14,13 @@ import {
   mangleRecordRetain,
   mangleRecordStruct,
 } from "../mangle.js";
+
+type BoxNewPointerType = Extract<IrType, {
+  kind: Exclude<PointerKind, "string" | "array" | "func" | "dyn" | "jsval" | "caught" | "promise" | "generator">
+}>;
+type RejectedArrayPointerType = Extract<IrType, {
+  kind: Exclude<PointerKind, "string" | "array" | "bytes" | "record" | "object" | "union" | "jsval" | "child" | "netServer" | "symbol" | "classval" | "func">
+}>;
 
 export function cType(t: IrType): string {
   switch (t.kind) {
@@ -157,6 +164,12 @@ export function releaseCallC(type: IrType, expr: string): string {
 
 /** The runtime's box-kind tag for a boxed (captured) variable's type. */
 export function boxKindC(t: IrType): string {
+  if (POINTER_KINDS.has(t.kind) &&
+      t.kind !== "string" && t.kind !== "array" && t.kind !== "func" &&
+      t.kind !== "dyn" && t.kind !== "jsval" && t.kind !== "caught" &&
+      t.kind !== "promise" && t.kind !== "generator") {
+    throw new InternalCompilerError(`emitter bug: ${t.kind} boxes go through boxNewC, not boxKindC`);
+  }
   switch (t.kind) {
     case "f64":
     case "date":
@@ -169,34 +182,6 @@ export function boxKindC(t: IrType): string {
       return "SCR_BOX_ARR";
     case "func":
       return "SCR_BOX_FUNC";
-    case "object":
-    case "classval":
-    case "record":
-    case "union":
-    case "map":
-    case "set":
-    case "regex":
-    case "url":
-    case "searchParams":
-    case "symbol":
-    case "stats":
-    case "fileHandle":
-    case "spawnRes":
-    case "child":
-    case "netServer":
-    case "netSocket":
-    case "http2Session":
-    case "http2Stream":
-    case "dgramSocket":
-    case "testCtx":
-    case "httpReq":
-    case "httpRes":
-    case "httpClientReq":
-    case "secureCtx":
-    case "fsWatcher":
-    case "childStream":
-    case "bytes":
-      throw new InternalCompilerError(`emitter bug: ${t.kind} boxes go through boxNewC, not boxKindC`);
     case "procStream":
       // Scalar (the fd double) — the f64 box carries it.
       return "SCR_BOX_F64";
@@ -221,7 +206,7 @@ export function boxKindC(t: IrType): string {
     case "void":
       throw new InternalCompilerError("emitter bug: box of void");
     default: {
-      const _exhaustive: never = t;
+      const _exhaustive: never = t as Exclude<typeof t, BoxNewPointerType>;
       void _exhaustive;
       throw new InternalCompilerError("unreachable");
     }
@@ -270,6 +255,13 @@ export function cFnPtrCast(ft: IrType & { kind: "func" }): string {
  * reach it — that answer needs emitter state, so construction goes through
  * CEmitter.arrNewC, which overrides this for traced-array elements. */
 export function elemKindC(elem: IrType): string {
+  if (POINTER_KINDS.has(elem.kind) &&
+      elem.kind !== "string" && elem.kind !== "array" && elem.kind !== "bytes" &&
+      elem.kind !== "record" && elem.kind !== "object" && elem.kind !== "union" &&
+      elem.kind !== "jsval" && elem.kind !== "child" && elem.kind !== "netServer" &&
+      elem.kind !== "symbol" && elem.kind !== "classval" && elem.kind !== "func") {
+    throw new InternalCompilerError(`emitter bug: array of ${elem.kind} (frontend rejects these)`);
+  }
   switch (elem.kind) {
     case "f64":
       return "SCR_ELEM_F64";
@@ -311,38 +303,15 @@ export function elemKindC(elem: IrType): string {
     // pointer identity — exactly JS function identity.
     case "func":
       return "SCR_ELEM_REF";
-    case "map":
-    case "set":
-    case "regex":
     case "date":
-    case "url":
-    case "searchParams":
-    case "stats":
-    case "fileHandle":
-    case "spawnRes":
-    case "netSocket":
-    case "http2Session":
-    case "http2Stream":
-    case "dgramSocket":
-    case "testCtx":
-    case "httpReq":
-    case "httpRes":
-    case "httpClientReq":
-    case "secureCtx":
-    case "fsWatcher":
-    case "childStream":
     case "procStream":
-    case "dyn":
-    case "caught":
-    case "promise":
-    case "generator":
     case "undefinedT":
     case "nullT":
       throw new InternalCompilerError(`emitter bug: array of ${elem.kind} (frontend rejects these)`);
     case "void":
       throw new InternalCompilerError("emitter bug: array of void");
     default: {
-      const _exhaustive: never = elem;
+      const _exhaustive: never = elem as Exclude<typeof elem, RejectedArrayPointerType>;
       void _exhaustive;
       throw new InternalCompilerError("unreachable");
     }

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -40,7 +40,7 @@ import type {
   IrUnionDef,
   SrcLoc,
 } from "../../ir/nodes.js";
-import { ffiCallbackType, funcOf, isFfiCallbackParam, isFfiContextParam, isFfiReleaseParam, isRefCounted, isUnitType, mapOf, moduleEmbedsCompressedNpm, moduleUsesDgram, moduleUsesDynInvoke, moduleEmbedsBuiltin, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, RUNTIME_EMITTER_CLASS, STRING, VOID } from "../../ir/nodes.js";
+import { ffiCallbackType, funcOf, isFfiCallbackParam, isFfiContextParam, isFfiReleaseParam, isRefCounted, isUnitType, mapOf, moduleEmbedsCompressedNpm, moduleUsesDgram, moduleUsesDynInvoke, moduleEmbedsBuiltin, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, POINTER_KINDS, type PointerKind, RUNTIME_EMITTER_CLASS, STRING, VOID } from "../../ir/nodes.js";
 import { allocateFfiCallbackAdapters, hasForeignFfiCallback, hasRetainedFfiCallback, type FfiCallbackAdapter } from "../ffi-callbacks.js";
 import {
   mangleAsyncSpawn,
@@ -89,6 +89,10 @@ export interface Temp {
   name: string;
   type: IrType;
 }
+
+type TruthyPointerType = Extract<IrType, {
+  kind: Exclude<PointerKind, "string" | "union" | "dyn" | "jsval" | "caught">
+}>;
 
 /** A scope entry: a refcounted local, either held directly or through a
  * capture box (boxed locals release their BOX; the box frees its contents). */
@@ -2031,6 +2035,15 @@ export class CEmitter {
    * `x == x` rejects NaN, `x != 0` rejects both zeros; strings only need
    * their length — no runtime call, no ownership change. */
   truthyC(t: Temp): string {
+    if (POINTER_KINDS.has(t.type.kind) &&
+        t.type.kind !== "string" && t.type.kind !== "union" &&
+        t.type.kind !== "dyn" && t.type.kind !== "jsval" &&
+        t.type.kind !== "caught") {
+      // JS objects are ALWAYS truthy ([] and {} included). These are
+      // non-NULL pointers, so the honest constant reads as a pointer
+      // test (no unused-value warnings, operand still evaluated).
+      return `${t.name} != NULL`;
+    }
     switch (t.type.kind) {
       case "bool":
         return t.name;
@@ -2051,40 +2064,6 @@ export class CEmitter {
         // helper (switch on tag: unit arms false, scalar/string arms by
         // value, ref arms true, jsval arms ask the engine).
         return `${this.unionTruthyHelper(t.type.unionId)}(${t.name})`;
-      case "array":
-      case "map":
-      case "set":
-      case "regex":
-      case "url":
-      case "searchParams":
-      case "symbol":
-      case "stats":
-      case "fileHandle":
-      case "spawnRes":
-      case "child":
-      case "netServer":
-      case "netSocket":
-      case "http2Session":
-      case "http2Stream":
-      case "dgramSocket":
-      case "testCtx":
-      case "httpReq":
-      case "httpRes":
-      case "httpClientReq":
-      case "secureCtx":
-      case "fsWatcher":
-      case "childStream":
-      case "bytes":
-      case "func":
-      case "object":
-      case "classval":
-      case "record":
-      case "promise":
-      case "generator":
-        // JS objects are ALWAYS truthy ([] and {} included). These are
-        // non-NULL pointers, so the honest constant reads as a pointer
-        // test (no unused-value warnings, operand still evaluated).
-        return `${t.name} != NULL`;
       case "procStream":
         // A stream value is a JS object (always truthy); the scalar fd
         // representation is 1 or 2, so the honest constant reads as its
@@ -2102,7 +2081,7 @@ export class CEmitter {
       case "void":
         throw new InternalCompilerError("emitter bug: truthiness of void");
       default: {
-        const _exhaustive: never = t.type;
+        const _exhaustive: never = t.type as Exclude<typeof t.type, TruthyPointerType>;
         void _exhaustive;
         throw new InternalCompilerError("unreachable");
       }

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -81,7 +81,7 @@ import type {
   IrUnionDef,
   SrcLoc,
 } from "../../ir/nodes.js";
-import { canMarshalFuncIntoIsland, CAUGHT, DYN, F64, ffiCallbackType, islandCallbackRet, islandPromisePayloadTag, isFfiCallbackParam, isFfiContextParam, isFfiReleaseParam, isRefCounted, isUnitType, MAY_THROW_LIB_FNS, moduleEmbedsBuiltin, moduleEmbedsCompressedNpm, moduleUsesDynInvoke, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttpServer, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, NPM_COMPRESS_MIN, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, typeEquals, typeKey, VOID } from "../../ir/nodes.js";
+import { canMarshalFuncIntoIsland, CAUGHT, DYN, F64, ffiCallbackType, islandCallbackRet, islandPromisePayloadTag, isFfiCallbackParam, isFfiContextParam, isFfiReleaseParam, isRefCounted, isUnitType, MAY_THROW_LIB_FNS, moduleEmbedsBuiltin, moduleEmbedsCompressedNpm, moduleUsesDynInvoke, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttpServer, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, NPM_COMPRESS_MIN, POINTER_KINDS, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, typeEquals, typeKey, VOID } from "../../ir/nodes.js";
 import { matchIntegerBytesForLoop } from "../../ir/integer-loops.js";
 import { allocateFfiCallbackAdapters, collectFfiRetainedOps, hasForeignFfiCallback, hasRetainedFfiCallback, parseFfiCallbackKey, type FfiCallbackAdapter } from "../ffi-callbacks.js";
 import { computeMayThrow } from "../emission/may-throw.js";
@@ -1233,52 +1233,17 @@ class LlEmitter {
   // ── types ───────────────────────────────────────────────────────────────
 
   private llType(t: IrType): string {
+    if (POINTER_KINDS.has(t.kind) && t.kind !== "http2Session" && t.kind !== "http2Stream") return "ptr";
     switch (t.kind) {
       case "f64":
       case "date":
         return "double";
       case "bool":
         return "i1";
-      case "string":
-      case "array":
-      case "record":
-      case "union":
-      case "func":
-      case "map":
-      case "set":
-      case "symbol":
-      case "regex":
-      case "promise":
-      case "bytes":
-      case "url":
-      case "searchParams":
-      case "stats":
-      case "fileHandle":
-      case "spawnRes":
-      case "child":
-      case "childStream":
-      case "generator":
-      case "dyn":
-      case "jsval":
-      case "fsWatcher":
-      case "netServer":
-      case "netSocket":
-      case "dgramSocket":
-      case "httpReq":
-      case "httpRes":
-      case "httpClientReq":
-      case "secureCtx":
-      case "testCtx":
-        return "ptr";
       case "procStream":
         // A SCALAR kind: the stream value IS its fd (1 = stdout, 2 =
         // stderr) — no heap, no refcount.
         return "double";
-      case "object":
-        return "ptr";
-      case "classval":
-      case "caught": // catch bindings: ScrCaught snapshot boxes
-        return "ptr";
       case "void":
         return "void";
       default:

--- a/packages/compiler/src/backend/llvm/shapes.ts
+++ b/packages/compiler/src/backend/llvm/shapes.ts
@@ -11,7 +11,7 @@
  * Anything outside the tier refuses loudly (LlvmUnsupportedError naming
  * the type kind) — the tables never guess. */
 import type { IrModule, IrRecordShape, IrType } from "../../ir/nodes.js";
-import { funcOf, isRefCounted, mapOf, runtimeRcStem, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, VOID } from "../../ir/nodes.js";
+import { funcOf, isRefCounted, mapOf, POINTER_KINDS, runtimeRcStem, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, STRING, VOID } from "../../ir/nodes.js";
 import {
   mangleClassRelease,
   mangleClassRetain,
@@ -363,45 +363,13 @@ export function boxAccess(t: IrType): "f64" | "bool" | "ref" {
 /** A record field's in-struct LLVM type. bool fields store as i8 (the C
  * _Bool layout); loads/stores convert at the access site. */
 export function llFieldType(t: IrType): "double" | "i8" | "ptr" {
+  if (POINTER_KINDS.has(t.kind) && t.kind !== "http2Session" && t.kind !== "http2Stream") return "ptr";
   switch (t.kind) {
     case "f64":
     case "date":
       return "double";
     case "bool":
       return "i8";
-    case "string":
-    case "array":
-    case "record":
-    case "object":
-    case "classval":
-    case "union":
-    case "func":
-    case "map":
-    case "set":
-    case "symbol":
-    case "regex":
-    case "promise":
-    case "bytes":
-    case "url":
-    case "searchParams":
-    case "stats":
-    case "fileHandle":
-    case "spawnRes":
-    case "child":
-    case "childStream":
-    case "generator":
-    case "dyn":
-    case "jsval":
-    case "fsWatcher":
-    case "netServer":
-    case "netSocket":
-    case "dgramSocket":
-    case "httpReq":
-    case "httpRes":
-    case "httpClientReq":
-    case "secureCtx":
-    case "testCtx":
-      return "ptr";
     default:
       throw new LlvmUnsupportedError(`type:${t.kind}`);
   }

--- a/packages/compiler/src/ir/nodes.test.ts
+++ b/packages/compiler/src/ir/nodes.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from "vitest";
+import { HANDLE_KINDS, POINTER_KINDS } from "./nodes.js";
+
+describe("IR kind sets", () => {
+  test("keeps procStream as the scalar handle exception", () => {
+    expect(HANDLE_KINDS.has("procStream")).toBe(true);
+    expect(POINTER_KINDS.has("procStream")).toBe(false);
+    for (const kind of HANDLE_KINDS) {
+      if (kind !== "procStream") expect(POINTER_KINDS.has(kind)).toBe(true);
+    }
+  });
+
+  test("distinguishes pointer values from object-like scalars", () => {
+    expect(POINTER_KINDS.has("record")).toBe(true);
+    expect(POINTER_KINDS.has("date")).toBe(false);
+  });
+});

--- a/packages/compiler/src/ir/nodes.ts
+++ b/packages/compiler/src/ir/nodes.ts
@@ -312,6 +312,69 @@ export type IrType =
   | { kind: "nullT" }
   | { kind: "void" }; // return position only
 
+const POINTER_HANDLE_KINDS = [
+  "stats",
+  "fileHandle",
+  "spawnRes",
+  "child",
+  "netServer",
+  "netSocket",
+  "http2Session",
+  "http2Stream",
+  "dgramSocket",
+  "testCtx",
+  "httpReq",
+  "httpRes",
+  "httpClientReq",
+  "secureCtx",
+  "fsWatcher",
+  "childStream",
+] as const satisfies readonly IrType["kind"][];
+
+interface IrKindSet<K extends IrType["kind"]> extends ReadonlySet<IrType["kind"]> {
+  has(kind: IrType["kind"]): kind is K;
+}
+
+function irKindSet<const K extends readonly IrType["kind"][]>(kinds: K): IrKindSet<K[number]> {
+  return new Set<IrType["kind"]>(kinds) as unknown as IrKindSet<K[number]>;
+}
+
+/** The opaque runtime handle kinds. procStream is the one scalar handle;
+ * every other handle has pointer representation. */
+const HANDLE_KIND_LIST = [
+  ...POINTER_HANDLE_KINDS,
+  "procStream",
+] as const;
+export type HandleKind = typeof HANDLE_KIND_LIST[number];
+type HandleType = Extract<IrType, { kind: HandleKind }>;
+export const HANDLE_KINDS = irKindSet(HANDLE_KIND_LIST);
+
+/** The IR kinds represented as pointers in both native backends. */
+const POINTER_KIND_LIST = [
+  "string",
+  "array",
+  "map",
+  "set",
+  "regex",
+  "bytes",
+  "url",
+  "searchParams",
+  "symbol",
+  ...POINTER_HANDLE_KINDS,
+  "func",
+  "object",
+  "classval",
+  "record",
+  "union",
+  "dyn",
+  "jsval",
+  "caught",
+  "promise",
+  "generator",
+] as const;
+export type PointerKind = typeof POINTER_KIND_LIST[number];
+export const POINTER_KINDS = irKindSet(POINTER_KIND_LIST);
+
 /** Runtime RC symbol stem for each IR type kind. An empty stem means the
  * kind is scalar/unit or uses an emitted per-shape helper (object/record).
  * Keeping this exhaustive makes a new runtime handle kind a compile error
@@ -603,6 +666,7 @@ export function unionFuncSetArmsOk(arms: IrType[]): boolean {
  * canonical) shapeId/unionId, so keys stay finite and comparable. Lives in
  * the IR (not the frontend) because both ends need it. */
 export function typeKey(t: IrType): string {
+  if (HANDLE_KINDS.has(t.kind)) return t.kind;
   switch (t.kind) {
     case "f64":
     case "date":
@@ -612,23 +676,6 @@ export function typeKey(t: IrType): string {
     case "url":
     case "searchParams":
     case "symbol":
-    case "stats":
-    case "fileHandle":
-    case "spawnRes":
-    case "child":
-    case "netServer":
-    case "netSocket":
-    case "http2Session":
-    case "http2Stream":
-    case "dgramSocket":
-    case "testCtx":
-    case "httpReq":
-    case "httpRes":
-    case "httpClientReq":
-    case "secureCtx":
-    case "fsWatcher":
-    case "childStream":
-    case "procStream":
     case "dyn":
     case "jsval":
     case "caught":
@@ -661,7 +708,7 @@ export function typeKey(t: IrType): string {
     case "generator":
       return `generator<${typeKey(t.yieldT)},${typeKey(t.retT)},${typeKey(t.nextT)}>`;
     default: {
-      const _exhaustive: never = t;
+      const _exhaustive: never = t as Exclude<typeof t, HandleType>;
       void _exhaustive;
       throw new InternalCompilerError("unreachable");
     }
@@ -5327,6 +5374,7 @@ function isJsonSafeAt(
   inRecordField: boolean,
   visiting: Set<string>,
 ): boolean {
+  if (HANDLE_KINDS.has(t.kind)) return false;
   switch (t.kind) {
     case "f64":
     case "string":
@@ -5392,23 +5440,6 @@ function isJsonSafeAt(
     // Buffers as {type:"Buffer",data:[...]} in Node — neither shape is
     // representable type-directedly; rejected like Maps.
     case "bytes":
-    case "stats":
-    case "fileHandle":
-    case "spawnRes":
-    case "child":
-    case "netServer":
-    case "netSocket":
-    case "http2Session":
-    case "http2Stream":
-    case "dgramSocket":
-    case "testCtx":
-    case "httpReq":
-    case "httpRes":
-    case "httpClientReq":
-    case "secureCtx":
-    case "fsWatcher":
-    case "childStream":
-    case "procStream":
     case "dyn":
     case "jsval":
     case "caught":
@@ -5427,7 +5458,7 @@ function isJsonSafeAt(
     case "nullT":
       return true;
     default: {
-      const _exhaustive: never = t;
+      const _exhaustive: never = t as Exclude<typeof t, HandleType>;
       void _exhaustive;
       throw new InternalCompilerError("unreachable");
     }


### PR DESCRIPTION
- Export canonical handle and pointer kind sets from the IR.
- Replace repeated C and LLVM dispatch ladders with membership checks.
- Preserve exhaustiveness and cover the scalar handle exception.