### PR TITLE
refactor: share IR construction helpers

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-assert.ts
+++ b/packages/compiler/src/frontend/lowering/lower-assert.ts
@@ -28,6 +28,7 @@ import { jsFuncNameOf, own } from "./lowerer.js";
 import { NARROW_FIRST } from "./surfaces.js";
 import { typeReachesItself } from "./lower-inspect.js";
 import { BOOL, CAUGHT, DYN, DYN_HANDLE_KINDS, F64, IrExpr, IrLibFn, IrStmt, IrType, REGEX, RUNTIME_ERROR_CLASSES, STRING, SrcLoc, VOID, isUnitType, typeEquals, typeKey } from "../../ir/nodes.js";
+import { boolLit, numLit, strLit, varRef } from "../../ir/build.js";
 
 /** node:assert/strict binds the loose NAMES to the strict comparisons —
  * Node's own aliasing (`strict.equal === assert.strictEqual`). */
@@ -66,9 +67,8 @@ function lowerMessageArg(
   node: ts.Expression | undefined,
   loc: SrcLoc,
 ): { msg: IrExpr; hasMsg: IrExpr } {
-  const flag = (value: boolean): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
   if (!node || (ts.isIdentifier(node) && node.text === "undefined")) {
-    return { msg: { kind: "strLit", value: "", type: STRING, loc }, hasMsg: flag(false) };
+    return { msg: { kind: "strLit", value: "", type: STRING, loc }, hasMsg: boolLit(false, loc) };
   }
   const msg = L.lowerExpr(node);
   if (msg.type.kind !== "string") {
@@ -78,7 +78,7 @@ function lowerMessageArg(
       "only string messages lower (Node also accepts an Error to throw — construct and throw it directly)",
     );
   }
-  return { msg, hasMsg: flag(true) };
+  return { msg, hasMsg: boolLit(true, loc) };
 }
 
 /** The module-function dispatch — the spoke's entry, called from both the
@@ -243,7 +243,7 @@ function lowerAssertEqual(
     b = emptyArrayLit(bNode) ? (adoptedEmpty(a.type) ?? L.lowerExpr(bNode)) : L.lowerExpr(bNode);
   }
   const { msg, hasMsg } = lowerMessageArg(L, expr.arguments[2], loc);
-  const flag = (value: boolean): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
+
   // CHECKED-DYNAMIC operands (dyn-vs-dyn, dyn-vs-static): both sides
   // cross into the checked-dynamic tree and one runtime entry answers the whole quartet —
   // SameValue for the strict pair (boxed-closure identity for
@@ -304,7 +304,7 @@ function lowerAssertEqual(
     return {
       kind: "libCall",
       fn: "assert.eqDyn",
-      args: [box(a, aNode), box(b, bNode), flag(negated), flag(deep), msg, hasMsg],
+      args: [box(a, aNode), box(b, bNode), boolLit(negated, loc), boolLit(deep, loc), msg, hasMsg],
       type: VOID,
       loc,
     };
@@ -328,7 +328,7 @@ function lowerAssertEqual(
     return {
       kind: "libCall",
       fn: scalarFn,
-      args: [a, b, flag(negated), flag(deep), msg, hasMsg],
+      args: [a, b, boolLit(negated, loc), boolLit(deep, loc), msg, hasMsg],
       type: VOID,
       loc,
     };
@@ -350,11 +350,11 @@ function lowerAssertEqual(
       // Brands shape only the failure HEADER (same-structure vs
       // reference-equal expectation); an unclassifiable side defers to the
       // content probe.
-      const brandsEq = flag(brandA === null || brandB === null || brandA === brandB);
+      const brandsEq = boolLit(brandA === null || brandB === null || brandA === brandB, loc);
       return {
         kind: "libCall",
         fn: "assert.refEqBytes",
-        args: [a, b, flag(negated), brandsEq, msg, hasMsg],
+        args: [a, b, boolLit(negated, loc), brandsEq, msg, hasMsg],
         type: VOID,
         loc,
       };
@@ -369,14 +369,14 @@ function lowerAssertEqual(
     const verdict: IrExpr = {
       kind: "libCall",
       fn: "assert.bytesDeepEq",
-      args: [a, b, flag(brandA === brandB)],
+      args: [a, b, boolLit(brandA === brandB, loc)],
       type: BOOL,
       loc,
     };
     return {
       kind: "libCall",
       fn: "assert.deepResult",
-      args: [verdict, flag(negated), msg, hasMsg],
+      args: [verdict, boolLit(negated, loc), msg, hasMsg],
       type: VOID,
       loc,
     };
@@ -391,7 +391,7 @@ function lowerAssertEqual(
     return {
       kind: "libCall",
       fn: "assert.refEqFn",
-      args: [a, b, flag(negated), msg, hasMsg],
+      args: [a, b, boolLit(negated, loc), msg, hasMsg],
       type: VOID,
       loc,
     };
@@ -418,7 +418,7 @@ function lowerAssertEqual(
     return {
       kind: "libCall",
       fn: "assert.deepResult",
-      args: [flag(true), flag(negated), msg, hasMsg],
+      args: [boolLit(true, loc), boolLit(negated, loc), msg, hasMsg],
       type: VOID,
       loc,
     };
@@ -432,7 +432,7 @@ function lowerAssertEqual(
   return {
     kind: "libCall",
     fn: "assert.deepResult",
-    args: [verdict, flag(negated), msg, hasMsg],
+    args: [verdict, boolLit(negated, loc), msg, hasMsg],
     type: VOID,
     loc,
   };
@@ -823,11 +823,7 @@ function assertThrowsHelper(
   const name = `%assert.${mode}.${L.assertHelpers.size}`;
   L.assertHelpers.set(key, name);
 
-  const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-  const flag = (value: boolean): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
-  const str = (value: string): IrExpr => ({ kind: "strLit", value, type: STRING, loc });
-  const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-  const caughtRef = (): IrExpr => ref("e.0", CAUGHT);
+  const caughtRef = (): IrExpr => varRef("e.0", CAUGHT, loc);
   const errT: IrType = { kind: "object", className: "%Error" };
   const narrowed = (): IrExpr => ({ kind: "caughtNarrow", value: caughtRef(), type: errT, loc });
   const isInstance = (className: string): IrExpr => ({
@@ -838,8 +834,8 @@ function assertThrowsHelper(
     expr: { kind: "libCall", fn, args, type: VOID, loc },
     loc,
   });
-  const m = (): IrExpr => ref("m.0", STRING);
-  const hm = (): IrExpr => ref("hm.0", BOOL);
+  const m = (): IrExpr => varRef("m.0", STRING, loc);
+  const hm = (): IrExpr => varRef("hm.0", BOOL, loc);
   const doReturn: IrStmt = { kind: "return", value: null, loc };
   const rethrow: IrStmt = { kind: "rethrow", localId: "e.0", loc };
   const ifStmt = (cond: IrExpr, then: IrStmt[]): IrStmt => ({ kind: "if", cond, then, else_: null, loc });
@@ -872,8 +868,8 @@ function assertThrowsHelper(
     expected.keys.forEach((k, i) => {
       stmts.push(
         lib(k.kind === "str" ? "assert.shapeStr" : "assert.shapeRe", [
-          num(k.id),
-          ref(shapeParamIds[i]!, k.kind === "str" ? STRING : REGEX),
+          numLit(k.id, loc),
+          varRef(shapeParamIds[i]!, k.kind === "str" ? STRING : REGEX, loc),
         ]),
       );
     });
@@ -885,16 +881,16 @@ function assertThrowsHelper(
   // compile-time rendering of a regex-literal name); a non-literal regex
   // name drops the detail (a documented sliver).
   const ename = ((): { e: IrExpr; has: boolean } => {
-    if (expected.form === "class") return { e: str(expected.displayName), has: true };
+    if (expected.form === "class") return { e: strLit(expected.displayName, loc), has: true };
     if (expected.form === "shape") {
       const i = expected.keys.findIndex((k) => k.id === 2);
       if (i >= 0) {
         const k = expected.keys[i]!;
-        if (k.kind === "str") return { e: ref(shapeParamIds[i]!, STRING), has: true };
-        if (k.enameBake !== null) return { e: str(k.enameBake), has: true };
+        if (k.kind === "str") return { e: varRef(shapeParamIds[i]!, STRING, loc), has: true };
+        if (k.enameBake !== null) return { e: strLit(k.enameBake, loc), has: true };
       }
     }
-    return { e: str(""), has: false };
+    return { e: strLit("", loc), has: false };
   })();
 
   let catchBody: IrStmt[];
@@ -922,7 +918,7 @@ function assertThrowsHelper(
               {
                 kind: "libCall",
                 fn: "assert.regexErrTest",
-                args: [ref("re.0", REGEX), narrowed()],
+                args: [varRef("re.0", REGEX, loc), narrowed()],
                 type: BOOL,
                 loc,
               },
@@ -947,7 +943,7 @@ function assertThrowsHelper(
         catchBody = [
           ifStmt(isInstance(expected.className), [doReturn]),
           ifStmt(isInstance("%Error"), [
-            lib("assert.throwsMismatch", [str(expected.displayName), narrowed(), m(), hm()]),
+            lib("assert.throwsMismatch", [strLit(expected.displayName, loc), narrowed(), m(), hm()]),
           ]),
           // A non-Error thrown value: propagate (SEMANTICS.md 104; the
           // mismatch throw above never falls through — its pending
@@ -958,7 +954,7 @@ function assertThrowsHelper(
       case "regex":
         catchBody = [
           ifStmt(isInstance("%Error"), [
-            lib("assert.throwsRegex", [ref("re.0", REGEX), narrowed(), m(), hm()]),
+            lib("assert.throwsRegex", [varRef("re.0", REGEX, loc), narrowed(), m(), hm()]),
             doReturn,
           ]),
           rethrow,
@@ -982,7 +978,7 @@ function assertThrowsHelper(
         catchBody = [
           lib("assert.expectsErrDyn", [
             { kind: "caughtToDyn", value: caughtRef(), type: DYN, loc },
-            ref("ev.0", DYN),
+            varRef("ev.0", DYN, loc),
             m(),
             hm(),
           ]),
@@ -999,14 +995,14 @@ function assertThrowsHelper(
     tryBody = [
       {
         kind: "exprStmt",
-        expr: { kind: "callValue", callee: ref("f.0", fnT), args: [], type: fnT.ret, loc },
+        expr: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: [], type: fnT.ret, loc },
         loc,
       },
     ];
   } else {
     let awaited: IrExpr;
     if (recvIsPromise) {
-      awaited = ref("f.0", recvType);
+      awaited = varRef("f.0", recvType, loc);
     } else {
       const fnT = recvType as IrType & { kind: "func" };
       const promT = fnT.ret;
@@ -1014,10 +1010,10 @@ function assertThrowsHelper(
       body.push({
         kind: "varDecl",
         localId: "pr.0",
-        init: { kind: "callValue", callee: ref("f.0", fnT), args: [], type: promT, loc },
+        init: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: [], type: promT, loc },
         loc,
       });
-      awaited = ref("pr.0", promT);
+      awaited = varRef("pr.0", promT, loc);
     }
     const inner = (awaited.type as IrType & { kind: "promise" }).inner;
     tryBody = [
@@ -1026,7 +1022,7 @@ function assertThrowsHelper(
   }
   body.push({ kind: "tryCatch", tryBody, catchBody, catchLocalId: "e.0", finallyBody: null, loc });
   if (mode !== "dnr") {
-    body.push(lib("assert.throwsNone", [flag(mode === "rejects"), ename.e, flag(ename.has), m(), hm()]));
+    body.push(lib("assert.throwsNone", [boolLit(mode === "rejects", loc), ename.e, boolLit(ename.has, loc), m(), hm()]));
   }
   body.push(doReturn);
 
@@ -1299,13 +1295,10 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
   const name = `%assert.deq.${L.assertHelpers.size}`;
   L.assertHelpers.set(key, name);
 
-  const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-  const a = (): IrExpr => ref("a.0", t);
-  const b = (): IrExpr => ref("b.0", t);
-  const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-  const boolLit = (value: boolean): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
+  const a = (): IrExpr => varRef("a.0", t, loc);
+  const b = (): IrExpr => varRef("b.0", t, loc);
   const ret = (value: IrExpr): IrStmt => ({ kind: "return", value, loc });
-  const retFalse: IrStmt = ret(boolLit(false));
+  const retFalse: IrStmt = ret(boolLit(false, loc));
   const not = (operand: IrExpr): IrExpr => ({ kind: "unary", op: "!", operand, type: BOOL, loc });
   const neq = (left: IrExpr, right: IrExpr): IrExpr => ({ kind: "bin", op: "!==", left, right, type: BOOL, loc });
   /** if (cond) return false; */
@@ -1313,7 +1306,7 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
   /** Deep-compare two same-typed exprs through the per-type helper. */
   const deq = (elemT: IrType, x: IrExpr, y: IrExpr): IrExpr =>
     isUnitType(elemT)
-      ? boolLit(true)
+      ? boolLit(true, loc)
       : { kind: "call", callee: deepEqHelper(L, elemT, loc), args: [x, y], type: BOOL, loc };
 
   let locals: { id: string; name: string; type: IrType; mutable: boolean }[] = [
@@ -1346,13 +1339,13 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
         bailIf(neq(len(a()), len(b()))),
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-          cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: len(a()), type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
-          body: [bailIf(not(deq(t.elem, at(a(), ref("i.0", F64)), at(b(), ref("i.0", F64)))))],
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+          cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: len(a()), type: BOOL, loc },
+          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
+          body: [bailIf(not(deq(t.elem, at(a(), varRef("i.0", F64, loc)), at(b(), varRef("i.0", F64, loc)))))],
           loc,
         },
-        ret(boolLit(true)),
+        ret(boolLit(true, loc)),
       ];
       break;
     }
@@ -1365,7 +1358,7 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
         if (isUnitType(f.type)) continue; // a unit field is equal by type
         body.push(bailIf(not(deq(f.type, get(a(), f.name, f.type), get(b(), f.name, f.type)))));
       }
-      body.push(ret(boolLit(true)));
+      body.push(ret(boolLit(true, loc)));
       break;
     }
     case "union": {
@@ -1402,18 +1395,18 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
         { id: "av.0", name: "av", type: valueT, mutable: false },
         { id: "bv.0", name: "bv", type: getT, mutable: false },
       );
-      const i = (): IrExpr => ref("i.0", F64);
-      const k = (): IrExpr => ref("k.0", t.key);
+      const i = (): IrExpr => varRef("i.0", F64, loc);
+      const k = (): IrExpr => varRef("k.0", t.key, loc);
       // The b-side value: get() answers `V | undefined`; has() already
       // proved presence, so a plain V narrows through the value arm.
       const bValue: IrExpr =
         getT === valueT
-          ? ref("bv.0", getT)
+          ? varRef("bv.0", getT, loc)
           : {
               kind: "unionNarrow",
               unionId: (getT as IrType & { kind: "union" }).unionId,
               tag: L.armTag((getT as IrType & { kind: "union" }).unionId, valueT),
-              value: ref("bv.0", getT),
+              value: varRef("bv.0", getT, loc),
               type: valueT,
               loc,
             };
@@ -1421,41 +1414,41 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
         bailIf(neq(mi("size", a(), [], F64), mi("size", b(), [], F64))),
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: { kind: "bin", op: "<", left: i(), right: mi("iterCount", a(), [], F64), type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: num(1), type: F64, loc }, loc },
+          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: numLit(1, loc), type: F64, loc }, loc },
           body: [
             { kind: "if", cond: not(mi("iterLive", a(), [i()], BOOL)), then: [{ kind: "continue", loc }], else_: null, loc },
             { kind: "varDecl", localId: "k.0", init: mi("iterKey", a(), [i()], t.key), loc },
             bailIf(not(mi("has", b(), [k()], BOOL))),
             { kind: "varDecl", localId: "av.0", init: mi("iterValue", a(), [i()], valueT), loc },
             { kind: "varDecl", localId: "bv.0", init: mi("get", b(), [k()], getT), loc },
-            bailIf(not(deq(valueT, ref("av.0", valueT), bValue))),
+            bailIf(not(deq(valueT, varRef("av.0", valueT, loc), bValue))),
           ],
           loc,
         },
-        ret(boolLit(true)),
+        ret(boolLit(true, loc)),
       ];
       break;
     }
     case "set": {
       const si = (method: "size" | "iterCount" | "iterLive" | "iterKey" | "has", receiver: IrExpr, args: IrExpr[], type: IrType): IrExpr => ({ kind: "setIntrinsic", method, receiver, args, type, loc });
       locals.push({ id: "i.0", name: "i", type: F64, mutable: true });
-      const i = (): IrExpr => ref("i.0", F64);
+      const i = (): IrExpr => varRef("i.0", F64, loc);
       body = [
         bailIf(neq(si("size", a(), [], F64), si("size", b(), [], F64))),
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: { kind: "bin", op: "<", left: i(), right: si("iterCount", a(), [], F64), type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: num(1), type: F64, loc }, loc },
+          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: numLit(1, loc), type: F64, loc }, loc },
           body: [
             { kind: "if", cond: not(si("iterLive", a(), [i()], BOOL)), then: [{ kind: "continue", loc }], else_: null, loc },
             bailIf(not(si("has", b(), [si("iterKey", a(), [i()], t.elem)], BOOL))),
           ],
           loc,
         },
-        ret(boolLit(true)),
+        ret(boolLit(true, loc)),
       ];
       break;
     }
@@ -1489,17 +1482,17 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
       { id: "eq.0", name: "eq", type: BOOL, mutable: false },
     ];
     body = [
-      { kind: "if", cond: { kind: "bin", op: "===", left: a(), right: b(), type: BOOL, loc }, then: [ret(boolLit(true))], else_: null, loc },
+      { kind: "if", cond: { kind: "bin", op: "===", left: a(), right: b(), type: BOOL, loc }, then: [ret(boolLit(true, loc))], else_: null, loc },
       {
         kind: "if",
         cond: { kind: "libCall", fn: "assert.deqEnter", args: [a(), b()], type: BOOL, loc },
-        then: [ret(boolLit(true))],
+        then: [ret(boolLit(true, loc))],
         else_: null,
         loc,
       },
       { kind: "varDecl", localId: "eq.0", init: { kind: "call", callee: walkName, args: [a(), b()], type: BOOL, loc }, loc },
       { kind: "exprStmt", expr: { kind: "libCall", fn: "assert.deqLeave", args: [], type: VOID, loc }, loc },
-      ret(ref("eq.0", BOOL)),
+      ret(varRef("eq.0", BOOL, loc)),
     ];
   }
 

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -33,6 +33,7 @@ import { CRYPTO_CIPHERS, CRYPTO_CONSTANTS, CRYPTO_CURVES, CRYPTO_HASHES } from "
 import { timerStyleCallback } from "./lower-calls.js";
 import { registerHttpClientFnBinding, voidizedCallback } from "./lower-server.js";
 import { BOOL, BYTES_U8, CHILD_T, CHILDSTREAM_T, DYN, F64, FILEHANDLE_T, FSWATCHER_T, PROCSTREAM_T, IrExpr, IrFunction, IrLibFn, IrLocal, IrStmt, IrType, JSVAL, NULL_T, SEARCH_PARAMS_T, SPAWNRES_T, STRING, SrcLoc, UNDEFINED_T, VOID, arrayOf, canBoxFuncIntoDyn, canConvertToDyn, funcOf, isUnitType, typeEquals, typeKey } from "../../ir/nodes.js";
