### PR TITLE
fix(compiler): resolve TypeScript workspace specifiers

### DIFF
--- a/packages/compiler/src/frontend/npm.ts
+++ b/packages/compiler/src/frontend/npm.ts
@@ -89,6 +89,7 @@ import { dirname, extname, join, resolve } from "node:path";
 import ts from "typescript5";
 import { cjsLexedExportsOf } from "./cjs-lexer.js";
 import { trackedDirectoryExists, trackedFileExists, trackedReadFile, trackedRealpath } from "./input-tracker.js";
+import { workspacePackageOfPath } from "./shared.js";
 
 export type EmbeddedFormat = "esm" | "cjs" | "json";
 
@@ -1399,6 +1400,27 @@ export class NpmGraphBuilder {
     return null;
   }
 
+  /** A workspace package can expose TypeScript source whose relative
+   * specifiers use the emitted-JavaScript spelling (`./value.js` beside
+   * `value.ts`). TypeScript's bundler resolver substitutes the source
+   * extension there; published npm graphs keep resolveFile's strict Node
+   * runtime rules. */
+  private resolveWorkspaceFile(path: string): string | null {
+    const substitutions = path.endsWith(".js")
+      ? [path.slice(0, -3) + ".ts", path.slice(0, -3) + ".tsx"]
+      : path.endsWith(".jsx")
+        ? [path.slice(0, -4) + ".tsx", path.slice(0, -4) + ".ts"]
+        : path.endsWith(".mjs")
+          ? [path.slice(0, -4) + ".mts"]
+          : path.endsWith(".cjs")
+            ? [path.slice(0, -4) + ".cts"]
+            : [path + ".ts", path + ".tsx"];
+    for (const candidate of substitutions) {
+      if (this.host.isFile(candidate)) return candidate;
+    }
+    return this.resolveFile(path);
+  }
+
   /** "a → b → c" — the package chain from the user's import to the point
    * of failure, for diagnostics. */
   private static chainOf(chain: readonly string[], last?: string): string {
@@ -1648,7 +1670,10 @@ export class NpmGraphBuilder {
         // for import()/static-in-lazy sites — require-reached specs embed
         // NO edge and the island's require shim throws Node's
         // MODULE_NOT_FOUND with the live require stack at the call.
-        const file = this.resolveFile(resolve(dirname(key), spec));
+        const absolute = resolve(dirname(key), spec);
+        const file = workspacePackageOfPath(key) === null
+          ? this.resolveFile(absolute)
+          : this.resolveWorkspaceFile(absolute);
         const to = file === null ? null : this.host.realpath(file);
         if (!to) {
           if (eager) {

--- a/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/main.ts
+++ b/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/main.ts
@@ -1,0 +1,5 @@
+import { bare, value } from "workspace-js-specifiers-b";
+
+const output = value as string;
+const bareOutput = bare as string;
+console.log(output, bareOutput);

--- a/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/node_modules/workspace-js-specifiers-b
+++ b/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/node_modules/workspace-js-specifiers-b
@@ -1,0 +1,1 @@
+../packages/b

--- a/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/package.json
+++ b/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace-js-specifiers-root",
+  "private": true,
+  "type": "module",
+  "workspaces": ["packages/*"]
+}

--- a/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/packages/b/bare.ts
+++ b/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/packages/b/bare.ts
@@ -1,0 +1,1 @@
+export const bare = "workspace extensionless specifier";

--- a/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/packages/b/index.ts
+++ b/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/packages/b/index.ts
@@ -1,0 +1,2 @@
+export { bare } from "./bare";
+export { value } from "./value.js";

--- a/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/packages/b/package.json
+++ b/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/packages/b/package.json
@@ -1,0 +1,6 @@
+{
+  "name": "workspace-js-specifiers-b",
+  "version": "1.0.0",
+  "type": "module",
+  "exports": "./index.ts"
+}

--- a/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/packages/b/value.ts
+++ b/tests/fixtures/npm/scriptc-only/workspace-js-specifiers/packages/b/value.ts
@@ -1,0 +1,1 @@
+export const value = "workspace .js specifier";

--- a/tests/harness/npm.test.ts
+++ b/tests/harness/npm.test.ts
@@ -161,6 +161,17 @@ describe(`typed-callback boundary (scriptc-only${sanitize ? ", sanitized" : ""})
   }, 120_000);
 });
 
+describe(`workspace package resolution (scriptc-only${sanitize ? ", sanitized" : ""})`, () => {
+  test("TypeScript sources resolve relative .js and extensionless specifiers", async () => {
+    const binary = await build(join(fixturesRoot, "npm/scriptc-only/workspace-js-specifiers/main.ts"));
+    const res = await runBinary(binary, []);
+    expect(res.stdout.toString("utf8")).toBe(
+      "workspace .js specifier workspace extensionless specifier\n",
+    );
+    expect(res.exitCode).toBe(0);
+  }, 120_000);
+});
+
 describe(`npm differential (${cases.length} programs${sanitize ? ", sanitized" : ""}${shardSuffix()})`, () => {
   test.for(cases.map((c) => [c.name, c] as const))("%s", async ([, c]) => {
     const binary = await build(c.entry);


### PR DESCRIPTION
## Summary

- resolve emitted `.js` spellings to workspace `.ts`/`.tsx` source files
- resolve extensionless relative imports inside workspace TypeScript packages
- keep published npm package graphs on strict Node runtime resolution
- add a scriptc-only workspace regression fixture

## Validation

- `pnpm -r build`
- full plain `tests/harness/npm.test.ts`: 62 passed
- new regression in the sanitized lane: passed
- `git diff --check`

The local full fallback reaches two existing `library-mode` K10 ASan failures caused by a 96-byte `scr_arr_new` leak. The same two failures reproduce on a clean `upstream/main` worktree, so they are unrelated to this resolver change.

Closes #187