### PR TITLE
refactor: share compiler builder helpers

### DIFF
--- a/packages/compiler/src/backend/emission/emit-exprs.ts
+++ b/packages/compiler/src/backend/emission/emit-exprs.ts
@@ -10,6 +10,7 @@ import { OVERFLOW_MEMBER } from "./emit-shapes.js";
 import { dynDestrCheckHelper, dynIterNHelper, dynKeyGetHelper } from "./emit-walkers.js";
 import { collectFfiRetainedOps, parseFfiCallbackKey } from "../ffi-callbacks.js";
 import { genResultThunkFor } from "./emit-async.js";
+import { isStableBytesOperand, newValueMayThrow, streamTypedRefEligible, undefinedArmTag } from "../../ir/analysis.js";
 
 function streamTypedRefCommitAdapter(
   E: CEmitter,
@@ -110,10 +111,6 @@ interface StreamTypedRefContext {
   prefix: string;
   defs: string[];
   adapters: Map<string, StreamTypedRefAdapter>;
-}
-
-function streamTypedRefEligible(t: IrType): boolean {
-  return t.kind === "record" || t.kind === "array" || t.kind === "bytes";
 }
 
 /** Build the live dyn view of one typed stream value. Mutable reference
@@ -476,51 +473,6 @@ function dynPromiseAdapter(
 
 
 
-/** True when evaluating an index/value expression cannot overwrite the bytes
- * receiver binding. This deliberately small whitelist enables borrowed
- * receivers in typed-array hot loops while side-effecting/calling shapes
- * retain the full snapshot ownership required by JS evaluation order. */
-function isStableBytesOperand(e: IrExpr, receiverLocalId: string): boolean {
-  switch (e.kind) {
-    case "numLit":
-    case "boolLit":
-    case "varRef":
-    case "incDec":
-      return true;
-    case "assignExpr":
-      // An assignment nested under truthiness/ternary can still produce the
-      // numeric index/value while overwriting the bytes-typed receiver.
-      return e.localId !== receiverLocalId && isStableBytesOperand(e.value, receiverLocalId);
-    case "bin":
-      return (
-        isStableBytesOperand(e.left, receiverLocalId) &&
-        isStableBytesOperand(e.right, receiverLocalId)
-      );
-    case "unary":
-    case "toBool":
-      return isStableBytesOperand(e.operand, receiverLocalId);
-    case "logical":
-      return (
-        isStableBytesOperand(e.left, receiverLocalId) &&
-        isStableBytesOperand(e.right, receiverLocalId)
-      );
-    case "ternary":
-      return (
-        isStableBytesOperand(e.cond, receiverLocalId) &&
-        isStableBytesOperand(e.then, receiverLocalId) &&
-        isStableBytesOperand(e.else_, receiverLocalId)
-      );
-    case "bytesIntrinsic":
-      return (
-        (e.method === "get" || e.method === "length" || e.method === "byteLength") &&
-        e.receiver.kind === "varRef" &&
-        e.args.every((arg) => isStableBytesOperand(arg, receiverLocalId))
-      );
-    default:
-      return false;
-  }
-}
-
 /** Evaluate a bytes receiver as a borrow when it is a direct, unboxed
  * binding and all later operands are stable. The binding's scope/global
  * owner then keeps the value alive, avoiding retain/release traffic around
@@ -575,7 +527,7 @@ function emitMapLikeIntrinsic(
       const k = E.emitExpr(e.args[0]!);
       if (e.type.kind !== "union") throw new InternalCompilerError("emitter bug: map get result is not a union");
       const def = E.unionsById.get(e.type.unionId);
-      const undefTag = E.undefinedArmTag(e.type);
+      const undefTag = undefinedArmTag(e.type, E.unionsById);
       if (!def || undefTag < 0) throw new InternalCompilerError("emitter bug: map get union lacks its undefined arm");
       const absent = E.unitInstanceRef(e.type.unionId, undefTag);
       if (value.kind === "union") {
@@ -1066,7 +1018,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
           return { name, type: e.type };
         }
         if (e.type.kind !== "union") throw new InternalCompilerError("emitter bug: optChain result is not a union");
-        const undefTag = E.undefinedArmTag(e.type);
+        const undefTag = undefinedArmTag(e.type, E.unionsById);
         if (undefTag < 0) throw new InternalCompilerError("emitter bug: optChain result lacks its undefined arm");
         const name = `sc_t${E.tempCounter++}`;
         E.line(`${cDecl(e.type, name)};`);
@@ -1646,7 +1598,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             const elemT = e.receiver.type.elem;
             const def = E.unionsById.get(e.type.unionId);
             const tag = def ? def.arms.findIndex((a) => typeEquals(a, elemT)) : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (tag < 0 || undefTag < 0) throw new InternalCompilerError("emitter bug: shift union lacks its arms");
             const absent = E.unitInstanceRef(e.type.unionId, undefTag);
             const present =
@@ -2337,7 +2289,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
         const cast = `(void *(*)(${paramTypes.join(", ") || "void"}))`;
         const call = `(${cast}${callee.name}->ctor)(${args.map((a) => a.name).join(", ")})`;
         const t = E.newTemp(e.type, `(${cType(e.type).trim()})${call}`);
-        if (E.newValueMayThrow(cls)) E.emitPendingCheck();
+        if (newValueMayThrow(cls, E.classMeta, E.mayThrow)) E.emitPendingCheck();
         return t;
       }
       case "instanceOfValue": {
@@ -3443,7 +3395,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
               } else {
                 const st = shape.fields.find((f) => f.name === "scopeid")?.type;
                 if (st?.kind !== "union") throw new InternalCompilerError("emitter bug: networkInterfaces IPv4 scopeid type");
-                const undefTag = E.undefinedArmTag(st);
+                const undefTag = undefinedArmTag(st, E.unionsById);
                 E.line(`${r}->${mangleField("scopeid")} = scr_union_retain(${E.unitInstanceRef(st.unionId, undefTag)});`);
               }
               const rc = vAdapters(t);
@@ -3876,7 +3828,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             }
             const def = E.unionsById.get(e.type.unionId);
             const errTag = def ? def.arms.findIndex((a) => a.kind === "object" && a.className === "%Error") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (errTag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: spawnRes.error union lacks its arms");
             }
@@ -4438,7 +4390,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             if (e.type.kind !== "union") throw new InternalCompilerError("emitter bug: http.reqHeader result is not a union");
             const def = E.unionsById.get(e.type.unionId);
             const strTag = def ? def.arms.findIndex((a) => a.kind === "string") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (strTag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: http.reqHeader union lacks its arms");
             }
@@ -4506,7 +4458,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             if (e.type.kind !== "union") throw new InternalCompilerError("emitter bug: http.reqStatusCode result is not a union");
             const def = E.unionsById.get(e.type.unionId);
             const f64Tag = def ? def.arms.findIndex((a) => a.kind === "f64") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (f64Tag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: http.reqStatusCode union lacks its arms");
             }
@@ -4522,7 +4474,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             if (e.type.kind !== "union") throw new InternalCompilerError("emitter bug: net.sockEncrypted result is not a union");
             const def = E.unionsById.get(e.type.unionId);
             const boolTag = def ? def.arms.findIndex((a) => a.kind === "bool") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (boolTag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: net.sockEncrypted union lacks its arms");
             }
@@ -4537,7 +4489,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             if (e.type.kind !== "union") throw new InternalCompilerError("emitter bug: http.reqH2Stream result is not a union");
             const def = E.unionsById.get(e.type.unionId);
             const streamTag = def ? def.arms.findIndex((a) => a.kind === "http2Stream") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (streamTag < 0 || undefTag < 0) throw new InternalCompilerError("emitter bug: http.reqH2Stream union lacks its arms");
             const st = E.newTemp({ kind: "http2Stream" }, `scr_http_req_h2_stream(${arg(0)})`);
             E.moveTemp(st);
@@ -4557,7 +4509,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             if (e.type.kind !== "union") throw new InternalCompilerError("emitter bug: http.reqStatusMessage result is not a union");
             const def = E.unionsById.get(e.type.unionId);
             const strTag = def ? def.arms.findIndex((a) => a.kind === "string") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (strTag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: http.reqStatusMessage union lacks its arms");
             }
@@ -4694,7 +4646,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             if (e.type.kind !== "union") throw new InternalCompilerError("emitter bug: http.resGetHeader result is not a union");
             const def = E.unionsById.get(e.type.unionId);
             const strTag = def ? def.arms.findIndex((a) => a.kind === "string") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (strTag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: http.resGetHeader union lacks its arms");
             }
@@ -4767,7 +4719,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             if (e.type.kind !== "union") throw new InternalCompilerError("emitter bug: net.sockRemoteAddress result is not a union");
             const def = E.unionsById.get(e.type.unionId);
             const strTag = def ? def.arms.findIndex((a) => a.kind === "string") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (strTag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: net.sockRemoteAddress union lacks its arms");
             }
@@ -5835,7 +5787,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             }
             const def = E.unionsById.get(e.type.unionId);
             const strTag = def ? def.arms.findIndex((a) => a.kind === "string") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (strTag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: process.envGet union lacks its arms");
             }
@@ -6684,7 +6636,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             }
             const def = E.unionsById.get(e.type.unionId);
             const strTag = def ? def.arms.findIndex((a) => a.kind === "string") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (strTag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: error.code union lacks its arms");
             }
@@ -6987,7 +6939,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             }
             const def = E.unionsById.get(e.type.unionId);
             const f64Tag = def ? def.arms.findIndex((a) => a.kind === "f64") : -1;
-            const undefTag = E.undefinedArmTag(e.type);
+            const undefTag = undefinedArmTag(e.type, E.unionsById);
             if (f64Tag < 0 || undefTag < 0) {
               throw new InternalCompilerError("emitter bug: process.columns union lacks its arms");
             }
@@ -7644,7 +7596,7 @@ export function emitExpr(E: CEmitter, e: IrExpr): Temp {
             // into the union's dynCheck like any composite (or, for the
             // `any[] | undefined` defaulted-parameter spelling, the
             // jsval-element array exit wrapped into the data arm).
-            const undefTag = e.type.kind === "union" ? E.undefinedArmTag(e.type) : -1;
+            const undefTag = e.type.kind === "union" ? undefinedArmTag(e.type, E.unionsById) : -1;
             if (e.type.kind === "union" && undefTag >= 0) {
               const name = `sc_t${E.tempCounter++}`;
               E.line(`${cDecl(e.type, name)};`);

--- a/packages/compiler/src/backend/emission/emit-island.ts
+++ b/packages/compiler/src/backend/emission/emit-island.ts
@@ -8,6 +8,7 @@ import { deflateRawSync } from "node:zlib";
 import type { CEmitter } from "./emitter.js";
 import { cDecl, cFnPtrCast, cStringLiteral, releaseCallC } from "./emit-types.js";
 import { IrType, islandCallbackRet, NPM_COMPRESS_MIN, typeKey } from "../../ir/nodes.js";
+import { undefinedArmTag } from "../../ir/analysis.js";
 
 /** Embedded npm modules (--dynamic): every reached module's SOURCE as a
  * static string plus the resolution edges — the island's module loader
@@ -195,7 +196,7 @@ export function emitNpmEmbedding(E: CEmitter, out: string[]): void {
           // Composite (record/array/union): the jsExit pipeline — engine
           // JSON.stringify, json.parse, the interned dynCheck builder.
           canFail = true;
-          const utag = E.undefinedArmTag(p);
+          const utag = undefinedArmTag(p, E.unionsById);
           decls.push(`  ${cDecl(p, a)} = NULL;`);
           const roundTrip = [
             `    ScrStr *sc_j = scr_jsval_to_json(argv[${i}]);`,

--- a/packages/compiler/src/backend/emission/emit-shapes.ts
+++ b/packages/compiler/src/backend/emission/emit-shapes.ts
@@ -9,21 +9,11 @@ import type { IrFunction } from "../../ir/nodes.js";
 import { IrClassDef, IrType, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES, isRefCounted, mapOf, STRING } from "../../ir/nodes.js";
 import { mangleClassGcFree, mangleClassNew, mangleClassRelease, mangleClassReleaseDirect, mangleClassRetain, mangleClassStruct, mangleClassTrace, mangleCtorThunk, mangleField, mangleFunction, mangleRecordClone, mangleRecordGcFree, mangleRecordNew, mangleRecordRelease, mangleRecordRetain, mangleRecordStruct, mangleRecordTrace, mangleVtAdapter, mangleVtInstance, mangleVtStruct } from "../mangle.js";
 import { boxKindC, cDecl, cType, elemKindC, mapValKindC, releaseCallC, retainCallC, vAdapters } from "./emit-types.js";
+import { streamRooted } from "../../ir/analysis.js";
 
 /** The overflow map's C member name on index-signature record structs.
  * User fields mangle to `sc_fld_*`, so no field can collide. */
 export const OVERFLOW_MEMBER = "sc_ovf";
-
-/** True when the class descends from a runtime stream class: its struct
- * embeds the FULL ScrStream prefix (registry, display name, state
- * pointer) and its RC/trace helpers delegate the state block to
- * scr_stream_st_*. */
-function streamRooted(meta: ClassMeta): boolean {
-  for (let m = meta.base; m; m = m.base) {
-    if (RUNTIME_STREAM_CLASSES.has(m.def.name)) return true;
-  }
-  return false;
-}
 
 /** One virtual method slot of a hierarchy: the ROOT-MOST declaring class
  * owns the slot; its declaration's IrFunction fixes the slot's C signature

--- a/packages/compiler/src/backend/emission/emit-stmts.ts
+++ b/packages/compiler/src/backend/emission/emit-stmts.ts
@@ -11,6 +11,7 @@ import { boxAccess, cDecl, cStringLiteral, elemAccess, vAdapters } from "./emit-
 import { OVERFLOW_MEMBER } from "./emit-shapes.js";
 import { emitBytesReceiver } from "./emit-exprs.js";
 import { matchIntegerBytesForLoop } from "../../ir/integer-loops.js";
+import { endsWithJump } from "../../ir/analysis.js";
 
 
 
@@ -150,7 +151,7 @@ export function emitFunction(E: CEmitter, fn: IrFunction): void {
     E.scopes.push(scope);
     setup?.(scope);
     E.emitStmts(stmts);
-    const endedWithJump = E.endsWithJump(stmts);
+    const endedWithJump = endsWithJump(stmts);
     E.scopes.pop();
     if (!endedWithJump) E.releaseFrame(scope);
     E.indent--;
@@ -502,7 +503,7 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
           if (isRefCounted(elem)) E.scopes[E.scopes.length - 1]!.push({ name: local, type: elem });
         }
         E.emitStmts(s.body);
-        const endedWithJump = E.endsWithJump(s.body);
+        const endedWithJump = endsWithJump(s.body);
         const scope = E.scopes.pop()!;
         if (!endedWithJump) E.releaseFrame(scope);
         E.jumpTargets.pop();
@@ -756,7 +757,7 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
     };
 
     if (hasCatch && handler.used) {
-      if (!E.endsWithJump(s.tryBody)) {
+      if (!endsWithJump(s.tryBody)) {
         E.line(`goto ${afterTryLabel};`);
         afterTryLabelUsed = true;
       }
@@ -941,7 +942,7 @@ export function emitStmt(E: CEmitter, s: IrStmt): void {
     // Natural fall-off of the last body releases the shared scope here; a
     // jump (break/return/continue/throw) already released it before jumping.
     const lastBody = s.cases[s.cases.length - 1]?.body;
-    if (!lastBody || !E.endsWithJump(lastBody)) E.releaseFrame(scope);
+    if (!lastBody || !endsWithJump(lastBody)) E.releaseFrame(scope);
     if (target.usedEnd) E.line(`${endLabel}:;`);
   }
 

--- a/packages/compiler/src/backend/emission/emit-walkers.ts
+++ b/packages/compiler/src/backend/emission/emit-walkers.ts
@@ -8,70 +8,10 @@ import { InternalCompilerError } from "../../errors.js";
  * CEmitter and these functions only consult them through it. */
 import type { CEmitter } from "./emitter.js";
 import { DYN_HANDLE_KINDS, IrType, isRefCounted, typeEquals, typeKey } from "../../ir/nodes.js";
+import { dynDesc, undefinedArmTag } from "../../ir/analysis.js";
 import { cDecl, cStringLiteral, cType, elemAccess, releaseCallC, retainCallC, vAdapters } from "./emit-types.js";
 import { mangleField, mangleRecordNew, mangleRecordStruct } from "../mangle.js";
 import { OVERFLOW_MEMBER } from "./emit-shapes.js";
-
-/** Short human description of a dynCheck target for error messages
-   * ("expected number | string at $.items[2]"). Records read as "object" —
-   * the path already says where; the full shape would bloat messages. */
-  export function dynDesc(E: CEmitter, t: IrType): string {
-    switch (t.kind) {
-      case "f64":
-        return "number";
-      case "string":
-        return "string";
-      case "bool":
-        return "boolean";
-      case "record":
-        // Tuples read as "array": that IS the JSON representation the
-        // caller must supply (arity failures carry their own message).
-        return E.recordsById.get(t.shapeId)?.tuple ? "array" : "object";
-      case "array":
-        return "array";
-      case "nullT":
-        return "null";
-      // Reachable through optional-flavored record fields ("expected
-      // string | undefined at $.a" — honest: the fix is a string value OR
-      // omitting the key).
-      case "undefinedT":
-        return "undefined";
-      // dyn fields accept any dyn value — only reachable in messages as a
-      // sibling of a failing field, never as the failure itself.
-      case "dyn":
-        return "unknown";
-      case "bytes":
-        return "Uint8Array";
-      // The %Error extraction (an instanceof-Error narrow / cast on an
-      // unknown value): the failure names the class, like caughtCheck's.
-      case "object":
-        return t.className.replace(/^%/, "");
-      case "union": {
-        const def = E.unionsById.get(t.unionId);
-        if (!def) throw new InternalCompilerError(`emitter bug: dynDesc of unknown union ${t.unionId}`);
-        return def.arms.map((a) => E.dynDesc(a)).join(" | ");
-      }
-      // Function targets (the checked-dynamic function boundary): the
-      // failure names the expected callability, not the full signature —
-      // the path already says where.
-      case "func":
-        return "function";
-      // Map/Set-valued index signatures (Record<string, Map<K, V>>): only
-      // reachable through the keyed-read miss trap's message — no dynCheck
-      // ever expects one.
-      case "map":
-        return "Map";
-      case "set":
-        return "Set";
-      default: {
-        // Runtime HANDLE targets name the class ("expected
-        // IncomingMessage at $, got string").
-        const h = DYN_HANDLE_KINDS.get(t.kind);
-        if (h) return h.cls;
-        throw new InternalCompilerError(`emitter bug: dynDesc of non-JSON type ${t.kind}`);
-      }
-    }
-  }
 
 /** The per-union ToBoolean helper (interned per unionId): switch on the
    * runtime tag — unit arms false, f64 arms 0/NaN-falsy, string arms
@@ -583,7 +523,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
         // overflow portion forces the dynamic path too (entry count is
         // runtime state).
         const droppable =
-          emitFields.some((f) => E.undefinedArmTag(f.type) >= 0) || !!shape.indexValue;
+          emitFields.some((f) => undefinedArmTag(f.type, E.unionsById) >= 0) || !!shape.indexValue;
         d.push(`  scr_jb_putc(b, '{');`);
         if (!droppable) {
           emitFields.forEach((f, i) => {
@@ -598,7 +538,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
           d.push(`  bool first = true;`);
           for (const f of emitFields) {
             const label = cStringLiteral(Buffer.from(`"${f.name}":`, "utf8"));
-            const utag = E.undefinedArmTag(f.type);
+            const utag = undefinedArmTag(f.type, E.unionsById);
             const pad = utag >= 0 ? "    " : "  ";
             if (utag >= 0) {
               d.push(`  if (v->${mangleField(f.name)}->tag != ${utag}) { /* undefined-valued field: dropped, like Node */`);
@@ -634,8 +574,8 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
             const skipUndef =
               iv.kind === "dyn"
                 ? `e->kind == SCR_DYN_UNDEF`
-                : E.undefinedArmTag(iv) >= 0
-                  ? `e->tag == ${E.undefinedArmTag(iv)}`
+                : undefinedArmTag(iv, E.unionsById) >= 0
+                  ? `e->tag == ${undefinedArmTag(iv, E.unionsById)}`
                   : null;
             if (skipUndef) {
               d.push(`      if (${skipUndef}) { /* undefined-valued entry: dropped, like Node */`);
@@ -822,7 +762,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
           const keyLit = cStringLiteral(Buffer.from(f.name, "utf8"));
           const keyLen = Buffer.byteLength(f.name, "utf8");
           d.push(`  m = scr_dyn_obj_get(d, ${keyLit}, ${keyLen});`);
-          if (E.undefinedArmTag(f.type) >= 0) {
+          if (undefinedArmTag(f.type, E.unionsById) >= 0) {
             // Optional-flavored field: a MISSING key is the undefined arm
             // (a match); a PRESENT key must fit the union as usual.
             d.push(`  if (m && !${E.dynMatchHelper(f.type)}(m)) return false;`);
@@ -1126,7 +1066,7 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
     E.dynBuilders.set(key, name);
     const sig = `static ${cType(t)}${cType(t).endsWith("*") ? "" : " "}${name}(const ScrDyn *d, const ScrDynPath *path)`;
     E.walkerProtos.push(`${sig}; /* check ${key} */`);
-    const want = cStringLiteral(Buffer.from(E.dynDesc(t), "utf8"));
+    const want = cStringLiteral(Buffer.from(dynDesc(t, E.recordsById, E.unionsById), "utf8"));
     const d: string[] = [`${sig} { /* check ${key} */`];
     if (isRefCounted(t) && t.kind !== "dyn") {
       const keyLit = cStringLiteral(Buffer.from(key, "utf8"));
@@ -1278,14 +1218,14 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
         for (const f of shape.fields) {
           const keyLit = cStringLiteral(Buffer.from(f.name, "utf8"));
           const keyLen = Buffer.byteLength(f.name, "utf8");
-          const fieldWant = cStringLiteral(Buffer.from(E.dynDesc(f.type), "utf8"));
+          const fieldWant = cStringLiteral(Buffer.from(dynDesc(f.type, E.recordsById, E.unionsById), "utf8"));
           // Width tolerance: only declared fields are looked up — extra JSON
           // keys are simply never examined (check-and-extract, not shape
           // equality). A missing field fails as "got undefined" — except
           // optional-flavored fields (undefined-armed unions), where the
           // missing key IS the undefined arm: the interned immortal
           // instance, no retain owed (rc == SIZE_MAX).
-          const utag = f.type.kind === "union" ? E.undefinedArmTag(f.type) : -1;
+          const utag = f.type.kind === "union" ? undefinedArmTag(f.type, E.unionsById) : -1;
           d.push(`  {`);
           d.push(`    ScrDynPath p = { path, ${keyLit}, 0 };`);
           d.push(`    const ScrDyn *m = scr_dyn_obj_get(d, ${keyLit}, ${keyLen});`);
@@ -2018,13 +1958,13 @@ export function jsonWriteHelper(E: CEmitter, t: IrType): string {
     // The miss path.
     if (t.kind === "dyn") {
       d.push(`  return scr_dyn_retain(scr_dyn_undefined());`);
-    } else if (t.kind === "union" && E.undefinedArmTag(t) >= 0) {
-      d.push(`  return ${E.unitInstanceRef(t.unionId, E.undefinedArmTag(t))};`);
+    } else if (t.kind === "union" && undefinedArmTag(t, E.unionsById) >= 0) {
+      d.push(`  return ${E.unitInstanceRef(t.unionId, undefinedArmTag(t, E.unionsById))};`);
     } else {
       // JS would answer undefined; T has no way to say it (the checker
       // claimed T without noUncheckedIndexedAccess) — trap like an array
       // OOB read instead of corrupting a typed slot (SEMANTICS.md).
-      d.push(`  scr_trap_fmt("scriptc: TypeError: record has no key '%.*s' (typed '${E.dynDesc(t)}' — no undefined is representable)\\n", (int)k->len, k->data);`);
+      d.push(`  scr_trap_fmt("scriptc: TypeError: record has no key '%.*s' (typed '${dynDesc(t, E.recordsById, E.unionsById)}' — no undefined is representable)\\n", (int)k->len, k->data);`);
     }
     d.push(`}`, ``);
     E.walkerDefs.push(...d);

--- a/packages/compiler/src/backend/emission/emitter.ts
+++ b/packages/compiler/src/backend/emission/emitter.ts
@@ -41,6 +41,7 @@ import type {
   SrcLoc,
 } from "../../ir/nodes.js";
 import { ffiCallbackType, funcOf, isFfiCallbackParam, isFfiContextParam, isFfiReleaseParam, isRefCounted, isUnitType, mapOf, moduleEmbedsCompressedNpm, moduleUsesDgram, moduleUsesDynInvoke, moduleEmbedsBuiltin, moduleUsesFetch, moduleUsesFsWatch, moduleUsesHttp2, moduleUsesHttpServer, moduleUsesNet, moduleUsesNodeTest, moduleUsesProcessEvents, moduleUsesStream, moduleUsesTls, moduleUsesTlsCa, POINTER_KINDS, type PointerKind, RUNTIME_EMITTER_CLASS, STRING, VOID } from "../../ir/nodes.js";
+import { undefinedArmTag } from "../../ir/analysis.js";
 import { allocateFfiCallbackAdapters, hasForeignFfiCallback, hasRetainedFfiCallback, type FfiCallbackAdapter } from "../ffi-callbacks.js";
 import {
   mangleAsyncSpawn,
@@ -57,7 +58,7 @@ import {
 } from "../mangle.js";
 import { cFnPtrCast, cType, releaseCallC, cStringLiteral, cDecl } from "./emit-types.js";
 import { computeMayThrow } from "./may-throw.js";
-import { dynDesc, unionTruthyHelper, unionEqHelper, unionToStrHelper, unionJoinHelper, jsonWriteHelper, jsonIndentHelper, dynMatchHelper, dynCheckHelper, dynFuncBoxHelper, dynToStrHelper, caughtToDynHelper, toDynHelper, recordKeyGetHelper, recordKeySetHelper } from "./emit-walkers.js";
+import { unionTruthyHelper, unionEqHelper, unionToStrHelper, unionJoinHelper, jsonWriteHelper, jsonIndentHelper, dynMatchHelper, dynCheckHelper, dynFuncBoxHelper, dynToStrHelper, caughtToDynHelper, toDynHelper, recordKeyGetHelper, recordKeySetHelper } from "./emit-walkers.js";
 import { VtSlot, ClassMeta, emitStructDefs, vtEntriesFor, vtSlotParams, emitVtableDecls, emitVtableInstances, emitVtAdapterDefs, emitHierarchyClassHelpers, emitClassObjs, emitCtorThunkDefs, errorVtStampLines, emitterVtStampLines, streamVtStampLines, traceAdapterC, traceArgC, boxNewC, arrNewC } from "./emit-shapes.js";
 import { emitAsyncScaffolding, childDataThunkFor, childExitThunkFor, childExitThunkFor2, closeBindThunkFor, connectResThunkFor, connectSockThunkFor, closeOverrideWrapFor, dgramMsgThunkFor, dnsLookupThunkFor, fsRenameThunkFor, netLookupAnswerThunkFor, emitterInvokeThunkFor, streamCbThunkFor, streamDataThunkFor, raceAdapterFor, resolveThunkFor, sniAnswerThunkFor } from "./emit-async.js";
 import { emitNpmEmbedding, islandAdapter, islandTypedAdapter } from "./emit-island.js";
@@ -1346,10 +1347,6 @@ export class CEmitter {
    * cell. Recursion terminates because recursive shapes/unions are rejected
    * by the frontend. */
 
-  dynDesc(t: IrType): string {
-    return dynDesc(this, t);
-  }
-
   islandAdapter(arity: number, retKind: "void" | "jsval" | "f64" | "bool" | "string"): string {
     return islandAdapter(this, arity, retKind);
   }
@@ -1619,15 +1616,6 @@ export class CEmitter {
     for (let i = this.scopes.length - 1; i >= scopeDepth; i--) this.releaseFrame(this.scopes[i]!);
   }
 
-  /** True when the last statement is a jump — its emission already released
-   * everything it had to, and the fall-through releases after it would be
-   * dead double-release code. `throw` counts: it unwinds (to a handler or
-   * out of the function) through the same release path. */
-  endsWithJump(stmts: IrStmt[]): boolean {
-    const last = stmts[stmts.length - 1]?.kind;
-    return last === "return" || last === "break" || last === "continue" || last === "throw" || last === "rethrow" || last === "runtimeFence";
-  }
-
   /** THE unwind path at a point where an exception is pending: release
    * everything between here and the innermost try handler — or the whole
    * function — via releaseForJump, then jump to the handler / return a
@@ -1701,28 +1689,6 @@ export class CEmitter {
     return sym;
   }
 
-  /** True when construction through a classval of `className` can throw:
-   * the runtime callee is the static class's constructor or any strict
-   * descendant's (classval flows never leave the subtree). */
-  newValueMayThrow(className: string): boolean {
-    const meta = this.classMeta.get(className);
-    if (!meta) throw new InternalCompilerError(`emitter bug: newValue on unknown class ${className}`);
-    const any = (m: ClassMeta): boolean =>
-      this.mayThrow.has(`%${m.def.name}.constructor`) || m.children.some(any);
-    return any(meta);
-  }
-
-  /** The undefined arm's tag of a union type, or -1 (not a union / no
-   * undefined arm). A record FIELD with such a type is optional-flavored:
-   * the JSON serializer DROPS it while it holds the undefined arm and the
-   * dynCheck builder produces the undefined arm for a MISSING key — both
-   * exactly Node's optional-field behavior. */
-  undefinedArmTag(t: IrType): number {
-    if (t.kind !== "union") return -1;
-    const def = this.unionsById.get(t.unionId);
-    return def ? def.arms.findIndex((a) => a.kind === "undefinedT") : -1;
-  }
-
   /** The interned immortal instance for a UNIT arm of a union — asserts the
    * arm really is payload-less (undefined/null). */
   internUnitInstance(unionId: string, tag: number): string {
@@ -1764,7 +1730,7 @@ export class CEmitter {
     if (t.kind === "jsval") {
       return [`  o->${mangleField(name)} = scr_jsval_undefined(); /* ${name} starts undefined */`];
     }
-    const tag = this.undefinedArmTag(t);
+    const tag = undefinedArmTag(t, this.unionsById);
     if (tag < 0 || t.kind !== "union") return [];
     return [`  o->${mangleField(name)} = ${this.unitInstanceRef(t.unionId, tag)}; /* ${name} starts undefined */`];
   }

--- a/packages/compiler/src/backend/llvm/blocks.ts
+++ b/packages/compiler/src/backend/llvm/blocks.ts
@@ -62,6 +62,39 @@ export class BlockBuilder {
     this.terminate(`br i1 ${v}, label %${t}, label %${f}`);
   }
 
+  /** Emit a double-indexed `for (i = 0; i < len; i++)` loop. `next` is
+   * exposed for bodies with internal branches that need to continue at the
+   * shared increment block. */
+  countedLoop(
+    len: string,
+    emitBody: (index: string, next: string) => void,
+    comparison: "olt" | "ole" = "olt",
+  ): void {
+    const indexSlot = this.slot();
+    this.entryAllocas.push(`${indexSlot} = alloca double`);
+    this.line(`store double 0x0000000000000000, ptr ${indexSlot}`);
+    const condition = this.newLabel("count.c");
+    const body = this.newLabel("count.b");
+    const next = this.newLabel("count.n");
+    const done = this.newLabel("count.e");
+    this.br(condition);
+    this.startBlock(condition);
+    const index = this.tmp();
+    const more = this.tmp();
+    this.line(`${index} = load double, ptr ${indexSlot}`);
+    this.line(`${more} = fcmp ${comparison} double ${index}, ${len}`);
+    this.condBr(more, body, done);
+    this.startBlock(body);
+    emitBody(index, next);
+    if (!this.isTerminated()) this.br(next);
+    this.startBlock(next);
+    const incremented = this.tmp();
+    this.line(`${incremented} = fadd double ${index}, 0x3FF0000000000000`);
+    this.line(`store double ${incremented}, ptr ${indexSlot}`);
+    this.br(condition);
+    this.startBlock(done);
+  }
+
   render(): string {
     return this.blocks
       .map((b, i) => {

--- a/packages/compiler/src/backend/llvm/classes.ts
+++ b/packages/compiler/src/backend/llvm/classes.ts
@@ -20,8 +20,9 @@ import { InternalCompilerError } from "../../errors.js";
  * Emitter- and stream-rooted classes stay out of the tier (their prefixes
  * embed runtime registry/state slots and their surfaces are async-shaped);
  * the emitter refuses them by name before anything here runs. */
-import type { IrClassDef, IrFunction, IrModule, IrType } from "../../ir/nodes.js";
+import type { IrClassDef, IrFunction, IrModule, IrType, IrUnionDef } from "../../ir/nodes.js";
 import { isRefCounted, RUNTIME_EMITTER_CLASS, RUNTIME_ERROR_CLASSES, RUNTIME_STREAM_CLASSES } from "../../ir/nodes.js";
+import { streamRooted, undefinedArmTag } from "../../ir/analysis.js";
 import {
   mangleClassGcFree,
   mangleClassNew,
@@ -173,17 +174,6 @@ function emitterRooted(meta: LlClassMeta): boolean {
   return meta.root.def.name === RUNTIME_EMITTER_CLASS;
 }
 
-/** True when the class descends from a runtime STREAM class: its struct
- * embeds the FULL ScrStream prefix (registry, display name, state
- * pointer) and its RC/trace helpers delegate the state block to
- * scr_stream_st_* (emit-shapes.ts's streamRooted). */
-function streamRooted(meta: LlClassMeta): boolean {
-  for (let m = meta.base; m; m = m.base) {
-    if (RUNTIME_STREAM_CLASSES.has(m.def.name)) return true;
-  }
-  return false;
-}
-
 /** The GEP index where a class's own fields start: rc at 0, the vtable
  * word at 1 on hierarchy members, then the emitter prefix (registry +
  * display name) on emitter-rooted classes, then the stream-state slot on
@@ -207,8 +197,8 @@ export function classFieldIndex(meta: LlClassMeta, field: string): { index: numb
  * undefined-armed union start as JS's `undefined`, never NULL), and the
  * interned NUL-terminated constants (emitter subclass display names). */
 export interface ClassHost extends ShapeHost {
+  readonly unionsById: Map<string, IrUnionDef>;
   unitInstanceRef(unionId: string, tag: number): string;
-  undefinedArmTag(t: IrType): number;
   cstr(text: string): string;
 }
 
@@ -230,7 +220,7 @@ function undefFieldInits(host: ClassHost, meta: LlClassMeta): string[] {
       return;
     }
     if (f.type.kind !== "union") return;
-    const tag = host.undefinedArmTag(f.type);
+    const tag = undefinedArmTag(f.type, host.unionsById);
     if (tag < 0) return;
     out.push(
       `  %uf${i} = getelementptr inbounds %${mangleClassStruct(meta.def.name)}, ptr %o, i64 0, i32 ${index}`,

--- a/packages/compiler/src/backend/llvm/dyn.ts
+++ b/packages/compiler/src/backend/llvm/dyn.ts
@@ -25,6 +25,7 @@ import { InternalCompilerError } from "../../errors.js";
  *   ScrDynPath { parent, key, index } — the %ScrDynPath type. */
 import type { IrType } from "../../ir/nodes.js";
 import { DYN_HANDLE_KINDS, isRefCounted, typeKey } from "../../ir/nodes.js";
+import { dynDesc, undefinedArmTag } from "../../ir/analysis.js";
 import { mangleRecordNew, mangleRecordStruct } from "../mangle.js";
 import { BlockBuilder } from "./blocks.js";
 import { arrNewCall, elemAccess, llFieldType, releaseSym, traceAdapter, traceArg, vAdapters } from "./shapes.js";
@@ -292,46 +293,6 @@ export class LlDyn {
     B.startBlock(lk);
   }
 
-  /* ── dynDesc (ported verbatim — pure strings) ──────────────────────── */
-
-  /** Short human description of a dynCheck target for error messages. */
-  dynDesc(t: IrType): string {
-    switch (t.kind) {
-      case "f64":
-        return "number";
-      case "string":
-        return "string";
-      case "bool":
-        return "boolean";
-      case "record":
-        return this.host.recordsById.get(t.shapeId)?.tuple ? "array" : "object";
-      case "array":
-        return "array";
-      case "nullT":
-        return "null";
-      case "undefinedT":
-        return "undefined";
-      case "dyn":
-        return "unknown";
-      case "bytes":
-        return "Uint8Array";
-      case "object":
-        return t.className.replace(/^%/, "");
-      case "union": {
-        const def = this.host.unionsById.get(t.unionId);
-        if (!def) throw new InternalCompilerError(`llvm emitter bug: dynDesc of unknown union ${t.unionId}`);
-        return def.arms.map((a) => this.dynDesc(a)).join(" | ");
-      }
-      case "func":
-        return "function";
-      default: {
-        const h = DYN_HANDLE_KINDS.get(t.kind);
-        if (h) return h.cls;
-        throw new InternalCompilerError(`llvm emitter bug: dynDesc of non-JSON type ${t.kind}`);
-      }
-    }
-  }
-
   /* ── dynMatchHelper (emit-walkers.ts, ported) ──────────────────────── */
 
   /** `sc_dm_<n>(ptr d) -> i1` — does this dyn fit T? Never throws. */
@@ -449,7 +410,7 @@ export class LlDyn {
           B.line(`${has} = icmp ne ptr ${m}, null`);
           const lTest = B.newLabel("dm.t");
           const lNext = B.newLabel("dm.n");
-          if (this.host.undefinedArmTag(f.type) >= 0) {
+          if (undefinedArmTag(f.type, this.host.unionsById) >= 0) {
             // Optional-flavored field: a MISSING key is the undefined arm
             // (a match); a PRESENT key must fit the union as usual.
             B.condBr(has, lTest, lNext);
@@ -572,7 +533,7 @@ export class LlDyn {
     const retTy = this.valTy(t);
     const dummy = retTy === "double" ? `double ${f64Lit(0)}` : retTy === "i1" ? "i1 false" : "ptr null";
     host.declare(`declare void @scr_dyn_check_fail(ptr, ptr, ptr)`);
-    const want = host.cstr(this.dynDesc(t));
+    const want = host.cstr(dynDesc(t, this.host.recordsById, this.host.unionsById));
     const B = new BlockBuilder();
     if (isRefCounted(t) && t.kind !== "dyn") {
       host.declare(`declare zeroext i1 @scr_dyn_typed_ref_is(ptr, ptr, ${host.sizeType})`);
@@ -864,8 +825,8 @@ export class LlDyn {
         requireKind(DK.OBJ, "dcr");
         B.line(`%r0 = call ptr @${mangleRecordNew(t.shapeId)}()`);
         for (const f of shape.fields) {
-          const fieldWant = host.cstr(this.dynDesc(f.type));
-          const utag = f.type.kind === "union" ? host.undefinedArmTag(f.type) : -1;
+          const fieldWant = host.cstr(dynDesc(f.type, this.host.recordsById, this.host.unionsById));
+          const utag = f.type.kind === "union" ? undefinedArmTag(f.type, host.unionsById) : -1;
           const m = this.objGetLit(B, "%d", f.name);
           if (f.type.kind === "dyn") {
             // An `unknown` field: a present key passes through, a missing
@@ -1366,68 +1327,51 @@ export class LlDyn {
           const len = B.tmp();
           B.line(`${ks} = call ptr @scr_map_keys_js_order(ptr ${ovf})`);
           B.line(`${len} = call double @scr_arr_len(ptr ${ks})`);
-          const iSlot = B.slot();
-          B.entryAllocas.push(`${iSlot} = alloca double`);
-          B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
-          const lc = B.newLabel("tdo.c");
-          const lb = B.newLabel("tdo.b");
-          const le = B.newLabel("tdo.e");
-          B.br(lc);
-          B.startBlock(lc);
-          const i = B.tmp();
-          const cont = B.tmp();
-          B.line(`${i} = load double, ptr ${iSlot}`);
-          B.line(`${cont} = fcmp olt double ${i}, ${len}`);
-          B.condBr(cont, lb, le);
-          B.startBlock(lb);
-          const k = B.tmp();
-          B.line(`${k} = call ptr @scr_arr_get_ref(ptr ${ks}, double ${i}) ; key (+1)`);
-          const { len: klen, data: kdata } = this.strParts(B, k);
-          if (iv.kind === "f64" || iv.kind === "bool") {
-            const outTy = iv.kind === "f64" ? "double" : "i8";
-            const outSlot = B.slot();
-            B.entryAllocas.push(`${outSlot} = alloca ${outTy}`);
-            B.line(`store ${outTy} ${iv.kind === "f64" ? f64Lit(0) : "0"}, ptr ${outSlot}`);
-            host.declare(`declare zeroext i1 @scr_map_get_str_${iv.kind === "f64" ? "f64" : "bool"}(ptr, ptr, ptr)`);
-            const found = B.tmp();
-            B.line(`${found} = call zeroext i1 @scr_map_get_str_${iv.kind === "f64" ? "f64" : "bool"}(ptr ${ovf}, ptr ${k}, ptr ${outSlot})`);
-            const raw = B.tmp();
-            B.line(`${raw} = load ${outTy}, ptr ${outSlot}`);
-            let val = raw;
-            if (iv.kind === "bool") {
-              val = B.tmp();
-              B.line(`${val} = trunc i8 ${raw} to i1`);
-            }
-            const boxed = B.tmp();
-            if (iv.kind === "f64") {
-              host.declare(`declare ptr @scr_dyn_new_num(double)`);
-              B.line(`${boxed} = call ptr @scr_dyn_new_num(double ${val})`);
+          B.countedLoop(len, (i) => {
+            const k = B.tmp();
+            B.line(`${k} = call ptr @scr_arr_get_ref(ptr ${ks}, double ${i}) ; key (+1)`);
+            const { len: klen, data: kdata } = this.strParts(B, k);
+            if (iv.kind === "f64" || iv.kind === "bool") {
+              const outTy = iv.kind === "f64" ? "double" : "i8";
+              const outSlot = B.slot();
+              B.entryAllocas.push(`${outSlot} = alloca ${outTy}`);
+              B.line(`store ${outTy} ${iv.kind === "f64" ? f64Lit(0) : "0"}, ptr ${outSlot}`);
+              host.declare(`declare zeroext i1 @scr_map_get_str_${iv.kind === "f64" ? "f64" : "bool"}(ptr, ptr, ptr)`);
+              const found = B.tmp();
+              B.line(`${found} = call zeroext i1 @scr_map_get_str_${iv.kind === "f64" ? "f64" : "bool"}(ptr ${ovf}, ptr ${k}, ptr ${outSlot})`);
+              const raw = B.tmp();
+              B.line(`${raw} = load ${outTy}, ptr ${outSlot}`);
+              let val = raw;
+              if (iv.kind === "bool") {
+                val = B.tmp();
+                B.line(`${val} = trunc i8 ${raw} to i1`);
+              }
+              const boxed = B.tmp();
+              if (iv.kind === "f64") {
+                host.declare(`declare ptr @scr_dyn_new_num(double)`);
+                B.line(`${boxed} = call ptr @scr_dyn_new_num(double ${val})`);
+              } else {
+                host.declare(`declare ptr @scr_dyn_new_bool(i1 zeroext)`);
+                B.line(`${boxed} = call ptr @scr_dyn_new_bool(i1 ${val})`);
+              }
+              B.line(`call void @scr_dyn_obj_set(ptr ${d}, ptr ${kdata}, ${host.sizeType} ${klen}, ptr ${boxed})`);
+            } else if (iv.kind === "dyn") {
+              // get_str_ref returns +1 — exactly the ownership obj_set takes.
+              host.declare(`declare ptr @scr_map_get_str_ref(ptr, ptr)`);
+              const hit = B.tmp();
+              B.line(`${hit} = call ptr @scr_map_get_str_ref(ptr ${ovf}, ptr ${k})`);
+              B.line(`call void @scr_dyn_obj_set(ptr ${d}, ptr ${kdata}, ${host.sizeType} ${klen}, ptr ${hit})`);
             } else {
-              host.declare(`declare ptr @scr_dyn_new_bool(i1 zeroext)`);
-              B.line(`${boxed} = call ptr @scr_dyn_new_bool(i1 ${val})`);
+              host.declare(`declare ptr @scr_map_get_str_ref(ptr, ptr)`);
+              const hit = B.tmp();
+              B.line(`${hit} = call ptr @scr_map_get_str_ref(ptr ${ovf}, ptr ${k})`);
+              const conv = B.tmp();
+              B.line(`${conv} = call ptr @${this.toDynHelper(iv)}(ptr ${hit})`);
+              B.line(`call void @scr_dyn_obj_set(ptr ${d}, ptr ${kdata}, ${host.sizeType} ${klen}, ptr ${conv})`);
+              B.line(`call void ${releaseSym(host, iv)}(ptr ${hit})`);
             }
-            B.line(`call void @scr_dyn_obj_set(ptr ${d}, ptr ${kdata}, ${host.sizeType} ${klen}, ptr ${boxed})`);
-          } else if (iv.kind === "dyn") {
-            // get_str_ref returns +1 — exactly the ownership obj_set takes.
-            host.declare(`declare ptr @scr_map_get_str_ref(ptr, ptr)`);
-            const hit = B.tmp();
-            B.line(`${hit} = call ptr @scr_map_get_str_ref(ptr ${ovf}, ptr ${k})`);
-            B.line(`call void @scr_dyn_obj_set(ptr ${d}, ptr ${kdata}, ${host.sizeType} ${klen}, ptr ${hit})`);
-          } else {
-            host.declare(`declare ptr @scr_map_get_str_ref(ptr, ptr)`);
-            const hit = B.tmp();
-            B.line(`${hit} = call ptr @scr_map_get_str_ref(ptr ${ovf}, ptr ${k})`);
-            const conv = B.tmp();
-            B.line(`${conv} = call ptr @${this.toDynHelper(iv)}(ptr ${hit})`);
-            B.line(`call void @scr_dyn_obj_set(ptr ${d}, ptr ${kdata}, ${host.sizeType} ${klen}, ptr ${conv})`);
-            B.line(`call void ${releaseSym(host, iv)}(ptr ${hit})`);
-          }
-          B.line(`call void @scr_str_release(ptr ${k})`);
-          const i2 = B.tmp();
-          B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
-          B.line(`store double ${i2}, ptr ${iSlot}`);
-          B.br(lc);
-          B.startBlock(le);
+            B.line(`call void @scr_str_release(ptr ${k})`);
+          });
           B.line(`call void @scr_arr_release(ptr ${ks})`);
         }
         if (cyclicRec) B.line(`call void @scr_dyn_from_leave()`);
@@ -1450,49 +1394,32 @@ export class LlDyn {
         B.line(`${d} = call ptr @scr_dyn_new_arr()`);
         const len = B.tmp();
         B.line(`${len} = call double @scr_arr_len(ptr %v)`);
-        const iSlot = B.slot();
-        B.entryAllocas.push(`${iSlot} = alloca double`);
-        B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
-        const lc = B.newLabel("tda.c");
-        const lb = B.newLabel("tda.b");
-        const le = B.newLabel("tda.e");
-        B.br(lc);
-        B.startBlock(lc);
-        const i = B.tmp();
-        const cont = B.tmp();
-        B.line(`${i} = load double, ptr ${iSlot}`);
-        B.line(`${cont} = fcmp olt double ${i}, ${len}`);
-        B.condBr(cont, lb, le);
-        B.startBlock(lb);
-        if (elem.kind === "f64" || elem.kind === "bool") {
-          const acc = elem.kind;
-          const accTy = elem.kind === "f64" ? "double" : "i1";
-          host.declare(`declare ${elem.kind === "bool" ? "zeroext i1" : accTy} @scr_arr_get_${acc}(ptr, double)`);
-          const e = B.tmp();
-          B.line(`${e} = call ${accTy} @scr_arr_get_${acc}(ptr %v, double ${i})`);
-          const boxed = B.tmp();
-          if (elem.kind === "f64") {
-            host.declare(`declare ptr @scr_dyn_new_num(double)`);
-            B.line(`${boxed} = call ptr @scr_dyn_new_num(double ${e})`);
+        B.countedLoop(len, (i) => {
+          if (elem.kind === "f64" || elem.kind === "bool") {
+            const acc = elem.kind;
+            const accTy = elem.kind === "f64" ? "double" : "i1";
+            host.declare(`declare ${elem.kind === "bool" ? "zeroext i1" : accTy} @scr_arr_get_${acc}(ptr, double)`);
+            const e = B.tmp();
+            B.line(`${e} = call ${accTy} @scr_arr_get_${acc}(ptr %v, double ${i})`);
+            const boxed = B.tmp();
+            if (elem.kind === "f64") {
+              host.declare(`declare ptr @scr_dyn_new_num(double)`);
+              B.line(`${boxed} = call ptr @scr_dyn_new_num(double ${e})`);
+            } else {
+              host.declare(`declare ptr @scr_dyn_new_bool(i1 zeroext)`);
+              B.line(`${boxed} = call ptr @scr_dyn_new_bool(i1 ${e})`);
+            }
+            B.line(`call void @scr_dyn_arr_push(ptr ${d}, ptr ${boxed})`);
           } else {
-            host.declare(`declare ptr @scr_dyn_new_bool(i1 zeroext)`);
-            B.line(`${boxed} = call ptr @scr_dyn_new_bool(i1 ${e})`);
+            host.declare(`declare ptr @scr_arr_get_ref(ptr, double)`);
+            const e = B.tmp();
+            B.line(`${e} = call ptr @scr_arr_get_ref(ptr %v, double ${i}) ; +1`);
+            const conv = B.tmp();
+            B.line(`${conv} = call ptr @${this.toDynHelper(elem)}(ptr ${e})`);
+            B.line(`call void @scr_dyn_arr_push(ptr ${d}, ptr ${conv})`);
+            B.line(`call void ${releaseSym(host, elem)}(ptr ${e})`);
           }
-          B.line(`call void @scr_dyn_arr_push(ptr ${d}, ptr ${boxed})`);
-        } else {
-          host.declare(`declare ptr @scr_arr_get_ref(ptr, double)`);
-          const e = B.tmp();
-          B.line(`${e} = call ptr @scr_arr_get_ref(ptr %v, double ${i}) ; +1`);
-          const conv = B.tmp();
-          B.line(`${conv} = call ptr @${this.toDynHelper(elem)}(ptr ${e})`);
-          B.line(`call void @scr_dyn_arr_push(ptr ${d}, ptr ${conv})`);
-          B.line(`call void ${releaseSym(host, elem)}(ptr ${e})`);
-        }
-        const i2 = B.tmp();
-        B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
-        B.line(`store double ${i2}, ptr ${iSlot}`);
-        B.br(lc);
-        B.startBlock(le);
+        });
         if (cyclicArr) B.line(`call void @scr_dyn_from_leave()`);
         B.terminate(`ret ptr ${d}`);
         break;

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -62,6 +62,7 @@ import { InternalCompilerError } from "../../errors.js";
  * lazy-inflate representation as the C debugging backend.
  */
 import { deflateRawSync } from "node:zlib";
+import { endsWithJump, isStableBytesOperand, newValueMayThrow, streamTypedRefEligible, undefinedArmTag } from "../../ir/analysis.js";
 import { emitLibraryIdentityLines } from "../library-identity.js";
 import type {
   IrBytesElem,
@@ -2952,14 +2953,6 @@ class LlEmitter {
     return `@${sym}`;
   }
 
-  /** The undefined arm's tag of a union type, or -1 (not a union / no
-   * undefined arm). */
-  undefinedArmTag(t: IrType): number {
-    if (t.kind !== "union") return -1;
-    const def = this.unionsById.get(t.unionId);
-    return def ? def.arms.findIndex((a) => a.kind === "undefinedT") : -1;
-  }
-
   declare(decl: string): void {
     this.decls.add(decl);
   }
@@ -3045,12 +3038,6 @@ class LlEmitter {
   private releaseForJump(frameDepth: number, scopeDepth: number): void {
     for (let i = this.frames.length - 1; i >= frameDepth; i--) this.releaseFrame(this.frames[i]!);
     for (let i = this.scopes.length - 1; i >= scopeDepth; i--) this.releaseScope(this.scopes[i]!);
-  }
-
-  private endsWithJump(stmts: IrStmt[]): boolean {
-    const last = stmts[stmts.length - 1]?.kind;
-    return last === "return" || last === "break" || last === "continue" ||
-      last === "throw" || last === "rethrow" || last === "runtimeFence";
   }
 
   /** THE unwind path at a point where an exception is pending: release
@@ -3380,15 +3367,6 @@ class LlEmitter {
     const meta = this.classMeta.get(className);
     if (!meta) throw new InternalCompilerError(`llvm emitter bug: unknown class ${className}`);
     return meta;
-  }
-
-  /** True when construction through a classval of `className` can throw:
-   * the runtime callee is the static class's constructor or any strict
-   * descendant's (classval flows never leave the subtree). */
-  private newValueMayThrow(className: string): boolean {
-    const any = (m: LlClassMeta): boolean =>
-      this.mayThrow.has(`%${m.def.name}.constructor`) || m.children.some(any);
-    return any(this.classMetaOf(className));
   }
 
   /** The field-slot pointer of a class member: rc at 0, the vtable word at
@@ -3890,7 +3868,7 @@ class LlEmitter {
     this.scopes.push(scope);
     setup?.(scope);
     this.emitStmts(stmts);
-    const ended = this.endsWithJump(stmts);
+    const ended = endsWithJump(stmts);
     this.scopes.pop();
     if (!ended) this.releaseScope(scope);
   }
@@ -4388,7 +4366,7 @@ class LlEmitter {
           if (isRefCounted(elem)) this.scopes[this.scopes.length - 1]!.push({ slot, type: elem });
         }
         this.emitStmts(s.body);
-        const endedWithJump = this.endsWithJump(s.body);
+        const endedWithJump = endsWithJump(s.body);
         const scope = this.scopes.pop()!;
         if (!endedWithJump) this.releaseScope(scope);
         this.jumpTargets.pop();
@@ -4753,7 +4731,7 @@ class LlEmitter {
     // Natural fall-off of the last body releases the shared scope; a jump
     // already released it before jumping.
     const lastBody = s.cases[s.cases.length - 1]?.body;
-    if (!lastBody || !this.endsWithJump(lastBody)) this.releaseScope(scope);
+    if (!lastBody || !endsWithJump(lastBody)) this.releaseScope(scope);
     B.br(end);
     B.startBlock(end);
   }
@@ -5133,31 +5111,12 @@ class LlEmitter {
         const acc = elemAccess(elem);
         let fill = acc === "f64" ? f64Lit(0) : acc === "bool" ? "false" : "null";
         if (elem.kind === "union") {
-          const tag = this.undefinedArmTag(elem);
+          const tag = undefinedArmTag(elem, this.unionsById);
           if (tag >= 0) fill = this.unitInstanceRef(elem.unionId, tag);
         }
-        const iSlot = B.slot();
-        B.entryAllocas.push(`${iSlot} = alloca double`);
-        B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
-        const lc = B.newLabel("anl.c");
-        const lb = B.newLabel("anl.b");
-        const le = B.newLabel("anl.e");
         const bound = B.tmp();
         B.line(`${bound} = fsub double ${n.name}, ${f64Lit(1)}`);
-        B.br(lc);
-        B.startBlock(lc);
-        const i = B.tmp();
-        const cont = B.tmp();
-        B.line(`${i} = load double, ptr ${iSlot}`);
-        B.line(`${cont} = fcmp ole double ${i}, ${bound}`);
-        B.condBr(cont, lb, le);
-        B.startBlock(lb);
-        this.arrPush(arr, acc, fill);
-        const i2 = B.tmp();
-        B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
-        B.line(`store double ${i2}, ptr ${iSlot}`);
-        B.br(lc);
-        B.startBlock(le);
+        B.countedLoop(bound, () => this.arrPush(arr, acc, fill), "ole");
         return out;
       }
       case "arrayGet": {
@@ -5887,7 +5846,7 @@ class LlEmitter {
           return this.own({ name: t, type: e.type });
         }
         if (e.type.kind !== "union") throw new LlvmUnsupportedError(`optChainResult:${e.type.kind}`, e.loc);
-        const undefTag = this.undefinedArmTag(e.type);
+        const undefTag = undefinedArmTag(e.type, this.unionsById);
         if (undefTag < 0) throw new InternalCompilerError("llvm emitter bug: optChain result lacks its undefined arm");
         const ty = this.llType(e.type);
         const slot = B.slot();
@@ -6588,7 +6547,7 @@ class LlEmitter {
         const t = B.tmp();
         B.line(`${t} = call ptr ${thunk}(${argList})`);
         const out = this.own({ name: t, type: e.type });
-        if (this.newValueMayThrow(cls)) this.emitPendingCheck();
+        if (newValueMayThrow(cls, this.classMeta, this.mayThrow)) this.emitPendingCheck();
         return out;
       }
       case "seqExpr": {
@@ -7288,7 +7247,7 @@ class LlEmitter {
             B.line(`${boxed} = call ptr @${adapter}(ptr ${v.name})`);
             return this.own({ name: boxed, type: e.type });
           }
-          if (!this.streamTypedRefEligible(v.type)) {
+          if (!streamTypedRefEligible(v.type)) {
             throw new InternalCompilerError(`llvm emitter bug: live dyn ref of ${typeKey(v.type)}`);
           }
           const key = typeKey(v.type);
@@ -8205,7 +8164,7 @@ class LlEmitter {
           B.line(`${t} = call ${this.llType(e.type)} @${helper}(ptr ${dom}, ptr null)`);
           return t;
         };
-        const undefTag = e.type.kind === "union" ? this.undefinedArmTag(e.type) : -1;
+        const undefTag = e.type.kind === "union" ? undefinedArmTag(e.type, this.unionsById) : -1;
         if (e.type.kind === "union" && undefTag >= 0) {
           this.declare(`declare zeroext i1 @scr_jsval_is_undefined(ptr)`);
           const isU = B.tmp();
@@ -8438,7 +8397,7 @@ class LlEmitter {
           this.declare(`declare ptr @scr_json_parse(ptr)`);
           this.declare(`declare void @scr_str_release(ptr)`);
           this.declare(`declare void @scr_dyn_release(ptr)`);
-          const utag = p.kind === "union" ? this.undefinedArmTag(p) : -1;
+          const utag = p.kind === "union" ? undefinedArmTag(p, this.unionsById) : -1;
           const b = blk++;
           if (p.kind === "union" && utag >= 0) {
             this.declare(`declare zeroext i1 @scr_jsval_is_undefined(ptr)`);
@@ -9886,28 +9845,11 @@ class LlEmitter {
     this.declare(`declare ${acc === "bool" ? "zeroext i1" : accTy} @scr_arr_get_${acc}(ptr, double)`);
     const len = B.tmp();
     B.line(`${len} = call double @scr_arr_len(ptr ${src})`);
-    const iSlot = B.slot();
-    B.entryAllocas.push(`${iSlot} = alloca double`);
-    B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
-    const lc = B.newLabel("cp.c");
-    const lb = B.newLabel("cp.b");
-    const le = B.newLabel("cp.e");
-    B.br(lc);
-    B.startBlock(lc);
-    const i = B.tmp();
-    const cont = B.tmp();
-    B.line(`${i} = load double, ptr ${iSlot}`);
-    B.line(`${cont} = fcmp olt double ${i}, ${len}`);
-    B.condBr(cont, lb, le);
-    B.startBlock(lb);
-    const v = B.tmp();
-    B.line(`${v} = call ${accTy} @scr_arr_get_${acc}(ptr ${src}, double ${i})`);
-    this.arrPush(dst, acc, v);
-    const i2 = B.tmp();
-    B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
-    B.line(`store double ${i2}, ptr ${iSlot}`);
-    B.br(lc);
-    B.startBlock(le);
+    B.countedLoop(len, (i) => {
+      const v = B.tmp();
+      B.line(`${v} = call ${accTy} @scr_arr_get_${acc}(ptr ${src}, double ${i})`);
+      this.arrPush(dst, acc, v);
+    });
   }
 
   private emitStrIntrinsic(e: IrExpr & { kind: "strIntrinsic" }): LlValue {
@@ -10215,7 +10157,7 @@ class LlEmitter {
         if (e.type.kind !== "union") throw new InternalCompilerError("llvm emitter bug: shift result is not a union");
         const def = this.unionsById.get(e.type.unionId);
         const tag = def ? def.arms.findIndex((a) => typeEquals(a, elem)) : -1;
-        const undefTag = this.undefinedArmTag(e.type);
+        const undefTag = undefinedArmTag(e.type, this.unionsById);
         if (tag < 0 || undefTag < 0) throw new InternalCompilerError("llvm emitter bug: shift union lacks its arms");
         this.declare(`declare double @scr_arr_len(ptr)`);
         const slot = B.slot();
@@ -10342,7 +10284,7 @@ class LlEmitter {
         const k = this.emitExpr(e.args[0]!);
         if (e.type.kind !== "union") throw new InternalCompilerError("llvm emitter bug: map get result is not a union");
         const def = this.unionsById.get(e.type.unionId);
-        const undefTag = this.undefinedArmTag(e.type);
+        const undefTag = undefinedArmTag(e.type, this.unionsById);
         if (!def || undefTag < 0) throw new InternalCompilerError("llvm emitter bug: map get union lacks its undefined arm");
         const absent = this.unitInstanceRef(e.type.unionId, undefTag);
         if (value.kind === "union") {
@@ -10520,59 +10462,12 @@ class LlEmitter {
     return out;
   }
 
-  /** Whether an index/value expression can overwrite the bytes receiver
-   * binding. Kept deliberately conservative; uncertain or calling shapes
-   * retain the ordinary owned-receiver snapshot. */
-  private isStableBytesOperand(e: IrExpr, receiverLocalId: string): boolean {
-    switch (e.kind) {
-      case "numLit":
-      case "boolLit":
-      case "varRef":
-      case "incDec":
-        return true;
-      case "assignExpr":
-        // A bytes assignment nested under truthiness/ternary can still
-        // produce the numeric index/value expected by the outer access.
-        return (
-          e.localId !== receiverLocalId &&
-          this.isStableBytesOperand(e.value, receiverLocalId)
-        );
-      case "bin":
-        return (
-          this.isStableBytesOperand(e.left, receiverLocalId) &&
-          this.isStableBytesOperand(e.right, receiverLocalId)
-        );
-      case "unary":
-      case "toBool":
-        return this.isStableBytesOperand(e.operand, receiverLocalId);
-      case "logical":
-        return (
-          this.isStableBytesOperand(e.left, receiverLocalId) &&
-          this.isStableBytesOperand(e.right, receiverLocalId)
-        );
-      case "ternary":
-        return (
-          this.isStableBytesOperand(e.cond, receiverLocalId) &&
-          this.isStableBytesOperand(e.then, receiverLocalId) &&
-          this.isStableBytesOperand(e.else_, receiverLocalId)
-        );
-      case "bytesIntrinsic":
-        return (
-          (e.method === "get" || e.method === "length" || e.method === "byteLength") &&
-          e.receiver.kind === "varRef" &&
-          e.args.every((arg) => this.isStableBytesOperand(arg, receiverLocalId))
-        );
-      default:
-        return false;
-    }
-  }
-
   /** Borrow a direct, unboxed bytes binding when later operands are stable.
    * Its scope/global owner keeps it alive through the access. */
   private emitBytesReceiver(receiver: IrExpr, following: IrExpr[]): LlValue {
     if (
       receiver.kind === "varRef" &&
-      following.every((operand) => this.isStableBytesOperand(operand, receiver.localId))
+      following.every((operand) => isStableBytesOperand(operand, receiver.localId))
     ) {
       const b = this.binding(receiver.localId);
       if (b.kind !== "boxed") {
@@ -11353,12 +11248,12 @@ class LlEmitter {
       B.br(join);
       return;
     }
-    if (resultType.kind !== "union" || this.undefinedArmTag(resultType) < 0) {
+    if (resultType.kind !== "union" || undefinedArmTag(resultType, this.unionsById) < 0) {
       this.keyedRecordReadDirectInto(slot, join, objName, keyName, shapeId, resultType, overflowOnly, loc);
       return;
     }
     const def = this.unionsById.get(resultType.unionId)!;
-    const undefTag = this.undefinedArmTag(resultType);
+    const undefTag = undefinedArmTag(resultType, this.unionsById);
     const ty = this.llType(resultType);
     // How a hit of type `vt` surfaces as the result union (the C helper's
     // `surface`): the same union passes through; anything else wraps into
@@ -11701,7 +11596,7 @@ class LlEmitter {
     }
     const mutableArms = union.arms
       .map((arm, tag) => ({ arm, tag }))
-      .filter(({ arm }) => this.streamTypedRefEligible(arm));
+      .filter(({ arm }) => streamTypedRefEligible(arm));
     if (mutableArms.length === 0) {
       throw new InternalCompilerError(`llvm emitter bug: live dyn ref of immutable union ${key}`);
     }
@@ -11766,10 +11661,6 @@ class LlEmitter {
     return sym;
   }
 
-  private streamTypedRefEligible(t: IrType): boolean {
-    return t.kind === "record" || t.kind === "array" || t.kind === "bytes";
-  }
-
   private streamTypedRefBoxValue(
     B: BlockBuilder,
     t: IrType,
@@ -11777,7 +11668,7 @@ class LlEmitter {
     ctx: LlStreamTypedRefContext,
   ): string {
     const boxed = B.tmp();
-    if (!this.streamTypedRefEligible(t)) {
+    if (!streamTypedRefEligible(t)) {
       const valueTy = t.kind === "f64"
         ? "double"
         : t.kind === "bool"
@@ -11905,43 +11796,26 @@ class LlEmitter {
       B.line(`${out} = call ptr @scr_dyn_new_arr()`);
       const len = B.tmp();
       B.line(`${len} = call double @scr_arr_len(ptr %p)`);
-      const iSlot = B.slot();
-      B.entryAllocas.push(`${iSlot} = alloca double`);
-      B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
-      const condition = B.newLabel("strm.c");
-      const body = B.newLabel("strm.b");
-      const done = B.newLabel("strm.e");
-      B.br(condition);
-      B.startBlock(condition);
-      const index = B.tmp();
-      const more = B.tmp();
-      B.line(`${index} = load double, ptr ${iSlot}`);
-      B.line(`${more} = fcmp olt double ${index}, ${len}`);
-      B.condBr(more, body, done);
-      B.startBlock(body);
-      let value: string;
-      if (elem.kind === "f64" || elem.kind === "bool") {
-        const valueTy = elem.kind === "f64" ? "double" : "i1";
-        this.declare(
-          `declare ${elem.kind === "bool" ? "zeroext i1" : valueTy} @scr_arr_get_${elem.kind}(ptr, double)`,
-        );
-        value = B.tmp();
-        B.line(`${value} = call ${valueTy} @scr_arr_get_${elem.kind}(ptr %p, double ${index})`);
-      } else {
-        this.declare(`declare ptr @scr_arr_get_ref(ptr, double)`);
-        value = B.tmp();
-        B.line(`${value} = call ptr @scr_arr_get_ref(ptr %p, double ${index}) ; +1`);
-      }
-      const boxed = this.streamTypedRefBoxValue(B, elem, value, ctx);
-      B.line(`call void @scr_dyn_arr_push(ptr ${out}, ptr ${boxed})`);
-      if (isRefCounted(elem)) {
-        B.line(`call void ${releaseSym(this, elem)}(ptr ${value})`);
-      }
-      const next = B.tmp();
-      B.line(`${next} = fadd double ${index}, ${f64Lit(1)}`);
-      B.line(`store double ${next}, ptr ${iSlot}`);
-      B.br(condition);
-      B.startBlock(done);
+      B.countedLoop(len, (index) => {
+        let value: string;
+        if (elem.kind === "f64" || elem.kind === "bool") {
+          const valueTy = elem.kind === "f64" ? "double" : "i1";
+          this.declare(
+            `declare ${elem.kind === "bool" ? "zeroext i1" : valueTy} @scr_arr_get_${elem.kind}(ptr, double)`,
+          );
+          value = B.tmp();
+          B.line(`${value} = call ${valueTy} @scr_arr_get_${elem.kind}(ptr %p, double ${index})`);
+        } else {
+          this.declare(`declare ptr @scr_arr_get_ref(ptr, double)`);
+          value = B.tmp();
+          B.line(`${value} = call ptr @scr_arr_get_ref(ptr %p, double ${index}) ; +1`);
+        }
+        const boxed = this.streamTypedRefBoxValue(B, elem, value, ctx);
+        B.line(`call void @scr_dyn_arr_push(ptr ${out}, ptr ${boxed})`);
+        if (isRefCounted(elem)) {
+          B.line(`call void ${releaseSym(this, elem)}(ptr ${value})`);
+        }
+      });
       B.terminate(`ret ptr ${out}`);
     } else {
       const out = B.tmp();
@@ -12077,7 +11951,7 @@ class LlEmitter {
       const rc = vAdapters(this, elem);
       const keyPtr = this.cstr(key);
       let commit: string;
-      if (this.streamTypedRefEligible(elem)) {
+      if (streamTypedRefEligible(elem)) {
         commit = this.streamTypedRefMaterializeAdapter(
           elem,
           { prefix: snapshot, adapters: new Map() },
@@ -12659,7 +12533,7 @@ class LlEmitter {
       if (e.type.kind !== "union") throw new InternalCompilerError("llvm emitter bug: spawnRes.error result is not a union");
       const def = this.unionsById.get(e.type.unionId);
       const errTag = def ? def.arms.findIndex((a) => a.kind === "object" && a.className === "%Error") : -1;
-      const undefTag = this.undefinedArmTag(e.type);
+      const undefTag = undefinedArmTag(e.type, this.unionsById);
       if (errTag < 0 || undefTag < 0) throw new InternalCompilerError("llvm emitter bug: spawnRes.error union lacks its arms");
       const recv = this.emitExpr(e.args[0]!);
       this.declare(`declare ptr @scr_spawn_res_error(ptr)`);
@@ -12937,7 +12811,7 @@ class LlEmitter {
         } else {
           const st = shape.fields.find((f) => f.name === "scopeid")?.type;
           if (st?.kind !== "union") throw new InternalCompilerError("llvm emitter bug: networkInterfaces IPv4 scopeid type");
-          const undefTag = this.undefinedArmTag(st);
+          const undefTag = undefinedArmTag(st, this.unionsById);
           const su = B.tmp();
           B.line(`${su} = call ptr @scr_union_retain_v(ptr ${this.unitInstanceRef(st.unionId, undefTag)})`);
           B.line(`store ptr ${su}, ptr ${this.recordFieldPtr(r, t.shapeId, "scopeid").ptr}`);
@@ -13823,7 +13697,7 @@ class LlEmitter {
       if (e.type.kind !== "union") throw new InternalCompilerError(`llvm emitter bug: ${e.fn} result is not a union`);
       const def = this.unionsById.get(e.type.unionId);
       const strTag = def ? def.arms.findIndex((a) => a.kind === "string") : -1;
-      const undefTag = this.undefinedArmTag(e.type);
+      const undefTag = undefinedArmTag(e.type, this.unionsById);
       if (strTag < 0 || undefTag < 0) throw new InternalCompilerError(`llvm emitter bug: ${e.fn} union lacks its arms`);
       const entry = {
         "net.sockRemoteAddress": "scr_net_sock_remote_address",
@@ -13843,7 +13717,7 @@ class LlEmitter {
       if (e.type.kind !== "union") throw new InternalCompilerError("llvm emitter bug: net.sockEncrypted result is not a union");
       const def = this.unionsById.get(e.type.unionId);
       const boolTag = def ? def.arms.findIndex((a) => a.kind === "bool") : -1;
-      const undefTag = this.undefinedArmTag(e.type);
+      const undefTag = undefinedArmTag(e.type, this.unionsById);
       if (boolTag < 0 || undefTag < 0) throw new InternalCompilerError("llvm emitter bug: net.sockEncrypted union lacks its arms");
       const args = e.args.map((a) => this.emitExpr(a));
       this.declare(`declare zeroext i1 @scr_net_sock_encrypted(ptr)`);
@@ -13875,7 +13749,7 @@ class LlEmitter {
       if (e.type.kind !== "union") throw new InternalCompilerError("llvm emitter bug: http.reqStatusCode result is not a union");
       const def = this.unionsById.get(e.type.unionId);
       const f64Tag = def ? def.arms.findIndex((a) => a.kind === "f64") : -1;
-      const undefTag = this.undefinedArmTag(e.type);
+      const undefTag = undefinedArmTag(e.type, this.unionsById);
       if (f64Tag < 0 || undefTag < 0) throw new InternalCompilerError("llvm emitter bug: http.reqStatusCode union lacks its arms");
       const args = e.args.map((a) => this.emitExpr(a));
       this.declare(`declare double @scr_http_req_status(ptr)`);
@@ -14100,7 +13974,7 @@ class LlEmitter {
       if (e.type.kind !== "union") throw new InternalCompilerError(`llvm emitter bug: ${e.fn} result is not a union`);
       const def = this.unionsById.get(e.type.unionId);
       const strTag = def ? def.arms.findIndex((a) => a.kind === "string") : -1;
-      const undefTag = this.undefinedArmTag(e.type);
+      const undefTag = undefinedArmTag(e.type, this.unionsById);
       if (strTag < 0 || undefTag < 0) throw new InternalCompilerError(`llvm emitter bug: ${e.fn} union lacks its arms`);
       const v = this.emitExpr(e.args[0]!);
       const sym = e.fn === "sym.desc" ? "scr_sym_desc" : "scr_sym_key_for";
@@ -14142,7 +14016,7 @@ class LlEmitter {
       if (e.type.kind !== "union") throw new InternalCompilerError("llvm emitter bug: error.code result is not a union");
       const def = this.unionsById.get(e.type.unionId);
       const strTag = def ? def.arms.findIndex((a) => a.kind === "string") : -1;
-      const undefTag = this.undefinedArmTag(e.type);
+      const undefTag = undefinedArmTag(e.type, this.unionsById);
       if (strTag < 0 || undefTag < 0) throw new InternalCompilerError("llvm emitter bug: error.code union lacks its arms");
       const recv = this.emitExpr(e.args[0]!);
       this.declare(`declare ptr @scr_error_code(ptr)`);
@@ -14167,7 +14041,7 @@ class LlEmitter {
       // the interned immortal undefined-arm instance.
       if (e.type.kind !== "union") throw new InternalCompilerError(`llvm emitter bug: ${e.fn} result is not a union`);
       const def = this.unionsById.get(e.type.unionId);
-      const undefTag = this.undefinedArmTag(e.type);
+      const undefTag = undefinedArmTag(e.type, this.unionsById);
       const isEnv = e.fn === "process.envGet";
       const valTag = def ? def.arms.findIndex((a) => a.kind === (isEnv ? "string" : "f64")) : -1;
       if (valTag < 0 || undefTag < 0) throw new InternalCompilerError(`llvm emitter bug: ${e.fn} union lacks its arms`);

--- a/packages/compiler/src/backend/llvm/walkers.ts
+++ b/packages/compiler/src/backend/llvm/walkers.ts
@@ -19,6 +19,7 @@ import { mangleRecordStruct } from "../mangle.js";
 import { BlockBuilder } from "./blocks.js";
 import { llFieldType, releaseSym, traceAdapter, type ShapeHost } from "./shapes.js";
 import { LlvmUnsupportedError } from "./unsupported.js";
+import { undefinedArmTag } from "../../ir/analysis.js";
 
 /** What the walkers need from the emitter beyond the shape tables: union
  * defs, the undefined-arm probe, interned ScrStr literals (unit-arm
@@ -26,7 +27,6 @@ import { LlvmUnsupportedError } from "./unsupported.js";
  * scr_error-style label texts). */
 export interface WalkerHost extends ShapeHost {
   readonly unionsById: Map<string, IrUnionDef>;
-  undefinedArmTag(t: IrType): number;
   /** `@`-ref of an interned immortal ScrStr literal. */
   internLiteral(text: string): string;
   /** `@`-ref of an interned NUL-terminated byte-array constant. */
@@ -265,7 +265,7 @@ export class LlWalkers {
     const byName = new Map(shape.fields.map((f) => [f.name, f]));
     const emitFields = order.map((n) => byName.get(n)).filter((f) => f !== undefined);
     const droppable =
-      emitFields.some((f) => this.host.undefinedArmTag(f.type) >= 0) || !!shape.indexValue;
+      emitFields.some((f) => undefinedArmTag(f.type, this.host.unionsById) >= 0) || !!shape.indexValue;
     this.putc(B, "%b", "123"); // '{'
     if (!droppable) {
       emitFields.forEach((f, i) => {
@@ -291,7 +291,7 @@ export class LlWalkers {
         B.line(`store i1 false, ptr ${first}`);
       };
       for (const f of emitFields) {
-        const utag = this.host.undefinedArmTag(f.type);
+        const utag = undefinedArmTag(f.type, this.host.unionsById);
         const v = this.loadField(B, "%v", shapeId, fieldIndex.get(f.name)!, f.type);
         let skip: string | null = null;
         if (utag >= 0) {
@@ -337,105 +337,85 @@ export class LlWalkers {
     const len = B.tmp();
     B.line(`${ks} = call ptr @scr_map_keys_js_order(ptr ${ovf})`);
     B.line(`${len} = call double @scr_arr_len(ptr ${ks})`);
-    const iSlot = B.slot();
-    B.entryAllocas.push(`${iSlot} = alloca double`);
-    B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
-    const lc = B.newLabel("ovf.c");
-    const lb = B.newLabel("ovf.b");
-    const ln = B.newLabel("ovf.n");
-    const le = B.newLabel("ovf.e");
-    B.br(lc);
-    B.startBlock(lc);
-    const i = B.tmp();
-    const cont = B.tmp();
-    B.line(`${i} = load double, ptr ${iSlot}`);
-    B.line(`${cont} = fcmp olt double ${i}, ${len}`);
-    B.condBr(cont, lb, le);
-    B.startBlock(lb);
-    const k = B.tmp();
-    B.line(`${k} = call ptr @scr_arr_get_ref(ptr ${ks}, double ${i}) ; key (+1)`);
-    // The entry value, type-directed off the overflow VALUE type.
-    let val: string;
-    if (iv.kind === "f64" || iv.kind === "bool") {
-      const outTy = iv.kind === "f64" ? "double" : "i8";
-      const outSlot = B.slot();
-      B.entryAllocas.push(`${outSlot} = alloca ${outTy}`);
-      B.line(`store ${outTy} ${iv.kind === "f64" ? f64Lit(0) : "0"}, ptr ${outSlot}`);
-      host.declare(`declare zeroext i1 @scr_map_get_str_${iv.kind === "f64" ? "f64" : "bool"}(ptr, ptr, ptr)`);
-      const found = B.tmp();
-      B.line(`${found} = call zeroext i1 @scr_map_get_str_${iv.kind === "f64" ? "f64" : "bool"}(ptr ${ovf}, ptr ${k}, ptr ${outSlot})`);
-      const raw = B.tmp();
-      B.line(`${raw} = load ${outTy}, ptr ${outSlot}`);
-      if (iv.kind === "bool") {
-        val = B.tmp();
-        B.line(`${val} = trunc i8 ${raw} to i1`);
+    B.countedLoop(len, (i, next) => {
+      const k = B.tmp();
+      B.line(`${k} = call ptr @scr_arr_get_ref(ptr ${ks}, double ${i}) ; key (+1)`);
+      // The entry value, type-directed off the overflow VALUE type.
+      let val: string;
+      if (iv.kind === "f64" || iv.kind === "bool") {
+        const outTy = iv.kind === "f64" ? "double" : "i8";
+        const outSlot = B.slot();
+        B.entryAllocas.push(`${outSlot} = alloca ${outTy}`);
+        B.line(`store ${outTy} ${iv.kind === "f64" ? f64Lit(0) : "0"}, ptr ${outSlot}`);
+        host.declare(`declare zeroext i1 @scr_map_get_str_${iv.kind === "f64" ? "f64" : "bool"}(ptr, ptr, ptr)`);
+        const found = B.tmp();
+        B.line(`${found} = call zeroext i1 @scr_map_get_str_${iv.kind === "f64" ? "f64" : "bool"}(ptr ${ovf}, ptr ${k}, ptr ${outSlot})`);
+        const raw = B.tmp();
+        B.line(`${raw} = load ${outTy}, ptr ${outSlot}`);
+        if (iv.kind === "bool") {
+          val = B.tmp();
+          B.line(`${val} = trunc i8 ${raw} to i1`);
+        } else {
+          val = raw;
+        }
       } else {
-        val = raw;
+        host.declare(`declare ptr @scr_map_get_str_ref(ptr, ptr)`);
+        val = B.tmp();
+        B.line(`${val} = call ptr @scr_map_get_str_ref(ptr ${ovf}, ptr ${k}) ; value (+1)`);
       }
-    } else {
-      host.declare(`declare ptr @scr_map_get_str_ref(ptr, ptr)`);
-      val = B.tmp();
-      B.line(`${val} = call ptr @scr_map_get_str_ref(ptr ${ovf}, ptr ${k}) ; value (+1)`);
-    }
-    // Undefined-valued entries drop, exactly the optional-field rule: a
-    // dyn value whose dyn kind follows its size_t RC word (enum
-    // member 6 — scr_runtime.h's ScrDynKind), or a union holding its
-    // undefined arm.
-    let skipUndef: string | null = null;
-    if (iv.kind === "dyn") {
-      const kp = B.tmp();
-      const kd = B.tmp();
-      const isu = B.tmp();
-      B.line(`${kp} = getelementptr inbounds i8, ptr ${val}, i64 ${this.abiOffset(8, 4)} ; ->kind`);
-      B.line(`${kd} = load i32, ptr ${kp}`);
-      B.line(`${isu} = icmp eq i32 ${kd}, 6 ; SCR_DYN_UNDEF (NULL is 0 — null members DO serialize)`);
-      skipUndef = isu;
-    } else if (this.host.undefinedArmTag(iv) >= 0) {
-      const tag = this.unionTag(B, val);
-      const isu = B.tmp();
-      B.line(`${isu} = icmp eq i32 ${tag}, ${this.host.undefinedArmTag(iv)}`);
-      skipUndef = isu;
-    }
-    if (skipUndef !== null) {
-      const ld = B.newLabel("ovf.d");
-      const write = B.newLabel("ovf.w");
-      B.condBr(skipUndef, ld, write);
-      B.startBlock(ld);
-      if (isRefCounted(iv)) B.line(`call void ${releaseSym(host, iv)}(ptr ${val})`);
+      // Undefined-valued entries drop, exactly the optional-field rule: a
+      // dyn value whose dyn kind follows its size_t RC word (enum
+      // member 6 — scr_runtime.h's ScrDynKind), or a union holding its
+      // undefined arm.
+      let skipUndef: string | null = null;
+      if (iv.kind === "dyn") {
+        const kp = B.tmp();
+        const kd = B.tmp();
+        const isu = B.tmp();
+        B.line(`${kp} = getelementptr inbounds i8, ptr ${val}, i64 ${this.abiOffset(8, 4)} ; ->kind`);
+        B.line(`${kd} = load i32, ptr ${kp}`);
+        B.line(`${isu} = icmp eq i32 ${kd}, 6 ; SCR_DYN_UNDEF (NULL is 0 — null members DO serialize)`);
+        skipUndef = isu;
+      } else if (undefinedArmTag(iv, this.host.unionsById) >= 0) {
+        const tag = this.unionTag(B, val);
+        const isu = B.tmp();
+        B.line(`${isu} = icmp eq i32 ${tag}, ${undefinedArmTag(iv, this.host.unionsById)}`);
+        skipUndef = isu;
+      }
+      if (skipUndef !== null) {
+        const ld = B.newLabel("ovf.d");
+        const write = B.newLabel("ovf.w");
+        B.condBr(skipUndef, ld, write);
+        B.startBlock(ld);
+        if (isRefCounted(iv)) B.line(`call void ${releaseSym(host, iv)}(ptr ${val})`);
+        B.line(`call void @scr_str_release(ptr ${k})`);
+        B.br(next);
+        B.startBlock(write);
+      }
+      // The comma dance over the shared `first` flag.
+      {
+        const isf = B.tmp();
+        const lcm = B.newLabel("ovf.cm");
+        const lj = B.newLabel("ovf.cj");
+        B.line(`${isf} = load i1, ptr ${first}`);
+        B.condBr(isf, lj, lcm);
+        B.startBlock(lcm);
+        this.putc(B, "%b", "44"); // ','
+        B.br(lj);
+        B.startBlock(lj);
+        B.line(`store i1 false, ptr ${first}`);
+      }
+      host.declare(`declare void @scr_jb_put_json_str(ptr, ptr)`);
+      B.line(`call void @scr_jb_put_json_str(ptr %b, ptr ${k})`);
+      this.putc(B, "%b", "58"); // ':'
+      if (edgeKeys) {
+        this.host.declare(`declare void @scr_jb_edge_key(ptr, ptr)`);
+        B.line(`call void @scr_jb_edge_key(ptr %b, ptr ${k})`);
+      }
+      B.line(`call void @${this.jsonWriteHelper(iv)}(ptr %b, ${this.valTy(iv)} ${val})`);
       B.line(`call void @scr_str_release(ptr ${k})`);
-      B.br(ln);
-      B.startBlock(write);
-    }
-    // The comma dance over the shared `first` flag.
-    {
-      const isf = B.tmp();
-      const lcm = B.newLabel("ovf.cm");
-      const lj = B.newLabel("ovf.cj");
-      B.line(`${isf} = load i1, ptr ${first}`);
-      B.condBr(isf, lj, lcm);
-      B.startBlock(lcm);
-      this.putc(B, "%b", "44"); // ','
-      B.br(lj);
-      B.startBlock(lj);
-      B.line(`store i1 false, ptr ${first}`);
-    }
-    host.declare(`declare void @scr_jb_put_json_str(ptr, ptr)`);
-    B.line(`call void @scr_jb_put_json_str(ptr %b, ptr ${k})`);
-    this.putc(B, "%b", "58"); // ':'
-    if (edgeKeys) {
-      this.host.declare(`declare void @scr_jb_edge_key(ptr, ptr)`);
-      B.line(`call void @scr_jb_edge_key(ptr %b, ptr ${k})`);
-    }
-    B.line(`call void @${this.jsonWriteHelper(iv)}(ptr %b, ${this.valTy(iv)} ${val})`);
-    B.line(`call void @scr_str_release(ptr ${k})`);
-    if (isRefCounted(iv)) B.line(`call void ${releaseSym(host, iv)}(ptr ${val})`);
-    B.br(ln);
-    B.startBlock(ln);
-    const i2 = B.tmp();
-    B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
-    B.line(`store double ${i2}, ptr ${iSlot}`);
-    B.br(lc);
-    B.startBlock(le);
+      if (isRefCounted(iv)) B.line(`call void ${releaseSym(host, iv)}(ptr ${val})`);
+    });
     host.declare(`declare void @scr_arr_release(ptr)`);
     B.line(`call void @scr_arr_release(ptr ${ks})`);
   }
@@ -450,54 +430,37 @@ export class LlWalkers {
     this.putc(B, "%b", "91"); // '['
     const len = B.tmp();
     B.line(`${len} = call double @scr_arr_len(ptr %v)`);
-    const iSlot = B.slot();
-    B.entryAllocas.push(`${iSlot} = alloca double`);
-    B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
-    const lc = B.newLabel("jwa.c");
-    const lb = B.newLabel("jwa.b");
-    const le = B.newLabel("jwa.e");
-    B.br(lc);
-    B.startBlock(lc);
-    const i = B.tmp();
-    const cont = B.tmp();
-    B.line(`${i} = load double, ptr ${iSlot}`);
-    B.line(`${cont} = fcmp olt double ${i}, ${len}`);
-    B.condBr(cont, lb, le);
-    B.startBlock(lb);
-    const nz = B.tmp();
-    const lcm = B.newLabel("jwa.cm");
-    const lj = B.newLabel("jwa.cj");
-    B.line(`${nz} = fcmp ogt double ${i}, ${f64Lit(0)}`);
-    B.condBr(nz, lcm, lj);
-    B.startBlock(lcm);
-    this.putc(B, "%b", "44"); // ','
-    B.br(lj);
-    B.startBlock(lj);
-    if (cyclic) {
-      const idx = B.tmp();
-      B.line(`${idx} = fptoui double ${i} to ${this.S}`);
-      this.jbEdgeIdx(B, idx);
-    }
-    if (elem.kind === "f64" || elem.kind === "bool") {
-      const acc = elem.kind;
-      const accTy = elem.kind === "f64" ? "double" : "i1";
-      host.declare(`declare ${elem.kind === "bool" ? "zeroext i1" : accTy} @scr_arr_get_${acc}(ptr, double)`);
-      const v = B.tmp();
-      B.line(`${v} = call ${accTy} @scr_arr_get_${acc}(ptr %v, double ${i})`);
-      B.line(`call void @${w}(ptr %b, ${accTy} ${v})`);
-    } else {
-      // _get_ref returns +1; release after writing.
-      host.declare(`declare ptr @scr_arr_get_ref(ptr, double)`);
-      const v = B.tmp();
-      B.line(`${v} = call ptr @scr_arr_get_ref(ptr %v, double ${i})`);
-      B.line(`call void @${w}(ptr %b, ptr ${v})`);
-      B.line(`call void ${releaseSym(host, elem)}(ptr ${v})`);
-    }
-    const i2 = B.tmp();
-    B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
-    B.line(`store double ${i2}, ptr ${iSlot}`);
-    B.br(lc);
-    B.startBlock(le);
+    B.countedLoop(len, (i) => {
+      const nz = B.tmp();
+      const lcm = B.newLabel("jwa.cm");
+      const lj = B.newLabel("jwa.cj");
+      B.line(`${nz} = fcmp ogt double ${i}, ${f64Lit(0)}`);
+      B.condBr(nz, lcm, lj);
+      B.startBlock(lcm);
+      this.putc(B, "%b", "44"); // ','
+      B.br(lj);
+      B.startBlock(lj);
+      if (cyclic) {
+        const idx = B.tmp();
+        B.line(`${idx} = fptoui double ${i} to ${this.S}`);
+        this.jbEdgeIdx(B, idx);
+      }
+      if (elem.kind === "f64" || elem.kind === "bool") {
+        const acc = elem.kind;
+        const accTy = elem.kind === "f64" ? "double" : "i1";
+        host.declare(`declare ${elem.kind === "bool" ? "zeroext i1" : accTy} @scr_arr_get_${acc}(ptr, double)`);
+        const v = B.tmp();
+        B.line(`${v} = call ${accTy} @scr_arr_get_${acc}(ptr %v, double ${i})`);
+        B.line(`call void @${w}(ptr %b, ${accTy} ${v})`);
+      } else {
+        // _get_ref returns +1; release after writing.
+        host.declare(`declare ptr @scr_arr_get_ref(ptr, double)`);
+        const v = B.tmp();
+        B.line(`${v} = call ptr @scr_arr_get_ref(ptr %v, double ${i})`);
+        B.line(`call void @${w}(ptr %b, ptr ${v})`);
+        B.line(`call void ${releaseSym(host, elem)}(ptr ${v})`);
+      }
+    });
     this.putc(B, "%b", "93"); // ']'
     if (cyclic) this.jbLeave(B);
   }
@@ -872,71 +835,52 @@ export class LlWalkers {
     host.declare(`declare void @scr_str_release(ptr)`);
     const B = new BlockBuilder();
     const buf = "%jb";
-    const iSlot = "%i";
-    B.entryAllocas.push(`${buf} = alloca %ScrJsonBuf`, `${iSlot} = alloca double`);
+    B.entryAllocas.push(`${buf} = alloca %ScrJsonBuf`);
     B.line(`call void @scr_jb_init(ptr ${buf})`);
-    B.line(`store double ${f64Lit(0)}, ptr ${iSlot}`);
     const len = B.tmp();
     B.line(`${len} = call double @scr_arr_len(ptr %a)`);
-    const lc = B.newLabel("uj.c");
-    const lb = B.newLabel("uj.b");
-    const ln = B.newLabel("uj.n");
-    const le = B.newLabel("uj.e");
-    B.br(lc);
-    B.startBlock(lc);
-    const i = B.tmp();
-    const cont = B.tmp();
-    B.line(`${i} = load double, ptr ${iSlot}`);
-    B.line(`${cont} = fcmp olt double ${i}, ${len}`);
-    B.condBr(cont, lb, le);
-    B.startBlock(lb);
-    // `if (i) put sep bytes` — separators between elements only.
-    const nz = B.tmp();
-    const lsep = B.newLabel("uj.s");
-    const lel = B.newLabel("uj.v");
-    B.line(`${nz} = fcmp ogt double ${i}, ${f64Lit(0)}`);
-    B.condBr(nz, lsep, lel);
-    B.startBlock(lsep);
-    this.putScrStr(B, buf, "%sep");
-    B.br(lel);
-    B.startBlock(lel);
-    const u = B.tmp();
-    B.line(`${u} = call ptr @scr_arr_get_ref(ptr %a, double ${i}) ; element (+1)`);
-    if (unitTags.length > 0) {
-      // Nullish arms print empty, exactly JS's join.
-      const tag = this.unionTag(B, u);
-      let acc = "";
-      for (const t of unitTags) {
-        const cnd = B.tmp();
-        B.line(`${cnd} = icmp eq i32 ${tag}, ${t}`);
-        if (acc === "") {
-          acc = cnd;
-        } else {
-          const o = B.tmp();
-          B.line(`${o} = or i1 ${acc}, ${cnd}`);
-          acc = o;
+    B.countedLoop(len, (i, next) => {
+      // `if (i) put sep bytes` — separators between elements only.
+      const nz = B.tmp();
+      const lsep = B.newLabel("uj.s");
+      const lel = B.newLabel("uj.v");
+      B.line(`${nz} = fcmp ogt double ${i}, ${f64Lit(0)}`);
+      B.condBr(nz, lsep, lel);
+      B.startBlock(lsep);
+      this.putScrStr(B, buf, "%sep");
+      B.br(lel);
+      B.startBlock(lel);
+      const u = B.tmp();
+      B.line(`${u} = call ptr @scr_arr_get_ref(ptr %a, double ${i}) ; element (+1)`);
+      if (unitTags.length > 0) {
+        // Nullish arms print empty, exactly JS's join.
+        const tag = this.unionTag(B, u);
+        let acc = "";
+        for (const t of unitTags) {
+          const cnd = B.tmp();
+          B.line(`${cnd} = icmp eq i32 ${tag}, ${t}`);
+          if (acc === "") {
+            acc = cnd;
+          } else {
+            const o = B.tmp();
+            B.line(`${o} = or i1 ${acc}, ${cnd}`);
+            acc = o;
+          }
         }
+        const lskip = B.newLabel("uj.k");
+        const lwrite = B.newLabel("uj.w");
+        B.condBr(acc, lskip, lwrite);
+        B.startBlock(lskip);
+        B.line(`call void @scr_union_release(ptr ${u})`);
+        B.br(next);
+        B.startBlock(lwrite);
       }
-      const lskip = B.newLabel("uj.k");
-      const lwrite = B.newLabel("uj.w");
-      B.condBr(acc, lskip, lwrite);
-      B.startBlock(lskip);
+      const s = B.tmp();
+      B.line(`${s} = call ptr @${toStr}(ptr ${u})`);
+      this.putScrStr(B, buf, s);
+      B.line(`call void @scr_str_release(ptr ${s})`);
       B.line(`call void @scr_union_release(ptr ${u})`);
-      B.br(ln);
-      B.startBlock(lwrite);
-    }
-    const s = B.tmp();
-    B.line(`${s} = call ptr @${toStr}(ptr ${u})`);
-    this.putScrStr(B, buf, s);
-    B.line(`call void @scr_str_release(ptr ${s})`);
-    B.line(`call void @scr_union_release(ptr ${u})`);
-    B.br(ln);
-    B.startBlock(ln);
-    const i2 = B.tmp();
-    B.line(`${i2} = fadd double ${i}, ${f64Lit(1)}`);
-    B.line(`store double ${i2}, ptr ${iSlot}`);
-    B.br(lc);
-    B.startBlock(le);
+    });
     const r = B.tmp();
     B.line(`${r} = call ptr @scr_jb_finish(ptr ${buf})`);
     B.terminate(`ret ptr ${r}`);

--- a/packages/compiler/src/frontend/lowering/lower-assert.ts
+++ b/packages/compiler/src/frontend/lowering/lower-assert.ts
@@ -28,7 +28,7 @@ import { jsFuncNameOf, own } from "./lowerer.js";
 import { NARROW_FIRST } from "./surfaces.js";
 import { typeReachesItself } from "./lower-inspect.js";
 import { BOOL, CAUGHT, DYN, DYN_HANDLE_KINDS, F64, IrExpr, IrLibFn, IrStmt, IrType, REGEX, RUNTIME_ERROR_CLASSES, STRING, SrcLoc, VOID, isUnitType, typeEquals, typeKey } from "../../ir/nodes.js";
-import { boolLit, numLit, strLit, varRef } from "../../ir/build.js";
+import { boolLit, countedFor, numLit, strLit, varRef } from "../../ir/build.js";
 
 /** node:assert/strict binds the loose NAMES to the strict comparisons —
  * Node's own aliasing (`strict.equal === assert.strictEqual`). */
@@ -1337,14 +1337,7 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
       locals.push({ id: "i.0", name: "i", type: F64, mutable: true });
       body = [
         bailIf(neq(len(a()), len(b()))),
-        {
-          kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-          cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: len(a()), type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
-          body: [bailIf(not(deq(t.elem, at(a(), varRef("i.0", F64, loc)), at(b(), varRef("i.0", F64, loc)))))],
-          loc,
-        },
+        countedFor(loc, len(a()), (i) => [bailIf(not(deq(t.elem, at(a(), i), at(b(), i))))]),
         ret(boolLit(true, loc)),
       ];
       break;
@@ -1412,12 +1405,7 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
             };
       body = [
         bailIf(neq(mi("size", a(), [], F64), mi("size", b(), [], F64))),
-        {
-          kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-          cond: { kind: "bin", op: "<", left: i(), right: mi("iterCount", a(), [], F64), type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: numLit(1, loc), type: F64, loc }, loc },
-          body: [
+        countedFor(loc, mi("iterCount", a(), [], F64), () => [
             { kind: "if", cond: not(mi("iterLive", a(), [i()], BOOL)), then: [{ kind: "continue", loc }], else_: null, loc },
             { kind: "varDecl", localId: "k.0", init: mi("iterKey", a(), [i()], t.key), loc },
             bailIf(not(mi("has", b(), [k()], BOOL))),
@@ -1425,8 +1413,7 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
             { kind: "varDecl", localId: "bv.0", init: mi("get", b(), [k()], getT), loc },
             bailIf(not(deq(valueT, varRef("av.0", valueT, loc), bValue))),
           ],
-          loc,
-        },
+        ),
         ret(boolLit(true, loc)),
       ];
       break;
@@ -1437,17 +1424,11 @@ function deepEqHelper(L: Lowerer, t: IrType, loc: SrcLoc): string {
       const i = (): IrExpr => varRef("i.0", F64, loc);
       body = [
         bailIf(neq(si("size", a(), [], F64), si("size", b(), [], F64))),
-        {
-          kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-          cond: { kind: "bin", op: "<", left: i(), right: si("iterCount", a(), [], F64), type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: i(), right: numLit(1, loc), type: F64, loc }, loc },
-          body: [
+        countedFor(loc, si("iterCount", a(), [], F64), () => [
             { kind: "if", cond: not(si("iterLive", a(), [i()], BOOL)), then: [{ kind: "continue", loc }], else_: null, loc },
             bailIf(not(si("has", b(), [si("iterKey", a(), [i()], t.elem)], BOOL))),
           ],
-          loc,
-        },
+        ),
         ret(boolLit(true, loc)),
       ];
       break;

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -33,7 +33,7 @@ import { CRYPTO_CIPHERS, CRYPTO_CONSTANTS, CRYPTO_CURVES, CRYPTO_HASHES } from "
 import { timerStyleCallback } from "./lower-calls.js";
 import { registerHttpClientFnBinding, voidizedCallback } from "./lower-server.js";
 import { BOOL, BYTES_U8, CHILD_T, CHILDSTREAM_T, DYN, F64, FILEHANDLE_T, FSWATCHER_T, PROCSTREAM_T, IrExpr, IrFunction, IrLibFn, IrLocal, IrStmt, IrType, JSVAL, NULL_T, SEARCH_PARAMS_T, SPAWNRES_T, STRING, SrcLoc, UNDEFINED_T, VOID, arrayOf, canBoxFuncIntoDyn, canConvertToDyn, funcOf, isUnitType, typeEquals, typeKey } from "../../ir/nodes.js";
-import { boolLit, numLit, strLit, varRef } from "../../ir/build.js";
+import { boolLit, countedFor, numLit, strLit, varRef } from "../../ir/build.js";
 
 /** Lower an optional builtin argument whose checker type is statically
  * undefined/void. The returned expression exists only to preserve effects;
@@ -4361,19 +4361,7 @@ function optionMember(p: ts.ObjectLiteralElementLike): { name: string; value: ts
       expr: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: callArgs, type: fnRet, loc },
       loc,
     });
-    const loop: IrStmt = {
-      kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-      cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: sp("sp.size", [], F64), type: BOOL, loc },
-      update: {
-        kind: "assign",
-        localId: "i.0",
-        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-        loc,
-      },
-      body,
-      loc,
-    };
+    const loop = countedFor(loc, sp("sp.size", [], F64), () => body);
     return {
       name,
       params: [

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -27,7 +27,7 @@ import { ambientNsRootOf, ambientUndefReadType, ambientUndefVarRootOf, ambientUn
 import { declSymbolOf } from "./lower-modules.js";
 import { expandoMemberRead } from "./lower-expando.js";
 import { npmStaticPackageOfPath } from "../npm-static.js";
-import { numLit, varRef } from "../../ir/build.js";
+import { countedFor, varRef } from "../../ir/build.js";
 
 /** How a parameter participates in CALL-SITE COMPLETION (the frontend
  * completes every call to the one full signature, so the IR and backends
@@ -6752,17 +6752,7 @@ export function lowerPromiseMethodCall(L: Lowerer, call: ts.CallExpression,
         init: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: F64, loc },
         loc,
       },
-      {
-        kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
-        update: {
-          kind: "assign",
-          localId: "i.0",
-          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-          loc,
-        },
-        body: [
+      countedFor(loc, varRef("n.0", F64, loc), () => [
           {
             kind: "varDecl",
             localId: "v.0",
@@ -6790,8 +6780,7 @@ export function lowerPromiseMethodCall(L: Lowerer, call: ts.CallExpression,
             loc,
           },
         ],
-        loc,
-      },
+      ),
       { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     L.liftedFns.push({ name, params, returnType: outT, locals, body, loc });

--- a/packages/compiler/src/frontend/lowering/lower-containers.ts
+++ b/packages/compiler/src/frontend/lowering/lower-containers.ts
@@ -13,7 +13,7 @@ import { isJsSourceFile, locOf } from "../program.js";
 import { islandPrimitiveExit, lowerDynDispatchMethodCall } from "./lower-calls.js";
 import { typeKey } from "../types.js";
 import { dynUndefinedExpr, own, WidthLift } from "./lowerer.js";
-import { boolLit, numLit, varRef } from "../../ir/build.js";
+import { boolLit, countedFor, numLit, varRef } from "../../ir/build.js";
 
 /** Lower an expression whose checker type is statically `undefined`/`void`.
  * Optional builtin arguments use this before their ordinary expected-type
@@ -1018,19 +1018,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       init: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: F64, loc },
       loc,
     };
-    const forLoop = (body: IrStmt[]): IrStmt => ({
-      kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-      cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
-      update: {
-        kind: "assign",
-        localId: "i.0",
-        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-        loc,
-      },
-      body,
-      loc,
-    });
+    const forLoop = (body: IrStmt[]): IrStmt =>
+      countedFor(loc, varRef("n.0", F64, loc), () => body);
 
     let returnType: IrType;
     let body: IrStmt[];
@@ -1190,24 +1179,28 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
       type: resultT,
       loc,
     };
+    const visit: IrStmt[] = [
+      { kind: "varDecl", localId: "v.0", init: getElemExpr(arrT, elem, loc), loc },
+      {
+        kind: "if",
+        cond: predToBool({
+          kind: "callValue",
+          callee: varRef("f.0", fnT, loc),
+          args: [v, varRef("i.0", F64, loc), varRef("a.0", arrT, loc)].slice(0, arity),
+          type: fnRet,
+          loc,
+        }),
+        then: [{ kind: "return", value: found, loc }],
+        else_: null,
+        loc,
+      },
+    ];
+    const loop = last
+      ? reverseCountedForLoop(loc, visit)
+      : countedFor(loc, varRef("n.0", F64, loc), () => visit);
     const body: IrStmt[] = [
       readLenStmt(arrT, loc),
-      (last ? reverseCountedForLoop : countedForLoop)(loc, [
-        { kind: "varDecl", localId: "v.0", init: getElemExpr(arrT, elem, loc), loc },
-        {
-          kind: "if",
-          cond: predToBool({
-            kind: "callValue",
-            callee: varRef("f.0", fnT, loc),
-            args: [v, varRef("i.0", F64, loc), varRef("a.0", arrT, loc)].slice(0, arity),
-            type: fnRet,
-            loc,
-          }),
-          then: [{ kind: "return", value: found, loc }],
-          else_: null,
-          loc,
-        },
-      ]),
+      loop,
       { kind: "return", value: miss, loc },
     ];
     L.liftedFns.push({
@@ -1245,23 +1238,25 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     const arrT = arrayOf(elem);
     const fnT = funcOf([elem, F64, arrT].slice(0, arity), fnRet);
 
+    const visit: IrStmt[] = [{
+      kind: "if",
+      cond: predToBool({
+        kind: "callValue",
+        callee: varRef("f.0", fnT, loc),
+        args: [getElemExpr(arrT, elem, loc), varRef("i.0", F64, loc), varRef("a.0", arrT, loc)].slice(0, arity),
+        type: fnRet,
+        loc,
+      }),
+      then: [{ kind: "return", value: varRef("i.0", F64, loc), loc }],
+      else_: null,
+      loc,
+    }];
+    const loop = last
+      ? reverseCountedForLoop(loc, visit)
+      : countedFor(loc, varRef("n.0", F64, loc), () => visit);
     const body: IrStmt[] = [
       readLenStmt(arrT, loc),
-      (last ? reverseCountedForLoop : countedForLoop)(loc, [
-        {
-          kind: "if",
-          cond: predToBool({
-            kind: "callValue",
-            callee: varRef("f.0", fnT, loc),
-            args: [getElemExpr(arrT, elem, loc), varRef("i.0", F64, loc), varRef("a.0", arrT, loc)].slice(0, arity),
-            type: fnRet,
-            loc,
-          }),
-          then: [{ kind: "return", value: varRef("i.0", F64, loc), loc }],
-          else_: null,
-          loc,
-        },
-      ]),
+      loop,
       { kind: "return", value: { kind: "numLit", value: -1, type: F64, loc }, loc },
     ];
     L.liftedFns.push({
@@ -1309,7 +1304,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     });
     const body: IrStmt[] = [
       readLenStmt(arrT, loc),
-      countedForLoop(loc, [
+      countedFor(loc, varRef("n.0", F64, loc), () => [
         {
           kind: "if",
           cond: method === "some" ? callF : { kind: "unary", op: "!", operand: callF, type: BOOL, loc },
@@ -1428,7 +1423,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     const body: IrStmt[] = [
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: fnRet, loc }, loc },
       readLenStmt(arrT, loc),
-      countedForLoop(loc, [
+      countedFor(loc, varRef("n.0", F64, loc), () => [
         {
           kind: "varDecl",
           localId: "r.0",
@@ -1880,24 +1875,27 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
           }]
         : []),
       readLenStmt(arrT, loc),
-      {
-        kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: numLit(1, loc), loc },
-        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
-        update: {
-          kind: "assign",
-          localId: "i.0",
-          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-          loc,
-        },
-        body: [
-          { kind: "varDecl", localId: "v.0", init: getElemExpr(arrT, elem, loc), loc },
-          { kind: "varDecl", localId: "j.0", init: { kind: "bin", op: "-", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
+      countedFor(
+        loc,
+        { kind: "bin", op: "-", left: varRef("n.0", F64, loc), right: numLit(1, loc), type: F64, loc },
+        (index) => [
+          {
+            kind: "varDecl",
+            localId: "v.0",
+            init: {
+              kind: "arrayGet",
+              arr: varRef("a.0", arrT, loc),
+              index: { kind: "bin", op: "+", left: index, right: numLit(1, loc), type: F64, loc },
+              type: elem,
+              loc,
+            },
+            loc,
+          },
+          { kind: "varDecl", localId: "j.0", init: index, loc },
           shiftLoop,
           { kind: "arraySet", arr: varRef("a.0", arrT, loc), index: jPlus1, value: varRef("v.0", elem, loc), loc },
         ],
-        loc,
-      },
+      ),
       { kind: "return", value: varRef("a.0", arrT, loc), loc },
     ];
     return {
@@ -2240,33 +2238,8 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     };
   }
 
-/** `for (i = 0; i < n; i++) { ...body }` over the conventional locals. */
-  function countedForLoop(loc: SrcLoc, body: IrStmt[]): IrStmt {
-    const i: IrExpr = { kind: "varRef", localId: "i.0", type: F64, loc };
-    return {
-      kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: { kind: "numLit", value: 0, type: F64, loc }, loc },
-      cond: {
-        kind: "bin",
-        op: "<",
-        left: i,
-        right: { kind: "varRef", localId: "n.0", type: F64, loc },
-        type: BOOL,
-        loc,
-      },
-      update: {
-        kind: "assign",
-        localId: "i.0",
-        value: { kind: "bin", op: "+", left: i, right: { kind: "numLit", value: 1, type: F64, loc }, type: F64, loc },
-        loc,
-      },
-      body,
-      loc,
-    };
-  }
-
 /** `for (i = n - 1; i >= 0; i--) { ...body }` over the conventional locals
-   * — countedForLoop walked backwards (the findLast pair's descending
+   * — countedFor walked backwards (the findLast pair's descending
    * index walk). */
   function reverseCountedForLoop(loc: SrcLoc, body: IrStmt[]): IrStmt {
     const i: IrExpr = { kind: "varRef", localId: "i.0", type: F64, loc };
@@ -2610,24 +2583,10 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
     };
     const body: IrStmt[] = [
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
-      {
-        kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-        cond: {
-          kind: "bin",
-          op: "<=",
-          left: varRef("i.0", F64, loc),
-          right: { kind: "bin", op: "-", left: varRef("n.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-          type: BOOL,
-          loc,
-        },
-        update: {
-          kind: "assign",
-          localId: "i.0",
-          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-          loc,
-        },
-        body: [
+      countedFor(
+        loc,
+        { kind: "libCall", fn: "math.floor", args: [varRef("n.0", F64, loc)], type: F64, loc },
+        () => [
           {
             kind: "exprStmt",
             expr: {
@@ -2649,8 +2608,7 @@ function filterCond(call: IrExpr, fnRet: IrType, loc: SrcLoc): IrExpr {
             loc,
           },
         ],
-        loc,
-      },
+      ),
       { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     return {
@@ -2833,17 +2791,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
             };
     const body: IrStmt[] = [
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
-      {
-        kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: iter("iterCount", [], F64), type: BOOL, loc },
-        update: {
-          kind: "assign",
-          localId: "i.0",
-          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-          loc,
-        },
-        body: [
+      countedFor(loc, iter("iterCount", [], F64), () => [
           {
             kind: "if",
             cond: iter("iterLive", [varRef("i.0", F64, loc)], BOOL),
@@ -2858,8 +2806,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
             loc,
           },
         ],
-        loc,
-      },
+      ),
       { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     return {
@@ -2983,24 +2930,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
       expr: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: callArgs, type: fnRet, loc },
       loc,
     });
-    const loop: IrStmt = {
-      kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-      cond: {
-        kind: "bin",
-        op: "<",
-        left: varRef("i.0", F64, loc),
-        right: iter("iterCount", [], F64),
-        type: BOOL,
-        loc,
-      },
-      update: {
-        kind: "assign",
-        localId: "i.0",
-        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-        loc,
-      },
-      body: [
+    const loop = countedFor(loc, iter("iterCount", [], F64), () => [
         {
           kind: "if",
           cond: iter("iterLive", [varRef("i.0", F64, loc)], BOOL),
@@ -3009,8 +2939,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
           loc,
         },
       ],
-      loc,
-    };
+    );
     const body: IrStmt[] = [
       { kind: "exprStmt", expr: iter("iterEnter", [], VOID), loc },
       {
@@ -3173,24 +3102,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
       expr: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: callArgs, type: fnRet, loc },
       loc,
     });
-    const loop: IrStmt = {
-      kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-      cond: {
-        kind: "bin",
-        op: "<",
-        left: varRef("i.0", F64, loc),
-        right: iter("iterCount", [], F64),
-        type: BOOL,
-        loc,
-      },
-      update: {
-        kind: "assign",
-        localId: "i.0",
-        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-        loc,
-      },
-      body: [
+    const loop = countedFor(loc, iter("iterCount", [], F64), () => [
         {
           kind: "if",
           cond: iter("iterLive", [varRef("i.0", F64, loc)], BOOL),
@@ -3199,8 +3111,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
           loc,
         },
       ],
-      loc,
-    };
+    );
     const body: IrStmt[] = [
       { kind: "exprStmt", expr: iter("iterEnter", [], VOID), loc },
       {
@@ -3403,12 +3314,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
         loc,
       },
       { kind: "varDecl", localId: "n.0", init: { kind: "arrIntrinsic", method: "length", receiver: varRef("items.0", itemsT, loc), args: [], type: F64, loc }, loc },
-      {
-        kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
-        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
-        body: [
+      countedFor(loc, varRef("n.0", F64, loc), () => [
           { kind: "varDecl", localId: "v.0", init: { kind: "arrayGet", arr: varRef("items.0", itemsT, loc), index: varRef("i.0", F64, loc), type: elem, loc }, loc },
           { kind: "varDecl", localId: "k.0", init: { kind: "callValue", callee: varRef("f.0", fnT, loc), args: callArgs, type: keyT, loc }, loc },
           { kind: "varDecl", localId: "cur.0", init: groupRead(), loc },
@@ -3433,8 +3339,7 @@ const MAP_ITER_METHODS = new Set(["keys", "values", "entries"]);
             loc,
           },
         ],
-        loc,
-      },
+      ),
       { kind: "return", value: gRef(), loc },
     ];
     return {
@@ -4838,24 +4743,10 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
     const e = varRef("e.0", tupleT, loc);
     const body: IrStmt[] = [
       { kind: "varDecl", localId: "m.0", init: { kind: "mapNew", type: mapT, loc }, loc },
-      {
-        kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-        cond: {
-          kind: "bin",
-          op: "<",
-          left: varRef("i.0", F64, loc),
-          right: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: F64, loc },
-          type: BOOL,
-          loc,
-        },
-        update: {
-          kind: "assign",
-          localId: "i.0",
-          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-          loc,
-        },
-        body: [
+      countedFor(
+        loc,
+        { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", arrT, loc), args: [], type: F64, loc },
+        () => [
           { kind: "varDecl", localId: "e.0", init: getElemExpr(arrT, tupleT, loc), loc },
           {
             kind: "exprStmt",
@@ -4873,8 +4764,7 @@ const ITER_TERMINALS = new Set(["toArray", "forEach", "reduce", "some", "every",
             loc,
           },
         ],
-        loc,
-      },
+      ),
       { kind: "return", value: varRef("m.0", mapT, loc), loc },
     ];
     return {
@@ -6416,29 +6306,11 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
               };
       body.push(
         { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: rRef, shapeId: argIr.shapeId, type: ksT, loc }, loc },
-        {
-          kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-          cond: {
-            kind: "bin",
-            op: "<",
-            left: varRef("i.0", F64, loc),
-            right: { kind: "arrIntrinsic", method: "length", receiver: ksRef, args: [], type: F64, loc },
-            type: BOOL,
-            loc,
-          },
-          update: {
-            kind: "assign",
-            localId: "i.0",
-            value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-            loc,
-          },
-          body: [
+        countedFor(loc, { kind: "arrIntrinsic", method: "length", receiver: ksRef, args: [], type: F64, loc }, () => [
             { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: ksRef, index: varRef("i.0", F64, loc), type: STRING, loc }, loc },
             push(loopPushed),
           ],
-          loc,
-        },
+        ),
         { kind: "return", value: outRef, loc },
       );
       const suffix = body.slice(1 + fieldStmts.size);
@@ -6540,39 +6412,25 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
     if (!helper) {
       helper = `%obj.fromEntries.${L.arrHofHelpers.size}`;
 
-      const tRef = varRef("t.0", argIr.elem, loc);
+      const tupleT = argIr.elem as IrType & { kind: "record" };
+      const tRef = varRef("t.0", tupleT, loc);
       const body: IrStmt[] = [
         { kind: "varDecl", localId: "out.0", init: { kind: "recordLit", fields: [], type: resultT, loc }, loc },
-        {
-          kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-          cond: {
-            kind: "bin",
-            op: "<",
-            left: varRef("i.0", F64, loc),
-            right: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", argIr, loc), args: [], type: F64, loc },
-            type: BOOL,
-            loc,
-          },
-          update: {
-            kind: "assign",
-            localId: "i.0",
-            value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-            loc,
-          },
-          body: [
-            { kind: "varDecl", localId: "t.0", init: { kind: "arrayGet", arr: varRef("a.0", argIr, loc), index: varRef("i.0", F64, loc), type: argIr.elem, loc }, loc },
+        countedFor(
+          loc,
+          { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", argIr, loc), args: [], type: F64, loc },
+          () => [
+            { kind: "varDecl", localId: "t.0", init: { kind: "arrayGet", arr: varRef("a.0", argIr, loc), index: varRef("i.0", F64, loc), type: tupleT, loc }, loc },
             {
               kind: "recordKeySet",
               obj: varRef("out.0", resultT, loc),
               shapeId: resultT.shapeId,
-              key: { kind: "recordGet", obj: tRef, shapeId: argIr.elem.shapeId, field: "0", type: STRING, loc },
-              value: convert({ kind: "recordGet", obj: tRef, shapeId: argIr.elem.shapeId, field: "1", type: valT, loc })!,
+              key: { kind: "recordGet", obj: tRef, shapeId: tupleT.shapeId, field: "0", type: STRING, loc },
+              value: convert({ kind: "recordGet", obj: tRef, shapeId: tupleT.shapeId, field: "1", type: valT, loc })!,
               loc,
             },
           ],
-          loc,
-        },
+        ),
         { kind: "return", value: varRef("out.0", resultT, loc), loc },
       ];
       L.arrHofHelpers.set(key, helper);
@@ -6584,7 +6442,7 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
           { id: "a.0", name: "a", type: argIr, mutable: true },
           { id: "out.0", name: "out", type: resultT, mutable: false },
           { id: "i.0", name: "i", type: F64, mutable: true },
-          { id: "t.0", name: "t", type: argIr.elem, mutable: false },
+          { id: "t.0", name: "t", type: tupleT, mutable: false },
         ],
         body,
         loc,
@@ -6623,24 +6481,10 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
         ({ kind: "bin", op: ">=", left: rowLen, right: numLit(n, loc), type: BOOL, loc });
       const body: IrStmt[] = [
         { kind: "varDecl", localId: "out.0", init: { kind: "recordLit", fields: [], type: resultT, loc }, loc },
-        {
-          kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-          cond: {
-            kind: "bin",
-            op: "<",
-            left: varRef("i.0", F64, loc),
-            right: { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", argIr, loc), args: [], type: F64, loc },
-            type: BOOL,
-            loc,
-          },
-          update: {
-            kind: "assign",
-            localId: "i.0",
-            value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-            loc,
-          },
-          body: [
+        countedFor(
+          loc,
+          { kind: "arrIntrinsic", method: "length", receiver: varRef("a.0", argIr, loc), args: [], type: F64, loc },
+          () => [
             { kind: "varDecl", localId: "t.0", init: { kind: "arrayGet", arr: varRef("a.0", argIr, loc), index: varRef("i.0", F64, loc), type: rowT, loc }, loc },
             {
               kind: "recordKeySet",
@@ -6672,8 +6516,7 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
               loc,
             },
           ],
-          loc,
-        },
+        ),
         { kind: "return", value: varRef("out.0", resultT, loc), loc },
       ];
       L.arrHofHelpers.set(key, helper);
@@ -6882,24 +6725,10 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
       const ovfLift = slotLift(fIv)!;
       body.push(
         { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: sRef, shapeId: fromId, type: ksT, loc }, loc },
-        {
-          kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-          cond: {
-            kind: "bin",
-            op: "<",
-            left: varRef("i.0", F64, loc),
-            right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
-            type: BOOL,
-            loc,
-          },
-          update: {
-            kind: "assign",
-            localId: "i.0",
-            value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-            loc,
-          },
-          body: [
+        countedFor(
+          loc,
+          { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
+          () => [
             { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: varRef("ks.0", ksT, loc), index: varRef("i.0", F64, loc), type: STRING, loc }, loc },
             {
               kind: "recordKeySet",
@@ -6910,8 +6739,7 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
               loc,
             },
           ],
-          loc,
-        },
+        ),
       );
     }
     body.push({ kind: "return", value: outRef, loc });
@@ -7058,38 +6886,24 @@ const DV_SETTERS: Record<string, { method: IrBytesIntrinsicMethod; le: boolean }
       const fromShape = L.shapes.get(plan.fromId)!;
       if (plan.ovfLift !== null && fromShape.indexValue) {
         const fIv = fromShape.indexValue;
+        const ovfLift = plan.ovfLift;
         body.push(
           { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: sRef, shapeId: plan.fromId, type: ksT, loc }, loc },
-          {
-            kind: "for",
-            init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-            cond: {
-              kind: "bin",
-              op: "<",
-              left: varRef("i.0", F64, loc),
-              right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
-              type: BOOL,
-              loc,
-            },
-            update: {
-              kind: "assign",
-              localId: "i.0",
-              value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc },
-              loc,
-            },
-            body: [
+          countedFor(
+            loc,
+            { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
+            () => [
               { kind: "varDecl", localId: "k.0", init: { kind: "arrayGet", arr: varRef("ks.0", ksT, loc), index: varRef("i.0", F64, loc), type: STRING, loc }, loc },
               {
                 kind: "recordKeySet",
                 obj: tRef,
                 shapeId: targetIr.shapeId,
                 key: varRef("k.0", STRING, loc),
-                value: intoSlot({ kind: "recordKeyGet", obj: sRef, shapeId: plan.fromId, key: varRef("k.0", STRING, loc), overflowOnly: true, type: fIv, loc }, plan.ovfLift),
+                value: intoSlot({ kind: "recordKeyGet", obj: sRef, shapeId: plan.fromId, key: varRef("k.0", STRING, loc), overflowOnly: true, type: fIv, loc }, ovfLift),
                 loc,
               },
             ],
-            loc,
-          },
+          ),
         );
       }
       body.push({ kind: "return", value: tRef, loc });
@@ -7576,14 +7390,11 @@ export type IndexMergeContributor =
       innerBody.push(writeFor(varRef("k.0", STRING, loc), rawRef, iv));
       body.push(
         { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: sRef, shapeId, type: ksT, loc }, loc },
-        {
-          kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-          cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc }, type: BOOL, loc },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
-          body: innerBody,
+        countedFor(
           loc,
-        },
+          { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
+          () => innerBody,
+        ),
       );
     }
     body.push({ kind: "return", value: outRef, loc });
@@ -7875,12 +7686,7 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
         loc,
       },
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
-      {
-        kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
-        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
-        body: [
+      countedFor(loc, varRef("n.0", F64, loc), () => [
           {
             kind: "varDecl",
             localId: "v.0",
@@ -7927,8 +7733,7 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
             loc,
           },
         ],
-        loc,
-      },
+      ),
       { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     return {
@@ -8000,12 +7805,7 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
         loc,
       },
       { kind: "varDecl", localId: "out.0", init: { kind: "arrayLit", elems: [], type: outT, loc }, loc },
-      {
-        kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-        cond: { kind: "bin", op: "<", left: varRef("i.0", F64, loc), right: varRef("n.0", F64, loc), type: BOOL, loc },
-        update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
-        body: [
+      countedFor(loc, varRef("n.0", F64, loc), () => [
           {
             kind: "varDecl",
             localId: "v.0",
@@ -8039,8 +7839,7 @@ function dynRecvThrows(dRef: IrExpr, mRef: IrExpr, fullRef: IrExpr, loc: SrcLoc)
             loc,
           },
         ],
-        loc,
-      },
+      ),
       { kind: "return", value: varRef("out.0", outT, loc), loc },
     ];
     return {

--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -27,7 +27,7 @@ import { mixinFnOfCallee } from "./lower-mixins.js";
 import { isConstAssertionTypeNode, isGenericCallableMemberType, isParseArgsDynTypeName, underConstAssertion, unitOnlyUnion } from "../types.js";
 import { lowerYield } from "./lower-generators.js";
 import { lowerStreamProperty, lowerStreamStateProperty, streamSidesOf } from "./lower-stream.js";
-import { numLit, varRef } from "../../ir/build.js";
+import { countedFor, numLit, varRef } from "../../ir/build.js";
 
 /** An assignable `obj.field` target — a class field, a record field, or a
  * class ACCESSOR property (reads become getter calls, writes setter calls;
@@ -9458,19 +9458,10 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
       const ksT = arrayOf(STRING);
       body.push(
         { kind: "varDecl", localId: "ks.0", init: { kind: "recordOvfKeys", obj: r, shapeId: recvT.shapeId, type: ksT, loc }, loc },
-        {
-          kind: "for",
-          init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-          cond: {
-            kind: "bin",
-            op: "<",
-            left: varRef("i.0", F64, loc),
-            right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
-            type: BOOL,
-            loc,
-          },
-          update: { kind: "assign", localId: "i.0", value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(1, loc), type: F64, loc }, loc },
-          body: [
+        countedFor(
+          loc,
+          { kind: "arrIntrinsic", method: "length", receiver: varRef("ks.0", ksT, loc), args: [], type: F64, loc },
+          () => [
             {
               kind: "if",
               cond: { kind: "strEq", negated: false, left: k, right: { kind: "arrayGet", arr: varRef("ks.0", ksT, loc), index: varRef("i.0", F64, loc), type: STRING, loc }, type: BOOL, loc },
@@ -9479,8 +9470,7 @@ export function lowerBinary(L: Lowerer, expr: ts.BinaryExpression): IrExpr {
               loc,
             },
           ],
-          loc,
-        },
+        ),
         ret({ kind: "boolLit", value: false, type: BOOL, loc }),
       );
       L.liftedFns.push({

--- a/packages/compiler/src/frontend/npm-static-rewrite.ts
+++ b/packages/compiler/src/frontend/npm-static-rewrite.ts
@@ -76,8 +76,10 @@
 import { dirname, join, resolve as resolvePath } from "node:path";
 import ts from "typescript5";
 import { cjsLexedExportsOf, cjsLexerVisibleNames } from "./cjs-lexer.js";
-import { resolveExports } from "./npm.js";
 import { trackedDirectoryExists, trackedFileExists, trackedReadFile } from "./input-tracker.js";
+import { resolveExports } from "./resolve.js";
+
+const NODE_REQUIRE_CONDITIONS = new Set(["require", "node", "default"]);
 
 /** True when `e` is exactly the `exports` identifier. */
 function isExportsIdent(e: ts.Expression): boolean {
@@ -290,7 +292,7 @@ function resolveBareRequireCjs(fromFile: string, spec: string): string | null {
           return null;
         }
         if (exports !== undefined) {
-          const target = resolveExports(exports, subpath, "require");
+          const target = resolveExports(exports, subpath, NODE_REQUIRE_CONDITIONS);
           return target === null ? null : resolveCjsBase(join(pkgDir, target));
         }
         return resolveCjsBase(subpath === "." ? pkgDir : join(pkgDir, subpath));

--- a/packages/compiler/src/frontend/npm.ts
+++ b/packages/compiler/src/frontend/npm.ts
@@ -89,6 +89,14 @@ import { dirname, extname, join, resolve } from "node:path";
 import ts from "typescript5";
 import { cjsLexedExportsOf } from "./cjs-lexer.js";
 import { trackedDirectoryExists, trackedFileExists, trackedReadFile, trackedRealpath } from "./input-tracker.js";
+import { resolveExports } from "./resolve.js";
+
+const NODE_IMPORT_CONDITIONS = new Set(["import", "node", "default"]);
+const NODE_REQUIRE_CONDITIONS = new Set(["require", "node", "default"]);
+
+function nodeExportConditions(mode: "import" | "require"): ReadonlySet<string> {
+  return mode === "import" ? NODE_IMPORT_CONDITIONS : NODE_REQUIRE_CONDITIONS;
+}
 
 export type EmbeddedFormat = "esm" | "cjs" | "json";
 
@@ -764,77 +772,6 @@ export function packageNameOfPath(path: string): string | null {
   return rest === "" ? null : packageNameOf(rest);
 }
 
-/** package.json "exports" resolution, per Node: subpath map with exact
- * keys first, then '*' patterns (longest literal prefix wins, the matched
- * text substitutes into the target), condition objects matched in OBJECT
- * KEY order against the enabled set ("import" or "require", plus "node"
- * and "default"), string targets, arrays taking the first resolvable
- * entry. Returns a path relative to the package dir, or null. */
-export function resolveExports(
-  exports: unknown,
-  subpath: string,
-  mode: "import" | "require",
-): string | null {
-  const enabled = new Set([mode, "node", "default"]);
-  const resolveTarget = (target: unknown, wildcard: string | null): string | null => {
-    if (typeof target === "string") {
-      return wildcard === null ? target : target.split("*").join(wildcard);
-    }
-    if (Array.isArray(target)) {
-      for (const t of target) {
-        const r = resolveTarget(t, wildcard);
-        if (r) return r;
-      }
-      return null;
-    }
-    if (target && typeof target === "object") {
-      for (const [key, value] of Object.entries(target)) {
-        if (key.startsWith(".")) continue; // a subpath map, not conditions
-        if (enabled.has(key)) {
-          const r = resolveTarget(value, wildcard);
-          if (r) return r;
-        }
-      }
-    }
-    return null;
-  };
-  if (typeof exports === "string" || Array.isArray(exports)) {
-    return subpath === "." ? resolveTarget(exports, null) : null;
-  }
-  if (exports && typeof exports === "object") {
-    const map = exports as Record<string, unknown>;
-    const keys = Object.keys(map);
-    const isSubpathMap = keys.every((k) => k.startsWith("."));
-    if (!isSubpathMap) {
-      // A bare condition object applies to the root subpath only.
-      return subpath === "." ? resolveTarget(exports, null) : null;
-    }
-    if (Object.prototype.hasOwnProperty.call(map, subpath)) {
-      return resolveTarget(map[subpath], null);
-    }
-    // Pattern keys: "./v4/locales/*" etc. Longest literal prefix wins.
-    let best: { key: string; prefix: string; suffix: string } | null = null;
-    for (const key of keys) {
-      const star = key.indexOf("*");
-      if (star < 0) continue;
-      const prefix = key.slice(0, star);
-      const suffix = key.slice(star + 1);
-      if (
-        subpath.startsWith(prefix) &&
-        subpath.length >= prefix.length + suffix.length &&
-        subpath.endsWith(suffix) &&
-        (!best || prefix.length > best.prefix.length)
-      ) {
-        best = { key, prefix, suffix };
-      }
-    }
-    if (!best) return null;
-    const wildcard = subpath.slice(best.prefix.length, subpath.length - best.suffix.length);
-    return resolveTarget(map[best.key], wildcard);
-  }
-  return null;
-}
-
 /** A bare-specifier import edge Node's ESM resolution REFUSES, with Node's
  * exact error message and code — or null (resolvable, or a shape this
  * probe stays conservative about). The three refusal shapes it answers,
@@ -886,7 +823,7 @@ export function probeNodeImportRefusal(
   // Node's PACKAGE_EXPORTS_RESOLVE outcome for the subpath.
   const withinScope = (pkgDir: string, pkg: PkgJson): NodeImportRefusal | null => {
     if (pkg.exports === undefined) return null; // legacy resolution — conservative
-    const target = resolveExports(pkg.exports, subpath, "import");
+    const target = resolveExports(pkg.exports, subpath, NODE_IMPORT_CONDITIONS);
     if (target === null) {
       return {
         code: "ERR_PACKAGE_PATH_NOT_EXPORTED",
@@ -1436,7 +1373,7 @@ export class NpmGraphBuilder {
       const selfPkg = this.pkgJsonOf(dir);
       if (selfPkg) {
         if (selfPkg.name === name && selfPkg.exports !== undefined) {
-          const fromExports = resolveExports(selfPkg.exports, subpath, mode);
+          const fromExports = resolveExports(selfPkg.exports, subpath, nodeExportConditions(mode));
           if (fromExports === null) {
             this.errors.push({
               message:
@@ -1470,7 +1407,7 @@ export class NpmGraphBuilder {
         let target: string;
         let forceEsm = false;
         if (pkg.exports !== undefined) {
-          const fromExports = resolveExports(pkg.exports, subpath, mode);
+          const fromExports = resolveExports(pkg.exports, subpath, nodeExportConditions(mode));
           if (fromExports === null) {
             this.errors.push({
               message:

--- a/packages/compiler/src/frontend/provenance.ts
+++ b/packages/compiler/src/frontend/provenance.ts
@@ -36,9 +36,10 @@ import { homedir, tmpdir } from "node:os";
 import { dirname, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import ts from "typescript5";
-import { resolveExports } from "./npm.js";
-import { resolveRelativeModule } from "./resolve.js";
+import { resolveExports, resolveRelativeModule } from "./resolve.js";
 import type { ProvenancePackageSource, ProvenanceSources } from "./provenance-registry.js";
+
+const NODE_IMPORT_CONDITIONS = new Set(["import", "node", "default"]);
 
 const execFileAsync = promisify(execFile);
 
@@ -291,7 +292,7 @@ function locatePackageDir(tree: string, name: string): string | null {
  * condition, else module/main/types fields (root subpath only). */
 function publishedTargetOf(pkgJson: Record<string, unknown>, subpath: string): string | null {
   if (pkgJson["exports"] !== undefined) {
-    return resolveExports(pkgJson["exports"], subpath, "import");
+    return resolveExports(pkgJson["exports"], subpath, NODE_IMPORT_CONDITIONS);
   }
   if (subpath !== ".") return subpath;
   for (const field of ["module", "main", "types"]) {

--- a/packages/compiler/src/frontend/resolve.ts
+++ b/packages/compiler/src/frontend/resolve.ts
@@ -339,14 +339,13 @@ const EXPORT_CONDITIONS = new Set(["types", "import", "default"]);
 const JS_ONLY_CONDITIONS = new Set(["import", "default"]);
 
 /** package.json "exports" lookup: exact subpath keys, then '*' patterns
- * (longest literal prefix wins), condition objects in object-key order,
- * arrays first-resolvable. Returns the target path relative to the package
- * directory, or null. Mirrors npm.ts's runtime resolver with the TYPES
- * condition set. */
-function resolveExportsTypes(
+ * (longest literal prefix wins), condition objects matched against the
+ * supplied set in object-key order, arrays first-resolvable. Returns the
+ * target path relative to the package directory, or null. */
+export function resolveExports(
   exports: unknown,
   subpath: string,
-  conditions: ReadonlySet<string> = EXPORT_CONDITIONS,
+  conditions: ReadonlySet<string>,
 ): string | null {
   const resolveTarget = (target: unknown, wildcard: string | null): string | null => {
     if (typeof target === "string") {
@@ -465,7 +464,7 @@ function resolveImportsField(imports: unknown, specifier: string): string | null
     if (!k.startsWith("#")) continue;
     rekeyed["." + k.slice(1)] = v;
   }
-  return resolveExportsTypes(rekeyed, "." + specifier.slice(1));
+  return resolveExports(rekeyed, "." + specifier.slice(1), EXPORT_CONDITIONS);
 }
 
 /** Absolute path of the nearest package.json at or above `fromFile`'s
@@ -538,7 +537,7 @@ export function resolveProjectImport(fromFile: string, specifier: string): strin
     const pkgName = parts.slice(0, nameLen).join("/");
     if (pkgName !== pkg.name || parts.length < nameLen) return null;
     const subpath = parts.length === nameLen ? "." : "./" + parts.slice(nameLen).join("/");
-    target = resolveExportsTypes(pkg.exports, subpath);
+    target = resolveExports(pkg.exports, subpath, EXPORT_CONDITIONS);
   }
   if (target === null) return null;
   const path = join(pkgDir, target);
@@ -746,7 +745,7 @@ export function resolveBareModule(
           })()
         : rawPkg;
     if (pkg?.exports !== undefined) {
-      const target = resolveExportsTypes(pkg.exports, subpath, conditions);
+      const target = resolveExports(pkg.exports, subpath, conditions);
       if (target !== null) {
         const file = loadTargetInPass(nmPkgDir, target, pass);
         if (file) return withWorkspace(packageAnswer(nmPkgDir, name, file));

--- a/packages/compiler/src/ir/analysis.ts
+++ b/packages/compiler/src/ir/analysis.ts
@@ -1,0 +1,124 @@
+import { InternalCompilerError } from "../errors.js";
+import {
+  DYN_HANDLE_KINDS,
+  RUNTIME_STREAM_CLASSES,
+  type IrExpr,
+  type IrRecordShape,
+  type IrStmt,
+  type IrType,
+  type IrUnionDef,
+} from "./nodes.js";
+
+/** The class-graph surface needed by backend-independent hierarchy queries. */
+export interface IrClassGraphNode {
+  readonly def: { readonly name: string };
+  readonly base: IrClassGraphNode | null;
+  readonly children: readonly IrClassGraphNode[];
+}
+
+/** Short human description of a dynCheck target for error messages. */
+export function dynDesc(
+  t: IrType,
+  recordsById: ReadonlyMap<string, IrRecordShape>,
+  unionsById: ReadonlyMap<string, IrUnionDef>,
+): string {
+  switch (t.kind) {
+    case "f64": return "number";
+    case "string": return "string";
+    case "bool": return "boolean";
+    case "record": return recordsById.get(t.shapeId)?.tuple ? "array" : "object";
+    case "array": return "array";
+    case "nullT": return "null";
+    case "undefinedT": return "undefined";
+    case "dyn": return "unknown";
+    case "bytes": return "Uint8Array";
+    case "object": return t.className.replace(/^%/, "");
+    case "union": {
+      const def = unionsById.get(t.unionId);
+      if (!def) throw new InternalCompilerError(`IR analysis bug: dynDesc of unknown union ${t.unionId}`);
+      return def.arms.map((arm) => dynDesc(arm, recordsById, unionsById)).join(" | ");
+    }
+    case "func": return "function";
+    case "map": return "Map";
+    case "set": return "Set";
+    default: {
+      const handle = DYN_HANDLE_KINDS.get(t.kind);
+      if (handle) return handle.cls;
+      throw new InternalCompilerError(`IR analysis bug: dynDesc of non-JSON type ${t.kind}`);
+    }
+  }
+}
+
+/** Whether evaluating an index/value expression can overwrite a bytes
+ * receiver binding. Deliberately conservative: uncertain shapes are false. */
+export function isStableBytesOperand(e: IrExpr, receiverLocalId: string): boolean {
+  switch (e.kind) {
+    case "numLit":
+    case "boolLit":
+    case "varRef":
+    case "incDec":
+      return true;
+    case "assignExpr":
+      return e.localId !== receiverLocalId && isStableBytesOperand(e.value, receiverLocalId);
+    case "bin":
+    case "logical":
+      return isStableBytesOperand(e.left, receiverLocalId) &&
+        isStableBytesOperand(e.right, receiverLocalId);
+    case "unary":
+    case "toBool":
+      return isStableBytesOperand(e.operand, receiverLocalId);
+    case "ternary":
+      return isStableBytesOperand(e.cond, receiverLocalId) &&
+        isStableBytesOperand(e.then, receiverLocalId) &&
+        isStableBytesOperand(e.else_, receiverLocalId);
+    case "bytesIntrinsic":
+      return (e.method === "get" || e.method === "length" || e.method === "byteLength") &&
+        e.receiver.kind === "varRef" &&
+        e.args.every((arg) => isStableBytesOperand(arg, receiverLocalId));
+    default:
+      return false;
+  }
+}
+
+/** The undefined arm's tag of a union type, or -1. */
+export function undefinedArmTag(
+  t: IrType,
+  unionsById: ReadonlyMap<string, IrUnionDef>,
+): number {
+  if (t.kind !== "union") return -1;
+  return unionsById.get(t.unionId)?.arms.findIndex((arm) => arm.kind === "undefinedT") ?? -1;
+}
+
+/** True when a statement list ends in a control-flow jump. */
+export function endsWithJump(stmts: readonly IrStmt[]): boolean {
+  const last = stmts[stmts.length - 1]?.kind;
+  return last === "return" || last === "break" || last === "continue" ||
+    last === "throw" || last === "rethrow" || last === "runtimeFence";
+}
+
+/** True when class-value construction can enter a throwing constructor in
+ * the static class's descendant subtree. */
+export function newValueMayThrow(
+  className: string,
+  classes: ReadonlyMap<string, IrClassGraphNode>,
+  mayThrow: ReadonlySet<string>,
+): boolean {
+  const meta = classes.get(className);
+  if (!meta) throw new InternalCompilerError(`IR analysis bug: newValue on unknown class ${className}`);
+  const any = (node: IrClassGraphNode): boolean =>
+    mayThrow.has(`%${node.def.name}.constructor`) || node.children.some(any);
+  return any(meta);
+}
+
+/** Types transported as live typed references across Web-stream dyn edges. */
+export function streamTypedRefEligible(t: IrType): boolean {
+  return t.kind === "record" || t.kind === "array" || t.kind === "bytes";
+}
+
+/** True when a class descends from a runtime stream class. */
+export function streamRooted(meta: IrClassGraphNode): boolean {
+  for (let current = meta.base; current; current = current.base) {
+    if (RUNTIME_STREAM_CLASSES.has(current.def.name)) return true;
+  }
+  return false;
+}

--- a/packages/compiler/src/ir/build.ts
+++ b/packages/compiler/src/ir/build.ts
@@ -1,4 +1,4 @@
-import { BOOL, F64, type IrExpr, type IrType, STRING, type SrcLoc } from "./nodes.js";
+import { BOOL, F64, type IrExpr, type IrStmt, type IrType, STRING, type SrcLoc } from "./nodes.js";
 
 export function varRef(localId: string, type: IrType, loc: SrcLoc): IrExpr {
   return { kind: "varRef", localId, type, loc };
@@ -14,4 +14,28 @@ export function strLit(value: string, loc: SrcLoc): IrExpr {
 
 export function boolLit(value: boolean, loc: SrcLoc): IrExpr {
   return { kind: "boolLit", value, type: BOOL, loc };
+}
+
+/** `for (i.0 = 0; i.0 < bound; i.0++)` over the conventional synthetic
+ * index local. The bound expression remains in the condition and is
+ * therefore evaluated once per iteration, matching the expanded IR. */
+export function countedFor(
+  loc: SrcLoc,
+  bound: IrExpr,
+  body: (index: IrExpr) => IrStmt[],
+): IrStmt {
+  const index = varRef("i.0", F64, loc);
+  return {
+    kind: "for",
+    init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+    cond: { kind: "bin", op: "<", left: index, right: bound, type: BOOL, loc },
+    update: {
+      kind: "assign",
+      localId: "i.0",
+      value: { kind: "bin", op: "+", left: index, right: numLit(1, loc), type: F64, loc },
+      loc,
+    },
+    body: body(index),
+    loc,
+  };
 }


### PR DESCRIPTION
- Consolidate package exports resolution behind explicit condition sets.
- Share counted-loop construction across frontend IR and LLVM emission.
- Move backend-neutral IR analyses into the shared IR layer.