+import { boolLit, numLit, strLit, varRef } from "../../ir/build.js";
 
 /** Lower an optional builtin argument whose checker type is statically
  * undefined/void. The returned expression exists only to preserve effects;
@@ -103,11 +104,6 @@ function lowerBuiltinOptionalDefault(
   }
   return L.coerceInto(node, value, expected);
 }
-
-
-
-
-
 
 /** Resolves an identifier to a supported builtin-module IMPORT BINDING:
    * a named import (through its alias, so `import { join as j }` matches)
@@ -1493,9 +1489,9 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         );
       }
       const path = L.lowerExprExpecting(expr.arguments[0]!, STRING);
-      const flag = (v: boolean): IrExpr => ({ kind: "boolLit", value: v, type: BOOL, loc });
-      const recursive = flag(opts.bools["recursive"] === true);
-      const force = flag(opts.bools["force"] === true);
+
+      const recursive = boolLit(opts.bools["recursive"] === true, loc);
+      const force = boolLit(opts.bools["force"] === true, loc);
       if (opts.exprs["maxRetries"] === undefined && opts.exprs["retryDelay"] === undefined) {
         return { kind: "libCall", fn: "fs.rmOptsSync", args: [path, recursive, force], type: VOID, loc };
       }
@@ -1564,7 +1560,6 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         const data = L.lowerExprExpecting(expr.arguments[1]!, STRING);
         const pathLocal = L.declareHiddenLocal("%writePath", STRING);
         const dataLocal = L.declareHiddenLocal("%writeData", STRING);
-        const ref = (local: IrLocal): IrExpr => ({ kind: "varRef", localId: local.id, type: local.type, loc });
         const stmts: IrStmt[] = [
           { kind: "varDecl", localId: pathLocal.id, init: path, loc: path.loc },
           { kind: "varDecl", localId: dataLocal.id, init: data, loc: data.loc },
@@ -1577,12 +1572,12 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
           }
           const modeLocal = L.declareHiddenLocal("%writeMode", F64);
           stmts.push({ kind: "varDecl", localId: modeLocal.id, init: option.value, loc: option.value.loc });
-          mode = ref(modeLocal);
+          mode = varRef(modeLocal.id, modeLocal.type, loc);
         }
         const result: IrExpr = {
           kind: "libCall",
           fn: mode ? modeFn : plainFn,
-          args: mode ? [ref(pathLocal), ref(dataLocal), mode] : [ref(pathLocal), ref(dataLocal)],
+          args: mode ? [varRef(pathLocal.id, pathLocal.type, loc), varRef(dataLocal.id, dataLocal.type, loc), mode] : [varRef(pathLocal.id, pathLocal.type, loc), varRef(dataLocal.id, dataLocal.type, loc)],
           type: resultType,
           loc,
         };
@@ -1861,8 +1856,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const argv = L.lowerChildArgsArg(expr.arguments[1], loc);
     const optsNode = expr.arguments[2];
 
-    const num = (v: number): IrExpr => ({ kind: "numLit", value: v, type: F64, loc });
-    let timeout: IrExpr = num(0);
+    let timeout: IrExpr = numLit(0, loc);
     let killSignal: IrExpr = { kind: "strLit", value: "", type: STRING, loc };
     // stdio modes (scr_child.c's core): stdin 0 = /dev/null ("pipe" with
     // no input and "ignore" both read nothing), 2 = inherit; stdout/
@@ -2008,7 +2002,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     return {
       kind: "libCall",
       fn: "cp.spawnSyncOpts",
-      args: [cmd, argv, timeout, killSignal, num(inMode), num(outMode), num(errMode)],
+      args: [cmd, argv, timeout, killSignal, numLit(inMode, loc), numLit(outMode, loc), numLit(errMode, loc)],
       type: SPAWNRES_T,
       loc,
     };
@@ -2041,18 +2035,16 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const argsNode = expr.arguments.length === 3 ? expr.arguments[1] : undefined;
     const optsNode = expr.arguments[expr.arguments.length - 1];
 
-    const bool = (v: boolean): IrExpr => ({ kind: "boolLit", value: v, type: BOOL, loc });
-    const numLit = (v: number): IrExpr => ({ kind: "numLit", value: v, type: F64, loc });
     const emptyStr: IrExpr = { kind: "strLit", value: "", type: STRING, loc };
     // Per-slot stdio modes (scr_child.c: 0 ignore, 1 inherit, 2 fd) and
     // the out/err fd expressions for mode 2 (the daemon-log idiom:
     // stdio: ["ignore", logFd, logFd]).
     let sawStdio = false;
     let inMode = 0, outMode = 0, errMode = 0;
-    let outFd: IrExpr = numLit(0);
-    let errFd: IrExpr = numLit(0);
-    let detached: IrExpr = bool(false);
-    let hasEnv: IrExpr = bool(false);
+    let outFd: IrExpr = numLit(0, loc);
+    let errFd: IrExpr = numLit(0, loc);
+    let detached: IrExpr = boolLit(false, loc);
+    let hasEnv: IrExpr = boolLit(false, loc);
     let envPairs: IrExpr = { kind: "arrayLit", elems: [], type: arrayOf(STRING), loc };
     let cwd: IrExpr = emptyStr;
     let plain = true; // exactly { stdio: "ignore" }: the historical libCall
@@ -2083,8 +2075,8 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
               detached = {
                 kind: "ternary",
                 cond,
-                then: bool(cs.whenTrue ? lit : false),
-                else_: bool(cs.whenTrue ? false : lit),
+                then: boolLit(cs.whenTrue ? lit : false, loc),
+                else_: boolLit(cs.whenTrue ? false : lit, loc),
                 type: BOOL,
                 loc,
               };
@@ -2173,10 +2165,10 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
           }
           case "detached": {
             if (m.value.kind === ts.SyntaxKind.TrueKeyword) {
-              detached = bool(true);
+              detached = boolLit(true, loc);
               plain = false;
             } else if (m.value.kind === ts.SyntaxKind.FalseKeyword) {
-              detached = bool(false);
+              detached = boolLit(false, loc);
             } else {
               L.noLowering(
                 "spawn with a non-literal detached option",
@@ -2187,7 +2179,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
             break;
           }
           case "env":
-            hasEnv = bool(true);
+            hasEnv = boolLit(true, loc);
             envPairs = L.recordToEnvPairs(m.value);
             plain = false;
             break;
@@ -2221,7 +2213,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     return {
       kind: "libCall",
       fn: "cp.spawnOpts",
-      args: [cmd, argv, numLit(inMode), numLit(outMode), numLit(errMode), outFd, errFd, detached, hasEnv, envPairs, cwd],
+      args: [cmd, argv, numLit(inMode, loc), numLit(outMode, loc), numLit(errMode, loc), outFd, errFd, detached, hasEnv, envPairs, cwd],
       type: CHILD_T,
       loc,
     };
@@ -2283,8 +2275,6 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     // the argv[1] the display formatter reads.
     const cmdArg: IrExpr = shell ? { kind: "strLit", value: "/bin/sh", type: STRING, loc } : cmd;
 
-    const bool = (v: boolean): IrExpr => ({ kind: "boolLit", value: v, type: BOOL, loc });
-    const num = (v: number): IrExpr => ({ kind: "numLit", value: v, type: F64, loc });
     const emptyStr: IrExpr = { kind: "strLit", value: "", type: STRING, loc };
     const emptyPairs: IrExpr = { kind: "arrayLit", elems: [], type: arrayOf(STRING), loc };
 
@@ -2294,11 +2284,11 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     // means the option is absent (no stdin pipe), distinct from "" (pipe
     // empty stdin — immediate EOF), Node's exact reading of the member.
     let input: IrExpr = emptyStr;
-    let hasInput: IrExpr = bool(false);
+    let hasInput: IrExpr = boolLit(false, loc);
     let cwd: IrExpr = emptyStr;
-    let hasEnv: IrExpr = bool(false);
+    let hasEnv: IrExpr = boolLit(false, loc);
     let envPairs: IrExpr = emptyPairs;
-    let timeout: IrExpr = num(0);
+    let timeout: IrExpr = numLit(0, loc);
     let stdoutMode = 1;
     let stderrMode = 0;
     let stdinInherit = false;
@@ -2322,7 +2312,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
           return {
             kind: "libCall",
             fn: "cp.execSync",
-            args: [cmdArg, argvExpr, bool(shell), runtime.input, runtime.hasInput, runtime.cwd, bool(false), emptyPairs, runtime.timeout, runtime.stdoutMode, runtime.stderrMode],
+            args: [cmdArg, argvExpr, boolLit(shell, loc), runtime.input, runtime.hasInput, runtime.cwd, boolLit(false, loc), emptyPairs, runtime.timeout, runtime.stdoutMode, runtime.stderrMode],
             type: STRING,
             loc,
           };
@@ -2471,11 +2461,11 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
               break;
             }
             input = L.lowerExprExpecting(m.value, STRING);
-            hasInput = bool(true);
+            hasInput = boolLit(true, loc);
             break;
           }
           case "env": {
-            hasEnv = bool(true);
+            hasEnv = boolLit(true, loc);
             envPairs = L.recordToEnvPairs(m.value);
             // A later inline env member overrides an earlier conditional
             // spread (JS object-literal order); an earlier member stays
@@ -2537,7 +2527,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const execCall = (hasE: IrExpr, pairs: IrExpr): IrExpr => ({
       kind: "libCall",
       fn: "cp.execSync",
-      args: [cmdArg, argvExpr, bool(shell), input, hasInput, cwd, hasE, pairs, timeout, num(stdoutMode + (stdinInherit ? 4 : 0)), num(stderrMode)],
+      args: [cmdArg, argvExpr, boolLit(shell, loc), input, hasInput, cwd, hasE, pairs, timeout, numLit(stdoutMode + (stdinInherit ? 4 : 0), loc), numLit(stderrMode, loc)],
       type: STRING,
       loc,
     });
@@ -2547,7 +2537,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
       // between the arms and only the taken arm evaluates, so each still
       // runs exactly once; the env pairs build only in their own arm
       // (where the condition's narrowing holds).
-      const withEnv = execCall(bool(true), condEnvSpread.pairs);
+      const withEnv = execCall(boolLit(true, loc), condEnvSpread.pairs);
       const without = execCall(hasEnv, envPairs);
       return {
         kind: "ternary",
@@ -2654,17 +2644,15 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const name = `%cp.stdioMode.${fd}.${L.arrHofHelpers.size}`;
     L.arrHofHelpers.set(key, name);
     const optsT: IrType = { kind: "record", shapeId };
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (v: number): IrExpr => ({ kind: "numLit", value: v, type: F64, loc });
-    const str = (v: string): IrExpr => ({ kind: "strLit", value: v, type: STRING, loc });
-    const strEq = (l: IrExpr, r: string): IrExpr => ({ kind: "strEq", negated: false, left: l, right: str(r), type: BOOL, loc });
+
+    const strEq = (l: IrExpr, r: string): IrExpr => ({ kind: "strEq", negated: false, left: l, right: strLit(r, loc), type: BOOL, loc });
     const throwType = (msg: IrExpr): IrStmt => ({
       kind: "throw",
       value: { kind: "libCall", fn: "error.new", args: [msg], type: { kind: "object", className: "%TypeError" }, loc },
       loc,
     });
     const concat = (l: IrExpr, r: IrExpr): IrExpr => ({ kind: "strConcat", left: l, right: r, type: STRING, loc });
-    const o = ref("o.0", optsT);
+    const o = varRef("o.0", optsT, loc);
     const locals = [
       { id: "o.0", name: "o", type: optsT, mutable: false },
       { id: "s.0", name: "s", type: STRING, mutable: false },
@@ -2676,15 +2664,15 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     // fd 2: pipe=1 (capture, no echo), ignore=2; the no-stdio default is
     // 1 for stdout and 0 (capture+echo) for stderr.
     const modeStmts = (s: IrExpr): IrStmt[] => [
-      { kind: "if", cond: strEq(s, "pipe"), then: [{ kind: "return", value: num(1), loc }], else_: null, loc },
+      { kind: "if", cond: strEq(s, "pipe"), then: [{ kind: "return", value: numLit(1, loc), loc }], else_: null, loc },
       {
         kind: "if",
         cond: strEq(s, "ignore"),
-        then: [{ kind: "return", value: num(fd === 1 ? 0 : 2), loc }],
+        then: [{ kind: "return", value: numLit(fd === 1 ? 0 : 2, loc), loc }],
         else_: null,
         loc,
       },
-      throwType(concat(concat(str('execSync stdio "'), s), str('" has no static lowering ("pipe" and "ignore" are the supported modes)'))),
+      throwType(concat(concat(strLit('execSync stdio "', loc), s), strLit('" has no static lowering ("pipe" and "ignore" are the supported modes)', loc))),
     ];
     const body: IrStmt[] = [];
     if (fd === 1) {
@@ -2702,13 +2690,13 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         cond: {
           kind: "logical",
           op: "&&",
-          left: { kind: "strEq", negated: true, left: ref("e.0", STRING), right: str("utf8"), type: BOOL, loc },
-          right: { kind: "strEq", negated: true, left: ref("e.0", STRING), right: str("utf-8"), type: BOOL, loc },
+          left: { kind: "strEq", negated: true, left: varRef("e.0", STRING, loc), right: strLit("utf8", loc), type: BOOL, loc },
+          right: { kind: "strEq", negated: true, left: varRef("e.0", STRING, loc), right: strLit("utf-8", loc), type: BOOL, loc },
           type: BOOL,
           loc,
         },
         then: [
-          throwType(concat(concat(str('execSync output is captured as utf8 — encoding "'), ref("e.0", STRING)), str('" has no static lowering'))),
+          throwType(concat(concat(strLit('execSync output is captured as utf8 — encoding "', loc), varRef("e.0", STRING, loc)), strLit('" has no static lowering', loc))),
         ],
         else_: null,
         loc,
@@ -2722,7 +2710,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     body.push({
       kind: "if",
       cond: { kind: "unionIsTag", unionId: stdioT.unionId, tag: uTag, negated: false, value: sd, type: BOOL, loc },
-      then: [{ kind: "return", value: num(fd === 1 ? 1 : 0), loc }],
+      then: [{ kind: "return", value: numLit(fd === 1 ? 1 : 0, loc), loc }],
       else_: null,
       loc,
     });
@@ -2731,7 +2719,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
       cond: { kind: "unionIsTag", unionId: stdioT.unionId, tag: sTag, negated: false, value: sd, type: BOOL, loc },
       then: [
         { kind: "varDecl", localId: "s.0", init: { kind: "unionNarrow", unionId: stdioT.unionId, tag: sTag, value: sd, type: STRING, loc }, loc },
-        ...modeStmts(ref("s.0", STRING)),
+        ...modeStmts(varRef("s.0", STRING, loc)),
       ],
       else_: null,
       loc,
@@ -2742,11 +2730,11 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
       init: { kind: "unionNarrow", unionId: stdioT.unionId, tag: aTag, value: sd, type: arrayOf(STRING), loc },
       loc,
     });
-    const aRef = ref("a.0", arrayOf(STRING));
+    const aRef = varRef("a.0", arrayOf(STRING), loc);
     const lenGt: IrExpr = {
       kind: "bin",
       op: "<",
-      left: num(fd),
+      left: numLit(fd, loc),
       right: { kind: "arrIntrinsic", method: "length", receiver: aRef, args: [], type: F64, loc },
       type: BOOL,
       loc,
@@ -2754,11 +2742,11 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     body.push({
       kind: "if",
       cond: { kind: "unary", op: "!", operand: lenGt, type: BOOL, loc },
-      then: [{ kind: "return", value: num(1), loc }],
+      then: [{ kind: "return", value: numLit(1, loc), loc }],
       else_: null,
       loc,
     });
-    body.push(...modeStmts({ kind: "arrayGet", arr: aRef, index: num(fd), type: STRING, loc }));
+    body.push(...modeStmts({ kind: "arrayGet", arr: aRef, index: numLit(fd, loc), type: STRING, loc }));
     L.liftedFns.push({
       name,
       params: [{ localId: "o.0", name: "o", type: optsT }],
@@ -2836,15 +2824,13 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const argv = L.lowerChildArgsArg(expr.arguments[1], loc);
     const optsNode = expr.arguments[2];
 
-    const bool = (v: boolean): IrExpr => ({ kind: "boolLit", value: v, type: BOOL, loc });
-    const num = (v: number): IrExpr => ({ kind: "numLit", value: v, type: F64, loc });
     const emptyStr: IrExpr = { kind: "strLit", value: "", type: STRING, loc };
     const helper = execFileAsyncHelper(L, loc);
     const envRecT: IrType = { kind: "record", shapeId: helper.envShapeId };
     const envRec = (has: boolean, pairs: IrExpr): IrExpr => ({
       kind: "recordLit",
       fields: [
-        { name: "has", value: bool(has) },
+        { name: "has", value: boolLit(has, loc) },
         { name: "pairs", value: pairs },
       ],
       type: envRecT,
@@ -2853,7 +2839,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const emptyPairs = (): IrExpr => ({ kind: "arrayLit", elems: [], type: arrayOf(STRING), loc });
     let cwd: IrExpr = emptyStr;
     let env: IrExpr = envRec(false, emptyPairs());
-    let timeout: IrExpr = num(0);
+    let timeout: IrExpr = numLit(0, loc);
     if (optsNode) {
       if (!ts.isObjectLiteralExpression(optsNode)) {
         L.noLowering(
@@ -2982,7 +2968,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const recT: IrType = { kind: "record", shapeId };
     const envRecT: IrType = { kind: "record", shapeId: envShapeId };
     const strArrT = arrayOf(STRING);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
+
     const body: IrStmt[] = [
       {
         kind: "varDecl",
@@ -2991,12 +2977,12 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
           kind: "libCall",
           fn: "cp.execCapture",
           args: [
-            ref("cmd.0", STRING),
-            ref("argv.0", strArrT),
-            ref("cwd.0", STRING),
-            { kind: "recordGet", obj: ref("env.0", envRecT), shapeId: envShapeId, field: "has", type: BOOL, loc },
-            { kind: "recordGet", obj: ref("env.0", envRecT), shapeId: envShapeId, field: "pairs", type: strArrT, loc },
-            ref("timeout.0", F64),
+            varRef("cmd.0", STRING, loc),
+            varRef("argv.0", strArrT, loc),
+            varRef("cwd.0", STRING, loc),
+            { kind: "recordGet", obj: varRef("env.0", envRecT, loc), shapeId: envShapeId, field: "has", type: BOOL, loc },
+            { kind: "recordGet", obj: varRef("env.0", envRecT, loc), shapeId: envShapeId, field: "pairs", type: strArrT, loc },
+            varRef("timeout.0", F64, loc),
           ],
           type: SPAWNRES_T,
           loc,
@@ -3008,8 +2994,8 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         value: {
           kind: "recordLit",
           fields: [
-            { name: "stderr", value: { kind: "libCall", fn: "spawnRes.stderr", args: [ref("r.0", SPAWNRES_T)], type: STRING, loc } },
-            { name: "stdout", value: { kind: "libCall", fn: "spawnRes.stdout", args: [ref("r.0", SPAWNRES_T)], type: STRING, loc } },
+            { name: "stderr", value: { kind: "libCall", fn: "spawnRes.stderr", args: [varRef("r.0", SPAWNRES_T, loc)], type: STRING, loc } },
+            { name: "stdout", value: { kind: "libCall", fn: "spawnRes.stdout", args: [varRef("r.0", SPAWNRES_T, loc)], type: STRING, loc } },
           ],
           type: recT,
           loc,
@@ -3621,10 +3607,10 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const name = `%strdec.${op}.${L.widthHelpers.size}`;
     L.widthHelpers.set(key, name);
     const recT: IrType = { kind: "record", shapeId };
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
+
     const pendingRead = (): IrExpr => ({
       kind: "recordGet",
-      obj: ref("d.0", recT),
+      obj: varRef("d.0", recT, loc),
       shapeId,
       field: "%pending",
       type: F64,
@@ -3632,7 +3618,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     });
     const encRead = (): IrExpr => ({
       kind: "recordGet",
-      obj: ref("d.0", recT),
+      obj: varRef("d.0", recT, loc),
       shapeId,
       field: "%enc",
       type: STRING,
@@ -3653,18 +3639,18 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         {
           kind: "varDecl",
           localId: "s.0",
-          init: { kind: "libCall", fn: "strdec.write", args: [encRead(), pendingRead(), ref("chunk.0", BYTES_U8)], type: STRING, loc },
+          init: { kind: "libCall", fn: "strdec.write", args: [encRead(), pendingRead(), varRef("chunk.0", BYTES_U8, loc)], type: STRING, loc },
           loc,
         },
         {
           kind: "recordSet",
-          obj: ref("d.0", recT),
+          obj: varRef("d.0", recT, loc),
           shapeId,
           field: "%pending",
-          value: { kind: "libCall", fn: "strdec.next", args: [encRead(), pendingRead(), ref("chunk.0", BYTES_U8)], type: F64, loc },
+          value: { kind: "libCall", fn: "strdec.next", args: [encRead(), pendingRead(), varRef("chunk.0", BYTES_U8, loc)], type: F64, loc },
           loc,
         },
-        { kind: "return", value: ref("s.0", STRING), loc },
+        { kind: "return", value: varRef("s.0", STRING, loc), loc },
       ];
     } else {
       body = [
@@ -3676,13 +3662,13 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
         },
         {
           kind: "recordSet",
-          obj: ref("d.0", recT),
+          obj: varRef("d.0", recT, loc),
           shapeId,
           field: "%pending",
           value: { kind: "numLit", value: 0, type: F64, loc },
           loc,
         },
-        { kind: "return", value: ref("s.0", STRING), loc },
+        { kind: "return", value: varRef("s.0", STRING, loc), loc },
       ];
     }
     L.liftedFns.push({ name, params, returnType: STRING, locals, body, loc });
@@ -4345,12 +4331,10 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const paramTypes: IrType[] =
       arity === 0 ? [] : arity === 1 ? [STRING] : arity === 2 ? [STRING, STRING] : [STRING, STRING, SEARCH_PARAMS_T];
     const fnT = funcOf(paramTypes, fnRet);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
     const sp = (fn: "sp.size" | "sp.keyAt" | "sp.valAt", extra: IrExpr[], type: IrType): IrExpr => ({
       kind: "libCall",
       fn,
-      args: [ref("sp.0", SEARCH_PARAMS_T), ...extra],
+      args: [varRef("sp.0", SEARCH_PARAMS_T, loc), ...extra],
       type,
       loc,
     });
@@ -4363,28 +4347,28 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const body: IrStmt[] = [];
     if (arity >= 1) {
       locals.push({ id: "v.0", name: "v", type: STRING, mutable: false });
-      body.push({ kind: "varDecl", localId: "v.0", init: sp("sp.valAt", [ref("i.0", F64)], STRING), loc });
-      callArgs.push(ref("v.0", STRING));
+      body.push({ kind: "varDecl", localId: "v.0", init: sp("sp.valAt", [varRef("i.0", F64, loc)], STRING), loc });
+      callArgs.push(varRef("v.0", STRING, loc));
     }
     if (arity >= 2) {
       locals.push({ id: "k.0", name: "k", type: STRING, mutable: false });
-      body.push({ kind: "varDecl", localId: "k.0", init: sp("sp.keyAt", [ref("i.0", F64)], STRING), loc });
-      callArgs.push(ref("k.0", STRING));
+      body.push({ kind: "varDecl", localId: "k.0", init: sp("sp.keyAt", [varRef("i.0", F64, loc)], STRING), loc });
+      callArgs.push(varRef("k.0", STRING, loc));
     }
-    if (arity === 3) callArgs.push(ref("sp.0", SEARCH_PARAMS_T));
+    if (arity === 3) callArgs.push(varRef("sp.0", SEARCH_PARAMS_T, loc));
     body.push({
       kind: "exprStmt",
-      expr: { kind: "callValue", callee: ref("f.0", fnT), args: callArgs, type: fnRet, loc },
+      expr: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: callArgs, type: fnRet, loc },
       loc,
     });
     const loop: IrStmt = {
       kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-      cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: sp("sp.size", [], F64), type: BOOL, loc },
+      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+      cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: sp("sp.size", [], F64), type: BOOL, loc },
       update: {
         kind: "assign",
         localId: "i.0",
-        value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
         loc,
       },
       body,
@@ -4416,16 +4400,15 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
     const loc = locOf(call);
     const receiver = (): IrExpr => L.lowerExprExpecting(access.expression, FILEHANDLE_T);
     const promise = (inner: IrType): IrType => ({ kind: "promise", inner });
-    const bool = (value: boolean): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
     const num = (node: ts.Expression | undefined, dflt: number): { value: IrExpr; defaulted: IrExpr } => {
       const defaultValue = { kind: "numLit", value: dflt, type: F64, loc } satisfies IrExpr;
-      if (!node) return { value: defaultValue, defaulted: bool(true) };
+      if (!node) return { value: defaultValue, defaulted: boolLit(true, loc) };
       const undefinedArg = lowerStaticallyUndefinedBuiltinArg(L, node);
       if (undefinedArg) {
-        return { value: defaultAfterUndefined(undefinedArg, defaultValue), defaulted: bool(true) };
+        return { value: defaultAfterUndefined(undefinedArg, defaultValue), defaulted: boolLit(true, loc) };
       }
       if ((L.typeOf(node).flags & ts.TypeFlags.Null) !== 0) {
-        return { value: defaultAfterUndefined(L.lowerExpr(node), defaultValue), defaulted: bool(true) };
+        return { value: defaultAfterUndefined(L.lowerExpr(node), defaultValue), defaulted: boolLit(true, loc) };
       }
       const value = L.lowerExpr(node);
       if (value.type.kind === "union") {
@@ -4475,7 +4458,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
           };
         }
       }
-      return { value: L.coerceInto(node, value, F64), defaulted: bool(false) };
+      return { value: L.coerceInto(node, value, F64), defaulted: boolLit(false, loc) };
     };
     const utf8 = (node: ts.Expression | undefined): IrExpr => {
       const dflt = { kind: "strLit", value: "utf8", type: STRING, loc } satisfies IrExpr;
@@ -7774,15 +7757,14 @@ function staticTextDecoderEncoding(label: string): StaticTextDecoderEncoding | n
     L.widthHelpers.set(key, name);
     const recT: IrType = { kind: "record", shapeId };
     const pairsT = arrayOf(STRING);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
     const pairAt = (offset: number): IrExpr => ({
       kind: "arrayGet",
-      arr: ref("ps.0", pairsT),
+      arr: varRef("ps.0", pairsT, loc),
       index:
         offset === 0
-          ? ref("i.0", F64)
-          : { kind: "bin", op: "+", left: ref("i.0", F64), right: num(offset), type: F64, loc },
+          ? varRef("i.0", F64, loc)
+          : { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(offset, loc), type: F64, loc },
       type: STRING,
       loc,
     });
@@ -7801,25 +7783,25 @@ function staticTextDecoderEncoding(label: string): StaticTextDecoderEncoding | n
       },
       {
         kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
         cond: {
           kind: "bin",
           op: "<",
-          left: ref("i.0", F64),
-          right: { kind: "arrIntrinsic", method: "length", receiver: ref("ps.0", pairsT), args: [], type: F64, loc },
+          left: varRef("i.0", F64, loc),
+          right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ps.0", pairsT, loc), args: [], type: F64, loc },
           type: BOOL,
           loc,
         },
         update: {
           kind: "assign",
           localId: "i.0",
-          value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(2), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(2, loc), type: F64, loc },
           loc,
         },
         body: [
           {
             kind: "recordKeySet",
-            obj: ref("out.0", recT),
+            obj: varRef("out.0", recT, loc),
             shapeId,
             key: pairAt(0),
             value: { kind: "unionWrap", unionId: iv.unionId, tag: strTag, value: pairAt(1), type: iv, loc },
@@ -7828,7 +7810,7 @@ function staticTextDecoderEncoding(label: string): StaticTextDecoderEncoding | n
         ],
         loc,
       },
-      { kind: "return", value: ref("out.0", recT), loc },
+      { kind: "return", value: varRef("out.0", recT, loc), loc },
     ];
     L.liftedFns.push({
       name,

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -27,6 +27,7 @@ import { ambientNsRootOf, ambientUndefReadType, ambientUndefVarRootOf, ambientUn
 import { declSymbolOf } from "./lower-modules.js";
 import { expandoMemberRead } from "./lower-expando.js";
 import { npmStaticPackageOfPath } from "../npm-static.js";
+import { numLit, varRef } from "../../ir/build.js";
 
 /** How a parameter participates in CALL-SITE COMPLETION (the frontend
  * completes every call to the one full signature, so the IR and backends
@@ -6745,8 +6746,6 @@ export function lowerPromiseMethodCall(L: Lowerer, call: ts.CallExpression,
     const arrT = arrayOf(elem);
     const outT = arrayOf(outElem);
     const fnT = funcOf([elem], BOOL);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
     const locals: IrLocal[] = [
       { id: "a.0", name: "a", type: arrT, mutable: true },
       ...(test === "callback" ? [{ id: "f.0", name: "f", type: fnT, mutable: true } as IrLocal] : []),
@@ -6759,10 +6758,10 @@ export function lowerPromiseMethodCall(L: Lowerer, call: ts.CallExpression,
       { localId: "a.0", name: "a", type: arrT },
       ...(test === "callback" ? [{ localId: "f.0", name: "f", type: fnT }] : []),
     ];
-    const v = ref("v.0", elem);
+    const v = varRef("v.0", elem, loc);
     const cond: IrExpr =
       test === "callback"
-        ? { kind: "callValue", callee: ref("f.0", fnT), args: [v], type: BOOL, loc }
+        ? { kind: "callValue", callee: varRef("f.0", fnT, loc), args: [v], type: BOOL, loc }
         : { kind: "toBool", operand: v, type: BOOL, loc };
     const kept: IrExpr =
       tag !== null && elem.kind === "union"
@@ -6773,24 +6772,24 @@ export function lowerPromiseMethodCall(L: Lowerer, call: ts.CallExpression,
       {
         kind: "varDecl",
         localId: "n.0",
-        init: { kind: "arrIntrinsic", method: "length", receiver: ref("a.0", arrT), args: [], type: F64, loc },
+        init: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: F64, loc },
         loc,
       },
       {
         kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-        cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: ref("n.0", F64), type: BOOL, loc },
+        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
         update: {
           kind: "assign",
           localId: "i.0",
-          value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
           loc,
         },
         body: [
           {
             kind: "varDecl",
             localId: "v.0",
-            init: { kind: "arrayGet", arr: ref("a.0", arrT), index: ref("i.0", F64), type: elem, loc },
+            init: { kind: "arrayGet", arr: varRef("a.0", arrT, loc), index: varRef("i.0", F64, loc), type: elem, loc },
             loc,
           },
           {
@@ -6802,7 +6801,7 @@ export function lowerPromiseMethodCall(L: Lowerer, call: ts.CallExpression,
                 expr: {
                   kind: "arrIntrinsic",
                   method: "push",
-                  receiver: ref("out.0", outT),
+                  receiver: varRef("out.0", outT, loc),
                   args: [kept],
                   type: F64,
                   loc,
@@ -6816,7 +6815,7 @@ export function lowerPromiseMethodCall(L: Lowerer, call: ts.CallExpression,
         ],
         loc,
       },
-      { kind: "return", value: ref("out.0", outT), loc },
+      { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     L.liftedFns.push({ name, params, returnType: outT, locals, body, loc });
     return name;

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -13,6 +13,7 @@ import { isJsSourceFile, locOf } from "../program.js";
 import { islandPrimitiveExit, lowerDynDispatchMethodCall } from "./lower-calls.js";
 import { typeKey } from "../types.js";
 import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
+import { boolLit, numLit, varRef } from "../../ir/build.js";
 
 /** Lower an expression whose checker type is statically `undefined`/`void`.
  * Optional builtin arguments use this before their ordinary expected-type
@@ -852,11 +853,10 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     if (!name) {
       name = `%arr.idxOr.${L.arrHofHelpers.size}`;
       L.arrHofHelpers.set(key, name);
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const i = ref("i.0", F64);
-      const n = ref("n.0", F64);
-      const v = ref("v.0", elem);
+
+      const i = varRef("i.0", F64, loc);
+      const n = varRef("n.0", F64, loc);
+      const v = varRef("v.0", elem, loc);
       const lt = (l: IrExpr, r: IrExpr): IrExpr => ({ kind: "bin", op: "<", left: l, right: r, type: BOOL, loc });
       const miss: IrExpr = {
         kind: "unionWrap",
@@ -869,7 +869,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       const body: IrStmt[] = [
         readLenStmt(arrT, loc),
         { kind: "if", cond: { kind: "bin", op: "!==", left: i, right: i, type: BOOL, loc }, then: [{ kind: "return", value: miss, loc }], else_: null, loc },
-        { kind: "if", cond: lt(i, num(0)), then: [{ kind: "return", value: miss, loc }], else_: null, loc },
+        { kind: "if", cond: lt(i, numLit(0, loc)), then: [{ kind: "return", value: miss, loc }], else_: null, loc },
         { kind: "if", cond: { kind: "bin", op: ">=", left: i, right: n, type: BOOL, loc }, then: [{ kind: "return", value: miss, loc }], else_: null, loc },
         // A fractional index is a property miss too (floor(i) < i exactly
         // when i has a fraction; negatives already returned above).
@@ -880,7 +880,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           else_: null,
           loc,
         },
-        { kind: "varDecl", localId: "v.0", init: { kind: "arrayGet", arr: ref("a.0", arrT), index: i, type: elem, loc }, loc },
+        { kind: "varDecl", localId: "v.0", init: { kind: "arrayGet", arr: varRef("a.0", arrT, loc), index: i, type: elem, loc }, loc },
         {
           kind: "return",
           value: elem.kind === "union"
@@ -924,7 +924,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     const name = `%arr.concat.${L.arrHofHelpers.size}`;
     L.arrHofHelpers.set(key, name);
     const arrT = arrayOf(elem);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
+
     const locals: IrLocal[] = [
       { id: "a.0", name: "a", type: arrT, mutable: false },
       ...shape.map((s, i): IrLocal => ({ id: `x.${i}`, name: `x${i}`, type: s === "a" ? arrT : elem, mutable: false })),
@@ -939,7 +939,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       expr: {
         kind: "arrIntrinsic",
         method: s === "a" ? "pushSpread" : "push",
-        receiver: ref("out.0", arrT),
+        receiver: varRef("out.0", arrT, loc),
         args: [src],
         type: F64,
         loc,
@@ -948,9 +948,9 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     });
     const body: IrStmt[] = [
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: arrT, loc }, loc },
-      append("a", ref("a.0", arrT)),
-      ...shape.map((s, i) => append(s, ref(`x.${i}`, s === "a" ? arrT : elem))),
-      { kind: "return", value: ref("out.0", arrT), loc },
+      append("a", varRef("a.0", arrT, loc)),
+      ...shape.map((s, i) => append(s, varRef(`x.${i}`, s === "a" ? arrT : elem, loc))),
+      { kind: "return", value: varRef("out.0", arrT, loc), loc },
     ];
     L.liftedFns.push({ name, params, returnType: arrT, locals, body, loc });
     return name;
@@ -975,8 +975,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     loc: SrcLoc,): IrFunction {
     const arrT = arrayOf(elem);
     const fnT = funcOf([elem, F64, arrT].slice(0, arity), fnRet);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
     const locals: IrLocal[] = [
       { id: "a.0", name: "a", type: arrT, mutable: true },
       { id: "f.0", name: "f", type: fnT, mutable: true },
@@ -989,15 +988,15 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     ];
     const callF = (arg: IrExpr): IrExpr => ({
       kind: "callValue",
-      callee: ref("f.0", fnT),
-      args: [arg, ref("i.0", F64), ref("a.0", arrT)].slice(0, arity),
+      callee: varRef("f.0", fnT, loc),
+      args: [arg, varRef("i.0", F64, loc), varRef("a.0", arrT, loc)].slice(0, arity),
       type: fnRet,
       loc,
     });
     const getElem: IrExpr = {
       kind: "arrayGet",
-      arr: ref("a.0", arrT),
-      index: ref("i.0", F64),
+      arr: varRef("a.0", arrT, loc),
+      index: varRef("i.0", F64, loc),
       type: elem,
       loc,
     };
@@ -1006,7 +1005,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       expr: {
         kind: "arrIntrinsic",
         method: "push",
-        receiver: ref("out.0", outT),
+        receiver: varRef("out.0", outT, loc),
         args: [value],
         type: F64,
         loc,
@@ -1016,17 +1015,17 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     const readLen: IrStmt = {
       kind: "varDecl",
       localId: "n.0",
-      init: { kind: "arrIntrinsic", method: "length", receiver: ref("a.0", arrT), args: [], type: F64, loc },
+      init: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: F64, loc },
       loc,
     };
     const forLoop = (body: IrStmt[]): IrStmt => ({
       kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-      cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: ref("n.0", F64), type: BOOL, loc },
+      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+      cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
       update: {
         kind: "assign",
         localId: "i.0",
-        value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
         loc,
       },
       body,
@@ -1043,7 +1042,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
         readLen,
         forLoop([push(outT, callF(getElem))]),
-        { kind: "return", value: ref("out.0", outT), loc },
+        { kind: "return", value: varRef("out.0", outT, loc), loc },
       ];
     } else if (method === "filter") {
       locals.push(
@@ -1060,13 +1059,13 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
             kind: "if",
             // ToBoolean over the predicate's answer — inert when it already
             // returned bool, the per-union helper when it returned a union.
-            cond: filterCond(callF(ref("v.0", elem)), fnRet, loc),
-            then: [push(arrT, ref("v.0", elem))],
+            cond: filterCond(callF(varRef("v.0", elem, loc)), fnRet, loc),
+            then: [push(arrT, varRef("v.0", elem, loc))],
             else_: null,
             loc,
           },
         ]),
-        { kind: "return", value: ref("out.0", arrT), loc },
+        { kind: "return", value: varRef("out.0", arrT, loc), loc },
       ];
     } else {
       returnType = VOID;
@@ -1177,8 +1176,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     L.arrHofHelpers.set(key, name);
     const arrT = arrayOf(elem);
     const fnT = funcOf([elem, F64, arrT].slice(0, arity), fnRet);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const v = ref("v.0", elem);
+
+    const v = varRef("v.0", elem, loc);
     const found: IrExpr =
       foundTag === null
         ? v
@@ -1199,8 +1198,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           kind: "if",
           cond: predToBool({
             kind: "callValue",
-            callee: ref("f.0", fnT),
-            args: [v, ref("i.0", F64), ref("a.0", arrT)].slice(0, arity),
+            callee: varRef("f.0", fnT, loc),
+            args: [v, varRef("i.0", F64, loc), varRef("a.0", arrT, loc)].slice(0, arity),
             type: fnRet,
             loc,
           }),
@@ -1245,7 +1244,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     L.arrHofHelpers.set(key, name);
     const arrT = arrayOf(elem);
     const fnT = funcOf([elem, F64, arrT].slice(0, arity), fnRet);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
+
     const body: IrStmt[] = [
       readLenStmt(arrT, loc),
       (last ? reverseCountedForLoop : countedForLoop)(loc, [
@@ -1253,12 +1252,12 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           kind: "if",
           cond: predToBool({
             kind: "callValue",
-            callee: ref("f.0", fnT),
-            args: [getElemExpr(arrT, elem, loc), ref("i.0", F64), ref("a.0", arrT)].slice(0, arity),
+            callee: varRef("f.0", fnT, loc),
+            args: [getElemExpr(arrT, elem, loc), varRef("i.0", F64, loc), varRef("a.0", arrT, loc)].slice(0, arity),
             type: fnRet,
             loc,
           }),
-          then: [{ kind: "return", value: ref("i.0", F64), loc }],
+          then: [{ kind: "return", value: varRef("i.0", F64, loc), loc }],
           else_: null,
           loc,
         },
@@ -1301,12 +1300,10 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     L.arrHofHelpers.set(key, name);
     const arrT = arrayOf(elem);
     const fnT = funcOf([elem, F64, arrT].slice(0, arity), fnRet);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const bool = (value: boolean): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
     const callF: IrExpr = predToBool({
       kind: "callValue",
-      callee: ref("f.0", fnT),
-      args: [getElemExpr(arrT, elem, loc), ref("i.0", F64), ref("a.0", arrT)].slice(0, arity),
+      callee: varRef("f.0", fnT, loc),
+      args: [getElemExpr(arrT, elem, loc), varRef("i.0", F64, loc), varRef("a.0", arrT, loc)].slice(0, arity),
       type: fnRet,
       loc,
     });
@@ -1316,12 +1313,12 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         {
           kind: "if",
           cond: method === "some" ? callF : { kind: "unary", op: "!", operand: callF, type: BOOL, loc },
-          then: [{ kind: "return", value: bool(method === "some"), loc }],
+          then: [{ kind: "return", value: boolLit(method === "some", loc), loc }],
           else_: null,
           loc,
         },
       ]),
-      { kind: "return", value: bool(method !== "some"), loc },
+      { kind: "return", value: boolLit(method !== "some", loc), loc },
     ];
     L.liftedFns.push({
       name,
@@ -1401,16 +1398,15 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     const arrT = arrayOf(elem);
     const inner = fnRet.elem;
     const fnT = funcOf([elem, F64, arrT].slice(0, arity), fnRet);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
     const innerLoop: IrStmt = {
       kind: "for",
-      init: { kind: "varDecl", localId: "j.0", init: num(0), loc },
-      cond: { kind: "bin", op: "<", left: ref("j.0", F64), right: ref("m.0", F64), type: BOOL, loc },
+      init: { kind: "varDecl", localId: "j.0", init: numLit(0, loc), loc },
+      cond: { kind: "bin", op: "<", left: varRef("j.0", F64, loc), right: varRef("m.0", F64, loc), type: BOOL, loc },
       update: {
         kind: "assign",
         localId: "j.0",
-        value: { kind: "bin", op: "+", left: ref("j.0", F64), right: num(1), type: F64, loc },
+        value: { kind: "bin", op: "+", left: varRef("j.0", F64, loc), right: numLit(1, loc), type: F64, loc },
         loc,
       },
       body: [
@@ -1419,8 +1415,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           expr: {
             kind: "arrIntrinsic",
             method: "push",
-            receiver: ref("out.0", fnRet),
-            args: [{ kind: "arrayGet", arr: ref("r.0", fnRet), index: ref("j.0", F64), type: inner, loc }],
+            receiver: varRef("out.0", fnRet, loc),
+            args: [{ kind: "arrayGet", arr: varRef("r.0", fnRet, loc), index: varRef("j.0", F64, loc), type: inner, loc }],
             type: F64,
             loc,
           },
@@ -1438,8 +1434,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           localId: "r.0",
           init: {
             kind: "callValue",
-            callee: ref("f.0", fnT),
-            args: [getElemExpr(arrT, elem, loc), ref("i.0", F64), ref("a.0", arrT)].slice(0, arity),
+            callee: varRef("f.0", fnT, loc),
+            args: [getElemExpr(arrT, elem, loc), varRef("i.0", F64, loc), varRef("a.0", arrT, loc)].slice(0, arity),
             type: fnRet,
             loc,
           },
@@ -1448,12 +1444,12 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         {
           kind: "varDecl",
           localId: "m.0",
-          init: { kind: "arrIntrinsic", method: "length", receiver: ref("r.0", fnRet), args: [], type: F64, loc },
+          init: { kind: "arrIntrinsic", method: "length", receiver: varRef("r.0", fnRet, loc), args: [], type: F64, loc },
           loc,
         },
         innerLoop,
       ]),
-      { kind: "return", value: ref("out.0", fnRet), loc },
+      { kind: "return", value: varRef("out.0", fnRet, loc), loc },
     ];
     L.liftedFns.push({
       name,
@@ -1526,12 +1522,11 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     L.arrHofHelpers.set(key, name);
     const arrT = arrayOf(elem);
     const fnT = funcOf([accT, elem, F64, arrT].slice(0, arity), accT);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const n = ref("n.0", F64);
-    const i = ref("i.0", F64);
+
+    const n = varRef("n.0", F64, loc);
+    const i = varRef("i.0", F64, loc);
     const right = method === "reduceRight";
-    const at = (index: IrExpr): IrExpr => ({ kind: "arrayGet", arr: ref("a.0", arrT), index, type: elem, loc });
+    const at = (index: IrExpr): IrExpr => ({ kind: "arrayGet", arr: varRef("a.0", arrT, loc), index, type: elem, loc });
     const locals: IrLocal[] = [
       { id: "a.0", name: "a", type: arrT, mutable: true },
       { id: "f.0", name: "f", type: fnT, mutable: true },
@@ -1546,11 +1541,11 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       ...(hasInit ? [{ localId: "z.0", name: "z", type: accT }] : []),
     ];
     const seedStmts: IrStmt[] = hasInit
-      ? [{ kind: "varDecl", localId: "acc.0", init: ref("z.0", accT), loc }]
+      ? [{ kind: "varDecl", localId: "acc.0", init: varRef("z.0", accT, loc), loc }]
       : [
           {
             kind: "if",
-            cond: { kind: "bin", op: "===", left: n, right: num(0), type: BOOL, loc },
+            cond: { kind: "bin", op: "===", left: n, right: numLit(0, loc), type: BOOL, loc },
             then: [
               {
                 kind: "throw",
@@ -1577,25 +1572,25 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           {
             kind: "varDecl",
             localId: "acc.0",
-            init: at(right ? { kind: "bin", op: "-", left: n, right: num(1), type: F64, loc } : num(0)),
+            init: at(right ? { kind: "bin", op: "-", left: n, right: numLit(1, loc), type: F64, loc } : numLit(0, loc)),
             loc,
           },
         ];
     // Loop bounds: with init the walk covers every index; the seeded form
     // starts one past the seed. reduce ascends, reduceRight descends.
     const start: IrExpr = right
-      ? { kind: "bin", op: "-", left: n, right: num(hasInit ? 1 : 2), type: F64, loc }
-      : num(hasInit ? 0 : 1);
+      ? { kind: "bin", op: "-", left: n, right: numLit(hasInit ? 1 : 2, loc), type: F64, loc }
+      : numLit(hasInit ? 0 : 1, loc);
     const loop: IrStmt = {
       kind: "for",
       init: { kind: "varDecl", localId: "i.0", init: start, loc },
       cond: right
-        ? { kind: "bin", op: ">=", left: i, right: num(0), type: BOOL, loc }
+        ? { kind: "bin", op: ">=", left: i, right: numLit(0, loc), type: BOOL, loc }
         : { kind: "bin", op: "<", left: i, right: n, type: BOOL, loc },
       update: {
         kind: "assign",
         localId: "i.0",
-        value: { kind: "bin", op: right ? "-" : "+", left: i, right: num(1), type: F64, loc },
+        value: { kind: "bin", op: right ? "-" : "+", left: i, right: numLit(1, loc), type: F64, loc },
         loc,
       },
       body: [
@@ -1604,8 +1599,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           localId: "acc.0",
           value: {
             kind: "callValue",
-            callee: ref("f.0", fnT),
-            args: [ref("acc.0", accT), at(i), i, ref("a.0", arrT)].slice(0, arity),
+            callee: varRef("f.0", fnT, loc),
+            args: [varRef("acc.0", accT, loc), at(i), i, varRef("a.0", arrT, loc)].slice(0, arity),
             type: accT,
             loc,
           },
@@ -1618,7 +1613,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       readLenStmt(arrT, loc),
       ...seedStmts,
       loop,
-      { kind: "return", value: ref("acc.0", accT), loc },
+      { kind: "return", value: varRef("acc.0", accT, loc), loc },
     ];
     L.liftedFns.push({ name, params, returnType: accT, locals, body, loc });
     return name;
@@ -1720,10 +1715,9 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     if (existing) return existing;
     const name = `%arr.sortCmpStr`;
     L.arrHofHelpers.set(key, name);
-    const ref = (localId: string): IrExpr => ({ kind: "varRef", localId, type: STRING, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
     const cmp = (op: "<" | ">"): IrExpr => ({
-      kind: "strCmp", op, left: ref("a.0"), right: ref("b.0"), utf16: true, type: BOOL, loc,
+      kind: "strCmp", op, left: varRef("a.0", STRING, loc), right: varRef("b.0", STRING, loc), utf16: true, type: BOOL, loc,
     });
     const body: IrStmt[] = [
       {
@@ -1731,8 +1725,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         value: {
           kind: "ternary",
           cond: cmp("<"),
-          then: num(-1),
-          else_: { kind: "ternary", cond: cmp(">"), then: num(1), else_: num(0), type: F64, loc },
+          then: numLit(-1, loc),
+          else_: { kind: "ternary", cond: cmp(">"), then: numLit(1, loc), else_: numLit(0, loc), type: F64, loc },
           type: F64,
           loc,
         },
@@ -1780,11 +1774,10 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
   ): IrFunction {
     const arrT = arrayOf(elem);
     const fnT = funcOf([elem, elem].slice(0, arity), F64);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const j = ref("j.0", F64);
-    const at = (index: IrExpr): IrExpr => ({ kind: "arrayGet", arr: ref("a.0", arrT), index, type: elem, loc });
-    const jPlus1: IrExpr = { kind: "bin", op: "+", left: j, right: num(1), type: F64, loc };
+
+    const j = varRef("j.0", F64, loc);
+    const at = (index: IrExpr): IrExpr => ({ kind: "arrayGet", arr: varRef("a.0", arrT, loc), index, type: elem, loc });
+    const jPlus1: IrExpr = { kind: "bin", op: "+", left: j, right: numLit(1, loc), type: F64, loc };
     const isUndefined = (value: IrExpr): IrExpr | null => {
       if (elem.kind === "union" && undefinedTag !== null) {
         return {
@@ -1816,17 +1809,17 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       op: ">",
       left: {
         kind: "callValue",
-        callee: ref("f.0", fnT),
-        args: [at(j), ref("v.0", elem)].slice(0, arity),
+        callee: varRef("f.0", fnT, loc),
+        args: [at(j), varRef("v.0", elem, loc)].slice(0, arity),
         type: F64,
         loc,
       },
-      right: num(0),
+      right: numLit(0, loc),
       type: BOOL,
       loc,
     };
     const leftUndefined = isUndefined(at(j));
-    const valueUndefined = isUndefined(ref("v.0", elem));
+    const valueUndefined = isUndefined(varRef("v.0", elem, loc));
     // CompareArrayElements: undefined always sinks and never reaches the
     // user comparator. Ternaries preserve that callback suppression.
     const shouldShift: IrExpr =
@@ -1855,14 +1848,14 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         : compareGreater;
     const shiftLoop: IrStmt = {
       kind: "while",
-      cond: { kind: "bin", op: ">=", left: j, right: num(0), type: BOOL, loc },
+      cond: { kind: "bin", op: ">=", left: j, right: numLit(0, loc), type: BOOL, loc },
       body: [
         {
           kind: "if",
           cond: shouldShift,
           then: [
-            { kind: "arraySet", arr: ref("a.0", arrT), index: jPlus1, value: at(j), loc },
-            { kind: "assign", localId: "j.0", value: { kind: "bin", op: "-", left: j, right: num(1), type: F64, loc }, loc },
+            { kind: "arraySet", arr: varRef("a.0", arrT, loc), index: jPlus1, value: at(j), loc },
+            { kind: "assign", localId: "j.0", value: { kind: "bin", op: "-", left: j, right: numLit(1, loc), type: F64, loc }, loc },
           ],
           else_: [{ kind: "break", loc }],
           loc,
@@ -1878,7 +1871,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
             value: {
               kind: "arrIntrinsic" as const,
               method: "slice" as const,
-              receiver: ref("a.0", arrT),
+              receiver: varRef("a.0", arrT, loc),
               args: [],
               type: arrT,
               loc,
@@ -1889,23 +1882,23 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       readLenStmt(arrT, loc),
       {
         kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: num(1), loc },
-        cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: ref("n.0", F64), type: BOOL, loc },
+        init: { kind: "varDecl", localId: "i.0", init: numLit(1, loc), loc },
+        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
         update: {
           kind: "assign",
           localId: "i.0",
-          value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
           loc,
         },
         body: [
           { kind: "varDecl", localId: "v.0", init: getElemExpr(arrT, elem, loc), loc },
-          { kind: "varDecl", localId: "j.0", init: { kind: "bin", op: "-", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
+          { kind: "varDecl", localId: "j.0", init: { kind: "bin", op: "-", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
           shiftLoop,
-          { kind: "arraySet", arr: ref("a.0", arrT), index: jPlus1, value: ref("v.0", elem), loc },
+          { kind: "arraySet", arr: varRef("a.0", arrT, loc), index: jPlus1, value: varRef("v.0", elem, loc), loc },
         ],
         loc,
       },
-      { kind: "return", value: ref("a.0", arrT), loc },
+      { kind: "return", value: varRef("a.0", arrT, loc), loc },
     ];
     return {
       name,
@@ -2020,23 +2013,12 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
   ): IrFunction {
     const bytesT = BYTES_U8;
     const fnT = funcOf([F64, F64].slice(0, arity), F64);
-    const ref = (localId: string, type: IrType): IrExpr => ({
-      kind: "varRef",
-      localId,
-      type,
-      loc,
-    });
-    const num = (value: number): IrExpr => ({
-      kind: "numLit",
-      value,
-      type: F64,
-      loc,
-    });
-    const j = ref("j.0", F64);
+
+    const j = varRef("j.0", F64, loc);
     const at = (index: IrExpr): IrExpr => ({
       kind: "bytesIntrinsic",
       method: "get",
-      receiver: ref("a.0", bytesT),
+      receiver: varRef("a.0", bytesT, loc),
       args: [index],
       type: F64,
       loc,
@@ -2045,15 +2027,15 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       kind: "bin",
       op: "+",
       left: j,
-      right: num(1),
+      right: numLit(1, loc),
       type: F64,
       loc,
     };
     const compare: IrExpr = hasComparator
       ? {
           kind: "callValue",
-          callee: ref("f.0", fnT),
-          args: [at(j), ref("v.0", F64)].slice(0, arity),
+          callee: varRef("f.0", fnT, loc),
+          args: [at(j), varRef("v.0", F64, loc)].slice(0, arity),
           type: F64,
           loc,
         }
@@ -2061,7 +2043,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           kind: "bin",
           op: "-",
           left: at(j),
-          right: ref("v.0", F64),
+          right: varRef("v.0", F64, loc),
           type: F64,
           loc,
         };
@@ -2071,7 +2053,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         kind: "bin",
         op: ">=",
         left: j,
-        right: num(0),
+        right: numLit(0, loc),
         type: BOOL,
         loc,
       },
@@ -2082,14 +2064,14 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
             kind: "bin",
             op: ">",
             left: compare,
-            right: num(0),
+            right: numLit(0, loc),
             type: BOOL,
             loc,
           },
           then: [
             {
               kind: "bytesSet",
-              arr: ref("a.0", bytesT),
+              arr: varRef("a.0", bytesT, loc),
               index: jPlus1,
               value: at(j),
               loc,
@@ -2101,7 +2083,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
                 kind: "bin",
                 op: "-",
                 left: j,
-                right: num(1),
+                right: numLit(1, loc),
                 type: F64,
                 loc,
               },
@@ -2137,7 +2119,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         value: {
           kind: "bytesIntrinsic",
           method: "slice",
-          receiver: ref("a.0", bytesT),
+          receiver: varRef("a.0", bytesT, loc),
           args: [],
           type: bytesT,
           loc,
@@ -2150,7 +2132,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         init: {
           kind: "bytesIntrinsic",
           method: "length",
-          receiver: ref("a.0", bytesT),
+          receiver: varRef("a.0", bytesT, loc),
           args: [],
           type: F64,
           loc,
@@ -2162,14 +2144,14 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         init: {
           kind: "varDecl",
           localId: "i.0",
-          init: num(1),
+          init: numLit(1, loc),
           loc,
         },
         cond: {
           kind: "bin",
           op: "<",
-          left: ref("i.0", F64),
-          right: ref("n.0", F64),
+          left: varRef("i.0", F64, loc),
+          right: varRef("n.0", F64, loc),
           type: BOOL,
           loc,
         },
@@ -2179,8 +2161,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           value: {
             kind: "bin",
             op: "+",
-            left: ref("i.0", F64),
-            right: num(1),
+            left: varRef("i.0", F64, loc),
+            right: numLit(1, loc),
             type: F64,
             loc,
           },
@@ -2190,7 +2172,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           {
             kind: "varDecl",
             localId: "v.0",
-            init: at(ref("i.0", F64)),
+            init: at(varRef("i.0", F64, loc)),
             loc,
           },
           {
@@ -2199,8 +2181,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
             init: {
               kind: "bin",
               op: "-",
-              left: ref("i.0", F64),
-              right: num(1),
+              left: varRef("i.0", F64, loc),
+              right: numLit(1, loc),
               type: F64,
               loc,
             },
@@ -2209,15 +2191,15 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           shiftLoop,
           {
             kind: "bytesSet",
-            arr: ref("a.0", bytesT),
+            arr: varRef("a.0", bytesT, loc),
             index: jPlus1,
-            value: ref("v.0", F64),
+            value: varRef("v.0", F64, loc),
             loc,
           },
         ],
         loc,
       },
-      { kind: "return", value: ref("a.0", bytesT), loc },
+      { kind: "return", value: varRef("a.0", bytesT, loc), loc },
     ];
     return {
       name,
@@ -2352,12 +2334,11 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       name = `%arr.at.${L.arrHofHelpers.size}`;
       L.arrHofHelpers.set(key, name);
       const arrT = arrayOf(elem);
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const t = ref("t.0", F64);
-      const i = ref("i.0", F64);
-      const n = ref("n.0", F64);
-      const v = ref("v.0", elem);
+
+      const t = varRef("t.0", F64, loc);
+      const i = varRef("i.0", F64, loc);
+      const n = varRef("n.0", F64, loc);
+      const v = varRef("v.0", elem, loc);
       const found: IrExpr =
         foundTag === null
           ? v
@@ -2380,28 +2361,28 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         { kind: "varDecl", localId: "t.0", init: floorOf(i), loc },
         {
           kind: "if",
-          cond: lt(i, num(0)),
-          then: [{ kind: "assign", localId: "t.0", value: { kind: "bin", op: "-", left: num(0), right: floorOf({ kind: "bin", op: "-", left: num(0), right: i, type: F64, loc }), type: F64, loc }, loc }],
+          cond: lt(i, numLit(0, loc)),
+          then: [{ kind: "assign", localId: "t.0", value: { kind: "bin", op: "-", left: numLit(0, loc), right: floorOf({ kind: "bin", op: "-", left: numLit(0, loc), right: i, type: F64, loc }), type: F64, loc }, loc }],
           else_: null,
           loc,
         },
         {
           kind: "if",
           cond: { kind: "libCall", fn: "num.isNaN", args: [i], type: BOOL, loc },
-          then: [{ kind: "assign", localId: "t.0", value: num(0), loc }],
+          then: [{ kind: "assign", localId: "t.0", value: numLit(0, loc), loc }],
           else_: null,
           loc,
         },
         {
           kind: "if",
-          cond: lt(t, num(0)),
+          cond: lt(t, numLit(0, loc)),
           then: [{ kind: "assign", localId: "t.0", value: { kind: "bin", op: "+", left: t, right: n, type: F64, loc }, loc }],
           else_: null,
           loc,
         },
         {
           kind: "if",
-          cond: lt(t, num(0)),
+          cond: lt(t, numLit(0, loc)),
           then: [{ kind: "return", value: miss, loc }],
           else_: null,
           loc,
@@ -2416,7 +2397,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         {
           kind: "varDecl",
           localId: "v.0",
-          init: { kind: "arrayGet", arr: ref("a.0", arrT), index: t, type: elem, loc },
+          init: { kind: "arrayGet", arr: varRef("a.0", arrT, loc), index: t, type: elem, loc },
           loc,
         },
         { kind: "return", value: found, loc },
@@ -2565,22 +2546,22 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
    */
   function buildStrCharsFn(name: string, loc: SrcLoc): IrFunction {
     const outT = arrayOf(STRING);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
+
     const sLen = (recv: IrExpr): IrExpr => ({ kind: "strIntrinsic", method: "length", receiver: recv, args: [], type: F64, loc });
     const body: IrStmt[] = [
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
       { kind: "varDecl", localId: "i.0", init: { kind: "numLit", value: 0, type: F64, loc }, loc },
       {
         kind: "while",
-        cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: sLen(ref("s.0", STRING)), type: BOOL, loc },
+        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: sLen(varRef("s.0", STRING, loc)), type: BOOL, loc },
         body: [
-          { kind: "varDecl", localId: "ch.0", init: { kind: "strIntrinsic", method: "cpAt", receiver: ref("s.0", STRING), args: [ref("i.0", F64)], type: STRING, loc }, loc },
-          { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: sLen(ref("ch.0", STRING)), type: F64, loc }, loc },
-          { kind: "exprStmt", expr: { kind: "arrIntrinsic", method: "push", receiver: ref("out.0", outT), args: [ref("ch.0", STRING)], type: F64, loc }, loc },
+          { kind: "varDecl", localId: "ch.0", init: { kind: "strIntrinsic", method: "cpAt", receiver: varRef("s.0", STRING, loc), args: [varRef("i.0", F64, loc)], type: STRING, loc }, loc },
+          { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: sLen(varRef("ch.0", STRING, loc)), type: F64, loc }, loc },
+          { kind: "exprStmt", expr: { kind: "arrIntrinsic", method: "push", receiver: varRef("out.0", outT, loc), args: [varRef("ch.0", STRING, loc)], type: F64, loc }, loc },
         ],
         loc,
       },
