### PR TITLE
fix: erase non-validatable 'as T' casts instead of SC1090 in --dynamic mode

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -7147,15 +7147,12 @@ export function lowerTemplate(L: Lowerer, expr: ts.TemplateExpression): IrExpr {
       if (targetTs.flags & ts.TypeFlags.Any) return inner;
       const target = L.mapTypeOf(targetTs);
       if (!target) L.badType(expr.type, targetTs);
-      if (!L.boundarySafe(target)) {
-        L.unsupported(
-          "SC1090",
-          expr,
-          `a checked cast of 'any' to '${L.fmt(target)}' ` +
-            `(an 'any' value can only be validated against JSON-representable types: ` +
-            `number, string, boolean, records, arrays, and unions of those)`,
-        );
-      }
+      // A target type that ITSELF maps to jsval — same erasure as the Any fast-path above.
+      if (target.kind === "jsval") return inner;
+      // Non-boundary-safe targets (functions, callable records, class instances, etc.)
+      // cannot be JSON-validated. JSVAL is already an opaque engine handle — the `as T`
+      // assertion is TypeScript-only and should erase rather than attempt validation.
+      if (!L.boundarySafe(target)) return inner;
       return { kind: "jsExit", value: inner, type: target, loc: locOf(expr) };
     }
     const targetTs = L.checker.getTypeFromTypeNode(expr.type);


### PR DESCRIPTION
## Problem

In `--dynamic` mode, `value as SomeType` where `SomeType` is not boundary-safe (e.g. a function type, a recursive generic, a conditional type) emitted SC1090. The compiler rejected these casts rather than erasing them.

TypeScript `as` casts are developer assertions — they carry no runtime semantics. In `--dynamic` mode the JSVAL island already provides an escape hatch for npm values; a cast to a non-checkable type should be a no-op, not an error.

## Fix

**`lower-exprs.ts`**:

- If the cast target is `JSVAL`: erase (return the expression as-is).
- If the cast target is not boundary-safe (`!boundarySafe(expected)`): erase.

This mirrors how TypeScript itself treats casts at runtime — identity operation.

## Verification

```typescript
const fn = npmPkg.getHandler() as (req: Request) => Promise<Response>;
```
Compiles and the handler is callable at runtime. `packages/compiler` builds clean.