### PR TITLE
refactor: centralize runtime fence deferral

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -5873,21 +5873,7 @@ const inliningPredicates = new Set<ts.Symbol>();
       // position. ICEs (SC9001) stay compile errors, exactly like
       // lowerStmts; probe mode (diagSink) keeps the poison.
       if (!(e instanceof PoisonError)) throw e;
-      if (
-        !isJsSourceFile(node.getSourceFile()) ||
-        L.diagSink !== null ||
-        L.diags.length <= diagsBefore ||
-        L.diags.slice(diagsBefore).some((d) => d.code === "SC9001")
-      ) {
-        throw e;
-      }
-      const captured = L.diags.splice(diagsBefore);
-      L.runtimeFences.push(...captured);
-      const first = captured[0]!;
-      const pos = ts.getLineAndCharacterOfPosition(
-        L.program.getSourceFile(first.loc.file) ?? node.getSourceFile(),
-        first.loc.start,
-      );
+      if (!isJsSourceFile(node.getSourceFile())) throw e;
       const params: IrParam[] = funcType.params.map((t, i) => ({ localId: `%pf${i}`, name: `%pf${i}`, type: t }));
       // A REST-MARKED value type hides one synthetic trailing dyn-array
       // param in the lifted function (the boxed call thunk fills it) —
@@ -5898,26 +5884,17 @@ const inliningPredicates = new Set<ts.Symbol>();
       if (funcType.rest === true && funcType.restAbi !== "jsval") {
         params.push({ localId: "%pfrest", name: "%pfrest", type: DYN });
       }
-      const lifted: IrFunction = {
+      const fence = L.deferToRuntimeFence(diagsBefore, node, {
+        kind: "closure",
         name: fnName,
         params,
         returnType: bodyReturn,
-        locals: params.map((p) => ({ id: p.localId, name: p.name, type: p.type, mutable: false })),
-        captures: [],
-        body: [
-          {
-            kind: "runtimeFence",
-            code: first.code,
-            message: `${first.message} [${first.code} at ${first.loc.file}:${pos.line + 1}]`,
-            loc,
-          },
-        ],
-        loc,
-      };
-      if (isAsync) lifted.async = true;
-      if (fnCtx.generator) lifted.generator = fnCtx.generator;
-      L.liftedFns.push(lifted);
-      return { kind: "closure", fnName, captures: [], type: funcType, loc };
+        type: funcType,
+        ...(isAsync ? { async: true as const } : {}),
+        ...(fnCtx.generator ? { generator: fnCtx.generator } : {}),
+      });
+      if (!fence) throw e;
+      return fence;
     } finally {
       L.fnStack.pop();
     }
@@ -7952,14 +7929,7 @@ export function lowerFunction(L: Lowerer, decl: ts.FunctionDeclaration): IrFunct
       // at the declaration's position — so a reachable-but-broken
       // signature stops the RUN at its own site instead of the build.
       // ICEs (SC9001) stay compile errors, exactly like lowerStmts.
