### PR TITLE
fix: raise MAX_GENERIC_INSTANCES from 100 to 1000 to support Drizzle/Zod inference

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -67,7 +67,7 @@ export interface FnSig {
  * calling itself) converges, but POLYMORPHIC recursion (`f<T>` calling
  * `f<T[]>`) would request new instances forever — the cap turns that into a
  * diagnostic instead of a hang. */
-export const MAX_GENERIC_INSTANCES = 100;
+export const MAX_GENERIC_INSTANCES = 1000;
 
 /** A generic function-like declaration, collected instead of an FnSig —
  * top-level generic function declarations, class GENERIC METHODS (own type


### PR DESCRIPTION
## Problem

`MAX_GENERIC_INSTANCES` (the cap that detects polymorphic recursion) was set to 100. Real-world TypeScript codebases using Drizzle ORM, Zod, and similar heavily-generic libraries routinely exceed this limit during type inference, producing spurious SC1000 (max instantiation depth) errors on valid programs.

## Fix

**`lower-calls.ts`**: `MAX_GENERIC_INSTANCES` raised from `100` to `1000`.

The cap still serves its purpose — infinite polymorphic recursion hits 1000 just as reliably as it hit 100. The difference is that legitimate deep generic stacks (Drizzle's `select()` return type, Zod's `.parse()` inference) now pass through without false positives.

## Verification

A schema with 30+ Drizzle table joins and deep Zod inference compiles without SC1000. Artificially recursive types are still caught. `packages/compiler` builds clean.