-      { kind: "return", value: ref("out.0", outT), loc },
+      { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     return {
       name,
@@ -2620,8 +2601,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
   function buildArrayFromLenFn(name: string, fnRet: IrType, arity: number, loc: SrcLoc): IrFunction {
     const outT = arrayOf(fnRet);
     const fnT = funcOf([DYN, F64].slice(0, arity), fnRet);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
     const undef: IrExpr = {
       kind: "dynFrom",
       value: { kind: "unitLit", unit: "undefined", type: UNDEFINED_T, loc },
@@ -2632,19 +2612,19 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
       {
         kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
         cond: {
           kind: "bin",
           op: "<=",
-          left: ref("i.0", F64),
-          right: { kind: "bin", op: "-", left: ref("n.0", F64), right: num(1), type: F64, loc },
+          left: varRef("i.0", F64, loc),
+          right: { kind: "bin", op: "-", left: varRef("n.0", F64, loc), right: numLit(1, loc), type: F64, loc },
           type: BOOL,
           loc,
         },
         update: {
           kind: "assign",
           localId: "i.0",
-          value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
           loc,
         },
         body: [
@@ -2653,12 +2633,12 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
             expr: {
               kind: "arrIntrinsic",
               method: "push",
-              receiver: ref("out.0", outT),
+              receiver: varRef("out.0", outT, loc),
               args: [
                 {
                   kind: "callValue",
-                  callee: ref("f.0", fnT),
-                  args: [undef, ref("i.0", F64)].slice(0, arity),
+                  callee: varRef("f.0", fnT, loc),
+                  args: [undef, varRef("i.0", F64, loc)].slice(0, arity),
                   type: fnRet,
                   loc,
                 },
@@ -2671,7 +2651,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
         ],
         loc,
       },
-      { kind: "return", value: ref("out.0", outT), loc },
+      { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     return {
       name,
@@ -2829,15 +2809,14 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
     tupleT: (IrType & { kind: "record" }) | null,
     loc: SrcLoc,): IrFunction {
     const outT = arrayOf(elemT);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
     const iter = (
       m: "iterCount" | "iterLive" | "iterKey" | "iterValue",
       args: IrExpr[],
       type: IrType,
-    ): IrExpr => ({ kind: "mapIntrinsic", method: m, receiver: ref("m.0", mapT), args, type, loc });
-    const keyRead = iter("iterKey", [ref("i.0", F64)], mapT.key);
-    const valRead = iter("iterValue", [ref("i.0", F64)], mapT.value);
+    ): IrExpr => ({ kind: "mapIntrinsic", method: m, receiver: varRef("m.0", mapT, loc), args, type, loc });
+    const keyRead = iter("iterKey", [varRef("i.0", F64, loc)], mapT.key);
+    const valRead = iter("iterValue", [varRef("i.0", F64, loc)], mapT.value);
     const pushed: IrExpr =
       method === "keys"
         ? keyRead
@@ -2856,22 +2835,22 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
       {
         kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-        cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: iter("iterCount", [], F64), type: BOOL, loc },
+        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: iter("iterCount", [], F64), type: BOOL, loc },
         update: {
           kind: "assign",
           localId: "i.0",
-          value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
           loc,
         },
         body: [
           {
             kind: "if",
-            cond: iter("iterLive", [ref("i.0", F64)], BOOL),
+            cond: iter("iterLive", [varRef("i.0", F64, loc)], BOOL),
             then: [
               {
                 kind: "exprStmt",
-                expr: { kind: "arrIntrinsic", method: "push", receiver: ref("out.0", outT), args: [pushed], type: F64, loc },
+                expr: { kind: "arrIntrinsic", method: "push", receiver: varRef("out.0", outT, loc), args: [pushed], type: F64, loc },
                 loc,
               },
             ],
@@ -2881,7 +2860,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
         ],
         loc,
       },
-      { kind: "return", value: ref("out.0", outT), loc },
+      { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     return {
       name,
@@ -2959,8 +2938,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
       arity === 0 ? [] : arity === 1 ? [mapT.value] : [mapT.value, mapT.key],
       fnRet,
     );
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
     const iter = (
       method: "iterCount" | "iterLive" | "iterKey" | "iterValue" | "iterEnter" | "iterExit",
       args: IrExpr[],
@@ -2968,7 +2946,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
     ): IrExpr => ({
       kind: "mapIntrinsic",
       method,
-      receiver: ref("m.0", mapT),
+      receiver: varRef("m.0", mapT, loc),
       args,
       type,
       loc,
@@ -2985,33 +2963,33 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
       visitBody.push({
         kind: "varDecl",
         localId: "v.0",
-        init: iter("iterValue", [ref("i.0", F64)], mapT.value),
+        init: iter("iterValue", [varRef("i.0", F64, loc)], mapT.value),
         loc,
       });
-      callArgs.push(ref("v.0", mapT.value));
+      callArgs.push(varRef("v.0", mapT.value, loc));
     }
     if (arity === 2) {
       locals.push({ id: "k.0", name: "k", type: mapT.key, mutable: false });
       visitBody.push({
         kind: "varDecl",
         localId: "k.0",
-        init: iter("iterKey", [ref("i.0", F64)], mapT.key),
+        init: iter("iterKey", [varRef("i.0", F64, loc)], mapT.key),
         loc,
       });
-      callArgs.push(ref("k.0", mapT.key));
+      callArgs.push(varRef("k.0", mapT.key, loc));
     }
     visitBody.push({
       kind: "exprStmt",
-      expr: { kind: "callValue", callee: ref("f.0", fnT), args: callArgs, type: fnRet, loc },
+      expr: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: callArgs, type: fnRet, loc },
       loc,
     });
     const loop: IrStmt = {
       kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
       cond: {
         kind: "bin",
         op: "<",
-        left: ref("i.0", F64),
+        left: varRef("i.0", F64, loc),
         right: iter("iterCount", [], F64),
         type: BOOL,
         loc,
@@ -3019,13 +2997,13 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
       update: {
         kind: "assign",
         localId: "i.0",
-        value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
         loc,
       },
       body: [
         {
           kind: "if",
-          cond: iter("iterLive", [ref("i.0", F64)], BOOL),
+          cond: iter("iterLive", [varRef("i.0", F64, loc)], BOOL),
           then: visitBody,
           else_: null,
           loc,
@@ -3160,8 +3138,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
     loc: SrcLoc,): IrFunction {
     const elem = setT.elem;
     const fnT = funcOf(Array.from({ length: arity }, () => elem), fnRet);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
     const iter = (
       method: "iterCount" | "iterLive" | "iterKey" | "iterEnter" | "iterExit",
       args: IrExpr[],
@@ -3169,7 +3146,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
     ): IrExpr => ({
       kind: "setIntrinsic",
       method,
-      receiver: ref("m.0", setT),
+      receiver: varRef("m.0", setT, loc),
       args,
       type,
       loc,
@@ -3186,23 +3163,23 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
       visitBody.push({
         kind: "varDecl",
         localId: "v.0",
-        init: iter("iterKey", [ref("i.0", F64)], elem),
+        init: iter("iterKey", [varRef("i.0", F64, loc)], elem),
         loc,
       });
-      for (let i = 0; i < arity; i++) callArgs.push(ref("v.0", elem));
+      for (let i = 0; i < arity; i++) callArgs.push(varRef("v.0", elem, loc));
     }
     visitBody.push({
       kind: "exprStmt",
-      expr: { kind: "callValue", callee: ref("f.0", fnT), args: callArgs, type: fnRet, loc },
+      expr: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: callArgs, type: fnRet, loc },
       loc,
     });
     const loop: IrStmt = {
       kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
       cond: {
         kind: "bin",
         op: "<",
-        left: ref("i.0", F64),
+        left: varRef("i.0", F64, loc),
         right: iter("iterCount", [], F64),
         type: BOOL,
         loc,
@@ -3210,13 +3187,13 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
       update: {
         kind: "assign",
         localId: "i.0",
-        value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
         loc,
       },
       body: [
         {
           kind: "if",
-          cond: iter("iterLive", [ref("i.0", F64)], BOOL),
+          cond: iter("iterLive", [varRef("i.0", F64, loc)], BOOL),
           then: visitBody,
           else_: null,
           loc,
@@ -3386,10 +3363,9 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
       : (L.shapes.get(resultT.shapeId)!.indexValue as IrType & { kind: "union" });
     const arrTag = L.armTag(iv.unionId, itemsT);
     const undefTag = L.armTag(iv.unionId, UNDEFINED_T);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const gRef = (): IrExpr => ref("g.0", resultT);
-    const kRef = (): IrExpr => ref("k.0", keyT);
+
+    const gRef = (): IrExpr => varRef("g.0", resultT, loc);
+    const kRef = (): IrExpr => varRef("k.0", keyT, loc);
     // Record keys are property keys: an f64 key stringifies (JS's exact
     // number ToString); map keys stay typed.
     const storeKey = (): IrExpr =>
@@ -3399,14 +3375,14 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
         ? { kind: "mapIntrinsic", method: "get", receiver: gRef(), args: [storeKey()], type: iv, loc }
         : { kind: "recordKeyGet", obj: gRef(), shapeId: (resultT as IrType & { kind: "record" }).shapeId, key: storeKey(), overflowOnly: true, type: iv, loc };
     const freshGroup = (): IrExpr =>
-      ({ kind: "arrayLit", elems: [ref("v.0", elem)], type: itemsT, loc });
+      ({ kind: "arrayLit", elems: [varRef("v.0", elem, loc)], type: itemsT, loc });
     const groupWrite = (): IrStmt =>
       isMap
         ? { kind: "exprStmt", expr: { kind: "mapIntrinsic", method: "set", receiver: gRef(), args: [storeKey(), freshGroup()], type: VOID, loc }, loc }
         : { kind: "recordKeySet", obj: gRef(), shapeId: (resultT as IrType & { kind: "record" }).shapeId, key: storeKey(), value: { kind: "unionWrap", unionId: iv.unionId, tag: arrTag, value: freshGroup(), type: iv, loc }, loc };
     const callArgs: IrExpr[] = [];
-    if (arity >= 1) callArgs.push(ref("v.0", elem));
-    if (arity === 2) callArgs.push(ref("i.0", F64));
+    if (arity >= 1) callArgs.push(varRef("v.0", elem, loc));
+    if (arity === 2) callArgs.push(varRef("i.0", F64, loc));
     const locals: IrLocal[] = [
       { id: "items.0", name: "items", type: itemsT, mutable: true },
       { id: "f.0", name: "f", type: fnT, mutable: true },
@@ -3426,19 +3402,19 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
           : { kind: "recordLit", fields: [], type: resultT, loc },
         loc,
       },
-      { kind: "varDecl", localId: "n.0", init: { kind: "arrIntrinsic", method: "length", receiver: ref("items.0", itemsT), args: [], type: F64, loc }, loc },
+      { kind: "varDecl", localId: "n.0", init: { kind: "arrIntrinsic", method: "length", receiver: varRef("items.0", itemsT, loc), args: [], type: F64, loc }, loc },
       {
         kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-        cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: ref("n.0", F64), type: BOOL, loc },
-        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
+        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
+        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
         body: [
-          { kind: "varDecl", localId: "v.0", init: { kind: "arrayGet", arr: ref("items.0", itemsT), index: ref("i.0", F64), type: elem, loc }, loc },
-          { kind: "varDecl", localId: "k.0", init: { kind: "callValue", callee: ref("f.0", fnT), args: callArgs, type: keyT, loc }, loc },
+          { kind: "varDecl", localId: "v.0", init: { kind: "arrayGet", arr: varRef("items.0", itemsT, loc), index: varRef("i.0", F64, loc), type: elem, loc }, loc },
+          { kind: "varDecl", localId: "k.0", init: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: callArgs, type: keyT, loc }, loc },
           { kind: "varDecl", localId: "cur.0", init: groupRead(), loc },
           {
             kind: "if",
-            cond: { kind: "unionIsTag", unionId: iv.unionId, tag: undefTag, negated: false, value: ref("cur.0", iv), type: BOOL, loc },
+            cond: { kind: "unionIsTag", unionId: iv.unionId, tag: undefTag, negated: false, value: varRef("cur.0", iv, loc), type: BOOL, loc },
             then: [groupWrite()],
             else_: [
               {
@@ -3446,8 +3422,8 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
                 expr: {
                   kind: "arrIntrinsic",
                   method: "push",
-                  receiver: { kind: "unionNarrow", unionId: iv.unionId, tag: arrTag, value: ref("cur.0", iv), type: itemsT, loc },
-                  args: [ref("v.0", elem)],
+                  receiver: { kind: "unionNarrow", unionId: iv.unionId, tag: arrTag, value: varRef("cur.0", iv, loc), type: itemsT, loc },
+                  args: [varRef("v.0", elem, loc)],
                   type: F64,
                   loc,
                 },
@@ -3677,13 +3653,13 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     name = "%iter.budget";
     L.arrHofHelpers.set(key, name);
     const v = (): IrExpr => ({ kind: "varRef", localId: "v.0", type: F64, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
     // trunc without an Infinity-poisoned fmod: values at or past 2^53 are
     // already integers (Infinity included), so only smaller ones truncate.
     const t = (): IrExpr => ({
       kind: "ternary",
-      cond: { kind: "bin", op: "<", left: v(), right: num(9007199254740992), type: BOOL, loc },
-      then: { kind: "bin", op: "-", left: v(), right: { kind: "bin", op: "%", left: v(), right: num(1), type: F64, loc }, type: F64, loc },
+      cond: { kind: "bin", op: "<", left: v(), right: numLit(9007199254740992, loc), type: BOOL, loc },
+      then: { kind: "bin", op: "-", left: v(), right: { kind: "bin", op: "%", left: v(), right: numLit(1, loc), type: F64, loc }, type: F64, loc },
       else_: v(),
       type: F64,
       loc,
@@ -3692,7 +3668,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       kind: "logical",
       op: "||",
       left: { kind: "bin", op: "!==", left: v(), right: v(), type: BOOL, loc },
-      right: { kind: "bin", op: "<", left: t(), right: num(0), type: BOOL, loc },
+      right: { kind: "bin", op: "<", left: t(), right: numLit(0, loc), type: BOOL, loc },
       type: BOOL,
       loc,
     };
@@ -3735,9 +3711,6 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     termArgTs: IrType[],
     resultT: IrType,
     loc: SrcLoc,): IrFunction {
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const boolLit = (value: boolean): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
     const locals: IrLocal[] = [{ id: "items.0", name: "items", type: itemsT, mutable: true }];
     const params: IrParam[] = [{ localId: "items.0", name: "items", type: itemsT }];
     let n = 0;
@@ -3753,8 +3726,8 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       return id;
     };
     const doneId = addLocal("done", BOOL, true);
-    const done = (): IrExpr => ref(doneId, BOOL);
-    const setDone: IrStmt = { kind: "assign", localId: doneId, value: boolLit(true), loc };
+    const done = (): IrExpr => varRef(doneId, BOOL, loc);
+    const setDone: IrStmt = { kind: "assign", localId: doneId, value: boolLit(true, loc), loc };
     // Parameters in call order: per-stage budget/callback, then terminal's.
     interface StageSlot { kind: string; paramId: string; fnT?: (IrType & { kind: "func" }) | undefined; cntId?: string | undefined; elem: IrType }
     // The entries() seed builds each pass's [index, element] pair — the
@@ -3787,12 +3760,12 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
         ? addLocal("k", F64, true)
         : undefined;
     const bump = (id: string): IrStmt =>
-      ({ kind: "assign", localId: id, value: { kind: "bin", op: "+", left: ref(id, F64), right: num(1), type: F64, loc }, loc });
+      ({ kind: "assign", localId: id, value: { kind: "bin", op: "+", left: varRef(id, F64, loc), right: numLit(1, loc), type: F64, loc }, loc });
     const callWith = (fnT: IrType & { kind: "func" }, fnId: string, value: IrExpr, cntId: string | undefined): IrExpr => {
       const args: IrExpr[] = [];
       if (fnT.params.length >= 1) args.push(value);
-      if (cntId !== undefined && fnT.params.length >= 2) args.push(ref(cntId, F64));
-      return { kind: "callValue", callee: ref(fnId, fnT), args, type: fnT.ret, loc };
+      if (cntId !== undefined && fnT.params.length >= 2) args.push(varRef(cntId, F64, loc));
+      return { kind: "callValue", callee: varRef(fnId, fnT, loc), args, type: fnT.ret, loc };
     };
     // Terminal state.
     const preLoop: IrStmt[] = [];
@@ -3804,53 +3777,53 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     if (terminal === "toArray") {
       outId = addLocal("out", resultT, false);
       preLoop.push({ kind: "varDecl", localId: outId, init: { kind: "arrayLit", elems: [], type: resultT, loc }, loc });
-      postLoop.push({ kind: "return", value: ref(outId, resultT), loc });
+      postLoop.push({ kind: "return", value: varRef(outId, resultT, loc), loc });
     } else if (terminal === "some" || terminal === "every") {
       resId = addLocal("res", BOOL, true);
-      preLoop.push({ kind: "varDecl", localId: resId, init: boolLit(terminal === "every"), loc });
-      postLoop.push({ kind: "return", value: ref(resId, BOOL), loc });
+      preLoop.push({ kind: "varDecl", localId: resId, init: boolLit(terminal === "every", loc), loc });
+      postLoop.push({ kind: "return", value: varRef(resId, BOOL, loc), loc });
     } else if (terminal === "find") {
       resId = addLocal("res", resultT, true);
       const undef = L.wrappedUndefined(resultT, loc);
       if (undef === null) throw new InternalCompilerError("lowerer bug: find result union lacks undefined");
       preLoop.push({ kind: "varDecl", localId: resId, init: undef, loc });
-      postLoop.push({ kind: "return", value: ref(resId, resultT), loc });
+      postLoop.push({ kind: "return", value: varRef(resId, resultT, loc), loc });
     } else if (terminal === "reduce") {
       accId = addLocal("acc", resultT, true);
       if (termIds.length === 2) {
-        preLoop.push({ kind: "varDecl", localId: accId, init: ref(termIds[1]!, resultT), loc });
+        preLoop.push({ kind: "varDecl", localId: accId, init: varRef(termIds[1]!, resultT, loc), loc });
       } else {
         hasAccId = addLocal("hasAcc", BOOL, true);
-        preLoop.push({ kind: "varDecl", localId: hasAccId, init: boolLit(false), loc });
+        preLoop.push({ kind: "varDecl", localId: hasAccId, init: boolLit(false, loc), loc });
         postLoop.push({
           kind: "if",
-          cond: { kind: "unary", op: "!", operand: ref(hasAccId, BOOL), type: BOOL, loc },
+          cond: { kind: "unary", op: "!", operand: varRef(hasAccId, BOOL, loc), type: BOOL, loc },
           then: [throwTypeError({ kind: "strLit", value: "Reduce of a done iterator with no initial value", type: STRING, loc }, loc)],
           else_: null,
           loc,
         });
       }
-      postLoop.push({ kind: "return", value: ref(accId, resultT), loc });
+      postLoop.push({ kind: "return", value: varRef(accId, resultT, loc), loc });
     } else {
       postLoop.push({ kind: "return", value: null, loc });
     }
-    if (termCntId !== undefined) preLoop.push({ kind: "varDecl", localId: termCntId, init: num(0), loc });
+    if (termCntId !== undefined) preLoop.push({ kind: "varDecl", localId: termCntId, init: numLit(0, loc), loc });
     // done starts true when any take budget is zero (nothing pulls).
-    let doneInit: IrExpr = boolLit(false);
+    let doneInit: IrExpr = boolLit(false, loc);
     for (const s of slots) {
       if (s.kind !== "take") continue;
-      const isZero: IrExpr = { kind: "bin", op: "===", left: ref(s.paramId, F64), right: num(0), type: BOOL, loc };
+      const isZero: IrExpr = { kind: "bin", op: "===", left: varRef(s.paramId, F64, loc), right: numLit(0, loc), type: BOOL, loc };
       doneInit = doneInit.kind === "boolLit" ? isZero : { kind: "logical", op: "||", left: doneInit, right: isZero, type: BOOL, loc };
     }
     preLoop.unshift({ kind: "varDecl", localId: doneId, init: doneInit, loc });
     for (const s of slots) {
-      if (s.cntId !== undefined) preLoop.push({ kind: "varDecl", localId: s.cntId, init: num(0), loc });
+      if (s.cntId !== undefined) preLoop.push({ kind: "varDecl", localId: s.cntId, init: numLit(0, loc), loc });
     }
     // The terminal's per-element statements over `value`.
     const terminalBody = (value: IrExpr): IrStmt[] => {
       const out: IrStmt[] = [];
       if (terminal === "toArray") {
-        out.push({ kind: "exprStmt", expr: { kind: "arrIntrinsic", method: "push", receiver: ref(outId, resultT), args: [value], type: F64, loc }, loc });
+        out.push({ kind: "exprStmt", expr: { kind: "arrIntrinsic", method: "push", receiver: varRef(outId, resultT, loc), args: [value], type: F64, loc }, loc });
       } else if (terminal === "forEach") {
         out.push({ kind: "exprStmt", expr: callWith(termFnT!, termIds[0]!, value, termCntId), loc });
       } else if (terminal === "some" || terminal === "every") {
@@ -3859,7 +3832,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
         out.push({
           kind: "if",
           cond,
-          then: [{ kind: "assign", localId: resId, value: boolLit(terminal === "some"), loc }, setDone],
+          then: [{ kind: "assign", localId: resId, value: boolLit(terminal === "some", loc), loc }, setDone],
           else_: null,
           loc,
         });
@@ -3880,17 +3853,17 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       } else {
         // reduce
         const reducer = (): IrExpr => {
-          const args: IrExpr[] = [ref(accId, resultT), value];
-          if (termFnT!.params.length === 3) args.push(ref(termCntId!, F64));
-          return { kind: "callValue", callee: ref(termIds[0]!, termFnT!), args, type: resultT, loc };
+          const args: IrExpr[] = [varRef(accId, resultT, loc), value];
+          if (termFnT!.params.length === 3) args.push(varRef(termCntId!, F64, loc));
+          return { kind: "callValue", callee: varRef(termIds[0]!, termFnT!, loc), args, type: resultT, loc };
         };
         if (hasAccId !== "") {
           out.push({
             kind: "if",
-            cond: { kind: "unary", op: "!", operand: ref(hasAccId, BOOL), type: BOOL, loc },
+            cond: { kind: "unary", op: "!", operand: varRef(hasAccId, BOOL, loc), type: BOOL, loc },
             then: [
               { kind: "assign", localId: accId, value, loc },
-              { kind: "assign", localId: hasAccId, value: boolLit(true), loc },
+              { kind: "assign", localId: hasAccId, value: boolLit(true, loc), loc },
             ],
             else_: [{ kind: "assign", localId: accId, value: reducer(), loc }],
             loc,
@@ -3913,7 +3886,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
           return [
             { kind: "varDecl", localId: vId, init: callWith(s.fnT!, s.paramId, value, s.cntId), loc },
             ...(s.cntId !== undefined ? [bump(s.cntId)] : []),
-            ...inner(ref(vId, s.fnT!.ret)),
+            ...inner(varRef(vId, s.fnT!.ret, loc)),
           ];
         };
       } else if (s.kind === "filter") {
@@ -3922,7 +3895,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
           return [
             { kind: "varDecl", localId: okId, init: callWith(s.fnT!, s.paramId, value, s.cntId), loc },
             ...(s.cntId !== undefined ? [bump(s.cntId)] : []),
-            { kind: "if", cond: { kind: "unary", op: "!", operand: ref(okId, BOOL), type: BOOL, loc }, then: [{ kind: "continue", loc }], else_: null, loc },
+            { kind: "if", cond: { kind: "unary", op: "!", operand: varRef(okId, BOOL, loc), type: BOOL, loc }, then: [{ kind: "continue", loc }], else_: null, loc },
             ...inner(value),
           ];
         };
@@ -3930,7 +3903,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
         emit = (value) => [
           {
             kind: "if",
-            cond: { kind: "bin", op: "<", left: ref(s.cntId!, F64), right: ref(s.paramId, F64), type: BOOL, loc },
+            cond: { kind: "bin", op: "<", left: varRef(s.cntId!, F64, loc), right: varRef(s.paramId, F64, loc), type: BOOL, loc },
             then: [bump(s.cntId!), { kind: "continue", loc }],
             else_: null,
             loc,
@@ -3946,7 +3919,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
           bump(s.cntId!),
           {
             kind: "if",
-            cond: { kind: "bin", op: ">=", left: ref(s.cntId!, F64), right: ref(s.paramId, F64), type: BOOL, loc },
+            cond: { kind: "bin", op: ">=", left: varRef(s.cntId!, F64, loc), right: varRef(s.paramId, F64, loc), type: BOOL, loc },
             then: [setDone],
             else_: null,
             loc,
@@ -3965,19 +3938,19 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
             ...(s.cntId !== undefined ? [bump(s.cntId)] : []),
             {
               kind: "for",
-              init: { kind: "varDecl", localId: jId, init: num(0), loc },
+              init: { kind: "varDecl", localId: jId, init: numLit(0, loc), loc },
               cond: {
                 kind: "logical",
                 op: "&&",
-                left: { kind: "bin", op: "<", left: ref(jId, F64), right: { kind: "arrIntrinsic", method: "length", receiver: ref(arrId, innerT), args: [], type: F64, loc }, type: BOOL, loc },
+                left: { kind: "bin", op: "<", left: varRef(jId, F64, loc), right: { kind: "arrIntrinsic", method: "length", receiver: varRef(arrId, innerT, loc), args: [], type: F64, loc }, type: BOOL, loc },
                 right: { kind: "unary", op: "!", operand: done(), type: BOOL, loc },
                 type: BOOL,
                 loc,
               },
-              update: { kind: "assign", localId: jId, value: { kind: "bin", op: "+", left: ref(jId, F64), right: num(1), type: F64, loc }, loc },
+              update: { kind: "assign", localId: jId, value: { kind: "bin", op: "+", left: varRef(jId, F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
               body: [
-                { kind: "varDecl", localId: wId, init: { kind: "arrayGet", arr: ref(arrId, innerT), index: ref(jId, F64), type: innerT.elem, loc }, loc },
-                ...inner(ref(wId, innerT.elem)),
+                { kind: "varDecl", localId: wId, init: { kind: "arrayGet", arr: varRef(arrId, innerT, loc), index: varRef(jId, F64, loc), type: innerT.elem, loc }, loc },
+                ...inner(varRef(wId, innerT.elem, loc)),
               ],
               loc,
             },
@@ -3987,12 +3960,12 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     }
     const iId = addLocal("i", F64, true);
     const vId = addLocal("v", seedT, false);
-    const elemRead = (): IrExpr => ({ kind: "arrayGet", arr: ref("items.0", itemsT), index: ref(iId, F64), type: itemsT.elem, loc });
+    const elemRead = (): IrExpr => ({ kind: "arrayGet", arr: varRef("items.0", itemsT, loc), index: varRef(iId, F64, loc), type: itemsT.elem, loc });
     const seedInit: IrExpr = srcProj === "entries"
       ? {
           kind: "recordLit",
           fields: [
-            { name: "0", value: ref(iId, F64) },
+            { name: "0", value: varRef(iId, F64, loc) },
             { name: "1", value: elemRead() },
           ],
           type: seedT,
@@ -4001,19 +3974,19 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       : elemRead();
     const loop: IrStmt = {
       kind: "for",
-      init: { kind: "varDecl", localId: iId, init: num(0), loc },
+      init: { kind: "varDecl", localId: iId, init: numLit(0, loc), loc },
       cond: {
         kind: "logical",
         op: "&&",
-        left: { kind: "bin", op: "<", left: ref(iId, F64), right: { kind: "arrIntrinsic", method: "length", receiver: ref("items.0", itemsT), args: [], type: F64, loc }, type: BOOL, loc },
+        left: { kind: "bin", op: "<", left: varRef(iId, F64, loc), right: { kind: "arrIntrinsic", method: "length", receiver: varRef("items.0", itemsT, loc), args: [], type: F64, loc }, type: BOOL, loc },
         right: { kind: "unary", op: "!", operand: done(), type: BOOL, loc },
         type: BOOL,
         loc,
       },
-      update: { kind: "assign", localId: iId, value: { kind: "bin", op: "+", left: ref(iId, F64), right: num(1), type: F64, loc }, loc },
+      update: { kind: "assign", localId: iId, value: { kind: "bin", op: "+", left: varRef(iId, F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
       body: [
         { kind: "varDecl", localId: vId, init: seedInit, loc },
-        ...emit(ref(vId, seedT)),
+        ...emit(varRef(vId, seedT, loc)),
       ],
       loc,
     };
@@ -4097,11 +4070,9 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     loc: SrcLoc,): IrFunction {
     const elem = setT.elem;
     const predicate = method === "isSubsetOf" || method === "isSupersetOf" || method === "isDisjointFrom";
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const boolLit = (value: boolean): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
+
     const setOp = (recv: string, m: IrSetIntrinsicMethod, args: IrExpr[], type: IrType): IrExpr =>
-      ({ kind: "setIntrinsic", method: m, receiver: ref(recv, setT), args, type, loc });
+      ({ kind: "setIntrinsic", method: m, receiver: varRef(recv, setT, loc), args, type, loc });
     const locals: IrLocal[] = [
       { id: "a.0", name: "a", type: setT, mutable: true },
       { id: "b.0", name: "b", type: setT, mutable: true },
@@ -4114,23 +4085,23 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       nextLocal += 1;
       locals.push({ id: iId, name: "i", type: F64, mutable: true });
       locals.push({ id: vId, name: "v", type: elem, mutable: false });
-      const v = ref(vId, elem);
+      const v = varRef(vId, elem, loc);
       return {
         kind: "for",
-        init: { kind: "varDecl", localId: iId, init: num(0), loc },
-        cond: { kind: "bin", op: "<", left: ref(iId, F64), right: setOp(src, "iterCount", [], F64), type: BOOL, loc },
+        init: { kind: "varDecl", localId: iId, init: numLit(0, loc), loc },
+        cond: { kind: "bin", op: "<", left: varRef(iId, F64, loc), right: setOp(src, "iterCount", [], F64), type: BOOL, loc },
         update: {
           kind: "assign",
           localId: iId,
-          value: { kind: "bin", op: "+", left: ref(iId, F64), right: num(1), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef(iId, F64, loc), right: numLit(1, loc), type: F64, loc },
           loc,
         },
         body: [
           {
             kind: "if",
-            cond: setOp(src, "iterLive", [ref(iId, F64)], BOOL),
+            cond: setOp(src, "iterLive", [varRef(iId, F64, loc)], BOOL),
             then: [
-              { kind: "varDecl", localId: vId, init: setOp(src, "iterKey", [ref(iId, F64)], elem), loc },
+              { kind: "varDecl", localId: vId, init: setOp(src, "iterKey", [varRef(iId, F64, loc)], elem), loc },
               ...visit(v),
             ],
             else_: null,
@@ -4143,10 +4114,10 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     const has = (src: string, v: IrExpr): IrExpr => setOp(src, "has", [v], BOOL);
     const not = (e: IrExpr): IrExpr => ({ kind: "unary", op: "!", operand: e, type: BOOL, loc });
     const addTo = (v: IrExpr): IrStmt =>
-      ({ kind: "exprStmt", expr: { kind: "setIntrinsic", method: "add", receiver: ref("r.0", setT), args: [v], type: VOID, loc }, loc });
+      ({ kind: "exprStmt", expr: { kind: "setIntrinsic", method: "add", receiver: varRef("r.0", setT, loc), args: [v], type: VOID, loc }, loc });
     const addIf = (cond: IrExpr, v: IrExpr): IrStmt[] => [{ kind: "if", cond, then: [addTo(v)], else_: null, loc }];
     const returnIf = (cond: IrExpr, value: boolean): IrStmt[] =>
-      [{ kind: "if", cond, then: [{ kind: "return", value: boolLit(value), loc }], else_: null, loc }];
+      [{ kind: "if", cond, then: [{ kind: "return", value: boolLit(value, loc), loc }], else_: null, loc }];
     const body: IrStmt[] = [];
     if (!predicate) {
       locals.push({ id: "r.0", name: "r", type: setT, mutable: false });
@@ -4185,7 +4156,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       default:
         throw new InternalCompilerError(`lowerer bug: unknown set combine method ${method}`);
     }
-    body.push({ kind: "return", value: predicate ? boolLit(true) : ref("r.0", setT), loc });
+    body.push({ kind: "return", value: predicate ? boolLit(true, loc) : varRef("r.0", setT, loc), loc });
     return {
       name,
       params: [
@@ -4260,12 +4231,11 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       const sp = L.declareHiddenLocal("%spof", SP);
       const i = L.declareHiddenLocal("%iterof", F64);
       i.mutable = true;
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
       const read = (fn: "sp.size" | "sp.keyAt" | "sp.valAt", idx: boolean): IrExpr => ({
         kind: "libCall",
         fn,
-        args: idx ? [ref(sp.id, SP), ref(i.id, F64)] : [ref(sp.id, SP)],
+        args: idx ? [varRef(sp.id, SP, loc), varRef(i.id, F64, loc)] : [varRef(sp.id, SP, loc)],
         type: idx ? STRING : F64,
         loc,
       });
@@ -4353,12 +4323,12 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       const body = L.inCtl("loop", () => L.lowerScopedBlock(stmt.statement));
       const loop: IrStmt = {
         kind: "for",
-        init: { kind: "varDecl", localId: i.id, init: num(0), loc },
-        cond: { kind: "bin", op: "<", left: ref(i.id, F64), right: read("sp.size", false), type: BOOL, loc },
+        init: { kind: "varDecl", localId: i.id, init: numLit(0, loc), loc },
+        cond: { kind: "bin", op: "<", left: varRef(i.id, F64, loc), right: read("sp.size", false), type: BOOL, loc },
         update: {
           kind: "assign",
           localId: i.id,
-          value: { kind: "bin", op: "+", left: ref(i.id, F64), right: num(1), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef(i.id, F64, loc), right: numLit(1, loc), type: F64, loc },
           loc,
         },
         body: [...binds, ...body],
@@ -4416,23 +4386,22 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       const arr = L.declareHiddenLocal("%arof", arrT);
       const i = L.declareHiddenLocal("%iterof", F64);
       i.mutable = true;
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const keyRead = (): IrExpr => ref(i.id, F64);
+
+      const keyRead = (): IrExpr => varRef(i.id, F64, loc);
       const valRead = (): IrExpr =>
         arrT.kind === "array"
           ? {
               kind: "arrayGet",
-              arr: ref(arr.id, arrT),
-              index: ref(i.id, F64),
+              arr: varRef(arr.id, arrT, loc),
+              index: varRef(i.id, F64, loc),
               type: elemT,
               loc,
             }
           : {
               kind: "bytesIntrinsic",
               method: "get",
-              receiver: ref(arr.id, arrT),
-              args: [ref(i.id, F64)],
+              receiver: varRef(arr.id, arrT, loc),
+              args: [varRef(i.id, F64, loc)],
               type: F64,
               loc,
             };
@@ -4518,17 +4487,17 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       const body = L.inCtl("loop", () => L.lowerScopedBlock(stmt.statement));
       const loop: IrStmt = {
         kind: "for",
-        init: { kind: "varDecl", localId: i.id, init: num(0), loc },
+        init: { kind: "varDecl", localId: i.id, init: numLit(0, loc), loc },
         cond: {
           kind: "bin",
           op: "<",
-          left: ref(i.id, F64),
+          left: varRef(i.id, F64, loc),
           right:
             arrT.kind === "array"
               ? {
                   kind: "arrIntrinsic",
                   method: "length",
-                  receiver: ref(arr.id, arrT),
+                  receiver: varRef(arr.id, arrT, loc),
                   args: [],
                   type: F64,
                   loc,
@@ -4536,7 +4505,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
               : {
                   kind: "bytesIntrinsic",
                   method: "length",
-                  receiver: ref(arr.id, arrT),
+                  receiver: varRef(arr.id, arrT, loc),
                   args: [],
                   type: F64,
                   loc,
@@ -4547,7 +4516,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
         update: {
           kind: "assign",
           localId: i.id,
-          value: { kind: "bin", op: "+", left: ref(i.id, F64), right: num(1), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef(i.id, F64, loc), right: numLit(1, loc), type: F64, loc },
           loc,
         },
         body: [...binds, ...body],
@@ -4612,16 +4581,15 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       const m = L.declareHiddenLocal(isMap ? "%mapof" : "%setof", contT);
       const i = L.declareHiddenLocal("%iterof", F64);
       i.mutable = true; // the loop counter reassigns (hidden locals default const)
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
       const iter = (method: string, args: IrExpr[], type: IrType): IrExpr =>
         isMap
-          ? { kind: "mapIntrinsic", method: method as IrMapIntrinsicMethod, receiver: ref(m.id, contT), args, type, loc }
-          : { kind: "setIntrinsic", method: method as IrSetIntrinsicMethod, receiver: ref(m.id, contT), args, type, loc };
+          ? { kind: "mapIntrinsic", method: method as IrMapIntrinsicMethod, receiver: varRef(m.id, contT, loc), args, type, loc }
+          : { kind: "setIntrinsic", method: method as IrSetIntrinsicMethod, receiver: varRef(m.id, contT, loc), args, type, loc };
       const keyT = isMap ? (contT as IrType & { kind: "map" }).key : (contT as IrType & { kind: "set" }).elem;
-      const keyRead = (): IrExpr => iter("iterKey", [ref(i.id, F64)], keyT);
+      const keyRead = (): IrExpr => iter("iterKey", [varRef(i.id, F64, loc)], keyT);
       const valRead = (): IrExpr =>
-        iter("iterValue", [ref(i.id, F64)], (contT as IrType & { kind: "map" }).value);
+        iter("iterValue", [varRef(i.id, F64, loc)], (contT as IrType & { kind: "map" }).value);
       // The pair's second position (a Map's value; a Set entry repeats the
       // element — JS's [v, v]) and the single yield (a Map's `.values()`
       // reads the value; everything else reads the key/element).
@@ -4741,18 +4709,18 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
       const exitStmt = (): IrStmt => ({ kind: "exprStmt", expr: iter("iterExit", [], VOID), loc });
       const loop: IrStmt = {
         kind: "for",
-        init: { kind: "varDecl", localId: i.id, init: num(0), loc },
-        cond: { kind: "bin", op: "<", left: ref(i.id, F64), right: iter("iterCount", [], F64), type: BOOL, loc },
+        init: { kind: "varDecl", localId: i.id, init: numLit(0, loc), loc },
+        cond: { kind: "bin", op: "<", left: varRef(i.id, F64, loc), right: iter("iterCount", [], F64), type: BOOL, loc },
         update: {
           kind: "assign",
           localId: i.id,
-          value: { kind: "bin", op: "+", left: ref(i.id, F64), right: num(1), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef(i.id, F64, loc), right: numLit(1, loc), type: F64, loc },
           loc,
         },
         body: [
           {
             kind: "if",
-            cond: iter("iterLive", [ref(i.id, F64)], BOOL),
+            cond: iter("iterLive", [varRef(i.id, F64, loc)], BOOL),
             then: [...binds, ...exitBeforeReturns(body, exitStmt)],
             else_: null,
             loc,
@@ -4866,26 +4834,25 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     kT: IrType,
     vT: IrType,
     loc: SrcLoc,): IrFunction {
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const e = ref("e.0", tupleT);
+
+    const e = varRef("e.0", tupleT, loc);
     const body: IrStmt[] = [
       { kind: "varDecl", localId: "m.0", init: { kind: "mapNew", type: mapT, loc }, loc },
       {
         kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
         cond: {
           kind: "bin",
           op: "<",
-          left: ref("i.0", F64),
-          right: { kind: "arrIntrinsic", method: "length", receiver: ref("a.0", arrT), args: [], type: F64, loc },
+          left: varRef("i.0", F64, loc),
+          right: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: F64, loc },
           type: BOOL,
           loc,
         },
         update: {
           kind: "assign",
           localId: "i.0",
-          value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
           loc,
         },
         body: [
@@ -4895,7 +4862,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
             expr: {
               kind: "mapIntrinsic",
               method: "set",
-              receiver: ref("m.0", mapT),
+              receiver: varRef("m.0", mapT, loc),
               args: [
                 { kind: "recordGet", obj: e, shapeId: tupleT.shapeId, field: "0", type: kT, loc },
                 { kind: "recordGet", obj: e, shapeId: tupleT.shapeId, field: "1", type: vT, loc },
@@ -4908,7 +4875,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
         ],
         loc,
       },
-      { kind: "return", value: ref("m.0", mapT), loc },
+      { kind: "return", value: varRef("m.0", mapT, loc), loc },
     ];
     return {
       name,
@@ -5207,17 +5174,16 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
    * relational operators' exact machinery — one interned helper, no new IR
    * or runtime surface). */
   function buildLocaleCompareFn(name: string, loc: SrcLoc): IrFunction {
-    const ref = (localId: string): IrExpr => ({ kind: "varRef", localId, type: STRING, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const cmp = (op: "<" | ">"): IrExpr => ({ kind: "strCmp", op, left: ref("a.0"), right: ref("b.0"), type: BOOL, loc });
+
+    const cmp = (op: "<" | ">"): IrExpr => ({ kind: "strCmp", op, left: varRef("a.0", STRING, loc), right: varRef("b.0", STRING, loc), type: BOOL, loc });
     const body: IrStmt[] = [
       {
         kind: "return",
         value: {
           kind: "ternary",
           cond: cmp("<"),
-          then: num(-1),
-          else_: { kind: "ternary", cond: cmp(">"), then: num(1), else_: num(0), type: F64, loc },
+          then: numLit(-1, loc),
+          else_: { kind: "ternary", cond: cmp(">"), then: numLit(1, loc), else_: numLit(0, loc), type: F64, loc },
           type: F64,
           loc,
         },
@@ -6331,10 +6297,9 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
     let helper = L.arrHofHelpers.get(key);
     if (!helper) {
       helper = `%obj.${member}.${L.arrHofHelpers.size}`;
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const outRef = ref("out.0", resultT);
-      const rRef = ref("r.0", argIr);
+
+      const outRef = varRef("out.0", resultT, loc);
+      const rRef = varRef("r.0", argIr, loc);
       const push = (value: IrExpr): IrStmt => ({
         kind: "exprStmt",
         expr: { kind: "arrIntrinsic", method: "push", receiver: outRef, args: [value], type: F64, loc },
@@ -6430,8 +6395,8 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
       // value read back through the overflow-only keyed read (declared
       // names never live in the overflow map).
       const ksT = arrayOf(STRING);
-      const ksRef = ref("ks.0", ksT);
-      const kRef = ref("k.0", STRING);
+      const ksRef = varRef("ks.0", ksT, loc);
+      const kRef = varRef("k.0", STRING, loc);
       const readValue: IrExpr | null = valueT
         ? { kind: "recordKeyGet", obj: rRef, shapeId: argIr.shapeId, key: kRef, overflowOnly: true, type: valueT, loc }
         : null;
@@ -6453,11 +6418,11 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
         { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: rRef, shapeId: argIr.shapeId, type: ksT, loc }, loc },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: {
             kind: "bin",
             op: "<",
-            left: ref("i.0", F64),
+            left: varRef("i.0", F64, loc),
             right: { kind: "arrIntrinsic", method: "length", receiver: ksRef, args: [], type: F64, loc },
             type: BOOL,
             loc,
@@ -6465,11 +6430,11 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
           update: {
             kind: "assign",
             localId: "i.0",
-            value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+            value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
             loc,
           },
           body: [
-            { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: ksRef, index: ref("i.0", F64), type: STRING, loc }, loc },
+            { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: ksRef, index: varRef("i.0", F64, loc), type: STRING, loc }, loc },
             push(loopPushed),
           ],
           loc,
@@ -6574,33 +6539,32 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
     let helper = L.arrHofHelpers.get(key);
     if (!helper) {
       helper = `%obj.fromEntries.${L.arrHofHelpers.size}`;
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const tRef = ref("t.0", argIr.elem);
+
+      const tRef = varRef("t.0", argIr.elem, loc);
       const body: IrStmt[] = [
         { kind: "varDecl", localId: "out.0", init: { kind: "recordLit", fields: [], type: resultT, loc }, loc },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: {
             kind: "bin",
             op: "<",
-            left: ref("i.0", F64),
-            right: { kind: "arrIntrinsic", method: "length", receiver: ref("a.0", argIr), args: [], type: F64, loc },
+            left: varRef("i.0", F64, loc),
+            right: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", argIr, loc), args: [], type: F64, loc },
             type: BOOL,
             loc,
           },
           update: {
             kind: "assign",
             localId: "i.0",
-            value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+            value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
             loc,
           },
           body: [
-            { kind: "varDecl", localId: "t.0", init: { kind: "arrayGet", arr: ref("a.0", argIr), index: ref("i.0", F64), type: argIr.elem, loc }, loc },
+            { kind: "varDecl", localId: "t.0", init: { kind: "arrayGet", arr: varRef("a.0", argIr, loc), index: varRef("i.0", F64, loc), type: argIr.elem, loc }, loc },
             {
               kind: "recordKeySet",
-              obj: ref("out.0", resultT),
+              obj: varRef("out.0", resultT, loc),
               shapeId: resultT.shapeId,
               key: { kind: "recordGet", obj: tRef, shapeId: argIr.elem.shapeId, field: "0", type: STRING, loc },
               value: convert({ kind: "recordGet", obj: tRef, shapeId: argIr.elem.shapeId, field: "1", type: valT, loc })!,
@@ -6609,7 +6573,7 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
           ],
           loc,
         },
-        { kind: "return", value: ref("out.0", resultT), loc },
+        { kind: "return", value: varRef("out.0", resultT, loc), loc },
       ];
       L.arrHofHelpers.set(key, helper);
       L.liftedFns.push({
@@ -6652,41 +6616,40 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
     let helper = L.arrHofHelpers.get(key);
     if (!helper) {
       helper = `%obj.fromEntries.${L.arrHofHelpers.size}`;
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const tRef = ref("t.0", rowT);
+
+      const tRef = varRef("t.0", rowT, loc);
       const rowLen: IrExpr = { kind: "arrIntrinsic", method: "length", receiver: tRef, args: [], type: F64, loc };
       const lenAtLeast = (n: number): IrExpr =>
-        ({ kind: "bin", op: ">=", left: rowLen, right: num(n), type: BOOL, loc });
+        ({ kind: "bin", op: ">=", left: rowLen, right: numLit(n, loc), type: BOOL, loc });
       const body: IrStmt[] = [
         { kind: "varDecl", localId: "out.0", init: { kind: "recordLit", fields: [], type: resultT, loc }, loc },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: {
             kind: "bin",
             op: "<",
-            left: ref("i.0", F64),
-            right: { kind: "arrIntrinsic", method: "length", receiver: ref("a.0", argIr), args: [], type: F64, loc },
+            left: varRef("i.0", F64, loc),
+            right: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", argIr, loc), args: [], type: F64, loc },
             type: BOOL,
             loc,
           },
           update: {
             kind: "assign",
             localId: "i.0",
-            value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+            value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
             loc,
           },
           body: [
-            { kind: "varDecl", localId: "t.0", init: { kind: "arrayGet", arr: ref("a.0", argIr), index: ref("i.0", F64), type: rowT, loc }, loc },
+            { kind: "varDecl", localId: "t.0", init: { kind: "arrayGet", arr: varRef("a.0", argIr, loc), index: varRef("i.0", F64, loc), type: rowT, loc }, loc },
             {
               kind: "recordKeySet",
-              obj: ref("out.0", resultT),
+              obj: varRef("out.0", resultT, loc),
               shapeId: resultT.shapeId,
               key: {
                 kind: "ternary",
                 cond: lenAtLeast(1),
-                then: { kind: "arrayGet", arr: tRef, index: num(0), type: STRING, loc },
+                then: { kind: "arrayGet", arr: tRef, index: numLit(0, loc), type: STRING, loc },
                 else_: { kind: "strLit", value: "undefined", type: STRING, loc },
                 type: STRING,
                 loc,
@@ -6698,7 +6661,7 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
                   kind: "unionWrap",
                   unionId: valT.unionId,
                   tag: strTag,
-                  value: { kind: "arrayGet", arr: tRef, index: num(1), type: STRING, loc },
+                  value: { kind: "arrayGet", arr: tRef, index: numLit(1, loc), type: STRING, loc },
                   type: valT,
                   loc,
                 },
@@ -6711,7 +6674,7 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
           ],
           loc,
         },
-        { kind: "return", value: ref("out.0", resultT), loc },
+        { kind: "return", value: varRef("out.0", resultT, loc), loc },
       ];
       L.arrHofHelpers.set(key, helper);
       L.liftedFns.push({
@@ -6843,10 +6806,9 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
     L.widthHelpers.set(key, name);
     const fromT: IrType = { kind: "record", shapeId: fromId };
     const toT: IrType = { kind: "record", shapeId: toId };
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const sRef = ref("s.0", fromT);
-    const outRef = ref("out.0", toT);
+
+    const sRef = varRef("s.0", fromT, loc);
+    const outRef = varRef("out.0", toT, loc);
     const intoSlot = (v: IrExpr, lift: WidthLift | "dyn"): IrExpr =>
       lift === "dyn"
         ? { kind: "dynFrom", value: v, type: DYN, loc }
@@ -6922,29 +6884,29 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
         { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: sRef, shapeId: fromId, type: ksT, loc }, loc },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: {
             kind: "bin",
             op: "<",
-            left: ref("i.0", F64),
-            right: { kind: "arrIntrinsic", method: "length", receiver: ref("ks.0", ksT), args: [], type: F64, loc },
+            left: varRef("i.0", F64, loc),
+            right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
             type: BOOL,
             loc,
           },
           update: {
             kind: "assign",
             localId: "i.0",
-            value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+            value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
             loc,
           },
           body: [
-            { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: ref("ks.0", ksT), index: ref("i.0", F64), type: STRING, loc }, loc },
+            { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: varRef("ks.0", ksT, loc), index: varRef("i.0", F64, loc), type: STRING, loc }, loc },
             {
               kind: "recordKeySet",
               obj: outRef,
               shapeId: toId,
-              key: ref("k.0", STRING),
-              value: intoSlot({ kind: "recordKeyGet", obj: sRef, shapeId: fromId, key: ref("k.0", STRING), overflowOnly: true, type: fIv, loc }, ovfLift),
+              key: varRef("k.0", STRING, loc),
+              value: intoSlot({ kind: "recordKeyGet", obj: sRef, shapeId: fromId, key: varRef("k.0", STRING, loc), overflowOnly: true, type: fIv, loc }, ovfLift),
               loc,
             },
           ],
@@ -7061,10 +7023,9 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
       L.widthHelpers.set(key, name);
       const toT: IrType = { kind: "record", shapeId: targetIr.shapeId };
       const fromT: IrType = { kind: "record", shapeId: plan.fromId };
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const tRef = ref("t.0", toT);
-      const sRef = ref("s.0", fromT);
+
+      const tRef = varRef("t.0", toT, loc);
+      const sRef = varRef("s.0", fromT, loc);
       const intoSlot = (v: IrExpr, lift: WidthLift | "dyn"): IrExpr =>
         lift === "dyn" ? { kind: "dynFrom", value: v, type: DYN, loc } : L.applyWidthLift(lift, v, tIv, loc);
       const body: IrStmt[] = [];
@@ -7101,29 +7062,29 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
           { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: sRef, shapeId: plan.fromId, type: ksT, loc }, loc },
           {
             kind: "for",
-            init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+            init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
             cond: {
               kind: "bin",
               op: "<",
-              left: ref("i.0", F64),
-              right: { kind: "arrIntrinsic", method: "length", receiver: ref("ks.0", ksT), args: [], type: F64, loc },
+              left: varRef("i.0", F64, loc),
+              right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
               type: BOOL,
               loc,
             },
             update: {
               kind: "assign",
               localId: "i.0",
-              value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc },
+              value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
               loc,
             },
             body: [
-              { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: ref("ks.0", ksT), index: ref("i.0", F64), type: STRING, loc }, loc },
+              { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: varRef("ks.0", ksT, loc), index: varRef("i.0", F64, loc), type: STRING, loc }, loc },
               {
                 kind: "recordKeySet",
                 obj: tRef,
                 shapeId: targetIr.shapeId,
-                key: ref("k.0", STRING),
-                value: intoSlot({ kind: "recordKeyGet", obj: sRef, shapeId: plan.fromId, key: ref("k.0", STRING), overflowOnly: true, type: fIv, loc }, plan.ovfLift),
+                key: varRef("k.0", STRING, loc),
+                value: intoSlot({ kind: "recordKeyGet", obj: sRef, shapeId: plan.fromId, key: varRef("k.0", STRING, loc), overflowOnly: true, type: fIv, loc }, plan.ovfLift),
                 loc,
               },
             ],
@@ -7276,9 +7237,8 @@ export type IndexMergeContributor =
     L.widthHelpers.set(key, name);
     const toT: IrType = { kind: "record", shapeId: toId };
     const ksT = arrayOf(STRING);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const outRef = ref("out.0", toT);
+
+    const outRef = varRef("out.0", toT, loc);
     const params: IrParam[] = [];
     const locals: IrLocal[] = [{ id: "out.0", name: "out", type: toT, mutable: false }];
     const body: IrStmt[] = [
@@ -7298,8 +7258,8 @@ export type IndexMergeContributor =
           kind: "recordKeySet",
           obj: outRef,
           shapeId: toId,
-          key: ref(kid, STRING),
-          value: ref(pid, tIv),
+          key: varRef(kid, STRING, loc),
+          value: varRef(pid, tIv, loc),
           overflowOnly: true,
           loc,
         });
@@ -7314,7 +7274,7 @@ export type IndexMergeContributor =
           obj: outRef,
           shapeId: toId,
           key: { kind: "strLit", value: c.name, type: STRING, loc },
-          value: ref(pid, tIv),
+          value: varRef(pid, tIv, loc),
           overflowOnly: true,
           loc,
         };
@@ -7326,7 +7286,7 @@ export type IndexMergeContributor =
           const undefTag = L.armTag(tIv.unionId, UNDEFINED_T);
           body.push({
             kind: "if",
-            cond: { kind: "unionIsTag", unionId: tIv.unionId, tag: undefTag, negated: true, value: ref(pid, tIv), type: BOOL, loc },
+            cond: { kind: "unionIsTag", unionId: tIv.unionId, tag: undefTag, negated: true, value: varRef(pid, tIv, loc), type: BOOL, loc },
             then: [write],
             else_: null,
             loc,
@@ -7343,7 +7303,7 @@ export type IndexMergeContributor =
       const sid = `s.${ci}`;
       params.push({ localId: sid, name: `s${ci}`, type: fromT });
       locals.push({ id: sid, name: `s${ci}`, type: fromT, mutable: false });
-      const sRef = ref(sid, fromT);
+      const sRef = varRef(sid, fromT, loc);
       // A FIXED-shape source: each declared field keyed-writes through its
       // own planned lift (absent optionals skip — the unset convention);
       // no overflow exists to walk.
@@ -7408,24 +7368,24 @@ export type IndexMergeContributor =
         { kind: "varDecl", localId: ks, init: { kind: "recordOvfKeys", obj: sRef, shapeId: plan.shapeId, type: ksT, loc }, loc },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: iv, init: num(0), loc },
+          init: { kind: "varDecl", localId: iv, init: numLit(0, loc), loc },
           cond: {
             kind: "bin",
             op: "<",
-            left: ref(iv, F64),
-            right: { kind: "arrIntrinsic", method: "length", receiver: ref(ks, ksT), args: [], type: F64, loc },
+            left: varRef(iv, F64, loc),
+            right: { kind: "arrIntrinsic", method: "length", receiver: varRef(ks, ksT, loc), args: [], type: F64, loc },
             type: BOOL,
             loc,
           },
-          update: { kind: "assign", localId: iv, value: { kind: "bin", op: "+", left: ref(iv, F64), right: num(1), type: F64, loc }, loc },
+          update: { kind: "assign", localId: iv, value: { kind: "bin", op: "+", left: varRef(iv, F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
           body: [
-            { kind: "varDecl", localId: kv, init: { kind: "arrayGet", arr: ref(ks, ksT), index: ref(iv, F64), type: STRING, loc }, loc },
+            { kind: "varDecl", localId: kv, init: { kind: "arrayGet", arr: varRef(ks, ksT, loc), index: varRef(iv, F64, loc), type: STRING, loc }, loc },
             {
               kind: "recordKeySet",
               obj: outRef,
               shapeId: toId,
-              key: ref(kv, STRING),
-              value: intoSlot({ kind: "recordKeyGet", obj: sRef, shapeId: plan.shapeId, key: ref(kv, STRING), overflowOnly: true, type: fIv, loc }),
+              key: varRef(kv, STRING, loc),
+              value: intoSlot({ kind: "recordKeyGet", obj: sRef, shapeId: plan.shapeId, key: varRef(kv, STRING, loc), overflowOnly: true, type: fIv, loc }),
               overflowOnly: true,
               loc,
             },
@@ -7499,10 +7459,9 @@ export type IndexMergeContributor =
     L.widthHelpers.set(key, name);
     const recT: IrType = { kind: "record", shapeId };
     const arrT = arrayOf(STRING);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const sRef = ref("s.0", recT);
-    const outRef = ref("out.0", arrT);
+
+    const sRef = varRef("s.0", recT, loc);
+    const outRef = varRef("out.0", arrT, loc);
     // The string value of a field/overflow read: unwrap the union arm, or
     // pass a plain string through.
     const asStr = (raw: IrExpr, t: IrType): IrExpr => {
@@ -7549,8 +7508,8 @@ export type IndexMergeContributor =
           { id: `a.${uid}`, name: `a${uid}`, type: aT, mutable: false },
           { id: `j.${uid}`, name: `j${uid}`, type: F64, mutable: true },
         );
-        const aRef = ref(`a.${uid}`, aT);
-        const jRef = ref(`j.${uid}`, F64);
+        const aRef = varRef(`a.${uid}`, aT, loc);
+        const jRef = varRef(`j.${uid}`, F64, loc);
         chain = [{
           kind: "if",
           cond: isTag(ha.arr),
@@ -7558,9 +7517,9 @@ export type IndexMergeContributor =
             { kind: "varDecl", localId: `a.${uid}`, init: narrowTo(ha.arr, aT), loc },
             {
               kind: "for",
-              init: { kind: "varDecl", localId: `j.${uid}`, init: num(0), loc },
+              init: { kind: "varDecl", localId: `j.${uid}`, init: numLit(0, loc), loc },
               cond: { kind: "bin", op: "<", left: jRef, right: { kind: "arrIntrinsic", method: "length", receiver: aRef, args: [], type: F64, loc }, type: BOOL, loc },
-              update: { kind: "assign", localId: `j.${uid}`, value: { kind: "bin", op: "+", left: jRef, right: num(1), type: F64, loc }, loc },
+              update: { kind: "assign", localId: `j.${uid}`, value: { kind: "bin", op: "+", left: jRef, right: numLit(1, loc), type: F64, loc }, loc },
               body: [push(k, { kind: "arrayGet", arr: aRef, index: jRef, type: STRING, loc })],
               loc,
             },
@@ -7606,22 +7565,22 @@ export type IndexMergeContributor =
         { id: "k.0", name: "k", type: STRING, mutable: false },
         { id: "raw.0", name: "raw", type: iv, mutable: false },
       );
-      const rawRead: IrExpr = { kind: "recordKeyGet", obj: sRef, shapeId, key: ref("k.0", STRING), overflowOnly: true, type: iv, loc };
+      const rawRead: IrExpr = { kind: "recordKeyGet", obj: sRef, shapeId, key: varRef("k.0", STRING, loc), overflowOnly: true, type: iv, loc };
       const utag = iv.kind === "union" ? L.armTag(iv.unionId, UNDEFINED_T) : -1;
       const innerBody: IrStmt[] = [
-        { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: ref("ks.0", ksT), index: ref("i.0", F64), type: STRING, loc }, loc },
+        { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: varRef("ks.0", ksT, loc), index: varRef("i.0", F64, loc), type: STRING, loc }, loc },
         { kind: "varDecl", localId: "raw.0", init: rawRead, loc },
       ];
-      const rawRef = ref("raw.0", iv);
+      const rawRef = varRef("raw.0", iv, loc);
       void utag;
-      innerBody.push(writeFor(ref("k.0", STRING), rawRef, iv));
+      innerBody.push(writeFor(varRef("k.0", STRING, loc), rawRef, iv));
       body.push(
         { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: sRef, shapeId, type: ksT, loc }, loc },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-          cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: { kind: "arrIntrinsic", method: "length", receiver: ref("ks.0", ksT), args: [], type: F64, loc }, type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+          cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc }, type: BOOL, loc },
+          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
           body: innerBody,
           loc,
         },
@@ -7703,8 +7662,8 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
     if (existing) return existing;
     const name = "%dyn.recvstr";
     L.arrHofHelpers.set(key, name);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const d = ref("d.0", DYN);
+
+    const d = varRef("d.0", DYN, loc);
     const body: IrStmt[] = [
       {
         kind: "if",
@@ -7713,7 +7672,7 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
         else_: null,
         loc,
       },
-      ...dynRecvThrows(d, ref("m.0", STRING), ref("full.0", STRING), loc),
+      ...dynRecvThrows(d, varRef("m.0", STRING, loc), varRef("full.0", STRING, loc), loc),
     ];
     L.liftedFns.push({
       name,
@@ -7894,14 +7853,13 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
     const outT = arrayOf(elemT);
     const retT = arrayOf(elemT);
     const fnT = funcOf([DYN, F64, DYN].slice(0, arity), retT);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const d = ref("d.0", DYN);
+
+    const d = varRef("d.0", DYN, loc);
     const body: IrStmt[] = [
       {
         kind: "if",
         cond: { kind: "dynTest", test: "array", negated: true, value: d, type: BOOL, loc },
-        then: dynRecvThrows(d, ref("m.0", STRING), ref("full.0", STRING), loc),
+        then: dynRecvThrows(d, varRef("m.0", STRING, loc), varRef("full.0", STRING, loc), loc),
         else_: null,
         loc,
       },
@@ -7919,14 +7877,14 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
       {
         kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-        cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: ref("n.0", F64), type: BOOL, loc },
-        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
+        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
+        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
         body: [
           {
             kind: "varDecl",
             localId: "v.0",
-            init: { kind: "dynKeyGet", key: { kind: "toString", operand: ref("i.0", F64), type: STRING, loc }, value: d, type: DYN, loc },
+            init: { kind: "dynKeyGet", key: { kind: "toString", operand: varRef("i.0", F64, loc), type: STRING, loc }, value: d, type: DYN, loc },
             loc,
           },
           {
@@ -7934,8 +7892,8 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
             localId: "r.0",
             init: {
               kind: "callValue",
-              callee: ref("f.0", fnT),
-              args: [ref("v.0", DYN), ref("i.0", F64), d].slice(0, arity),
+              callee: varRef("f.0", fnT, loc),
+              args: [varRef("v.0", DYN, loc), varRef("i.0", F64, loc), d].slice(0, arity),
               type: retT,
               loc,
             },
@@ -7944,22 +7902,22 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
           {
             kind: "varDecl",
             localId: "rn.0",
-            init: { kind: "arrIntrinsic", method: "length", receiver: ref("r.0", retT), args: [], type: F64, loc },
+            init: { kind: "arrIntrinsic", method: "length", receiver: varRef("r.0", retT, loc), args: [], type: F64, loc },
             loc,
           },
           {
             kind: "for",
-            init: { kind: "varDecl", localId: "j.0", init: num(0), loc },
-            cond: { kind: "bin", op: "<", left: ref("j.0", F64), right: ref("rn.0", F64), type: BOOL, loc },
-            update: { kind: "assign", localId: "j.0", value: { kind: "bin", op: "+", left: ref("j.0", F64), right: num(1), type: F64, loc }, loc },
+            init: { kind: "varDecl", localId: "j.0", init: numLit(0, loc), loc },
+            cond: { kind: "bin", op: "<", left: varRef("j.0", F64, loc), right: varRef("rn.0", F64, loc), type: BOOL, loc },
+            update: { kind: "assign", localId: "j.0", value: { kind: "bin", op: "+", left: varRef("j.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
             body: [
               {
                 kind: "exprStmt",
                 expr: {
                   kind: "arrIntrinsic",
                   method: "push",
-                  receiver: ref("out.0", outT),
-                  args: [{ kind: "arrayGet", arr: ref("r.0", retT), index: ref("j.0", F64), type: elemT, loc }],
+                  receiver: varRef("out.0", outT, loc),
+                  args: [{ kind: "arrayGet", arr: varRef("r.0", retT, loc), index: varRef("j.0", F64, loc), type: elemT, loc }],
                   type: F64,
                   loc,
                 },
@@ -7971,7 +7929,7 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
         ],
         loc,
       },
-      { kind: "return", value: ref("out.0", outT), loc },
+      { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     return {
       name,
@@ -8020,14 +7978,13 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
   function buildDynFilterFn(name: string, elemT: IrType, arity: number, loc: SrcLoc): IrFunction {
     const outT = arrayOf(elemT);
     const fnT = funcOf([DYN, F64, DYN].slice(0, arity), BOOL);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-    const d = ref("d.0", DYN);
+
+    const d = varRef("d.0", DYN, loc);
     const body: IrStmt[] = [
       {
         kind: "if",
         cond: { kind: "dynTest", test: "array", negated: true, value: d, type: BOOL, loc },
-        then: dynRecvThrows(d, ref("m.0", STRING), ref("full.0", STRING), loc),
+        then: dynRecvThrows(d, varRef("m.0", STRING, loc), varRef("full.0", STRING, loc), loc),
         else_: null,
         loc,
       },
@@ -8045,22 +8002,22 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
       {
         kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-        cond: { kind: "bin", op: "<", left: ref("i.0", F64), right: ref("n.0", F64), type: BOOL, loc },
-        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
+        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
+        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
         body: [
           {
             kind: "varDecl",
             localId: "v.0",
-            init: { kind: "dynKeyGet", key: { kind: "toString", operand: ref("i.0", F64), type: STRING, loc }, value: d, type: DYN, loc },
+            init: { kind: "dynKeyGet", key: { kind: "toString", operand: varRef("i.0", F64, loc), type: STRING, loc }, value: d, type: DYN, loc },
             loc,
           },
           {
             kind: "if",
             cond: {
               kind: "callValue",
-              callee: ref("f.0", fnT),
-              args: [ref("v.0", DYN), ref("i.0", F64), d].slice(0, arity),
+              callee: varRef("f.0", fnT, loc),
+              args: [varRef("v.0", DYN, loc), varRef("i.0", F64, loc), d].slice(0, arity),
               type: BOOL,
               loc,
             },
@@ -8070,8 +8027,8 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
                 expr: {
                   kind: "arrIntrinsic",
                   method: "push",
-                  receiver: ref("out.0", outT),
-                  args: [{ kind: "dynCheck", value: ref("v.0", DYN), type: elemT, loc }],
+                  receiver: varRef("out.0", outT, loc),
+                  args: [{ kind: "dynCheck", value: varRef("v.0", DYN, loc), type: elemT, loc }],
                   type: F64,
                   loc,
                 },
@@ -8084,7 +8041,7 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
         ],
         loc,
       },
-      { kind: "return", value: ref("out.0", outT), loc },
+      { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     return {
       name,

--- a/packages/compiler/src/frontend/lowering/lower-dgram.ts
+++ b/packages/compiler/src/frontend/lowering/lower-dgram.ts
@@ -13,6 +13,7 @@ import { ladderFenceExpr } from "./lowerer.js";
 import { isJsSourceFile, locOf } from "../program.js";
 import { BOOL, canBoxFuncIntoDyn, DGRAMSOCK_T, DYN, F64, funcOf, IrExpr, IrLibFn, IrType, SrcLoc, STRING, UNDEFINED_T, VOID } from "../../ir/nodes.js";
 import { DNS_LOOKUP_DOCUMENTED_OPTIONS, fenceOrDropOptionKey } from "./surfaces.js";
+import { boolLit } from "../../ir/build.js";
 
 const DGRAM_SURFACE_HINT =
   "bind, connect, send, address, close, unref/ref, and on/once of " +
@@ -70,9 +71,6 @@ function lowerCallbackArg(
   }
   return { cb, nparams: cb.type.params.length };
 }
-
-const boolLit = (value: boolean, loc: SrcLoc): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
-
 /** True iff `t` is the `Error | null` union — dns.lookup's first callback
  * parameter (NodeJS.ErrnoException maps to %Error in types.ts). */
 function isErrorOrNullUnion(L: Lowerer, t: IrType): boolean {

--- a/packages/compiler/src/frontend/lowering/lower-emitter.ts
+++ b/packages/compiler/src/frontend/lowering/lower-emitter.ts
@@ -43,6 +43,7 @@ import type { ClassInfo } from "./lower-classes.js";
 import { isJsSourceFile, locOf } from "../program.js";
 import { arrayOf, BOOL, canBoxFuncIntoDyn, canConvertToDyn, DYN, F64, IrExpr, IrFunction, IrLocal, IrParam, IrStmt, IrType, isUnitType, STRING, SrcLoc, typeEquals, typeKey, VOID } from "../../ir/nodes.js";
 import { streamForcedTuple, streamSidesOf } from "./lower-stream.js";
+import { boolLit, strLit, varRef } from "../../ir/build.js";
 
 /** True when the class descends from (or is) the runtime emitter. */
 export function emitterRooted(L: Lowerer, info: ClassInfo | undefined | null): boolean {
@@ -223,10 +224,6 @@ function eventNameOf(L: Lowerer, member: string, arg: ts.Expression): string {
     "event names must be compile-time string literals (each event's argument tuple is unified statically; symbol names have no lowering)",
   );
 }
-
-const strLit = (value: string, loc: SrcLoc): IrExpr => ({ kind: "strLit", value, type: STRING, loc });
-const boolLit = (value: boolean, loc: SrcLoc): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
-
 /** The event's unified tuple, with conflicts reported at this site. */
 function tupleOf(L: Lowerer, table: Map<string, EventSig>, name: string, blame: ts.Node): IrType[] {
   const sig = table.get(name);
@@ -362,10 +359,9 @@ function lowerDynListenerCall(
   if (!helper) {
     helper = `%emitter.${registering ? "onDyn" : "offDyn"}.${L.arrHofHelpers.size}`;
     L.arrHofHelpers.set(key, helper);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
     const check: IrStmt = {
       kind: "exprStmt",
-      expr: { kind: "libCall", fn: "emitter.checkListener", args: [ref("cb.0", DYN)], type: VOID, loc },
+      expr: { kind: "libCall", fn: "emitter.checkListener", args: [varRef("cb.0", DYN, loc)], type: VOID, loc },
       loc,
     };
     const params = [
@@ -385,13 +381,13 @@ function lowerDynListenerCall(
       locals.push({ id: "a.0", name: "a", type: adapterT, mutable: false });
       body = [
         check,
-        { kind: "varDecl", localId: "a.0", init: { kind: "dynCheck", value: ref("cb.0", DYN), type: adapterT, loc }, loc },
+        { kind: "varDecl", localId: "a.0", init: { kind: "dynCheck", value: varRef("cb.0", DYN, loc), type: adapterT, loc }, loc },
         {
           kind: "return",
           value: {
             kind: "libCall",
             fn: onFn,
-            args: [ref("r.0", recvT), ref("n.0", STRING), ref("cb.0", DYN), ref("a.0", adapterT), ref("o.0", BOOL), ref("p.0", BOOL)],
+            args: [varRef("r.0", recvT, loc), varRef("n.0", STRING, loc), varRef("cb.0", DYN, loc), varRef("a.0", adapterT, loc), varRef("o.0", BOOL, loc), varRef("p.0", BOOL, loc)],
             type: recvT,
             loc,
           },
@@ -406,7 +402,7 @@ function lowerDynListenerCall(
           value: {
             kind: "libCall",
             fn: "emitter.offDyn",
-            args: [ref("r.0", recvT), ref("n.0", STRING), ref("cb.0", DYN)],
+            args: [varRef("r.0", recvT, loc), varRef("n.0", STRING, loc), varRef("cb.0", DYN, loc)],
             type: recvT,
             loc,
           },

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -27,6 +27,7 @@ import { mixinFnOfCallee } from "./lower-mixins.js";
 import { isConstAssertionTypeNode, isGenericCallableMemberType, isParseArgsDynTypeName, underConstAssertion, unitOnlyUnion } from "../types.js";
 import { lowerYield } from "./lower-generators.js";
 import { lowerStreamProperty, lowerStreamStateProperty, streamSidesOf } from "./lower-stream.js";
+import { numLit, varRef } from "../../ir/build.js";
 
 /** An assignable `obj.field` target — a class field, a record field, or a
  * class ACCESSOR property (reads become getter calls, writes setter calls;
@@ -55,7 +56,6 @@ export type FieldTarget =
       getType?: IrType & { kind: "func" };
       setType?: IrType & { kind: "func" };
     };
-
 
 /** A template piece's RAW text (String.raw's contract: escapes stay
  * characters). 7's client AST ships no rawText at runtime (the typing
@@ -1942,7 +1942,6 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
     L.unsupported("SC1090", expr, `syntax '${ts.SyntaxKind[expr.kind]}'`);
   }
 
-
 /** `c ? a : b` — see the inline comments. `expected` plays the contextual
    * array type's role when the caller knows the slot's array type and tsc's
    * API doesn't surface it (a ternary as a SPREAD source — lowerArrayLiteral
@@ -2317,7 +2316,6 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
     if (!def || def.arms.length !== 2) {
       L.unsupported("SC1090", expr, "a direct read from a runtime-optional capture with multiple value arms");
     }
-    const ref = (): IrExpr => ({ kind: "varRef", localId: local.id, type: local.type, loc });
     const message = property === null
       ? `${expr.text} is not a function`
       : `Cannot read properties of undefined (reading '${property}')`;
@@ -2328,7 +2326,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
         unionId: local.type.unionId,
         tag: undefTag,
         negated: false,
-        value: ref(),
+        value: varRef(local.id, local.type, loc),
         type: BOOL,
         loc,
       },
@@ -2343,7 +2341,7 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
         kind: "unionNarrow",
         unionId: local.type.unionId,
         tag: valueTag,
-        value: ref(),
+        value: varRef(local.id, local.type, loc),
         type: narrowed,
         loc,
       },
@@ -2758,9 +2756,9 @@ export function pureReemittable(e: IrExpr): boolean {
     const name = `%nullish.retag.${L.widthHelpers.size}`;
     L.widthHelpers.set(key, name);
     const def = L.unions.get(leftT.unionId)!;
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const l = ref("l.0", leftT);
-    const r = ref("r.0", resT);
+
+    const l = varRef("l.0", leftT, loc);
+    const r = varRef("r.0", resT, loc);
     const body: IrStmt[] = [];
     def.arms.forEach((arm, tag) => {
       if (isUnitType(arm)) return;
@@ -5819,9 +5817,8 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
     let helper = L.widthHelpers.get(key);
     if (!helper) {
       helper = `%rec.declmerge.${L.widthHelpers.size}`;
-      const ref = (localId: string, t: IrType): IrExpr => ({ kind: "varRef", localId, type: t, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const outRef = ref("out.0", type);
+
+      const outRef = varRef("out.0", type, loc);
       const ksT = arrayOf(STRING);
       const locals: IrLocal[] = [{ id: "out.0", name: "out", type, mutable: false }];
       const params = srcs.map((s, j) => {
@@ -5842,9 +5839,9 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
         },
       ];
       srcs.forEach((s, j) => {
-        const sRef = ref(`s${j}.0`, s.value.type);
-        const kRef = ref(`k${j}.0`, STRING);
-        const vRef = ref(`v${j}.0`, s.iv);
+        const sRef = varRef(`s${j}.0`, s.value.type, loc);
+        const kRef = varRef(`k${j}.0`, STRING, loc);
+        const vRef = varRef(`v${j}.0`, s.iv, loc);
         locals.push(
           { id: `ks${j}.0`, name: `ks${j}`, type: ksT, mutable: false },
           { id: `i${j}.0`, name: `i${j}`, type: F64, mutable: true },
@@ -5868,11 +5865,11 @@ export function lowerObjectLiteral(L: Lowerer, expr: ts.ObjectLiteralExpression)
           { kind: "varDecl", localId: `ks${j}.0`, init: { kind: "recordOvfKeys", obj: sRef, shapeId: s.shapeId, type: ksT, loc }, loc },
           {
             kind: "for",
-            init: { kind: "varDecl", localId: `i${j}.0`, init: num(0), loc },
-            cond: { kind: "bin", op: "<", left: ref(`i${j}.0`, F64), right: { kind: "arrIntrinsic", method: "length", receiver: ref(`ks${j}.0`, ksT), args: [], type: F64, loc }, type: BOOL, loc },
-            update: { kind: "assign", localId: `i${j}.0`, value: { kind: "bin", op: "+", left: ref(`i${j}.0`, F64), right: num(1), type: F64, loc }, loc },
+            init: { kind: "varDecl", localId: `i${j}.0`, init: numLit(0, loc), loc },
+            cond: { kind: "bin", op: "<", left: varRef(`i${j}.0`, F64, loc), right: { kind: "arrIntrinsic", method: "length", receiver: varRef(`ks${j}.0`, ksT, loc), args: [], type: F64, loc }, type: BOOL, loc },
+            update: { kind: "assign", localId: `i${j}.0`, value: { kind: "bin", op: "+", left: varRef(`i${j}.0`, F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
             body: [
-              { kind: "varDecl", localId: `k${j}.0`, init: { kind: "arrayGet", arr: ref(`ks${j}.0`, ksT), index: ref(`i${j}.0`, F64), type: STRING, loc }, loc },
+              { kind: "varDecl", localId: `k${j}.0`, init: { kind: "arrayGet", arr: varRef(`ks${j}.0`, ksT, loc), index: varRef(`i${j}.0`, F64, loc), type: STRING, loc }, loc },
               { kind: "varDecl", localId: `v${j}.0`, init: { kind: "recordKeyGet", obj: sRef, shapeId: s.shapeId, key: kRef, overflowOnly: true, type: s.iv, loc }, loc },
               ...dispatch,
             ],
@@ -9521,10 +9518,9 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
       helper = `%rec.haskey.${L.widthHelpers.size}`;
       L.widthHelpers.set(hkey, helper);
       const recT: IrType = { kind: "record", shapeId: recvT.shapeId };
-      const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const k = ref("k.0", STRING);
-      const r = ref("r.0", recT);
+
+      const k = varRef("k.0", STRING, loc);
+      const r = varRef("r.0", recT, loc);
       const body: IrStmt[] = [];
       const ret = (value: IrExpr): IrStmt => ({ kind: "return", value, loc });
       for (const f of shape.fields) {
@@ -9552,20 +9548,20 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
         { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: r, shapeId: recvT.shapeId, type: ksT, loc }, loc },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: {
             kind: "bin",
             op: "<",
-            left: ref("i.0", F64),
-            right: { kind: "arrIntrinsic", method: "length", receiver: ref("ks.0", ksT), args: [], type: F64, loc },
+            left: varRef("i.0", F64, loc),
+            right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
             type: BOOL,
             loc,
           },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(1), type: F64, loc }, loc },
+          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
           body: [
             {
               kind: "if",
-              cond: { kind: "strEq", negated: false, left: k, right: { kind: "arrayGet", arr: ref("ks.0", ksT), index: ref("i.0", F64), type: STRING, loc }, type: BOOL, loc },
+              cond: { kind: "strEq", negated: false, left: k, right: { kind: "arrayGet", arr: varRef("ks.0", ksT, loc), index: varRef("i.0", F64, loc), type: STRING, loc }, type: BOOL, loc },
               then: [ret({ kind: "boolLit", value: true, type: BOOL, loc })],
               else_: null,
               loc,
@@ -9986,8 +9982,8 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
         body.push({ kind: "varDecl", localId: "arr.0", init: narrowed, loc });
         mRef = { kind: "varRef", localId: "arr.0", type: arrayOf(STRING), loc };
       }
-      const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-      const elem = (index: number): IrExpr => ({ kind: "arrayGet", arr: mRef, index: num(index), type: STRING, loc });
+
+      const elem = (index: number): IrExpr => ({ kind: "arrayGet", arr: mRef, index: numLit(index, loc), type: STRING, loc });
       const values = new Map<string, IrExpr>();
       order.forEach((name, i) => {
         const idxs = indicesByName.get(name)!;

--- a/packages/compiler/src/frontend/lowering/lower-inspect.ts
+++ b/packages/compiler/src/frontend/lowering/lower-inspect.ts
@@ -40,15 +40,11 @@ import { isJsSourceFile } from "../program.js";
 import { BOOL, DYN, F64, IrExpr, IrStmt, IrType, RUNTIME_ERROR_CLASSES, STRING, SrcLoc, canConvertToDyn, canDynCheckTo, shapeHasAccessorSlots, typeKey } from "../../ir/nodes.js";
 import type { ClassInfo } from "./lower-classes.js";
 import { pureReemittable } from "./lower-exprs.js";
+import { boolLit, numLit, strLit, varRef } from "../../ir/build.js";
 
 /* ── IR construction shorthand ───────────────────────────────────────── */
-
-const str = (value: string, loc: SrcLoc): IrExpr => ({ kind: "strLit", value, type: STRING, loc });
-const num = (value: number, loc: SrcLoc): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-const boolLit = (value: boolean, loc: SrcLoc): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
-
 function concatAll(parts: IrExpr[], loc: SrcLoc): IrExpr {
-  if (parts.length === 0) return str("", loc);
+  if (parts.length === 0) return strLit("", loc);
   let out = parts[0]!;
   for (let i = 1; i < parts.length; i++) {
     out = { kind: "strConcat", left: out, right: parts[i]!, type: STRING, loc };
@@ -265,9 +261,9 @@ function inspectExpr(
     case "bool":
       return { kind: "toString", operand: value, type: STRING, loc };
     case "undefinedT":
-      return str("undefined", loc);
+      return strLit("undefined", loc);
     case "nullT":
-      return str("null", loc);
+      return strLit("null", loc);
     case "regex":
       return { kind: "libCall", fn: "insp.regex", args: [value], type: STRING, loc };
     case "symbol":
@@ -357,11 +353,10 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
   const name = `%util.insp.${L.inspectHelpers.size}`;
   L.inspectHelpers.set(key, name);
 
-  const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-  const v = (): IrExpr => ref("v.0", t);
-  const r = (): IrExpr => ref("r.0", F64);
-  const d = (): IrExpr => ref("d.0", F64);
-  const rPlus1 = (): IrExpr => ({ kind: "bin", op: "+", left: r(), right: num(1, loc), type: F64, loc });
+  const v = (): IrExpr => varRef("v.0", t, loc);
+  const r = (): IrExpr => varRef("r.0", F64, loc);
+  const d = (): IrExpr => varRef("d.0", F64, loc);
+  const rPlus1 = (): IrExpr => ({ kind: "bin", op: "+", left: r(), right: numLit(1, loc), type: F64, loc });
   const ret = (value: IrExpr): IrStmt => ({ kind: "return", value, loc });
   const exprStmt = (expr: IrExpr): IrStmt => ({ kind: "exprStmt", expr, loc });
   // CYCLE-CAPABLE composites (typeReachesItself) run Node's circular
@@ -396,7 +391,7 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
   const depthGate = (placeholder: string): IrStmt => ({
     kind: "if",
     cond: { kind: "bin", op: ">", left: r(), right: d(), type: BOOL, loc },
-    then: [ret(str(placeholder, loc))],
+    then: [ret(strLit(placeholder, loc))],
     else_: null,
     loc,
   });
@@ -419,27 +414,27 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
         { id: "s.0", name: "s", type: F64, mutable: false },
         { id: "i.0", name: "i", type: F64, mutable: true },
       );
-      const n = (): IrExpr => ref("n.0", F64);
-      const shown = (): IrExpr => ref("s.0", F64);
-      const i = (): IrExpr => ref("i.0", F64);
-      const hasMore = (): IrExpr => ({ kind: "bin", op: ">", left: n(), right: num(100, loc), type: BOOL, loc });
+      const n = (): IrExpr => varRef("n.0", F64, loc);
+      const shown = (): IrExpr => varRef("s.0", F64, loc);
+      const i = (): IrExpr => varRef("i.0", F64, loc);
+      const hasMore = (): IrExpr => ({ kind: "bin", op: ">", left: n(), right: numLit(100, loc), type: BOOL, loc });
       body = [
         { kind: "varDecl", localId: "n.0", init: len(), loc },
         {
           kind: "if",
-          cond: { kind: "bin", op: "===", left: n(), right: num(0, loc), type: BOOL, loc },
-          then: [ret(str("[]", loc))],
+          cond: { kind: "bin", op: "===", left: n(), right: numLit(0, loc), type: BOOL, loc },
+          then: [ret(strLit("[]", loc))],
           else_: null,
           loc,
         },
         depthGate("[Array]"),
-        { kind: "varDecl", localId: "s.0", init: { kind: "ternary", cond: hasMore(), then: num(100, loc), else_: n(), type: F64, loc }, loc },
+        { kind: "varDecl", localId: "s.0", init: { kind: "ternary", cond: hasMore(), then: numLit(100, loc), else_: n(), type: F64, loc }, loc },
         ...begin(),
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0, loc), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: { kind: "bin", op: "<", left: i(), right: shown(), type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: num(1, loc), type: F64, loc }, loc },
+          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: numLit(1, loc), type: F64, loc }, loc },
           body: [entry(child(t.elem, at(i())), isNumberFlag(L, t.elem, () => at(i()), loc))],
           loc,
         },
@@ -451,17 +446,17 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
               {
                 kind: "libCall",
                 fn: "insp.moreItems",
-                args: [{ kind: "bin", op: "-", left: n(), right: num(100, loc), type: F64, loc }],
+                args: [{ kind: "bin", op: "-", left: n(), right: numLit(100, loc), type: F64, loc }],
                 type: STRING,
                 loc,
               },
-              isNumberFlag(L, t.elem, () => at(num(100, loc)), loc),
+              isNumberFlag(L, t.elem, () => at(numLit(100, loc)), loc),
             ),
           ],
           else_: null,
           loc,
         },
-        ret(end(str("", loc), str("[", loc), str("]", loc), true, hasMore())),
+        ret(end(strLit("", loc), strLit("[", loc), strLit("]", loc), true, hasMore())),
       ];
       break;
     }
@@ -472,14 +467,14 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
       if (shape.tuple) {
         // Tuples ARE arrays to Node: bracket form, array-extras grouping.
         if (shape.fields.length === 0) {
-          body = [ret(str("[]", loc))];
+          body = [ret(strLit("[]", loc))];
           break;
         }
         body = [depthGate("[Array]"), ...begin()];
         for (const f of shape.fields) {
           body.push(entry(child(f.type, get(f.name, f.type)), isNumberFlag(L, f.type, () => get(f.name, f.type), loc)));
         }
-        body.push(ret(end(str("", loc), str("[", loc), str("]", loc), true, boolLit(false, loc))));
+        body.push(ret(end(strLit("", loc), strLit("[", loc), strLit("]", loc), true, boolLit(false, loc))));
         break;
       }
       if (shape.indexValue && shape.fields.length === 0) {
@@ -497,10 +492,10 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
           { id: "i.0", name: "i", type: F64, mutable: true },
           { id: "k.0", name: "k", type: STRING, mutable: false },
         );
-        const ks = (): IrExpr => ref("ks.0", ksT);
-        const n = (): IrExpr => ref("n.0", F64);
-        const i = (): IrExpr => ref("i.0", F64);
-        const k = (): IrExpr => ref("k.0", STRING);
+        const ks = (): IrExpr => varRef("ks.0", ksT, loc);
+        const n = (): IrExpr => varRef("n.0", F64, loc);
+        const i = (): IrExpr => varRef("i.0", F64, loc);
+        const k = (): IrExpr => varRef("k.0", STRING, loc);
         const keyedRead = (): IrExpr =>
           ({ kind: "recordKeyGet", obj: v(), shapeId: t.shapeId, key: k(), overflowOnly: true, type: iv, loc });
         body = [
@@ -508,8 +503,8 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
           { kind: "varDecl", localId: "n.0", init: { kind: "arrIntrinsic", method: "length", receiver: ks(), args: [], type: F64, loc }, loc },
           {
             kind: "if",
-            cond: { kind: "bin", op: "===", left: n(), right: num(0, loc), type: BOOL, loc },
-            then: [ret(str("{}", loc))],
+            cond: { kind: "bin", op: "===", left: n(), right: numLit(0, loc), type: BOOL, loc },
+            then: [ret(strLit("{}", loc))],
             else_: null,
             loc,
           },
@@ -517,16 +512,16 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
           ...begin(),
           {
             kind: "for",
-            init: { kind: "varDecl", localId: "i.0", init: num(0, loc), loc },
+            init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
             cond: { kind: "bin", op: "<", left: i(), right: n(), type: BOOL, loc },
-            update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: num(1, loc), type: F64, loc }, loc },
+            update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: numLit(1, loc), type: F64, loc }, loc },
             body: [
               { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: ks(), index: i(), type: STRING, loc }, loc },
               entry(
                 concatAll(
                   [
                     { kind: "libCall", fn: "insp.key", args: [k()], type: STRING, loc },
-                    str(": ", loc),
+                    strLit(": ", loc),
                     child(iv, keyedRead()),
                   ],
                   loc,
@@ -536,12 +531,12 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
             ],
             loc,
           },
-          ret(end(str("", loc), str("{", loc), str("}", loc), false, boolLit(false, loc))),
+          ret(end(strLit("", loc), strLit("{", loc), strLit("}", loc), false, boolLit(false, loc))),
         ];
         break;
       }
       if (shape.fields.length === 0) {
-        body = [ret(str("{}", loc))];
+        body = [ret(strLit("{}", loc))];
         break;
       }
       // Object.keys' declared order (SEMANTICS.md 36's stance). Retained
@@ -557,12 +552,12 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
           if (!ft) continue;
           body.push(
             entry(
-              concatAll([str(`${inspectKey(fname)}: `, loc), child(ft, get(fname, ft))], loc),
+              concatAll([strLit(`${inspectKey(fname)}: `, loc), child(ft, get(fname, ft))], loc),
               boolLit(false, loc),
             ),
           );
         }
-        body.push(ret(end(str("", loc), str("{", loc), str("}", loc), false, boolLit(false, loc))));
+        body.push(ret(end(strLit("", loc), strLit("{", loc), strLit("}", loc), false, boolLit(false, loc))));
       };
       rebuildShapeOrderBody();
       break;
@@ -579,35 +574,35 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
         { id: "i.0", name: "i", type: F64, mutable: true },
         { id: "c.0", name: "c", type: F64, mutable: true },
       );
-      const n = (): IrExpr => ref("n.0", F64);
-      const i = (): IrExpr => ref("i.0", F64);
-      const c = (): IrExpr => ref("c.0", F64);
+      const n = (): IrExpr => varRef("n.0", F64, loc);
+      const i = (): IrExpr => varRef("i.0", F64, loc);
+      const c = (): IrExpr => varRef("c.0", F64, loc);
       const label = isMap ? "Map" : "Set";
       const keyT = isMap ? (t as IrType & { kind: "map" }).key : (t as IrType & { kind: "set" }).elem;
-      const hasMore = (): IrExpr => ({ kind: "bin", op: ">", left: n(), right: num(100, loc), type: BOOL, loc });
+      const hasMore = (): IrExpr => ({ kind: "bin", op: ">", left: n(), right: numLit(100, loc), type: BOOL, loc });
       const entryValue = (): IrExpr => {
         const k = child(keyT, mi("iterKey", [i()], keyT));
         if (!isMap) return k;
         const valueT = (t as IrType & { kind: "map" }).value;
-        return concatAll([k, str(" => ", loc), child(valueT, mi("iterValue", [i()], valueT))], loc);
+        return concatAll([k, strLit(" => ", loc), child(valueT, mi("iterValue", [i()], valueT))], loc);
       };
       body = [
         { kind: "varDecl", localId: "n.0", init: mi("size", [], F64), loc },
         {
           kind: "if",
-          cond: { kind: "bin", op: "===", left: n(), right: num(0, loc), type: BOOL, loc },
-          then: [ret(str(`${label}(0) {}`, loc))],
+          cond: { kind: "bin", op: "===", left: n(), right: numLit(0, loc), type: BOOL, loc },
+          then: [ret(strLit(`${label}(0) {}`, loc))],
           else_: null,
           loc,
         },
         depthGate(`[${label}]`),
         ...begin(),
-        { kind: "varDecl", localId: "c.0", init: num(0, loc), loc },
+        { kind: "varDecl", localId: "c.0", init: numLit(0, loc), loc },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0, loc), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: { kind: "bin", op: "<", left: i(), right: mi("iterCount", [], F64), type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: num(1, loc), type: F64, loc }, loc },
+          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: numLit(1, loc), type: F64, loc }, loc },
           body: [
             {
               kind: "if",
@@ -618,13 +613,13 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
             },
             {
               kind: "if",
-              cond: { kind: "bin", op: "===", left: c(), right: num(100, loc), type: BOOL, loc },
+              cond: { kind: "bin", op: "===", left: c(), right: numLit(100, loc), type: BOOL, loc },
               then: [{ kind: "break", loc }],
               else_: null,
               loc,
             },
             entry(entryValue(), boolLit(false, loc)),
-            { kind: "assign", localId: "c.0", value: { kind: "bin", op: "+", left: c(), right: num(1, loc), type: F64, loc }, loc },
+            { kind: "assign", localId: "c.0", value: { kind: "bin", op: "+", left: c(), right: numLit(1, loc), type: F64, loc }, loc },
           ],
           loc,
         },
@@ -636,7 +631,7 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
               {
                 kind: "libCall",
                 fn: "insp.moreItems",
-                args: [{ kind: "bin", op: "-", left: n(), right: num(100, loc), type: F64, loc }],
+                args: [{ kind: "bin", op: "-", left: n(), right: numLit(100, loc), type: F64, loc }],
                 type: STRING,
                 loc,
               },
@@ -648,9 +643,9 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
         },
         ret(
           end(
-            str("", loc),
-            concatAll([str(`${label}(`, loc), { kind: "toString", operand: n(), type: STRING, loc }, str(") {", loc)], loc),
-            str("}", loc),
+            strLit("", loc),
+            concatAll([strLit(`${label}(`, loc), { kind: "toString", operand: n(), type: STRING, loc }, strLit(") {", loc)], loc),
+            strLit("}", loc),
             false,
             hasMore(),
           ),
@@ -674,7 +669,7 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
           loc,
         });
       });
-      body.push(ret(str("", loc))); // unreachable: some arm always matches
+      body.push(ret(strLit("", loc))); // unreachable: some arm always matches
       break;
     }
     case "object": {
@@ -689,7 +684,7 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
       // so a class whose only fields are private prints as `C {}`.
       const visible = info.def.fields.filter((f) => !f.name.startsWith("#"));
       if (visible.length === 0) {
-        body = [ret(str(`${display} {}`, loc))];
+        body = [ret(strLit(`${display} {}`, loc))];
         break;
       }
       const get = (field: string, type: IrType): IrExpr => ({ kind: "fieldGet", obj: v(), className: t.className, field, type, loc });
@@ -709,10 +704,10 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
       for (const f of ordered) {
         const key = symNames.has(f.name) ? f.name : inspectKey(f.name);
         body.push(
-          entry(concatAll([str(`${key}: `, loc), child(f.type, get(f.name, f.type))], loc), boolLit(false, loc)),
+          entry(concatAll([strLit(`${key}: `, loc), child(f.type, get(f.name, f.type))], loc), boolLit(false, loc)),
         );
       }
-      body.push(ret(end(str("", loc), str(`${display} {`, loc), str("}", loc), false, boolLit(false, loc))));
+      body.push(ret(end(strLit("", loc), strLit(`${display} {`, loc), strLit("}", loc), false, boolLit(false, loc))));
       break;
     }
     default:
@@ -726,7 +721,7 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
     // [Circular *N] and descends no further — Node's formatValue order
     // (a circular target beyond the depth budget still says Circular).
     locals.push({ id: "cc.0", name: "cc", type: F64, mutable: false });
-    const cc = (): IrExpr => ref("cc.0", F64);
+    const cc = (): IrExpr => varRef("cc.0", F64, loc);
     prependCycleGuard = (): void => {
       body.unshift(
         {
@@ -737,7 +732,7 @@ function inspectHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
         },
         {
           kind: "if",
-          cond: { kind: "bin", op: ">", left: cc(), right: num(0, loc), type: BOOL, loc },
+          cond: { kind: "bin", op: ">", left: cc(), right: numLit(0, loc), type: BOOL, loc },
           then: [ret({ kind: "libCall", fn: "insp.circular", args: [cc()], type: STRING, loc })],
           else_: null,
           loc,
@@ -788,17 +783,17 @@ function formatValueExpr(L: Lowerer, t: IrType, value: IrExpr, depth: number, lo
     case "bool":
       return { kind: "toString", operand: value, type: STRING, loc };
     case "undefinedT":
-      return str("undefined", loc);
+      return strLit("undefined", loc);
     case "nullT":
-      return str("null", loc);
+      return strLit("null", loc);
     case "symbol":
       return { kind: "libCall", fn: "sym.toString", args: [value], type: STRING, loc };
     case "dyn":
-      return { kind: "libCall", fn: "insp.dynS", args: [value, num(depth, loc)], type: STRING, loc };
+      return { kind: "libCall", fn: "insp.dynS", args: [value, numLit(depth, loc)], type: STRING, loc };
     case "union":
       return { kind: "call", callee: formatUnionHelper(L, t, depth, loc), args: [value], type: STRING, loc };
     default:
-      return inspectExpr(L, t, value, num(0, loc), num(depth, loc), loc);
+      return inspectExpr(L, t, value, numLit(0, loc), numLit(depth, loc), loc);
   }
 }
 
@@ -826,7 +821,7 @@ function formatUnionHelper(L: Lowerer, t: IrType & { kind: "union" }, depth: num
       loc,
     });
   });
-  body.push({ kind: "return", value: str("", loc), loc }); // unreachable: some arm always matches
+  body.push({ kind: "return", value: strLit("", loc), loc }); // unreachable: some arm always matches
   L.liftedFns.push({
     name,
     params: [{ localId: "v.0", name: "v", type: t }],
@@ -863,7 +858,7 @@ export function lowerConsoleInspectArg(
         `${surface} of an effectful '${L.fmt(t)}'-typed expression (evaluate it first: const v = ...; ${surface}(v))`,
       );
     }
-    return str(t.kind === "undefinedT" ? "undefined" : "null", loc);
+    return strLit(t.kind === "undefinedT" ? "undefined" : "null", loc);
   }
   if (t.kind === "bytes") {
     // One runtime representation serves Buffer AND Uint8Array; their
@@ -879,7 +874,7 @@ export function lowerConsoleInspectArg(
         `${surface} of '${tname}' values (Buffer's <Buffer ..> form is the lowered typed-array rendering; other typed arrays fence)`,
       );
     }
-    return inspectExpr(L, t, value, num(0, loc), num(2, loc), loc);
+    return inspectExpr(L, t, value, numLit(0, loc), numLit(2, loc), loc);
   }
   if (t.kind === "void") {
     // Node prints "undefined" for a void call's result; a void expression
@@ -977,15 +972,15 @@ function directCallableInspect(L: Lowerer, node: ts.Expression, loc: SrcLoc): Ir
   if (cls) {
     if (cls.builtinError) {
       // Node's Error constructors are native functions, not classes.
-      return str(`[Function: ${cls.def.name.replace(/^%/, "")}]`, loc);
+      return strLit(`[Function: ${cls.def.name.replace(/^%/, "")}]`, loc);
     }
     const base = cls.base ? ` extends ${cls.base.def.name.replace(/^%/, "")}` : "";
-    return str(`[class ${cls.def.name}${base}]`, loc);
+    return strLit(`[class ${cls.def.name}${base}]`, loc);
   }
   const decl = L.checker.declarationsOf(sym)[0];
   if (!decl) return null;
   if (ts.isFunctionDeclaration(decl) && decl.name) {
-    return str(`[Function: ${decl.name.text}]`, loc);
+    return strLit(`[Function: ${decl.name.text}]`, loc);
   }
   if (
     ts.isVariableDeclaration(decl) &&
@@ -996,7 +991,7 @@ function directCallableInspect(L: Lowerer, node: ts.Expression, loc: SrcLoc): Ir
     // JS name inference: the binding names the function value — unless
     // the function expression carries its OWN name, which wins.
     const own = ts.isFunctionExpression(decl.initializer) ? decl.initializer.name?.text : undefined;
-    return str(`[Function: ${own ?? decl.name.text}]`, loc);
+    return strLit(`[Function: ${own ?? decl.name.text}]`, loc);
   }
   return null;
 }
@@ -1020,7 +1015,7 @@ function lowerInspectCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc): IrE
   }
   if (ts.isArrowFunction(valueNode) || ts.isFunctionExpression(valueNode)) {
     parseInspectOptions(L, expr.arguments[1], false);
-    return str(valueNode.kind === ts.SyntaxKind.FunctionExpression && (valueNode as ts.FunctionExpression).name ? `[Function: ${(valueNode as ts.FunctionExpression).name!.text}]` : "[Function (anonymous)]", loc);
+    return strLit(valueNode.kind === ts.SyntaxKind.FunctionExpression && (valueNode as ts.FunctionExpression).name ? `[Function: ${(valueNode as ts.FunctionExpression).name!.text}]` : "[Function (anonymous)]", loc);
   }
   const value = L.lowerExpr(valueNode);
   if (value.type.kind === "bytes") {
@@ -1040,7 +1035,7 @@ function lowerInspectCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc): IrE
     }
     const bufDepth = parseInspectOptions(L, expr.arguments[1], false);
     void bufDepth; // Buffers render fully at any depth (custom inspect)
-    return inspectExpr(L, value.type, value, num(0, loc), num(2, loc), loc);
+    return inspectExpr(L, value.type, value, numLit(0, loc), numLit(2, loc), loc);
   }
   const walk = { recursive: false };
   const reason = inspectSupport(L, value.type, new Set(), walk);
@@ -1048,7 +1043,7 @@ function lowerInspectCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc): IrE
     L.noLowering(`util.inspect of '${L.fmt(value.type)}' values`, valueNode, reason);
   }
   const depth = parseInspectOptions(L, expr.arguments[1], walk.recursive);
-  return inspectExpr(L, value.type, value, num(0, loc), num(depth, loc), loc);
+  return inspectExpr(L, value.type, value, numLit(0, loc), numLit(depth, loc), loc);
 }
 
 /* ── util.format / util.formatWithOptions ────────────────────────────── */
@@ -1062,13 +1057,13 @@ function formatSArg(L: Lowerer, node: ts.Expression, depth: number, loc: SrcLoc)
   if (t.kind === "string") return value;
   if (t.kind === "f64") return { kind: "libCall", fn: "insp.f64", args: [value], type: STRING, loc };
   if (t.kind === "bool") return { kind: "toString", operand: value, type: STRING, loc };
-  if (t.kind === "undefinedT") return str("undefined", loc);
-  if (t.kind === "nullT") return str("null", loc);
+  if (t.kind === "undefinedT") return strLit("undefined", loc);
+  if (t.kind === "nullT") return strLit("null", loc);
   // %s of a symbol prints inspect's text ("Symbol(foo)") — String(sym)'s
   // answer too, one runtime call either way.
   if (t.kind === "symbol") return { kind: "libCall", fn: "sym.toString", args: [value], type: STRING, loc };
   if (t.kind === "dyn") {
-    return { kind: "libCall", fn: "insp.dynS", args: [value, num(depth, loc)], type: STRING, loc };
+    return { kind: "libCall", fn: "insp.dynS", args: [value, numLit(depth, loc)], type: STRING, loc };
   }
   // A UNION argument dispatches per arm at runtime: a string arm prints
   // VERBATIM (typeof arg === 'string' in Node's formatter — inspect's
@@ -1098,7 +1093,7 @@ function formatSArg(L: Lowerer, node: ts.Expression, depth: number, loc: SrcLoc)
   const walk = { recursive: false };
   const reason = inspectSupport(L, t, new Set(), walk);
   if (reason !== null) L.noLowering(`util.format %s of '${L.fmt(t)}' values`, node, reason);
-  return inspectExpr(L, t, value, num(0, loc), num(depth, loc), loc);
+  return inspectExpr(L, t, value, numLit(0, loc), numLit(depth, loc), loc);
 }
 
 /** %O (depth 2) / %o (showHidden, depth 4) — inspect with the spec's
@@ -1119,7 +1114,7 @@ function formatOArg(L: Lowerer, node: ts.Expression, depth: number, loc: SrcLoc)
       "%o renders with showHidden (arrays gain a hidden [length] entry) — use %O for the default rendering",
     );
   }
-  return inspectExpr(L, value.type, value, num(0, loc), num(depth, loc), loc);
+  return inspectExpr(L, value.type, value, numLit(0, loc), numLit(depth, loc), loc);
 }
 
 /** util.format(...) / util.formatWithOptions({}, ...): the compile-time
@@ -1139,7 +1134,7 @@ export function lowerFormatCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc
       );
     }
   }
-  if (argNodes.length === 0) return str("", loc);
+  if (argNodes.length === 0) return strLit("", loc);
   const first = argNodes[0]!;
   const firstIsLiteral = ts.isStringLiteral(first) || ts.isNoSubstitutionTemplateLiteral(first);
 
@@ -1159,7 +1154,7 @@ export function lowerFormatCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc
     // No substitutions possible: every argument joins with spaces.
     const parts: IrExpr[] = [];
     for (let i = 0; i < argNodes.length; i++) {
-      if (i > 0) parts.push(str(" ", loc));
+      if (i > 0) parts.push(strLit(" ", loc));
       parts.push(restArg(argNodes[i]!));
     }
     return concatAll(parts, loc);
@@ -1168,7 +1163,7 @@ export function lowerFormatCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc
   const fmt = (first as ts.StringLiteralLike).text;
   // Node's early return: a lone string first argument passes VERBATIM —
   // no substitution runs, "%%" stays "%%".
-  if (argNodes.length === 1) return str(fmt, loc);
+  if (argNodes.length === 1) return strLit(fmt, loc);
   const parts: IrExpr[] = [];
   let a = 0; // the arg cursor over argNodes (0 = the format string)
   let lastPos = 0;
@@ -1191,7 +1186,7 @@ export function lowerFormatCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc
           return {
             kind: "libCall",
             fn: "insp.f64",
-            args: [{ kind: "ternary", cond: value, then: num(1, loc), else_: num(0, loc), type: F64, loc }],
+            args: [{ kind: "ternary", cond: value, then: numLit(1, loc), else_: numLit(0, loc), type: F64, loc }],
             type: STRING,
             loc,
           };
@@ -1218,7 +1213,7 @@ export function lowerFormatCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc
         const value = L.lowerExpr(node);
         if (value.type.kind === "f64" || value.type.kind === "bool" || value.type.kind === "string") {
           const text: IrExpr = value.type.kind === "string" ? value : { kind: "toString", operand: value, type: STRING, loc };
-          const parsed: IrExpr = { kind: "libCall", fn: "num.parseInt", args: [text, num(0, loc)], type: F64, loc };
+          const parsed: IrExpr = { kind: "libCall", fn: "num.parseInt", args: [text, numLit(0, loc)], type: F64, loc };
           return { kind: "libCall", fn: "insp.f64", args: [parsed], type: STRING, loc };
         }
         L.noLowering(`util.format %i of '${L.fmt(value.type)}' values`, node);
@@ -1228,7 +1223,7 @@ export function lowerFormatCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc
         // %j — JSON.stringify; undefined-valued args print "undefined"
         // (Node appends the non-string result of tryStringify).
         const value = L.lowerExpr(node);
-        if (value.type.kind === "undefinedT") return str("undefined", loc);
+        if (value.type.kind === "undefinedT") return strLit("undefined", loc);
         // JSON.stringify(sym) is undefined in Node — %j prints the
         // "undefined" text. Folding drops the operand, so only
         // side-effect-free reads compose (the typeof-fold stance).
@@ -1240,7 +1235,7 @@ export function lowerFormatCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc
               "bind the symbol to a const first (the %j text is always \"undefined\")",
             );
           }
-          return str("undefined", loc);
+          return strLit("undefined", loc);
         }
         // A checked-dynamic argument (`console.error('headers: %j',
         // headers)` — the suite's http logging idiom): the runtime dyn
@@ -1274,7 +1269,7 @@ export function lowerFormatCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc
           case 111: // o
           case 105: { // i
             const node = args[++a]!;
-            if (lastPos !== i - 1) parts.push(str(fmt.slice(lastPos, i - 1), loc));
+            if (lastPos !== i - 1) parts.push(strLit(fmt.slice(lastPos, i - 1), loc));
             parts.push(convert(nextChar, node));
             lastPos = i + 1;
             continue;
@@ -1284,33 +1279,33 @@ export function lowerFormatCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc
             break;
           case 99: // c — consumes its argument, contributes nothing
             a += 1;
-            if (lastPos !== i - 1) parts.push(str(fmt.slice(lastPos, i - 1), loc));
+            if (lastPos !== i - 1) parts.push(strLit(fmt.slice(lastPos, i - 1), loc));
             lastPos = i + 1;
             continue;
           case 37: // %%
-            parts.push(str(fmt.slice(lastPos, i), loc));
+            parts.push(strLit(fmt.slice(lastPos, i), loc));
             lastPos = i + 1;
             continue;
           default:
             continue;
         }
       } else if (nextChar === 37) {
-        parts.push(str(fmt.slice(lastPos, i), loc));
+        parts.push(strLit(fmt.slice(lastPos, i), loc));
         lastPos = i + 1;
       }
     }
   }
   if (lastPos !== 0) {
     a++;
-    if (lastPos < fmt.length) parts.push(str(fmt.slice(lastPos), loc));
+    if (lastPos < fmt.length) parts.push(strLit(fmt.slice(lastPos), loc));
   } else {
     // No substitution touched the format string: it joins verbatim, and
     // the cursor advances past it.
-    parts.push(str(fmt, loc));
+    parts.push(strLit(fmt, loc));
     a++;
   }
   for (; a < args.length; a++) {
-    parts.push(str(" ", loc));
+    parts.push(strLit(" ", loc));
     parts.push(restArg(args[a]!));
   }
   return concatAll(parts, loc);

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -26,6 +26,7 @@ import {
   TLS_SERVER_DOCUMENTED_OPTIONS,
 } from "./surfaces.js";
 import { conditionalSpreadOf } from "./lower-exprs.js";
+import { boolLit, numLit, strLit, varRef } from "../../ir/build.js";
 
 const NARROW_DATA_HINT =
   'write/end take one string or one Uint8Array/Buffer value (narrow unions first)';
@@ -135,22 +136,33 @@ function receiverReturningCall(
   if (!existing) {
     L.arrHofHelpers.set(key, name);
     const params = callArgs.map((a, i) => ({ localId: `p${i}.0`, name: `p${i}`, type: a.type }));
-    const ref = (i: number): IrExpr => ({ kind: "varRef", localId: params[i]!.localId, type: params[i]!.type, loc });
     const body: IrStmt[] = [];
     if (opts?.prefix) {
       body.push({
         kind: "exprStmt",
-        expr: { kind: "libCall", fn: opts.prefix.fn, args: opts.prefix.argIndices.map(ref), type: VOID, loc },
+        expr: {
+          kind: "libCall",
+          fn: opts.prefix.fn,
+          args: opts.prefix.argIndices.map((i) => varRef(params[i]!.localId, params[i]!.type, loc)),
+          type: VOID,
+          loc,
+        },
         loc,
       });
     }
     const mainIdx = opts?.mainArgIndices ?? params.map((_, i) => i);
     body.push({
       kind: "exprStmt",
-      expr: { kind: "libCall", fn, args: mainIdx.map(ref), type: VOID, loc },
+      expr: {
+        kind: "libCall",
+        fn,
+        args: mainIdx.map((i) => varRef(params[i]!.localId, params[i]!.type, loc)),
+        type: VOID,
+        loc,
+      },
       loc,
     });
-    body.push({ kind: "return", value: ref(0), loc });
+    body.push({ kind: "return", value: varRef(params[0]!.localId, params[0]!.type, loc), loc });
     L.liftedFns.push({
       name,
       params,
@@ -224,9 +236,6 @@ function lowerCallbackArg(
   const adapted = voidizedCallback(L, cb, locOf(node));
   return { cb: adapted, nparams: cb.type.params.length };
 }
-
-const boolLit = (value: boolean, loc: SrcLoc): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
-
 /** Lowers a handle-kind method receiver. The checker's control flow can
  * narrow an untyped binding to the handle class (`let server; server =
  * createServer(...)` — the keep-alive shape) so the STATIC lowering
@@ -272,12 +281,11 @@ function h2HeaderRecordStmts(
   if (strTag < 0) return null;
   const recT: IrType = { kind: "record", shapeId };
   const pairsT = arrayOf(STRING);
-  const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-  const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
   const pairAt = (offset: number): IrExpr => ({
     kind: "arrayGet",
-    arr: ref(pairsLocal, pairsT),
-    index: offset === 0 ? ref("i.0", F64) : { kind: "bin", op: "+", left: ref("i.0", F64), right: num(offset), type: F64, loc },
+    arr: varRef(pairsLocal, pairsT, loc),
+    index: offset === 0 ? varRef("i.0", F64, loc) : { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(offset, loc), type: F64, loc },
     type: STRING,
     loc,
   });
@@ -285,15 +293,15 @@ function h2HeaderRecordStmts(
     { kind: "varDecl", localId: outLocal, init: { kind: "recordLit", fields: [], type: recT, loc }, loc },
     {
       kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
       cond: {
-        kind: "bin", op: "<", left: ref("i.0", F64),
-        right: { kind: "arrIntrinsic", method: "length", receiver: ref(pairsLocal, pairsT), args: [], type: F64, loc },
+        kind: "bin", op: "<", left: varRef("i.0", F64, loc),
+        right: { kind: "arrIntrinsic", method: "length", receiver: varRef(pairsLocal, pairsT, loc), args: [], type: F64, loc },
         type: BOOL, loc,
       },
-      update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(2), type: F64, loc }, loc },
+      update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(2, loc), type: F64, loc }, loc },
       body: [{
-        kind: "recordKeySet", obj: ref(outLocal, recT), shapeId, key: pairAt(0),
+        kind: "recordKeySet", obj: varRef(outLocal, recT, loc), shapeId, key: pairAt(0),
         value: { kind: "unionWrap", unionId: iv.unionId, tag: strTag, value: pairAt(1), type: iv, loc }, loc,
       }],
       loc,
@@ -303,9 +311,9 @@ function h2HeaderRecordStmts(
     const f64Tag = L.armTag(iv.unionId, F64);
     if (f64Tag < 0) return null;
     stmts.push({
-      kind: "recordKeySet", obj: ref(outLocal, recT), shapeId,
+      kind: "recordKeySet", obj: varRef(outLocal, recT, loc), shapeId,
       key: { kind: "strLit", value: ":status", type: STRING, loc },
-      value: { kind: "unionWrap", unionId: iv.unionId, tag: f64Tag, value: ref(statusLocal, F64), type: iv, loc }, loc,
+      value: { kind: "unionWrap", unionId: iv.unionId, tag: f64Tag, value: varRef(statusLocal, F64, loc), type: iv, loc }, loc,
     });
   }
   return stmts;
@@ -387,7 +395,6 @@ function h2HeadersCallbackAdapter(
   if (!existing) {
     L.arrHofHelpers.set(key, name);
     const impl = `${name}.impl`;
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
     const locals: import("../../ir/nodes.js").IrLocal[] = [
       { id: "f.0", name: "f", type: fromT, mutable: false, boxed: true },
       ...abiParams.map((p) => ({ id: p.localId, name: p.name, type: p.type, mutable: false })),
@@ -400,17 +407,17 @@ function h2HeadersCallbackAdapter(
       const stmts = h2HeaderRecordStmts(L, shapeId, "ps.0", "out.0", withStatus ? "st.0" : null, loc);
       if (stmts === null) L.unsupported("SC1090", node, `${what} whose headers parameter is not a supported header record`);
       body.push(...stmts!);
-      recordRef = ref("out.0", { kind: "record", shapeId });
+      recordRef = varRef("out.0", { kind: "record", shapeId }, loc);
     }
     // Assemble the user-call arguments in the user's declared order.
     const callArgs: IrExpr[] = [];
     const push = (e: IrExpr) => { if (callArgs.length < fromT.params.length) callArgs.push(e); };
-    if (handleT) push(ref("h.0", handleT));
-    if (recordRef) push(recordRef); else if (fromT.params.length > headersIdx) push(ref("ps.0", arrayOf(STRING)));
-    push(ref("fl.0", F64));
+    if (handleT) push(varRef("h.0", handleT, loc));
+    if (recordRef) push(recordRef); else if (fromT.params.length > headersIdx) push(varRef("ps.0", arrayOf(STRING), loc));
+    push(varRef("fl.0", F64, loc));
     body.push({
       kind: "exprStmt",
-      expr: { kind: "callValue", callee: ref("f.0", fromT), args: callArgs.slice(0, fromT.params.length), type: fromT.ret, loc },
+      expr: { kind: "callValue", callee: varRef("f.0", fromT, loc), args: callArgs.slice(0, fromT.params.length), type: fromT.ret, loc },
       loc,
     });
     L.liftedFns.push({ name: impl, params: abiParams, returnType: VOID, captures: [{ localId: "f.0", name: "f", type: fromT }], locals, body, loc });
@@ -1677,15 +1684,14 @@ function headersSnapshotHelper(L: Lowerer, shapeId: string, loc: SrcLoc): string
   L.widthHelpers.set(key, name);
   const recT: IrType = { kind: "record", shapeId };
   const pairsT = arrayOf(STRING);
-  const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-  const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
   const pairAt = (offset: number): IrExpr => ({
     kind: "arrayGet",
-    arr: ref("ps.0", pairsT),
+    arr: varRef("ps.0", pairsT, loc),
     index:
       offset === 0
-        ? ref("i.0", F64)
-        : { kind: "bin", op: "+", left: ref("i.0", F64), right: num(offset), type: F64, loc },
+        ? varRef("i.0", F64, loc)
+        : { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(offset, loc), type: F64, loc },
     type: STRING,
     loc,
   });
@@ -1693,7 +1699,7 @@ function headersSnapshotHelper(L: Lowerer, shapeId: string, loc: SrcLoc): string
     {
       kind: "varDecl",
       localId: "ps.0",
-      init: { kind: "libCall", fn: "http.reqHeaderPairs", args: [ref("r.0", HTTPREQ_T)], type: pairsT, loc },
+      init: { kind: "libCall", fn: "http.reqHeaderPairs", args: [varRef("r.0", HTTPREQ_T, loc)], type: pairsT, loc },
       loc,
     },
     {
@@ -1704,25 +1710,25 @@ function headersSnapshotHelper(L: Lowerer, shapeId: string, loc: SrcLoc): string
     },
     {
       kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
       cond: {
         kind: "bin",
         op: "<",
-        left: ref("i.0", F64),
-        right: { kind: "arrIntrinsic", method: "length", receiver: ref("ps.0", pairsT), args: [], type: F64, loc },
+        left: varRef("i.0", F64, loc),
+        right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ps.0", pairsT, loc), args: [], type: F64, loc },
         type: BOOL,
         loc,
       },
       update: {
         kind: "assign",
         localId: "i.0",
-        value: { kind: "bin", op: "+", left: ref("i.0", F64), right: num(2), type: F64, loc },
+        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(2, loc), type: F64, loc },
         loc,
       },
       body: [
         {
           kind: "recordKeySet",
-          obj: ref("out.0", recT),
+          obj: varRef("out.0", recT, loc),
           shapeId,
           key: pairAt(0),
           value: { kind: "unionWrap", unionId: iv.unionId, tag: strTag, value: pairAt(1), type: iv, loc },
@@ -1731,7 +1737,7 @@ function headersSnapshotHelper(L: Lowerer, shapeId: string, loc: SrcLoc): string
       ],
       loc,
     },
-    { kind: "return", value: ref("out.0", recT), loc },
+    { kind: "return", value: varRef("out.0", recT, loc), loc },
   ];
   L.liftedFns.push({
     name,
@@ -2534,14 +2540,13 @@ export function lowerHttpAgentNew(L: Lowerer, expr: ts.NewExpression): IrExpr | 
   if (!bi || bi.member !== "Agent" || (bi.module !== "http" && bi.module !== "https")) return null;
   const loc = locOf(expr);
   const api = `new ${bi.module}.Agent`;
-  const numLit = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-  const boolAt = (value: boolean): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
-  let keepAlive: IrExpr = boolAt(false);
-  let kaMsecs: IrExpr = numLit(-1);
-  let maxSockets: IrExpr = numLit(-1);
-  let maxFree: IrExpr = numLit(-1);
-  let timeout: IrExpr = numLit(-1);
-  let port: IrExpr = numLit(-1);
+
+  let keepAlive: IrExpr = boolLit(false, loc);
+  let kaMsecs: IrExpr = numLit(-1, loc);
+  let maxSockets: IrExpr = numLit(-1, loc);
+  let maxFree: IrExpr = numLit(-1, loc);
+  let timeout: IrExpr = numLit(-1, loc);
+  let port: IrExpr = numLit(-1, loc);
   const args = expr.arguments ?? [];
   if (args.length > 1) {
     L.noLowering(`${api} with ${args.length} arguments`, expr, "the supported form is new Agent(options?)");
@@ -2626,7 +2631,7 @@ export function lowerHttpAgentNew(L: Lowerer, expr: ts.NewExpression): IrExpr | 
   return {
     kind: "libCall",
     fn: "http.agentNew",
-    args: [boolAt(bi.module === "https"), keepAlive, kaMsecs, maxSockets, maxFree, timeout, port],
+    args: [boolLit(bi.module === "https", loc), keepAlive, kaMsecs, maxSockets, maxFree, timeout, port],
     type: DYN,
     loc,
   };
@@ -2846,8 +2851,8 @@ function lowerTlsConnectCall(L: Lowerer, expr: ts.CallExpression, loc: SrcLoc): 
     const t = L.typeOf(a);
     return (t.flags & ts.TypeFlags.Object) !== 0;
   };
-  const num = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-  let port: IrExpr = num(-1); // -1: the runtime reads options.port
+
+  let port: IrExpr = numLit(-1, loc); // -1: the runtime reads options.port
   let host: IrExpr = { kind: "strLit", value: "", type: STRING, loc }; // "": options.host / localhost
   let optsNode: ts.Expression | null = null;
   let i = 0;
@@ -4000,15 +4005,15 @@ function lowerHttpClientCall(L: Lowerer, expr: ts.CallExpression, member: "reque
     // lowering. A user-set connection header wins, Node's rule; a
     // non-literal headers record cannot be checked for one, so the combo
     // fences instead of double-sending.
-    const strLitAt = (value: string): IrExpr => ({ kind: "strLit", value, type: STRING, loc });
+
     if (headers === null) {
-      headers = { kind: "arrayLit", elems: [strLitAt("Connection"), strLitAt("close")], type: arrayOf(STRING), loc };
+      headers = { kind: "arrayLit", elems: [strLit("Connection", loc), strLit("close", loc)], type: arrayOf(STRING), loc };
     } else if (headers.kind === "arrayLit") {
       const hasConnection = headers.elems.some(
         (el, i) => i % 2 === 0 && el.kind === "strLit" && el.value.toLowerCase() === "connection",
       );
       if (!hasConnection) {
-        headers = { ...headers, elems: [...headers.elems, strLitAt("Connection"), strLitAt("close")] };
+        headers = { ...headers, elems: [...headers.elems, strLit("Connection", loc), strLit("close", loc)] };
       }
     } else {
       L.noLowering(
@@ -4019,8 +4024,7 @@ function lowerHttpClientCall(L: Lowerer, expr: ts.CallExpression, member: "reque
       );
     }
   }
-  const strLit = (value: string): IrExpr => ({ kind: "strLit", value, type: STRING, loc });
-  const numLit = (value: number): IrExpr => ({ kind: "numLit", value, type: F64, loc });
+
   if (connCb !== null && (host !== null || port !== null)) {
     // Node would use host/port only for the Host header once a dialer
     // exists — a silent half-use; set headers.host instead.
@@ -4044,18 +4048,18 @@ function lowerHttpClientCall(L: Lowerer, expr: ts.CallExpression, member: "reque
       "call http.request/https.request directly when passing an Agent",
     );
   }
-  host ??= strLit("localhost");
+  host ??= strLit("localhost", loc);
   // The binding mode's default port follows the runtime dial: 443 on the
   // TLS arm, 80 on the plain one — exactly each client's own default.
   // With an AGENT the sentinel -1 says "no port option": the runtime
   // consults the agent's (settable) defaultPort first, Node's merge.
   port ??= binding !== null
-    ? { kind: "ternary", cond: secureExpr(), then: numLit(443), else_: numLit(80), type: F64, loc }
-    : agentVal !== null ? numLit(-1)
-    : numLit(secure === true ? 443 : 80);
-  path ??= strLit("/");
-  method ??= strLit("GET");
-  timeout ??= numLit(0);
+    ? { kind: "ternary", cond: secureExpr(), then: numLit(443, loc), else_: numLit(80, loc), type: F64, loc }
+    : agentVal !== null ? numLit(-1, loc)
+    : numLit(secure === true ? 443 : 80, loc);
+  path ??= strLit("/", loc);
+  method ??= strLit("GET", loc);
+  timeout ??= numLit(0, loc);
   headers ??= { kind: "arrayLit", elems: [], type: arrayOf(STRING), loc };
   const autoEnd = boolLit(member === "get", loc);
   if (connCb !== null) {
@@ -4074,7 +4078,7 @@ function lowerHttpClientCall(L: Lowerer, expr: ts.CallExpression, member: "reque
   const base = [host, port, path, method, timeout, headers, autoEnd];
   if (secureish) {
     reject ??= boolLit(true, loc); /* Node's default: verify */
-    ca ??= strLit(""); /* none: /etc/ssl/cert.pem stands in for Node's roots */
+    ca ??= strLit("", loc); /* none: /etc/ssl/cert.pem stands in for Node's roots */
     base.push(reject, ca);
   }
   if (agentVal !== null) base.push(agentVal);
@@ -4641,7 +4645,6 @@ function lowerHttpResMethodCall(L: Lowerer, call: ts.CallExpression,
       if (!existing) {
         L.arrHofHelpers.set(key, helper);
         const params = all.map((a, i) => ({ localId: `p${i}.0`, name: `p${i}`, type: a.type }));
-        const ref = (i: number): IrExpr => ({ kind: "varRef", localId: params[i]!.localId, type: params[i]!.type, loc });
         L.liftedFns.push({
           name: helper,
           params,
@@ -4650,12 +4653,12 @@ function lowerHttpResMethodCall(L: Lowerer, call: ts.CallExpression,
           body: [
             {
               kind: "exprStmt",
-              expr: { kind: "libCall", fn: "http.resOnFinish", args: [ref(0), ref(all.length - 1)], type: VOID, loc },
+              expr: { kind: "libCall", fn: "http.resOnFinish", args: [varRef(params[0]!.localId, params[0]!.type, loc), varRef(params[all.length - 1]!.localId, params[all.length - 1]!.type, loc)], type: VOID, loc },
               loc,
             },
             {
               kind: "exprStmt",
-              expr: { kind: "libCall", fn, args: callArgs.map((_, i) => ref(i)), type: VOID, loc },
+              expr: { kind: "libCall", fn, args: callArgs.map((_, i) => varRef(params[i]!.localId, params[i]!.type, loc)), type: VOID, loc },
               loc,
             },
           ],

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -28,6 +28,7 @@ import { UNSUPPORTED, checkerPanicDiag, isCheckerPanic, requiresDynamicDiag } fr
 import { isParseArgsDynTypeName, isUnitOnlyTsType, unitOnlyUnion } from "../types.js";
 import { canonicalBuiltinModule, isRelativeSpecifier } from "../shared.js";
 import { probeNodeRequireRefusal } from "../npm.js";
+import { varRef } from "../../ir/build.js";
 
 /** `const X = /* @__PURE__ *\/ makeX()` at a module's top level: every
  * declarator initialized by a call (or `new`) carrying the bundler PURE
@@ -1482,7 +1483,6 @@ export function isParseArgsDynCheckerType(L: Lowerer, type: ts.Type): boolean {
             // its value converting into the checked-dynamic tree like any dyn-slot value.
             const rl = L.declareHiddenLocal("%delem", DYN);
             out.push({ kind: "varDecl", localId: rl.id, init: value, loc: elLoc });
-            const ref = (): IrExpr => ({ kind: "varRef", localId: rl.id, type: DYN, loc: elLoc });
             const dflt = L.coerceToExpected(L.lowerExpr(el.initializer), DYN);
             if (dflt.type.kind !== "dyn") {
               L.unsupported(
@@ -1493,9 +1493,9 @@ export function isParseArgsDynCheckerType(L: Lowerer, type: ts.Type): boolean {
             }
             value = {
               kind: "ternary",
-              cond: { kind: "dynTest", test: "undefined", value: ref(), type: BOOL, loc: elLoc },
+              cond: { kind: "dynTest", test: "undefined", value: varRef(rl.id, DYN, elLoc), type: BOOL, loc: elLoc },
               then: dflt,
-              else_: ref(),
+              else_: varRef(rl.id, DYN, elLoc),
               type: DYN,
               loc: elLoc,
             };
@@ -6449,10 +6449,10 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
     ) {
       throw new InternalCompilerError("internal: retained numeric iterator has a non-numeric source");
     }
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const indexRef = (): IrExpr => ref(state.indexLocalId, F64);
-    const doneRef = (): IrExpr => ref(state.doneLocalId, BOOL);
-    const sourceRef = (): IrExpr => ref(state.sourceLocalId, sourceT);
+
+    const indexRef = (): IrExpr => varRef(state.indexLocalId, F64, loc);
+    const doneRef = (): IrExpr => varRef(state.doneLocalId, BOOL, loc);
+    const sourceRef = (): IrExpr => varRef(state.sourceLocalId, sourceT, loc);
     const sourceLength = (): IrExpr => sourceT.kind === "array"
       ? {
           kind: "arrIntrinsic",
@@ -6488,7 +6488,7 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
       const value = varTarget
         ? L.declareHiddenLocal("%numiterValue", F64)
         : L.declareLocal(decl!.name as ts.Identifier, (decl!.name as ts.Identifier).text, F64, isLet);
-      const valueRef: IrExpr = ref(value.id, F64);
+      const valueRef: IrExpr = varRef(value.id, F64, loc);
       const blame: ts.Node = decl?.name ?? exprTargetNode ?? stmt.initializer;
       const head: IrStmt[] = [
         {

--- a/packages/compiler/src/frontend/lowering/lower-stream.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stream.ts
@@ -37,6 +37,7 @@ import { appendImplicitUndefinedReturn } from "./lower-calls.js";
 import { bufEncoding, knownBufEncoding } from "./lower-containers.js";
 import { probeLower } from "./lower-exprs.js";
 import { BOOL, DYN, F64, IrExpr, IrFunction, IrLibFn, IrStmt, IrType, RUNTIME_STREAM_CLASSES, STRING, SrcLoc, VOID, arrayOf, bytesOf, canBoxFuncIntoDyn, funcOf, typeEquals, typeKey } from "../../ir/nodes.js";
+import { boolLit, numLit, strLit } from "../../ir/build.js";
 
 const BYTES = bytesOf("u8");
 
@@ -136,11 +137,6 @@ export function streamForcedTuple(L: Lowerer, info: ClassInfo | undefined | null
   }
   return null;
 }
-
-const strLit = (value: string, loc: SrcLoc): IrExpr => ({ kind: "strLit", value, type: STRING, loc });
-const boolLit = (value: boolean, loc: SrcLoc): IrExpr => ({ kind: "boolLit", value, type: BOOL, loc });
-const f64Lit = (value: number, loc: SrcLoc): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-
 /* ── option callbacks (the leading-`this` closures) ─────────────────── */
 
 /** Lowers one option callback (method shorthand, function expression, or
@@ -461,8 +457,8 @@ function parseStreamOptions(
   fallbackCb?: (name: string) => IrExpr | null,
 ): StreamOptions {
   const out: StreamOptions = {
-    hwmR: f64Lit(-1, loc),
-    hwmW: f64Lit(-1, loc),
+    hwmR: numLit(-1, loc),
+    hwmW: numLit(-1, loc),
     autoDestroy: boolLit(true, loc),
     emitClose: boolLit(true, loc),
     allowHalfOpen: boolLit(true, loc),
@@ -699,8 +695,8 @@ function streamCtorArgs(L: Lowerer, cls: string, arg: ts.Expression | undefined,
   const o = parseStreamOptions(L, cls.slice(1), arg, thisType, shape.accepted, loc, fallbackCb);
   const head = shape.duplexShape
     ? [o.hwmR, o.hwmW, o.autoDestroy, o.emitClose, o.allowHalfOpen,
-       boolLit(o.readableSide, loc), boolLit(o.writableSide, loc), f64Lit(o.flags, loc)]
-    : [cls === "%Writable" ? o.hwmW : o.hwmR, o.autoDestroy, o.emitClose, f64Lit(o.flags, loc)];
+       boolLit(o.readableSide, loc), boolLit(o.writableSide, loc), numLit(o.flags, loc)]
+    : [cls === "%Writable" ? o.hwmW : o.hwmR, o.autoDestroy, o.emitClose, numLit(o.flags, loc)];
   return { args: [...head, ...o.cbs], encoding: o.encoding, badEncoding: o.badEncoding, pushEncoding: o.pushEncoding };
 }
 
@@ -905,7 +901,7 @@ export function lowerStreamSuperCall(L: Lowerer, info: ClassInfo, base: ClassInf
         expr: {
           kind: "libCall",
           fn: `${shape.fn}.initDyn` as IrLibFn,
-          args: [thisRef(), dynOpts, f64Lit(flags, loc), ...cbs],
+          args: [thisRef(), dynOpts, numLit(flags, loc), ...cbs],
           type: VOID,
           loc,
         },
@@ -1306,7 +1302,7 @@ export function lowerStreamModuleCall(L: Lowerer, call: ts.CallExpression,
       return {
         kind: "libCall",
         fn: "sp.pipeline",
-        args: [f64Lit(streams.length, loc), ...streams],
+        args: [numLit(streams.length, loc), ...streams],
         type: { kind: "promise", inner: VOID },
         loc,
       };
@@ -1367,9 +1363,9 @@ export function lowerStreamModuleCall(L: Lowerer, call: ts.CallExpression,
     // (lib/internal/streams/state.js: win32 keeps 16 KiB), so the fold
     // follows the TARGET platform like the path-module binding.
     if (args.length === 1 && args[0]!.kind === ts.SyntaxKind.FalseKeyword) {
-      return f64Lit(L.targetPlatform === "win32" ? 16384 : 65536, loc);
+      return numLit(L.targetPlatform === "win32" ? 16384 : 65536, loc);
     }
-    if (args.length === 1 && args[0]!.kind === ts.SyntaxKind.TrueKeyword) return f64Lit(16, loc);
+    if (args.length === 1 && args[0]!.kind === ts.SyntaxKind.TrueKeyword) return numLit(16, loc);
     L.noLowering("getDefaultHighWaterMark with a non-literal argument", call, "the objectMode flag must be a compile-time boolean");
   }
 
@@ -1414,7 +1410,7 @@ export function lowerStreamModuleCall(L: Lowerer, call: ts.CallExpression,
     return {
       kind: "libCall",
       fn: dyn ? "stream.pipelineDyn" : "stream.pipeline",
-      args: [f64Lit(streams.length, loc), ...streams, cb],
+      args: [numLit(streams.length, loc), ...streams, cb],
       type: last.type,
       loc,
     };
@@ -1563,7 +1559,7 @@ export function lowerStreamMethodCall(L: Lowerer, call: ts.CallExpression,
     requireSide(readableSide, "read");
     if (args.length > 1) L.noLowering(`read with ${args.length} arguments`, call);
     const receiver = L.lowerExpr(access.expression);
-    const size = args[0] ? L.lowerExprExpecting(args[0], F64) : f64Lit(-1, loc);
+    const size = args[0] ? L.lowerExprExpecting(args[0], F64) : numLit(-1, loc);
     const type: IrType = unionOf(L, [BYTES, { kind: "nullT" }]);
     const read: IrExpr = { kind: "libCall", fn: "readable.read", args: [receiver, size], type, loc };
     return L.maybeNarrow(read, call);
@@ -1745,7 +1741,7 @@ export function lowerStreamMethodCall(L: Lowerer, call: ts.CallExpression,
       flags |= 4;
       tail.push(cb);
     }
-    return { kind: "libCall", fn: "writable.end", args: [receiver, f64Lit(flags, loc), ...tail], type: receiver.type, loc };
+    return { kind: "libCall", fn: "writable.end", args: [receiver, numLit(flags, loc), ...tail], type: receiver.type, loc };
   }
 
   if (member === "cork" || member === "uncork") {

--- a/packages/compiler/src/frontend/lowering/lower-test.ts
+++ b/packages/compiler/src/frontend/lowering/lower-test.ts
@@ -15,7 +15,8 @@
 import * as ts from "../ts7/adapter.js";
 import type { Lowerer } from "./lowerer.js";
 import { locOf } from "../program.js";
-import { F64, IrExpr, IrType, SrcLoc, STRING, VOID, isUnitType } from "../../ir/nodes.js";
+import { IrExpr, IrType, SrcLoc, STRING, VOID, isUnitType } from "../../ir/nodes.js";
+import { numLit, strLit } from "../../ir/build.js";
 
 const TEST_FN_HINT =
   "test bodies take () or (t: TestContext) and return void or Promise<void>";
@@ -33,10 +34,6 @@ function requireStatementPosition(L: Lowerer, call: ts.CallExpression, what: str
     "call it as its own statement (await t.test(...) is the supported awaited form)",
   );
 }
-
-const strLit = (value: string, loc: SrcLoc): IrExpr => ({ kind: "strLit", value, type: STRING, loc });
-const numLit = (value: number, loc: SrcLoc): IrExpr => ({ kind: "numLit", value, type: F64, loc });
-
 /** The "file:line:col" of a registration call — the failing-section
  * "test at" line (Node reads the stack; the frontend HAS the position).
  * V8 frames point at the callee's NAME for member calls (`t.test(...)`

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -111,6 +111,7 @@ import { FieldTarget, lowerDynObjectLiteral, lowerExpr, maybeNarrow, lowerUnitCo
 import type { ExpandoMember } from "./lower-expando.js";
 import { lowerRecordFieldCall, lowerObjectMethodCall } from "./lower-calls.js";
 import { fenceCrossBlockNsRef, nsPathPrefix } from "./lower-namespaces.js";
+import { numLit, varRef } from "../../ir/build.js";
 
 /** Entry function name. '%' cannot appear in a TS identifier, so a user
  * function can never collide with it (mangling is injective per prefix). */
@@ -4810,8 +4811,7 @@ export class Lowerer {
     this.widthHelpers.set(key, name);
     const arrT: IrType = { kind: "array", elem: fromElem };
     const outT: IrType = { kind: "array", elem: toElem };
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: { kind: "f64" }, loc });
+
     const f64: IrType = { kind: "f64" };
     this.liftedFns.push({
       name,
@@ -4828,17 +4828,17 @@ export class Lowerer {
         {
           kind: "varDecl",
           localId: "n.0",
-          init: { kind: "arrIntrinsic", method: "length", receiver: ref("a.0", arrT), args: [], type: f64, loc },
+          init: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: f64, loc },
           loc,
         },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-          cond: { kind: "bin", op: "<", left: ref("i.0", f64), right: ref("n.0", f64), type: BOOL, loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+          cond: { kind: "bin", op: "<", left: varRef("i.0", f64, loc), right: varRef("n.0", f64, loc), type: BOOL, loc },
           update: {
             kind: "assign",
             localId: "i.0",
-            value: { kind: "bin", op: "+", left: ref("i.0", f64), right: num(1), type: f64, loc },
+            value: { kind: "bin", op: "+", left: varRef("i.0", f64, loc), right: numLit(1, loc), type: f64, loc },
             loc,
           },
           body: [
@@ -4847,11 +4847,11 @@ export class Lowerer {
               expr: {
                 kind: "arrIntrinsic",
                 method: "push",
-                receiver: ref("out.0", outT),
+                receiver: varRef("out.0", outT, loc),
                 args: [
                   this.applyWidthLift(
                     elemLift,
-                    { kind: "arrayGet", arr: ref("a.0", arrT), index: ref("i.0", f64), type: fromElem, loc },
+                    { kind: "arrayGet", arr: varRef("a.0", arrT, loc), index: varRef("i.0", f64, loc), type: fromElem, loc },
                     toElem,
                     loc,
                   ),
@@ -4864,7 +4864,7 @@ export class Lowerer {
           ],
           loc,
         },
-        { kind: "return", value: ref("out.0", outT), loc },
+        { kind: "return", value: varRef("out.0", outT, loc), loc },
       ],
       loc,
     });
@@ -6157,9 +6157,8 @@ export class Lowerer {
     const iv = shape.indexValue;
     const f64: IrType = { kind: "f64" };
     const ksT = arrayOf(STRING);
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: f64, loc });
-    const kRef = ref("k.0", STRING);
+
+    const kRef = varRef("k.0", STRING, loc);
     this.liftedFns.push({
       name,
       params: [{ localId: "r.0", name: "r", type: recT }],
@@ -6176,25 +6175,25 @@ export class Lowerer {
         { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: r, shapeId, type: ksT, loc }, loc },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
           cond: {
             kind: "bin",
             op: "<",
-            left: ref("i.0", f64),
-            right: { kind: "arrIntrinsic", method: "length", receiver: ref("ks.0", ksT), args: [], type: f64, loc },
+            left: varRef("i.0", f64, loc),
+            right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: f64, loc },
             type: BOOL,
             loc,
           },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: ref("i.0", f64), right: num(1), type: f64, loc }, loc },
+          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", f64, loc), right: numLit(1, loc), type: f64, loc }, loc },
           body: [
-            { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: ref("ks.0", ksT), index: ref("i.0", f64), type: STRING, loc }, loc },
+            { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: varRef("ks.0", ksT, loc), index: varRef("i.0", f64, loc), type: STRING, loc }, loc },
             {
               kind: "exprStmt",
               expr: {
                 kind: "jsOp",
                 op: "setIdx",
                 args: [
-                  ref("out.0", JSVAL),
+                  varRef("out.0", JSVAL, loc),
                   { kind: "jsMarshal", value: kRef, type: JSVAL, loc },
                   this.jsvalLiftExpr({ kind: "recordKeyGet", obj: r, shapeId, key: kRef, overflowOnly: true, type: iv, loc }, loc),
                 ],
@@ -6206,7 +6205,7 @@ export class Lowerer {
           ],
           loc,
         },
-        { kind: "return", value: ref("out.0", JSVAL), loc },
+        { kind: "return", value: varRef("out.0", JSVAL, loc), loc },
       ],
       loc,
     });
@@ -6225,8 +6224,7 @@ export class Lowerer {
     this.jsinHelpers.set(key, name);
     const arrT: IrType = { kind: "array", elem };
     const f64: IrType = { kind: "f64" };
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: f64, loc });
+
     this.liftedFns.push({
       name,
       params: [{ localId: "a.0", name: "a", type: arrT }],
@@ -6242,17 +6240,17 @@ export class Lowerer {
         {
           kind: "varDecl",
           localId: "n.0",
-          init: { kind: "arrIntrinsic", method: "length", receiver: ref("a.0", arrT), args: [], type: f64, loc },
+          init: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: f64, loc },
           loc,
         },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-          cond: { kind: "bin", op: "<", left: ref("i.0", f64), right: ref("n.0", f64), type: BOOL, loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+          cond: { kind: "bin", op: "<", left: varRef("i.0", f64, loc), right: varRef("n.0", f64, loc), type: BOOL, loc },
           update: {
             kind: "assign",
             localId: "i.0",
-            value: { kind: "bin", op: "+", left: ref("i.0", f64), right: num(1), type: f64, loc },
+            value: { kind: "bin", op: "+", left: varRef("i.0", f64, loc), right: numLit(1, loc), type: f64, loc },
             loc,
           },
           body: [
@@ -6262,10 +6260,10 @@ export class Lowerer {
                 kind: "jsOp",
                 op: "setIdx",
                 args: [
-                  ref("out.0", JSVAL),
-                  { kind: "jsMarshal", value: ref("i.0", f64), type: JSVAL, loc },
+                  varRef("out.0", JSVAL, loc),
+                  { kind: "jsMarshal", value: varRef("i.0", f64, loc), type: JSVAL, loc },
                   this.jsvalLiftExpr(
-                    { kind: "arrayGet", arr: ref("a.0", arrT), index: ref("i.0", f64), type: elem, loc },
+                    { kind: "arrayGet", arr: varRef("a.0", arrT, loc), index: varRef("i.0", f64, loc), type: elem, loc },
                     loc,
                   ),
                 ],
@@ -6277,7 +6275,7 @@ export class Lowerer {
           ],
           loc,
         },
-        { kind: "return", value: ref("out.0", JSVAL), loc },
+        { kind: "return", value: varRef("out.0", JSVAL, loc), loc },
       ],
       loc,
     });
@@ -6298,8 +6296,7 @@ export class Lowerer {
     const arrT: IrType = { kind: "array", elem: fromElem };
     const outT: IrType = { kind: "array", elem: JSVAL };
     const f64: IrType = { kind: "f64" };
-    const ref = (localId: string, type: IrType): IrExpr => ({ kind: "varRef", localId, type, loc });
-    const num = (value: number): IrExpr => ({ kind: "numLit", value, type: f64, loc });
+
     this.liftedFns.push({
       name,
       params: [{ localId: "a.0", name: "a", type: arrT }],
@@ -6315,17 +6312,17 @@ export class Lowerer {
         {
           kind: "varDecl",
           localId: "n.0",
-          init: { kind: "arrIntrinsic", method: "length", receiver: ref("a.0", arrT), args: [], type: f64, loc },
+          init: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: f64, loc },
           loc,
         },
         {
           kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: num(0), loc },
-          cond: { kind: "bin", op: "<", left: ref("i.0", f64), right: ref("n.0", f64), type: BOOL, loc },
+          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+          cond: { kind: "bin", op: "<", left: varRef("i.0", f64, loc), right: varRef("n.0", f64, loc), type: BOOL, loc },
           update: {
             kind: "assign",
             localId: "i.0",
-            value: { kind: "bin", op: "+", left: ref("i.0", f64), right: num(1), type: f64, loc },
+            value: { kind: "bin", op: "+", left: varRef("i.0", f64, loc), right: numLit(1, loc), type: f64, loc },
             loc,
           },
           body: [
@@ -6334,10 +6331,10 @@ export class Lowerer {
               expr: {
                 kind: "arrIntrinsic",
                 method: "push",
-                receiver: ref("out.0", outT),
+                receiver: varRef("out.0", outT, loc),
                 args: [
                   this.jsvalLiftExpr(
-                    { kind: "arrayGet", arr: ref("a.0", arrT), index: ref("i.0", f64), type: fromElem, loc },
+                    { kind: "arrayGet", arr: varRef("a.0", arrT, loc), index: varRef("i.0", f64, loc), type: fromElem, loc },
                     loc,
                   ),
                 ],
@@ -6349,7 +6346,7 @@ export class Lowerer {
           ],
           loc,
         },
-        { kind: "return", value: ref("out.0", outT), loc },
+        { kind: "return", value: varRef("out.0", outT, loc), loc },
       ],
       loc,
     });
@@ -6776,7 +6773,6 @@ export class Lowerer {
   genBodyReturnType(declared: IrType): IrType {
     return declared.kind === "generator" ? declared.retT : declared;
   }
-
 
   declaredReturnType(decl: ts.SignatureDeclaration, blame: ts.Node): IrType {
     return declaredReturnType(this, decl, blame);

--- a/packages/compiler/src/ir/build.ts
+++ b/packages/compiler/src/ir/build.ts
@@ -1,0 +1,17 @@
+import { BOOL, F64, type IrExpr, type IrType, STRING, type SrcLoc } from "./nodes.js";
+
+export function varRef(localId: string, type: IrType, loc: SrcLoc): IrExpr {
+  return { kind: "varRef", localId, type, loc };
+}
+
+export function numLit(value: number, loc: SrcLoc): IrExpr {
+  return { kind: "numLit", value, type: F64, loc };
+}
+
+export function strLit(value: string, loc: SrcLoc): IrExpr {
+  return { kind: "strLit", value, type: STRING, loc };
+}
+
+export function boolLit(value: boolean, loc: SrcLoc): IrExpr {
+  return { kind: "boolLit", value, type: BOOL, loc };
+}


### PR DESCRIPTION
- Add typed builders for variable references and primitive literals.
- Replace duplicated lowering-local constructors with the shared API.