-      if (
-        isJsSourceFile(decl.getSourceFile()) &&
-        L.diagSink === null &&
-        L.diags.length > diagsBefore &&
-        !L.diags.slice(diagsBefore).some((d) => d.code === "SC9001")
-      ) {
-        const captured = L.diags.splice(diagsBefore);
-        L.runtimeFences.push(...captured);
+      if (isJsSourceFile(decl.getSourceFile())) {
         // An ABI type naming a class that never REGISTERED (the sentence-
         // walker idiom's path type — the #private fence) is fine to emit:
         // callers CAN lower calls to this symbol (a same-typed param
@@ -7967,31 +7937,16 @@ export function lowerFunction(L: Lowerer, decl: ts.FunctionDeclaration): IrFunct
         // function must exist, and run()'s unregistered-class sweep
         // rewrites every such slot to the inert f64 placeholder before
         // emission — caller and fence stay ABI-consistent.
-        const first = captured[0]!;
-        const loc = locOf(decl);
-        const pos = ts.getLineAndCharacterOfPosition(
-          L.program.getSourceFile(first.loc.file) ?? decl.getSourceFile(),
-          first.loc.start,
-        );
         const params: IrParam[] = sig.params.map((p, i) => ({ localId: `%pf${i}`, name: `%pf${i}`, type: p.type }));
-        const fn: IrFunction = {
+        const fence = L.deferToRuntimeFence(diagsBefore, decl, {
+          kind: "function",
           name: sig.name,
           params,
           returnType: bodyReturn,
-          locals: params.map((p) => ({ id: p.localId, name: p.name, type: p.type, mutable: false })),
-          body: [
-            {
-              kind: "runtimeFence",
-              code: first.code,
-              message: `${first.message} [${first.code} at ${first.loc.file}:${pos.line + 1}]`,
-              loc,
-            },
-          ],
-          loc,
-        };
-        if (sig.isAsync) fn.async = true;
-        if (sig.generator !== undefined) fn.generator = sig.generator;
-        return fn;
+          ...(sig.isAsync ? { async: true as const } : {}),
+          ...(sig.generator ? { generator: sig.generator } : {}),
+        });
+        if (fence) return fence;
       }
       return null;
     } finally {

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -371,40 +371,14 @@ function lowerExprInner(L: Lowerer, expr: ts.Expression): IrExpr {
         // null keeps the closure shape (function-shaped members, and the
         // conditional-spread arms where getters cannot combine).
         const islandMemberFence = (diagsBefore: number, err: unknown, valueNode: ts.Node, getterName: string | null = null): IrExpr | null => {
-          if (
-            !(err instanceof PoisonError) ||
-            !isJsSourceFile(expr.getSourceFile()) ||
-            L.diagSink !== null ||
-            L.diags.length <= diagsBefore ||
-            L.diags.slice(diagsBefore).some((d) => d.code === "SC9001")
-          ) {
-            throw err;
-          }
-          const captured = L.diags.splice(diagsBefore);
-          L.runtimeFences.push(...captured);
-          const first = captured[0]!;
-          const pos = ts.getLineAndCharacterOfPosition(
-            L.program.getSourceFile(first.loc.file) ?? expr.getSourceFile(),
-            first.loc.start,
-          );
-          const fnName = `%fn${L.lambdaCounter++}_islfence`;
-          L.liftedFns.push({
-            name: fnName,
-            params: [],
+          if (!(err instanceof PoisonError) || !isJsSourceFile(expr.getSourceFile())) throw err;
+          const fence = L.deferToRuntimeFence(diagsBefore, valueNode, {
+            kind: "closure",
+            name: () => `%fn${L.lambdaCounter++}_islfence`,
             returnType: VOID,
-            locals: [],
-            captures: [],
-            body: [
-              {
-                kind: "runtimeFence",
-                code: first.code,
-                message: `${first.message} [${first.code} at ${first.loc.file}:${pos.line + 1}]`,
-                loc: locOf(valueNode),
-              },
-            ],
-            loc: locOf(valueNode),
+            type: { kind: "func", params: [], ret: VOID },
           });
-          const fence: IrExpr = { kind: "closure", fnName, captures: [], type: funcOf([], VOID), loc: locOf(valueNode) };
+          if (!fence) throw err;
           if (getterName !== null) {
             getters.push({ name: getterName, fn: L.jsvalIn(fence, valueNode), loc: locOf(valueNode) });
             return null;
@@ -4269,40 +4243,15 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
         // the diagnostics defer to the runtime-fence ledger, the object
         // builds, and only USING the member stops the run.
         const pureMember = ts.isIdentifier(valueExpr);
-        if (
-          !(err instanceof PoisonError) ||
-          !pureMember ||
-          L.diagSink !== null ||
-          L.diags.length <= propDiagsBefore ||
-          L.diags.slice(propDiagsBefore).some((d) => d.code === "SC9001")
-        ) {
-          throw err;
-        }
-        const captured = L.diags.splice(propDiagsBefore);
-        L.runtimeFences.push(...captured);
-        const first = captured[0]!;
-        const pos = ts.getLineAndCharacterOfPosition(
-          L.program.getSourceFile(first.loc.file) ?? expr.getSourceFile(),
-          first.loc.start,
-        );
-        const fnName = `%fn${L.lambdaCounter++}_dynfence`;
-        L.liftedFns.push({
-          name: fnName,
-          params: [],
+        if (!(err instanceof PoisonError) || !pureMember) throw err;
+        const fence = L.deferToRuntimeFence(propDiagsBefore, prop, {
+          kind: "closure",
+          name: () => `%fn${L.lambdaCounter++}_dynfence`,
           returnType: VOID,
-          locals: [],
-          captures: [],
-          body: [
-            {
-              kind: "runtimeFence",
-              code: first.code,
-              message: `${first.message} [${first.code} at ${first.loc.file}:${pos.line + 1}]`,
-              loc: locOf(prop),
-            },
-          ],
-          loc: locOf(prop),
+          type: { kind: "func", params: [], ret: VOID },
         });
-        raw = { kind: "closure", fnName, captures: [], type: funcOf([], VOID), loc: locOf(prop) };
+        if (!fence) throw err;
+        raw = fence;
       }
       let v = boxValue
         ? boxValue(valueExpr as ts.Expression, raw)
@@ -4322,39 +4271,14 @@ export function lowerOptionalChain(L: Lowerer, expr: ts.CallExpression | ts.Prop
           // members): the same call-time fence deferral as an unlowerable
           // member — the slot takes a boxed fence closure; only USING it
           // stops the run. Probe mode and ICEs keep the poison.
-          if (
-            !(err instanceof PoisonError) ||
-            L.diagSink !== null ||
-            L.diags.length <= convDiagsBefore ||
-            L.diags.slice(convDiagsBefore).some((d) => d.code === "SC9001")
-          ) {
-            throw err;
-          }
-          const captured = L.diags.splice(convDiagsBefore);
-          L.runtimeFences.push(...captured);
-          const first = captured[0]!;
-          const pos = ts.getLineAndCharacterOfPosition(
-            L.program.getSourceFile(first.loc.file) ?? expr.getSourceFile(),
-            first.loc.start,
-          );
-          const fnName = `%fn${L.lambdaCounter++}_dynfence`;
-          L.liftedFns.push({
-            name: fnName,
-            params: [],
+          if (!(err instanceof PoisonError)) throw err;
+          const fence = L.deferToRuntimeFence(convDiagsBefore, prop, {
+            kind: "closure",
+            name: () => `%fn${L.lambdaCounter++}_dynfence`,
             returnType: VOID,
-            locals: [],
-            captures: [],
-            body: [
-              {
-                kind: "runtimeFence",
-                code: first.code,
-                message: `${first.message} [${first.code} at ${first.loc.file}:${pos.line + 1}]`,
-                loc: locOf(prop),
-              },
-            ],
-            loc: locOf(prop),
+            type: { kind: "func", params: [], ret: VOID },
           });
-          const fence: IrExpr = { kind: "closure", fnName, captures: [], type: funcOf([], VOID), loc: locOf(prop) };
+          if (!fence) throw err;
           v = L.coerceToExpected(fence, DYN);
         }
       }
@@ -4414,32 +4338,20 @@ function fenceClosureProbe(
     return attempt();
   } catch (e) {
     if (!(e instanceof PoisonError)) throw e;
-    const captured = L.diags.splice(diagsBefore);
-    if (captured.some((d) => d.code === "SC9001")) {
-      L.diags.push(...captured);
-      throw e;
-    }
-    L.runtimeFences.push(...captured);
-    const first = captured[0];
-    const loc = locOf(node);
     const params = fieldType.params.map((t, i) => ({ localId: `p.${i}`, name: `p${i}`, type: t }));
-    const name = `%fence.fn.${L.liftedFns.length}`;
-    L.liftedFns.push({
-      name,
+    const fence = L.deferToRuntimeFence(diagsBefore, node, {
+      kind: "closure",
+      name: () => `%fence.fn.${L.liftedFns.length}`,
       params,
       returnType: fieldType.ret,
-      locals: params.map((p) => ({ id: p.localId, name: p.name, type: p.type, mutable: true })),
-      body: [
-        {
-          kind: "runtimeFence",
-          code: first?.code ?? "SC1090",
-          message: first?.message ?? "this function's body has no static lowering",
-          loc,
-        },
-      ],
-      loc,
+      paramsMutable: true,
+      type: fieldType,
+      fallback: { code: "SC1090", message: "this function's body has no static lowering" },
+      bareMessage: true,
+      allowDiagSink: true,
     });
-    return { kind: "closure", fnName: name, captures: [], type: fieldType, loc };
+    if (!fence) throw e;
+    return fence;
   }
 }
 

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -56,45 +56,19 @@ import {
    * island stops the run. Null (caller rethrows) outside the JS deferral
    * gate: TypeScript sources, probe mode, ICEs. */
   export function islandFuncValueFence(L: Lowerer, err: unknown, diagsBefore: number, node: ts.Node): IrExpr | null {
-    if (
-      !(err instanceof PoisonError) ||
-      !isJsSourceFile(node.getSourceFile()) ||
-      L.diagSink !== null ||
-      L.diags.length <= diagsBefore ||
-      L.diags.slice(diagsBefore).some((d) => d.code === "SC9001")
-    ) {
-      return null;
-    }
-    const captured = L.diags.splice(diagsBefore);
-    L.runtimeFences.push(...captured);
-    const first = captured[0]!;
-    const pos = ts.getLineAndCharacterOfPosition(
-      L.program.getSourceFile(first.loc.file) ?? node.getSourceFile(),
-      first.loc.start,
-    );
-    const loc = locOf(node);
-    const fnName = `%fn${L.lambdaCounter++}_islfence`;
-    L.liftedFns.push({
-      name: fnName,
-      params: [],
+    if (!(err instanceof PoisonError) || !isJsSourceFile(node.getSourceFile())) return null;
+    const fence = L.deferToRuntimeFence(diagsBefore, node, {
+      kind: "closure",
+      name: () => `%fn${L.lambdaCounter++}_islfence`,
       returnType: VOID,
-      locals: [],
-      captures: [],
-      body: [
-        {
-          kind: "runtimeFence",
-          code: first.code,
-          message: `${first.message} [${first.code} at ${first.loc.file}:${pos.line + 1}]`,
-          loc,
-        },
-      ],
-      loc,
+      type: { kind: "func", params: [], ret: VOID },
     });
+    if (!fence) return null;
     return {
       kind: "jsMarshal",
-      value: { kind: "closure", fnName, captures: [], type: { kind: "func", params: [], ret: VOID }, loc },
+      value: fence,
       type: JSVAL,
-      loc,
+      loc: fence.loc,
     };
   }
 

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -190,33 +190,11 @@ export function provenanceElidedConstDecl(L: Lowerer, decl: ts.VariableDeclarati
           // executed) or it reports exactly what the compile fence would
           // have said.
           if (deferFences && L.diagSink === null) {
-            const captured = L.diags.splice(diagsBefore);
-            if (captured.some((d) => d.code === "SC9001")) {
-              L.diags.push(...captured); // ICEs stay compile errors
-            } else {
-              const first = captured[0];
-              L.runtimeFences.push(...captured);
-              // The thrown message carries the fence's own position (the
-              // statement's line when the capture was empty) — a run-phase
-              // failure must name its blocker as precisely as a compile
-              // diagnostic would have.
-              const at = (d?: { loc: { file: string; start: number } }): string => {
-                const loc = d?.loc ?? { file: sf!.fileName, start: stmt.getStart(sf) };
-                const pos = ts.getLineAndCharacterOfPosition(
-                  d ? L.program.getSourceFile(loc.file) ?? sf! : sf!,
-                  loc.start,
-                );
-                return `${loc.file}:${pos.line + 1}`;
-              };
-              out.push({
-                kind: "runtimeFence",
-                code: first?.code ?? "SC1090",
-                message: first
-                  ? `${first.message} [${first.code} at ${at(first)}]`
-                  : `this statement uses a construct with no static lowering [SC1090 at ${at()}]`,
-                loc: locOf(stmt),
-              });
-            }
+            const fence = L.deferToRuntimeFence(diagsBefore, stmt, {
+              kind: "statement",
+              fallback: { code: "SC1090", message: "this statement uses a construct with no static lowering" },
+            });
+            if (fence) out.push(fence);
           }
         }
       }

--- a/packages/compiler/src/frontend/lowering/lowerer.ts
+++ b/packages/compiler/src/frontend/lowering/lowerer.ts
@@ -377,6 +377,44 @@ export interface LowerOptions {
   externalTypeSpecifiersByFile?: ReadonlyMap<string, readonly string[]>;
 }
 
+interface RuntimeFenceFallback {
+  code: `SC${number}`;
+  message: string;
+}
+
+interface RuntimeFenceBase {
+  /** Used only by catches that can legitimately have no fresh diagnostic. */
+  fallback?: RuntimeFenceFallback;
+  /** Legacy function-body fences throw the diagnostic text without a site suffix. */
+  bareMessage?: boolean;
+  /** The closure-probe fallback historically applies inside diagnostic captures. */
+  allowDiagSink?: boolean;
+}
+
+interface RuntimeFenceStatementTarget extends RuntimeFenceBase {
+  kind: "statement";
+}
+
+interface RuntimeFenceFunctionTarget extends RuntimeFenceBase {
+  kind: "function";
+  name: string | (() => string);
+  params?: IrParam[];
+  returnType: IrType;
+  paramsMutable?: boolean;
+  async?: true;
+  generator?: { yieldT: IrType; nextT: IrType };
+}
+
+interface RuntimeFenceClosureTarget extends Omit<RuntimeFenceFunctionTarget, "kind"> {
+  kind: "closure";
+  type: IrType & { kind: "func" };
+}
+
+type RuntimeFenceTarget =
+  | RuntimeFenceStatementTarget
+  | RuntimeFenceFunctionTarget
+  | RuntimeFenceClosureTarget;
+
 /** The Lowerer's pass configuration (see lowerToIr). */
 export interface LowererMode {
   /** Names of bodies a prior reachability pass reached; null lowers everything. */
@@ -3006,6 +3044,88 @@ export class Lowerer {
   }
 
   /* ── diagnostics plumbing ─────────────────────────────────────────── */
+
+  /** Converts diagnostics recorded since `diagsBefore` into a runtime
+   * fence. ICEs stay on the compile-diagnostic path; every other captured
+   * diagnostic moves to the runtime-fence ledger. Function targets share
+   * the same capture-free trap-function construction, while statement
+   * targets return the fence inline. Null means the conversion was not
+   * eligible (probe mode, no diagnostic/fallback, or an ICE). */
+  deferToRuntimeFence(
+    diagsBefore: number,
+    node: ts.Node,
+    target: RuntimeFenceStatementTarget,
+  ): IrStmt | null;
+  deferToRuntimeFence(
+    diagsBefore: number,
+    node: ts.Node,
+    target: RuntimeFenceFunctionTarget,
+  ): IrFunction | null;
+  deferToRuntimeFence(
+    diagsBefore: number,
+    node: ts.Node,
+    target: RuntimeFenceClosureTarget,
+  ): IrExpr | null;
+  deferToRuntimeFence(
+    diagsBefore: number,
+    node: ts.Node,
+    target: RuntimeFenceTarget,
+  ): IrStmt | IrFunction | IrExpr | null {
+    if (
+      (this.diagSink !== null && target.allowDiagSink !== true) ||
+      (this.diags.length <= diagsBefore && target.fallback === undefined)
+    ) {
+      return null;
+    }
+    const captured = this.diags.splice(diagsBefore);
+    if (captured.some((d) => d.code === "SC9001")) {
+      this.diags.push(...captured);
+      return null;
+    }
+    this.runtimeFences.push(...captured);
+
+    const first = captured[0];
+    const loc = locOf(node);
+    const code = first?.code ?? target.fallback!.code;
+    const baseMessage = first?.message ?? target.fallback!.message;
+    const messageLoc = first?.loc ?? loc;
+    const source = first
+      ? this.program.getSourceFile(messageLoc.file) ?? node.getSourceFile()
+      : node.getSourceFile();
+    const pos = ts.getLineAndCharacterOfPosition(source, messageLoc.start);
+    const fence: IrStmt = {
+      kind: "runtimeFence",
+      code,
+      message: target.bareMessage
+        ? baseMessage
+        : `${baseMessage} [${code} at ${messageLoc.file}:${pos.line + 1}]`,
+      loc,
+    };
+    if (target.kind === "statement") return fence;
+
+    const params = target.params ?? [];
+    const name = typeof target.name === "function" ? target.name() : target.name;
+    const fn: IrFunction = {
+      name,
+      params,
+      returnType: target.returnType,
+      locals: params.map((p) => ({
+        id: p.localId,
+        name: p.name,
+        type: p.type,
+        mutable: target.paramsMutable ?? false,
+      })),
+      body: [fence],
+      loc,
+    };
+    if (target.async) fn.async = true;
+    if (target.generator) fn.generator = target.generator;
+    if (target.kind === "function") return fn;
+
+    fn.captures = [];
+    this.liftedFns.push(fn);
+    return { kind: "closure", fnName: fn.name, captures: [], type: target.type, loc };
+  }
 
   /** All diagnostics land here; while a generic instance body is lowering,
    * the instantiation context is appended so the user knows which concrete


### PR DESCRIPTION
- Add a shared deferToRuntimeFence helper for diagnostics, messages, and trap IR.
- Preserve statement, closure, function ABI, probe, and SC9001 behavior.
- Replace eight duplicated lowering paths with compact helper calls.