### PR TITLE
refactor: consolidate compiler helpers

### DIFF
--- a/packages/compiler/src/backend/cc.ts
+++ b/packages/compiler/src/backend/cc.ts
@@ -1191,39 +1191,16 @@ async function ensureLreObjects(
     (sanitize ? "asan" : "plain") +
     (driver.argv.length === 1 && driver.argv[0] === "clang" ? "" : "-zigcc") +
     `-${vendorCacheTargetFlavor(driver)}-${buildIdentity}`;
-  const vendor = vendorEngineDir();
-  const objects = lreObjectPaths(sanitize, driver, buildIdentity, cacheRoot);
-  if ((await Promise.all(objects.map(validVendorArtifact))).every(Boolean)) return objects;
-
-  await mkdir(cacheRoot, { recursive: true });
-  const buildDir = await mkdtemp(join(tmpdir(), `scriptc-vendor-lre-${flavor}-`));
-  try {
-    // One -c per invocation: zig's COFF driver rejects multiple -c inputs
-    // in a single command ("coff does not support linking multiple
-    // objects"); per-file compiles produce the identical objects on every
-    // target.
-    for (const f of LRE_SOURCES) {
-      await execFileAsync(
-        driver.argv[0] ?? "clang",
-        [
-          ...driver.argv.slice(1),
-          "-std=c11",
-          ...driver.targetArgs,
-          ...(sanitize ? ["-O1", "-fsanitize=address"] : ["-Os"]),
-          "-I", vendor,
-          "-c", join(vendor, f),
-          "-o", join(buildDir, f.replace(/\.c$/, ".o")),
-        ],
-        { cwd: buildDir },
-      );
-    }
-    await Promise.all(objects.map((destination) =>
-      publishVendorArtifact(join(buildDir, basename(destination)), destination)
-    ));
-  } finally {
-    await rm(buildDir, { recursive: true, force: true });
-  }
-  return objects;
+  return ensureVendorObjects({
+    sanitize,
+    driver,
+    cacheRoot,
+    flavor,
+    name: "lre",
+    vendor: vendorEngineDir(),
+    sources: LRE_SOURCES,
+    objects: lreObjectPaths(sanitize, driver, buildIdentity, cacheRoot),
+  });
 }
 
 function vendorZlibDir(): string {
@@ -1269,16 +1246,37 @@ async function ensureZlibObjects(
     (sanitize ? "asan" : "plain") +
     (driver.argv.length === 1 && driver.argv[0] === "clang" ? "" : "-zigcc") +
     `-${vendorCacheTargetFlavor(driver)}-${buildIdentity}`;
-  const vendor = vendorZlibDir();
-  const objects = zlibObjectPaths(sanitize, driver, buildIdentity, cacheRoot);
+  return ensureVendorObjects({
+    sanitize,
+    driver,
+    cacheRoot,
+    flavor,
+    name: "zlib",
+    vendor: vendorZlibDir(),
+    sources: ZLIB_SOURCES,
+    objects: zlibObjectPaths(sanitize, driver, buildIdentity, cacheRoot),
+  });
+}
+
+/** Compile and atomically publish one cached set of vendored C objects. */
+async function ensureVendorObjects(options: {
+  sanitize: boolean;
+  driver: CcDriver;
+  cacheRoot: string;
+  flavor: string;
+  name: string;
+  vendor: string;
+  sources: readonly string[];
+  objects: string[];
+}): Promise<string[]> {
+  const { sanitize, driver, cacheRoot, flavor, name, vendor, sources, objects } = options;
   if ((await Promise.all(objects.map(validVendorArtifact))).every(Boolean)) return objects;
 
   await mkdir(cacheRoot, { recursive: true });
-  const buildDir = await mkdtemp(join(tmpdir(), `scriptc-vendor-zlib-${flavor}-`));
+  const buildDir = await mkdtemp(join(tmpdir(), `scriptc-vendor-${name}-${flavor}-`));
   try {
-    // One -c per invocation, the lre recipe (zig's COFF driver rejects
-    // multiple -c inputs in a single command).
-    for (const f of ZLIB_SOURCES) {
+    // Zig's COFF driver rejects multiple -c inputs in a single command.
+    for (const f of sources) {
       await execFileAsync(
         driver.argv[0] ?? "clang",
         [

--- a/packages/compiler/src/backend/llvm/classes.ts
+++ b/packages/compiler/src/backend/llvm/classes.ts
@@ -37,7 +37,7 @@ import {
   mangleVtInstance,
   mangleVtStruct,
 } from "../mangle.js";
-import { FN_ATTRS, llFieldType, releaseSym, traceAdapter, type ShapeHost } from "./shapes.js";
+import { FN_ATTRS, llFieldType, releaseBody, releaseSym, retainBody, traceAdapter, type ShapeHost } from "./shapes.js";
 
 /** One virtual method slot of a hierarchy: the ROOT-MOST declaring class
  * owns the slot; its declaration's IrFunction fixes the slot's ABI (the
@@ -327,27 +327,7 @@ export function emitClassShapes(
 
     // retain: NULL-tolerant, immortal-skip, mark-live on traced shapes —
     // layout-generic (rc at 0), so hierarchy members need no dispatch.
-    defs.push(
-      `define internal ptr @${mangleClassRetain(cls.name)}(ptr %o) ${FN_ATTRS} { ; retain ${cls.name}`,
-      `entry:`,
-      `  %isnull = icmp eq ptr %o, null`,
-      `  br i1 %isnull, label %done, label %check`,
-      `check:`,
-      `  %rc = load ${host.sizeType}, ptr %o`,
-      `  %imm = icmp eq ${host.sizeType} %rc, -1`,
-      `  br i1 %imm, label %done, label %inc`,
-      `inc:`,
-      `  %n = add ${host.sizeType} %rc, 1`,
-      `  store ${host.sizeType} %n, ptr %o`,
-      ...(traced
-        ? [`  %colorp = getelementptr i8, ptr %o, ${host.sizeType} -${host.cycleColorOffset}`, `  store i32 0, ptr %colorp ; mark live`]
-        : []),
-      `  br label %done`,
-      `done:`,
-      `  ret ptr %o`,
-      `}`,
-      ``,
-    );
+    defs.push(...retainBody(host, mangleClassRetain(cls.name), traced, `retain ${cls.name}`), ``);
 
     // The field-releasing teardown body shared by both release shapes
     // (the public one on standalone classes, the DIRECT one on hierarchy
@@ -426,34 +406,12 @@ export function emitClassShapes(
       reld.push(`done:`, `  ret void`, `}`, ``);
       defs.push(...reld);
     } else {
-      const rel: string[] = [
-        `define internal void @${mangleClassRelease(cls.name)}(ptr %o) ${FN_ATTRS} { ; release ${cls.name}`,
-        `entry:`,
-        `  %isnull = icmp eq ptr %o, null`,
-        `  br i1 %isnull, label %done, label %check`,
-        `check:`,
-        `  %rc = load ${host.sizeType}, ptr %o`,
-        `  %imm = icmp eq ${host.sizeType} %rc, -1`,
-        `  br i1 %imm, label %done, label %dec`,
-        `dec:`,
-        `  %n = sub ${host.sizeType} %rc, 1`,
-        `  store ${host.sizeType} %n, ptr %o`,
-        `  %dead = icmp eq ${host.sizeType} %n, 0`,
-        `  br i1 %dead, label %free, label %${traced ? "root" : "done"}`,
-        `free:`,
-      ];
-      teardown(rel);
-      rel.push(`  br label %done`);
-      if (traced) {
-        host.declare(`declare void @scr_cyc_on_release(ptr)`);
-        rel.push(
-          `root:`,
-          `  call void @scr_cyc_on_release(ptr %o) ; possible cycle root; may collect`,
-          `  br label %done`,
-        );
-      }
-      rel.push(`done:`, `  ret void`, `}`, ``);
-      defs.push(...rel);
+      const freeBody: string[] = [];
+      teardown(freeBody);
+      defs.push(
+        ...releaseBody(host, mangleClassRelease(cls.name), traced, freeBody, `release ${cls.name}`),
+        ``,
+      );
     }
 
     // new: zeroed allocation, rc = 1, the vtable word on hierarchy

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -3122,156 +3122,95 @@ class LlEmitter {
    * for the always-truthy object kinds (JS: [] and {} are truthy). */
   private truthy(v: LlValue): string {
     const B = this.B;
-    switch (v.type.kind) {
+    if (v.type.kind === "union") {
+      // The ARM value's ToBoolean: an inline tag switch (the C emitter's
+      // per-union interned helper, emitted at the use site instead).
+      const def = this.unionsById.get(v.type.unionId);
+      if (!def) throw new InternalCompilerError(`llvm emitter bug: truthiness of unknown union ${v.type.unionId}`);
+      const slot = B.slot();
+      B.entryAllocas.push(`${slot} = alloca i1`);
+      const join = B.newLabel("ut.j");
+      this.unionTagSwitch(v.name, def, (arm) => {
+        let valueName = "false";
+        if (arm.kind === "f64") {
+          valueName = B.tmp();
+          this.declare(`declare double @scr_union_get_f64(ptr)`);
+          B.line(`${valueName} = call double @scr_union_get_f64(ptr ${v.name})`);
+        } else if (arm.kind === "bool") {
+          valueName = B.tmp();
+          this.declare(`declare zeroext i1 @scr_union_get_bool(ptr)`);
+          B.line(`${valueName} = call zeroext i1 @scr_union_get_bool(ptr ${v.name})`);
+        } else if (arm.kind === "string") {
+          valueName = this.unionPeek(v.name);
+        }
+        const truthy = this.truthyOf(arm.kind, valueName, true);
+        B.line(`store i1 ${truthy}, ptr ${slot}`);
+        B.br(join);
+      });
+      B.startBlock(join);
+      const t = B.tmp();
+      B.line(`${t} = load i1, ptr ${slot}`);
+      return t;
+    }
+    return this.truthyOf(v.type.kind, v.name, false);
+  }
+
+  /** Emit truthiness for one non-union kind. Union arms are known-present,
+   * so object kinds become the constant true instead of a pointer test. */
+  private truthyOf(kind: IrType["kind"], valueName: string, unionArm: boolean): string {
+    const B = this.B;
+    switch (kind) {
+      case "undefinedT":
+      case "nullT":
+        if (!unionArm) throw new LlvmUnsupportedError(`truthy:${kind}`);
+        return "false";
       case "bool":
-        return v.name;
-      case "f64": {
-        const t = B.tmp();
-        B.line(`${t} = fcmp one double ${v.name}, ${f64Lit(0)}`);
-        return t;
+        return valueName;
+      case "f64":
+      case "procStream": {
+        if (unionArm && kind === "procStream") throw new LlvmUnsupportedError(`truthy:union:${kind}`);
+        const truthy = B.tmp();
+        B.line(`${truthy} = fcmp one double ${valueName}, ${f64Lit(0)}`);
+        return truthy;
       }
       case "string": {
         const lenp = B.tmp();
         const len = B.tmp();
-        const t = B.tmp();
-        B.line(`${lenp} = getelementptr inbounds %ScrStr, ptr ${v.name}, i64 0, i32 1`);
+        const truthy = B.tmp();
+        B.line(`${lenp} = getelementptr inbounds %ScrStr, ptr ${valueName}, i64 0, i32 1`);
         B.line(`${len} = load ${this.sizeType}, ptr ${lenp}`);
-        B.line(`${t} = icmp ne ${this.sizeType} ${len}, 0`);
-        return t;
+        B.line(`${truthy} = icmp ne ${this.sizeType} ${len}, 0`);
+        return truthy;
       }
       case "date":
         return "true";
-      case "array":
-      case "record":
-      case "object":
-      case "classval":
-      case "func":
-      case "map":
-      case "set":
-      case "symbol":
-      case "regex":
-      case "promise":
-      case "bytes":
-      case "url":
-      case "searchParams":
-      case "stats":
-      case "fileHandle":
-      case "spawnRes":
-      case "child":
-      case "childStream":
-      case "generator":
-      case "fsWatcher": {
-        // JS objects are ALWAYS truthy; the honest constant reads as a
-        // pointer test, exactly the C emitter's `!= NULL`.
-        const t = B.tmp();
-        B.line(`${t} = icmp ne ptr ${v.name}, null`);
-        return t;
-      }
-      case "procStream": {
-        // A stream value is a JS object (always truthy); the scalar fd
-        // representation is 1 or 2, so the honest constant reads as its
-        // own non-zero test.
-        const t = B.tmp();
-        B.line(`${t} = fcmp one double ${v.name}, ${f64Lit(0)}`);
-        return t;
+      case "array": case "record": case "object": case "classval": case "func":
+      case "map": case "set": case "symbol": case "regex": case "promise": case "bytes":
+      case "url": case "searchParams": case "stats": case "fileHandle": case "spawnRes":
+      case "child": case "childStream": case "generator": case "fsWatcher": {
+        if (unionArm) return "true";
+        const truthy = B.tmp();
+        B.line(`${truthy} = icmp ne ptr ${valueName}, null`);
+        return truthy;
       }
       case "dyn": {
-        // ToBoolean over the dyn kind (scr_dyn_truthy — JS-exact for
-        // every kind; borrowed, never throws): `v || dflt` and condition
-        // descent on checked-dynamic values.
+        if (unionArm) throw new LlvmUnsupportedError(`truthy:union:${kind}`);
         this.declare(`declare zeroext i1 @scr_dyn_truthy(ptr)`);
-        const t = B.tmp();
-        B.line(`${t} = call zeroext i1 @scr_dyn_truthy(ptr ${v.name})`);
-        return t;
+        const truthy = B.tmp();
+        B.line(`${truthy} = call zeroext i1 @scr_dyn_truthy(ptr ${valueName})`);
+        return truthy;
       }
       case "jsval": {
-        // Island truthiness: the engine's ToBoolean (never throws, no
-        // ownership change) — jsval operands are legal in `logical`.
+        if (unionArm) throw new LlvmUnsupportedError(`truthy:union:${kind}`);
         this.declare(`declare i32 @scr_jsval_truthy(ptr)`);
-        const r = B.tmp();
-        const t = B.tmp();
-        B.line(`${r} = call i32 @scr_jsval_truthy(ptr ${v.name})`);
-        B.line(`${t} = icmp ne i32 ${r}, 0`);
-        return t;
-      }
-      case "union": {
-        // The ARM value's ToBoolean: an inline tag switch (the C emitter's
-        // per-union interned helper, emitted at the use site instead).
-        const def = this.unionsById.get(v.type.unionId);
-        if (!def) throw new InternalCompilerError(`llvm emitter bug: truthiness of unknown union ${v.type.unionId}`);
-        const slot = B.slot();
-        B.entryAllocas.push(`${slot} = alloca i1`);
-        const join = B.newLabel("ut.j");
-        this.unionTagSwitch(v.name, def, (arm) => {
-          switch (arm.kind) {
-            case "undefinedT":
-            case "nullT":
-              B.line(`store i1 false, ptr ${slot}`);
-              break;
-            case "f64": {
-              const x = B.tmp();
-              const t = B.tmp();
-              this.declare(`declare double @scr_union_get_f64(ptr)`);
-              B.line(`${x} = call double @scr_union_get_f64(ptr ${v.name})`);
-              B.line(`${t} = fcmp one double ${x}, ${f64Lit(0)}`);
-              B.line(`store i1 ${t}, ptr ${slot}`);
-              break;
-            }
-            case "bool": {
-              const b = B.tmp();
-              this.declare(`declare zeroext i1 @scr_union_get_bool(ptr)`);
-              B.line(`${b} = call zeroext i1 @scr_union_get_bool(ptr ${v.name})`);
-              B.line(`store i1 ${b}, ptr ${slot}`);
-              break;
-            }
-            case "string": {
-              const p = this.unionPeek(v.name);
-              const lenp = B.tmp();
-              const len = B.tmp();
-              const t = B.tmp();
-              B.line(`${lenp} = getelementptr inbounds %ScrStr, ptr ${p}, i64 0, i32 1`);
-              B.line(`${len} = load ${this.sizeType}, ptr ${lenp}`);
-              B.line(`${t} = icmp ne ${this.sizeType} ${len}, 0`);
-              B.line(`store i1 ${t}, ptr ${slot}`);
-              break;
-            }
-            case "date":
-              B.line(`store i1 true, ptr ${slot} ; Date objects are truthy`);
-              break;
-            case "array":
-            case "record":
-            case "object":
-            case "classval":
-            case "func":
-            case "map":
-            case "set":
-            case "symbol":
-            case "regex":
-            case "promise":
-            case "bytes":
-            case "url":
-            case "searchParams":
-            case "stats":
-            case "fileHandle":
-            case "spawnRes":
-            case "child":
-            case "childStream":
-            case "generator":
-            case "fsWatcher":
-              B.line(`store i1 true, ptr ${slot} ; ${arm.kind}: objects are truthy`);
-              break;
-            default:
-              throw new LlvmUnsupportedError(`truthy:union:${arm.kind}`);
-          }
-          B.br(join);
-        });
-        B.startBlock(join);
-        const t = B.tmp();
-        B.line(`${t} = load i1, ptr ${slot}`);
-        return t;
+        const raw = B.tmp();
+        const truthy = B.tmp();
+        B.line(`${raw} = call i32 @scr_jsval_truthy(ptr ${valueName})`);
+        B.line(`${truthy} = icmp ne i32 ${raw}, 0`);
+        return truthy;
       }
       default:
-        throw new LlvmUnsupportedError(`truthy:${v.type.kind}`);
+        throw new LlvmUnsupportedError(`truthy:${unionArm ? "union:" : ""}${kind}`);
     }
   }
 

--- a/packages/compiler/src/backend/llvm/shapes.ts
+++ b/packages/compiler/src/backend/llvm/shapes.ts
@@ -414,10 +414,10 @@ function rcMembers(shape: IrRecordShape): { index: number; type: IrType; name: s
  * targets and obj-12 on wasm32,
  * so mark-live is one i32 store at obj-16 (scr_cyc_mark_live inlined —
  * the runtime's is a static inline with no external symbol). */
-function retainBody(host: ShapeHost, fnName: string, traced: boolean): string[] {
+export function retainBody(host: ShapeHost, fnName: string, traced: boolean, comment = ""): string[] {
   const S = host.sizeType;
   return [
-    `define internal ptr @${fnName}(ptr %o) ${FN_ATTRS} {`,
+    `define internal ptr @${fnName}(ptr %o) ${FN_ATTRS} {${comment ? ` ; ${comment}` : ""}`,
     `entry:`,
     `  %isnull = icmp eq ptr %o, null`,
     `  br i1 %isnull, label %done, label %check`,
@@ -436,6 +436,47 @@ function retainBody(host: ShapeHost, fnName: string, traced: boolean): string[] 
     `  ret ptr %o`,
     `}`,
   ];
+}
+
+/** Common NULL/immortal/decrement skeleton for ordinary object releases.
+ * `freeBody` owns the zero-ref teardown and must leave the current block at
+ * its end; traced objects also get the possible-cycle-root branch. */
+export function releaseBody(
+  host: ShapeHost,
+  fnName: string,
+  traced: boolean,
+  freeBody: string[],
+  comment = "",
+): string[] {
+  const S = host.sizeType;
+  const lines = [
+    `define internal void @${fnName}(ptr %o) ${FN_ATTRS} {${comment ? ` ; ${comment}` : ""}`,
+    `entry:`,
+    `  %isnull = icmp eq ptr %o, null`,
+    `  br i1 %isnull, label %done, label %check`,
+    `check:`,
+    `  %rc = load ${S}, ptr %o`,
+    `  %imm = icmp eq ${S} %rc, -1`,
+    `  br i1 %imm, label %done, label %dec`,
+    `dec:`,
+    `  %n = sub ${S} %rc, 1`,
+    `  store ${S} %n, ptr %o`,
+    `  %dead = icmp eq ${S} %n, 0`,
+    `  br i1 %dead, label %free, label %${traced ? "root" : "done"}`,
+    `free:`,
+    ...freeBody,
+    `  br label %done`,
+  ];
+  if (traced) {
+    host.declare(`declare void @scr_cyc_on_release(ptr)`);
+    lines.push(
+      `root:`,
+      `  call void @scr_cyc_on_release(ptr %o) ; possible cycle root; may collect`,
+      `  br label %done`,
+    );
+  }
+  lines.push(`done:`, `  ret void`, `}`);
+  return lines;
 }
 
 /** Per-record-shape LLVM emission: the named struct types (returned as
@@ -475,52 +516,29 @@ export function emitRecordShapes(host: ShapeHost, mod: IrModule): { typeDefs: st
     // refcounted member (runtime releases are NULL-tolerant) and free —
     // traced shapes route through the collector (on_dead/on_release,
     // scr_cyc_free) exactly like emit-shapes.ts.
-    const rel: string[] = [
-      `define internal void @${mangleRecordRelease(shape.id)}(ptr %o) ${FN_ATTRS} {`,
-      `entry:`,
-      `  %isnull = icmp eq ptr %o, null`,
-      `  br i1 %isnull, label %done, label %check`,
-      `check:`,
-      `  %rc = load ${host.sizeType}, ptr %o`,
-      `  %imm = icmp eq ${host.sizeType} %rc, -1`,
-      `  br i1 %imm, label %done, label %dec`,
-      `dec:`,
-      `  %n = sub ${host.sizeType} %rc, 1`,
-      `  store ${host.sizeType} %n, ptr %o`,
-      `  %dead = icmp eq ${host.sizeType} %n, 0`,
-      `  br i1 %dead, label %free, label %${traced ? "root" : "done"}`,
-      `free:`,
-    ];
+    const freeBody: string[] = [];
     if (traced) {
       host.declare(`declare void @scr_cyc_on_dead(ptr)`);
-      rel.push(`  call void @scr_cyc_on_dead(ptr %o)`);
+      freeBody.push(`  call void @scr_cyc_on_dead(ptr %o)`);
     }
     let t = 0;
     for (const m of refMembers) {
-      rel.push(
+      freeBody.push(
         `  %f${t} = getelementptr inbounds %${struct}, ptr %o, i64 0, i32 ${m.index}`,
         `  %v${t} = load ptr, ptr %f${t}`,
         `  call void ${releaseSym(host, m.type)}(ptr %v${t}) ; ${m.name}`,
       );
       t++;
     }
-    rel.push(`  call void @scr_obj_free_note()`);
+    freeBody.push(`  call void @scr_obj_free_note()`);
     if (traced) {
       host.declare(`declare void @scr_cyc_free(ptr)`);
-      host.declare(`declare void @scr_cyc_on_release(ptr)`);
-      rel.push(
-        `  call void @scr_cyc_free(ptr %o)`,
-        `  br label %done`,
-        `root:`,
-        `  call void @scr_cyc_on_release(ptr %o) ; possible cycle root; may collect`,
-        `  br label %done`,
-      );
+      freeBody.push(`  call void @scr_cyc_free(ptr %o)`);
     } else {
       host.declare(`declare void @free(ptr)`);
-      rel.push(`  call void @free(ptr %o)`, `  br label %done`);
+      freeBody.push(`  call void @free(ptr %o)`);
     }
-    rel.push(`done:`, `  ret void`, `}`, ``);
-    defs.push(...rel);
+    defs.push(...releaseBody(host, mangleRecordRelease(shape.id), traced, freeBody), ``);
 
     // new: zeroed allocation (+ the overflow map on index-signature
     // shapes), rc = 1, alloc note. Traced shapes allocate with the

--- a/packages/compiler/src/coverage/surface-manifest.ts
+++ b/packages/compiler/src/coverage/surface-manifest.ts
@@ -336,37 +336,26 @@ export function generateSurfaceManifest(compilerVersion: string): SurfaceManifes
         `differential evidence: ${evidence.join(", ")}`,
     });
   }
-  for (const option of NODE24_FETCH_COMPAT_PROFILE.requestInit) {
-    const evidence = option.evidence.map((item) =>
-      item.generated !== undefined
-        ? `generated:${item.generated}`
-        : `fixture:${item.fixture!}`
-    );
-    add({
-      id: option.id,
-      kind: "stdlib",
-      name: option.name,
-      status: "static",
-      note:
-        `${fetchTarget}; conversion: ${option.conversion}; ` +
-        `differential evidence: ${evidence.join(", ")}`,
-    });
-  }
-  for (const option of NODE24_FETCH_COMPAT_PROFILE.responseInit) {
-    const evidence = option.evidence.map((item) =>
-      item.generated !== undefined
-        ? `generated:${item.generated}`
-        : `fixture:${item.fixture!}`
-    );
-    add({
-      id: option.id,
-      kind: "stdlib",
-      name: option.name,
-      status: "static",
-      note:
-        `${fetchTarget}; conversion: ${option.conversion}; ` +
-        `differential evidence: ${evidence.join(", ")}`,
-    });
+  for (const options of [
+    NODE24_FETCH_COMPAT_PROFILE.requestInit,
+    NODE24_FETCH_COMPAT_PROFILE.responseInit,
+  ]) {
+    for (const option of options) {
+      const evidence = option.evidence.map((item) =>
+        item.generated !== undefined
+          ? `generated:${item.generated}`
+          : `fixture:${item.fixture!}`
+      );
+      add({
+        id: option.id,
+        kind: "stdlib",
+        name: option.name,
+        status: "static",
+        note:
+          `${fetchTarget}; conversion: ${option.conversion}; ` +
+          `differential evidence: ${evidence.join(", ")}`,
+      });
+    }
   }
   for (const row of NODE24_FETCH_COMPAT_PROFILE.inventory.entries) {
     if (row.status !== "dynamic-only" && row.status !== "unsupported") continue;

--- a/packages/compiler/src/frontend/cjs-lexer.ts
+++ b/packages/compiler/src/frontend/cjs-lexer.ts
@@ -144,15 +144,30 @@ function identPrefixOf(node: ts.Node, sf: ts.SourceFile): string {
   return sf.text.slice(start, identRunEnd(sf.text, start));
 }
 
-/** The bare `require('spec')` call merve recognizes: callee is exactly the
- * identifier `require` (no optional chaining), one string-literal argument
- * (quotes only — templates never match). */
-function bareRequireSpecOf(e: ts.Node): string | null {
+/** The bare `require('spec')` call merve recognizes. */
+export function bareRequireSpecOf(e: ts.Node): string | null {
   if (!ts.isCallExpression(e) || e.questionDotToken !== undefined) return null;
   if (!ts.isIdentifier(e.expression) || e.expression.text !== "require") return null;
   if (e.arguments.length !== 1) return null;
   const arg = e.arguments[0]!;
   return ts.isStringLiteral(arg) ? arg.text : null;
+}
+
+/** True when `e` is exactly the `exports` identifier. */
+export function isExportsIdent(e: ts.Expression): boolean {
+  return ts.isIdentifier(e) && e.text === "exports";
+}
+
+/** True when `e` is exactly `module.exports`. */
+export function isModuleExports(e: ts.Expression): boolean {
+  return (
+    ts.isPropertyAccessExpression(e) &&
+    e.questionDotToken === undefined &&
+    ts.isIdentifier(e.expression) &&
+    e.expression.text === "module" &&
+    ts.isIdentifier(e.name) &&
+    e.name.text === "exports"
+  );
 }
 
 /** The `require(...)` call at the very START of `e`'s source span, if any:
@@ -174,23 +189,6 @@ function leadingRequireOf(e: ts.Expression, sf: ts.SourceFile): { spec: string; 
     if (first === undefined || first.getStart(sf) !== start) return null;
     cur = first;
   }
-}
-
-/** True when `e` is exactly the `exports` identifier. */
-function isExportsIdent(e: ts.Expression): boolean {
-  return ts.isIdentifier(e) && e.text === "exports";
-}
-
-/** True when `e` is exactly `module.exports`. */
-function isModuleExports(e: ts.Expression): boolean {
-  return (
-    ts.isPropertyAccessExpression(e) &&
-    e.questionDotToken === undefined &&
-    ts.isIdentifier(e.expression) &&
-    e.expression.text === "module" &&
-    ts.isIdentifier(e.name) &&
-    e.name.text === "exports"
-  );
 }
 
 /** Skips ECMA whitespace and comments forward from `pos` (merve's

--- a/packages/compiler/src/frontend/lowering/call-position.ts
+++ b/packages/compiler/src/frontend/lowering/call-position.ts
@@ -1,0 +1,7 @@
+import * as ts from "../ts7/adapter.js";
+
+/** Calls whose result is ignored: ordinary expression statements and
+ * concise arrow bodies (whose contextual void result is discarded). */
+export function resultIsDiscarded(call: ts.CallExpression): boolean {
+  return ts.isExpressionStatement(call.parent) || ts.isArrowFunction(call.parent);
+}

--- a/packages/compiler/src/frontend/lowering/callback-arg.ts
+++ b/packages/compiler/src/frontend/lowering/callback-arg.ts
@@ -1,0 +1,76 @@
+import * as ts from "../ts7/adapter.js";
+import { canBoxFuncIntoDyn, DYN, funcOf, type IrExpr, type IrType, VOID } from "../../ir/nodes.js";
+import { locOf } from "../program.js";
+import type { Lowerer } from "./lowerer.js";
+
+interface CallbackArgOptions {
+  /** Event payload tuple for checked-dynamic callback adaptation. */
+  dynTuple?: readonly IrType[];
+  /** The dgram precedent: a raw dyn value may fill a zero-arg slot. */
+  dynZero?: boolean;
+  /** Validate every declared parameter (dgram); otherwise just the first. */
+  checkAllParams?: boolean;
+  /** Reject non-void callbacks instead of adapting their result away. */
+  rejectValueReturn?: boolean;
+  adapt?: (cb: IrExpr) => IrExpr;
+}
+
+/** Shared listener/callback shape validation for the Node spoke modules. */
+export function lowerCallbackArg(
+  L: Lowerer,
+  node: ts.Expression,
+  what: string,
+  maxParams: number,
+  paramOk: (param: IrType, index: number) => boolean,
+  paramHint: string,
+  options: CallbackArgOptions = {},
+): { cb: IrExpr; nparams: number } {
+  let cb = L.lowerExpr(node);
+  if (cb.type.kind === "dyn" && options.dynTuple !== undefined) {
+    const toT = funcOf([...options.dynTuple], VOID);
+    return {
+      cb: { kind: "dynCheck", value: cb, type: toT, loc: locOf(node) },
+      nparams: options.dynTuple.length,
+    };
+  }
+  if (
+    options.dynTuple !== undefined &&
+    cb.type.kind === "func" &&
+    (cb.type.rest === true ||
+      (cb.type.params.length > 0 && cb.type.params.some((param, i) => !paramOk(param, i)))) &&
+    cb.type.params.every((param) => param.kind === "dyn") &&
+    canBoxFuncIntoDyn(cb.type, (id) => L.shapes.get(id), (id) => L.unions.get(id))
+  ) {
+    const boxed: IrExpr = { kind: "dynFrom", value: cb, type: DYN, loc: locOf(node) };
+    const toT = funcOf([...options.dynTuple], VOID);
+    return {
+      cb: { kind: "dynCheck", value: boxed, type: toT, loc: locOf(node) },
+      nparams: options.dynTuple.length,
+    };
+  }
+  if (cb.type.kind === "dyn" && options.dynZero && maxParams === 0) {
+    cb = { kind: "dynCheck", value: cb, type: funcOf([], VOID), loc: locOf(node) };
+  }
+  if (cb.type.kind !== "func" || cb.type.params.length > maxParams) {
+    L.unsupported(
+      "SC1090",
+      node,
+      `${what} with more than ${maxParams} parameter${maxParams === 1 ? "" : "s"} (${paramHint})`,
+    );
+  }
+  if (options.rejectValueReturn && cb.type.ret.kind !== "void") {
+    L.unsupported(
+      "SC1090",
+      node,
+      "listeners returning a value (make the callback body a block, or return nothing)",
+    );
+  }
+  const params = options.checkAllParams ? cb.type.params : cb.type.params.slice(0, 1);
+  for (let i = 0; i < params.length; i++) {
+    if (!paramOk(params[i]!, i)) {
+      L.unsupported("SC1090", node, `${what} whose parameter is not supported (${paramHint})`);
+    }
+  }
+  const adapted = options.adapt?.(cb) ?? cb;
+  return { cb: adapted, nparams: cb.type.params.length };
+}

--- a/packages/compiler/src/frontend/lowering/lower-assert.ts
+++ b/packages/compiler/src/frontend/lowering/lower-assert.ts
@@ -23,6 +23,7 @@ import { InternalCompilerError } from "../../errors.js";
  * signature records, dyn/unknown) fences at the call site instead of
  * miscomparing. */
 import * as ts from "../ts7/adapter.js";
+import { resultIsDiscarded } from "./call-position.js";
 import type { Lowerer } from "./lowerer.js";
 import { jsFuncNameOf, own } from "./lowerer.js";
 import { NARROW_FIRST } from "./surfaces.js";
@@ -49,7 +50,7 @@ function canonicalAssertMember(module: string, member: string): string {
 /** VOID/never results are usable as statements and concise arrow bodies
  * only (the lower-dgram stance): nothing downstream can consume them. */
 function requireStatementPosition(L: Lowerer, call: ts.CallExpression, what: string): void {
-  if (ts.isExpressionStatement(call.parent) || ts.isArrowFunction(call.parent)) return;
+  if (resultIsDiscarded(call)) return;
   L.noLowering(
     `using the result of ${what}`,
     call,

--- a/packages/compiler/src/frontend/lowering/lower-builtins.ts
+++ b/packages/compiler/src/frontend/lowering/lower-builtins.ts
@@ -32,6 +32,7 @@ import { HTTP2_CONSTANTS } from "./http2-constants.js";
 import { CRYPTO_CIPHERS, CRYPTO_CONSTANTS, CRYPTO_CURVES, CRYPTO_HASHES } from "./crypto-tables.js";
 import { timerStyleCallback } from "./lower-calls.js";
 import { registerHttpClientFnBinding, voidizedCallback } from "./lower-server.js";
+import { pairsSnapshotHelper } from "./pairs-snapshot.js";
 import { BOOL, BYTES_U8, CHILD_T, CHILDSTREAM_T, DYN, F64, FILEHANDLE_T, FSWATCHER_T, PROCSTREAM_T, IrExpr, IrFunction, IrLibFn, IrLocal, IrStmt, IrType, JSVAL, NULL_T, SEARCH_PARAMS_T, SPAWNRES_T, STRING, SrcLoc, UNDEFINED_T, VOID, arrayOf, canBoxFuncIntoDyn, canConvertToDyn, funcOf, isUnitType, typeEquals, typeKey } from "../../ir/nodes.js";
 import { boolLit, countedFor, numLit, strLit, varRef } from "../../ir/build.js";
 
@@ -7731,88 +7732,11 @@ function staticTextDecoderEncoding(label: string): StaticTextDecoderEncoding | n
    * whose value slot is the `string | undefined` union (what ProcessEnv
    * maps to); anything else answers null and the caller keeps its fence. */
   export function envSnapshotHelper(L: Lowerer, shapeId: string, loc: SrcLoc): string | null {
-    const shape = L.shapes.get(shapeId);
-    if (!shape || shape.tuple || shape.fields.length > 0 || !shape.indexValue) return null;
-    const iv = shape.indexValue;
-    if (!typeEquals(iv, L.envValueType())) return null;
-    if (iv.kind !== "union") return null;
-    const strTag = L.armTag(iv.unionId, STRING);
-    if (strTag < 0) return null;
-    const key = `env.snapshot:${shapeId}`;
-    const existing = L.widthHelpers.get(key);
-    if (existing) return existing;
-    const name = `%env.snapshot.${L.widthHelpers.size}`;
-    L.widthHelpers.set(key, name);
-    const recT: IrType = { kind: "record", shapeId };
-    const pairsT = arrayOf(STRING);
-
-    const pairAt = (offset: number): IrExpr => ({
-      kind: "arrayGet",
-      arr: varRef("ps.0", pairsT, loc),
-      index:
-        offset === 0
-          ? varRef("i.0", F64, loc)
-          : { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(offset, loc), type: F64, loc },
-      type: STRING,
-      loc,
+    return pairsSnapshotHelper(L, shapeId, loc, {
+      keyPrefix: "env",
+      libCall: "process.envPairs",
+      indexValueOk: (indexValue) => typeEquals(indexValue, L.envValueType()),
     });
-    const body: IrStmt[] = [
-      {
-        kind: "varDecl",
-        localId: "ps.0",
-        init: { kind: "libCall", fn: "process.envPairs", args: [], type: pairsT, loc },
-        loc,
-      },
-      {
-        kind: "varDecl",
-        localId: "out.0",
-        init: { kind: "recordLit", fields: [], type: recT, loc },
-        loc,
-      },
-      {
-        kind: "for",
-        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-        cond: {
-          kind: "bin",
-          op: "<",
-          left: varRef("i.0", F64, loc),
-          right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ps.0", pairsT, loc), args: [], type: F64, loc },
-          type: BOOL,
-          loc,
-        },
-        update: {
-          kind: "assign",
-          localId: "i.0",
-          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(2, loc), type: F64, loc },
-          loc,
-        },
-        body: [
-          {
-            kind: "recordKeySet",
-            obj: varRef("out.0", recT, loc),
-            shapeId,
-            key: pairAt(0),
-            value: { kind: "unionWrap", unionId: iv.unionId, tag: strTag, value: pairAt(1), type: iv, loc },
-            loc,
-          },
-        ],
-        loc,
-      },
-      { kind: "return", value: varRef("out.0", recT, loc), loc },
-    ];
-    L.liftedFns.push({
-      name,
-      params: [],
-      returnType: recT,
-      locals: [
-        { id: "ps.0", name: "ps", type: pairsT, mutable: false },
-        { id: "out.0", name: "out", type: recT, mutable: false },
-        { id: "i.0", name: "i", type: F64, mutable: true },
-      ],
-      body,
-      loc,
-    });
-    return name;
   }
 
 export function isConsoleLog(L: Lowerer, call: ts.CallExpression): boolean {

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -28,6 +28,7 @@ import { declSymbolOf } from "./lower-modules.js";
 import { expandoMemberRead } from "./lower-expando.js";
 import { npmStaticPackageOfPath } from "../npm-static.js";
 import { countedFor, varRef } from "../../ir/build.js";
+import { rejectStaticThis } from "./static-this.js";
 
 /** How a parameter participates in CALL-SITE COMPLETION (the frontend
  * completes every call to the one full signature, so the IR and backends
@@ -315,8 +316,35 @@ export interface GenericInstance {
     return ts.isIdentifier(param.name) && param.name.text === "this";
   }
 
-  export function paramShapes(L: Lowerer, params: readonly ts.ParameterDeclaration[]): ParamShape[] {
-    return params.filter((p) => !isThisParameter(p)).map((param) => L.paramShape(param));
+  export function paramShapes(
+    L: Lowerer,
+    params: readonly ts.ParameterDeclaration[],
+    signature?: ts.Signature,
+    blameOf?: (param: ts.ParameterDeclaration, index: number) => ts.Node,
+  ): ParamShape[] {
+    if (!signature) return params.filter((p) => !isThisParameter(p)).map((param) => L.paramShape(param));
+    return params.map((declParam, i) => {
+      const symbol = signature.getParameters()[i];
+      const tsType = symbol ? L.checker.getTypeOfSymbol(symbol) : L.typeOf(declParam.name);
+      const mapped = L.mapTypeOf(tsType);
+      if (!mapped || mapped.kind === "void") L.badType(blameOf?.(declParam, i) ?? declParam.name, tsType);
+      if (declParam.dotDotDotToken) {
+        if (mapped.kind !== "array") L.badType(blameOf?.(declParam, i) ?? declParam.name, tsType);
+        return { type: mapped, mode: "rest" };
+      }
+      if (declParam.initializer) {
+        if (mapped.kind === "dyn" || mapped.kind === "jsval") {
+          return { type: mapped, mode: "omittable", bodyType: mapped };
+        }
+        const bodyType = L.stripUndefinedArm(mapped);
+        L.checkDefaultParamBodyType(declParam, bodyType);
+        return { type: L.withUndefinedArm(bodyType), mode: "omittable", bodyType };
+      }
+      if (declParam.questionToken && !L.bareUndefinedArmedUnion(mapped)) {
+        L.unsupported("SC1090", declParam, `optional parameters of type '${L.fmt(mapped)}'`);
+      }
+      return { type: mapped, mode: declParam.questionToken ? "omittable" : "required" };
+    });
   }
 
 /** The fences on a defaulted parameter's body type: it becomes the value
@@ -1004,32 +1032,7 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
     // the declaration's modes: rest stays the resolved array, a default's
     // ABI union is synthesized over the resolved body type — exactly the
     // paramShape rules, applied to post-substitution types.
-    const params: ParamShape[] = [];
-    rsig.getParameters().forEach((p, i) => {
-      const declParam = info.decl.parameters[i]!;
-      const pt = L.checker.getTypeOfSymbol(p);
-      const mapped = L.mapTypeOf(pt);
-      if (!mapped || mapped.kind === "void") L.badType(expr.arguments[i] ?? expr, pt);
-      if (declParam.dotDotDotToken) {
-        if (mapped.kind !== "array") L.badType(expr.arguments[i] ?? expr, pt);
-        params.push({ type: mapped, mode: "rest" });
-      } else if (declParam.initializer) {
-        if (mapped.kind === "dyn" || mapped.kind === "jsval") {
-          // Dynamic-tier default: the slot holds its tier's undefined
-          // directly (paramShape's rule — declareParams tests at runtime).
-          params.push({ type: mapped, mode: "omittable", bodyType: mapped });
-        } else {
-          const bodyType = L.stripUndefinedArm(mapped);
-          L.checkDefaultParamBodyType(declParam, bodyType);
-          params.push({ type: L.withUndefinedArm(bodyType), mode: "omittable", bodyType });
-        }
-      } else {
-        if (declParam.questionToken && !L.bareUndefinedArmedUnion(mapped)) {
-          L.unsupported("SC1090", declParam, `optional parameters of type '${L.fmt(mapped)}'`);
-        }
-        params.push({ type: mapped, mode: declParam.questionToken ? "omittable" : "required" });
-      }
-    });
+    const params = paramShapes(L, info.decl.parameters, rsig, (_param, i) => expr.arguments[i] ?? expr);
     const retTs = L.checker.getReturnTypeOfSignature(rsig);
     const returnType = L.mapTypeOf(retTs);
     if (!returnType) {
@@ -1409,25 +1412,11 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
       // are transparent (they inherit the method's `this`); this-binding
       // function forms are opaque.
       if (info.member?.kind === "static" && decl.body) {
-        const checkThis = (n: ts.Node): void => {
-          if (
-            ts.isFunctionExpression(n) || ts.isFunctionDeclaration(n) ||
-            ts.isMethodDeclaration(n) || ts.isConstructorDeclaration(n) ||
-            ts.isGetAccessor(n) || ts.isSetAccessor(n) ||
-            ts.isClassDeclaration(n) || ts.isClassExpression(n)
-          ) {
-            return;
-          }
-          if (n.kind === ts.SyntaxKind.ThisKeyword || n.kind === ts.SyntaxKind.SuperKeyword) {
-            L.unsupported(
-              "SC1090",
-              n,
-              `'${n.kind === ts.SyntaxKind.ThisKeyword ? "this" : "super"}' in static methods (it names the RECEIVER class — a dynamic value; reference the class by name instead)`,
-            );
-          }
-          n.forEachChild(checkThis);
-        };
-        decl.body.forEachChild(checkThis);
+        rejectStaticThis(
+          L,
+          decl.body,
+          (keyword) => `'${keyword}' in static methods (it names the RECEIVER class — a dynamic value; reference the class by name instead)`,
+        );
       }
       const params: IrParam[] = [];
       if (cls && info.member!.kind === "method") {
@@ -1692,32 +1681,7 @@ export function genericFnOf(L: Lowerer, ident: ts.Identifier): GenericFnInfo | n
     try {
       const declSig = L.checker.getSignatureFromDeclaration(info.decl);
       if (!declSig) L.unsupported("SC1090", ref, "this function form");
-      const params: ParamShape[] = [];
-      info.decl.parameters.forEach((declParam, i) => {
-        const p = declSig.getParameters()[i];
-        const pt = p ? L.checker.getTypeOfSymbol(p) : L.typeOf(declParam.name);
-        const mapped = L.mapTypeOf(pt);
-        if (!mapped || mapped.kind === "void") L.badType(declParam.name, pt);
-        if (declParam.dotDotDotToken) {
-          if (mapped.kind !== "array") L.badType(declParam.name, pt);
-          params.push({ type: mapped, mode: "rest" });
-        } else if (declParam.initializer) {
-          if (mapped.kind === "dyn" || mapped.kind === "jsval") {
-            // Dynamic-tier default: the slot holds its tier's undefined
-            // directly (paramShape's rule).
-            params.push({ type: mapped, mode: "omittable", bodyType: mapped });
-          } else {
-            const bodyType = L.stripUndefinedArm(mapped);
-            L.checkDefaultParamBodyType(declParam, bodyType);
-            params.push({ type: L.withUndefinedArm(bodyType), mode: "omittable", bodyType });
-          }
-        } else {
-          if (declParam.questionToken && !L.bareUndefinedArmedUnion(mapped)) {
-            L.unsupported("SC1090", declParam, `optional parameters of type '${L.fmt(mapped)}'`);
-          }
-          params.push({ type: mapped, mode: declParam.questionToken ? "omittable" : "required" });
-        }
-      });
+      const params = paramShapes(L, info.decl.parameters, declSig);
       const retTs = L.checker.getReturnTypeOfSignature(declSig);
       const returnType = L.mapTypeOf(retTs);
       if (!returnType) {

--- a/packages/compiler/src/frontend/lowering/lower-classes.ts
+++ b/packages/compiler/src/frontend/lowering/lower-classes.ts
@@ -22,6 +22,7 @@ import { uniqueSymbolKeyOf } from "./lower-exprs.js";
 import { lowerHttpAgentNew, lowerHttpServerNew } from "./lower-server.js";
 import { ambientNsRootOf, ambientUndefReadType, ambientUndefVarRootOf, ambientUndefinedFnSymbolOf, fenceEarlyAliasUse, fenceEarlyNsMemberRef, nsMemberIdentOf, nsUndefRead } from "./lower-namespaces.js";
 import { mixinResultBindingClassOf, type MixinInstanceInfo } from "./lower-mixins.js";
+import { rejectStaticThis } from "./static-this.js";
 
 export interface ClassInfo {
   def: IrClassDef;
@@ -1184,21 +1185,11 @@ export function collectClassShapeInner(L: Lowerer, decl: ts.ClassLikeDeclaration
           // with arrow functions transparent (they inherit the block's
           // `this`) and this-binding function forms opaque (their `this` is
           // their own).
-          const checkThis = (n: ts.Node): void => {
-            if (
-              ts.isFunctionExpression(n) || ts.isFunctionDeclaration(n) ||
-              ts.isMethodDeclaration(n) || ts.isConstructorDeclaration(n) ||
-              ts.isGetAccessor(n) || ts.isSetAccessor(n) ||
-              ts.isClassDeclaration(n) || ts.isClassExpression(n)
-            ) {
-              return;
-            }
-            if (n.kind === ts.SyntaxKind.ThisKeyword || n.kind === ts.SyntaxKind.SuperKeyword) {
-              L.unsupported("SC1090", n, "'this' in class static blocks (it names the class — reference the class by name instead)");
-            }
-            n.forEachChild(checkThis);
-          };
-          member.body.forEachChild(checkThis);
+          rejectStaticThis(
+            L,
+            member.body,
+            () => "'this' in class static blocks (it names the class — reference the class by name instead)",
+          );
           staticBlocks.push(member);
           continue;
         }
@@ -2539,21 +2530,12 @@ export function collectClassShapeInner(L: Lowerer, decl: ts.ClassLikeDeclaration
         // static block's), with arrows transparent and this-binding
         // function forms opaque — the static-block rule verbatim, named
         // here so the generic outside-a-method fence never fires first.
-        const checkThis = (n: ts.Node): void => {
-          if (
-            ts.isFunctionExpression(n) || ts.isFunctionDeclaration(n) ||
-            ts.isMethodDeclaration(n) || ts.isConstructorDeclaration(n) ||
-            ts.isGetAccessor(n) || ts.isSetAccessor(n) ||
-            ts.isClassDeclaration(n) || ts.isClassExpression(n)
-          ) {
-            return;
-          }
-          if (n.kind === ts.SyntaxKind.ThisKeyword || n.kind === ts.SyntaxKind.SuperKeyword) {
-            L.unsupported("SC1090", n, "'this' in static field initializers (it names the class — reference the class by name instead)");
-          }
-          n.forEachChild(checkThis);
-        };
-        checkThis(f.initializer);
+        rejectStaticThis(
+          L,
+          f.initializer,
+          () => "'this' in static field initializers (it names the class — reference the class by name instead)",
+          true,
+        );
         const value = L.lowerExprExpecting(f.initializer, f.type);
         out.push({ kind: "assign", localId: f.globalId, value, loc: locOf(f.initializer) });
       } catch (e) {
@@ -4152,24 +4134,6 @@ export function lowerClassMembers(L: Lowerer, info: ClassInfo): IrFunction[] {
   export function lowerStaticMethod(L: Lowerer, info: ClassInfo, name: string): IrFunction | null {
     const entry = info.staticMethods?.get(name);
     if (!entry?.member.body) return null;
-    const checkThis = (n: ts.Node): void => {
-      if (
-        ts.isFunctionExpression(n) || ts.isFunctionDeclaration(n) ||
-        ts.isMethodDeclaration(n) || ts.isConstructorDeclaration(n) ||
-        ts.isGetAccessor(n) || ts.isSetAccessor(n) ||
-        ts.isClassDeclaration(n) || ts.isClassExpression(n)
-      ) {
-        return;
-      }
-      if (n.kind === ts.SyntaxKind.ThisKeyword || n.kind === ts.SyntaxKind.SuperKeyword) {
-        L.unsupported(
-          "SC1090",
-          n,
-          `'${n.kind === ts.SyntaxKind.ThisKeyword ? "this" : "super"}' in static methods (it names the RECEIVER class — a dynamic value; reference the class by name instead)`,
-        );
-      }
-      n.forEachChild(checkThis);
-    };
     // Async statics: an async IrFunction like any module function — the
     // body returns the promise's INNER type, calls enter through the
     // fiber spawn wrapper (callTargetC routes by fn.async).
@@ -4181,7 +4145,11 @@ export function lowerClassMembers(L: Lowerer, info: ClassInfo): IrFunction[] {
     fnCtx.isAsync = isAsync;
     L.fnStack.push(fnCtx);
     try {
-      entry.member.body.forEachChild(checkThis);
+      rejectStaticThis(
+        L,
+        entry.member.body,
+        (keyword) => `'${keyword}' in static methods (it names the RECEIVER class — a dynamic value; reference the class by name instead)`,
+      );
       const declared = L.declareParams(entry.member.parameters, entry.params);
       const body = [...declared.prologue, ...L.lowerStmts(entry.member.body.statements)];
       const fn: IrFunction = {

--- a/packages/compiler/src/frontend/lowering/lower-dgram.ts
+++ b/packages/compiler/src/frontend/lowering/lower-dgram.ts
@@ -11,19 +11,38 @@ import * as ts from "../ts7/adapter.js";
 import type { Lowerer } from "./lowerer.js";
 import { ladderFenceExpr } from "./lowerer.js";
 import { isJsSourceFile, locOf } from "../program.js";
-import { BOOL, canBoxFuncIntoDyn, DGRAMSOCK_T, DYN, F64, funcOf, IrExpr, IrLibFn, IrType, SrcLoc, STRING, UNDEFINED_T, VOID } from "../../ir/nodes.js";
+import { BOOL, canBoxFuncIntoDyn, DGRAMSOCK_T, DYN, F64, IrExpr, IrLibFn, IrType, SrcLoc, STRING, UNDEFINED_T, VOID } from "../../ir/nodes.js";
 import { DNS_LOOKUP_DOCUMENTED_OPTIONS, fenceOrDropOptionKey } from "./surfaces.js";
 import { boolLit } from "../../ir/build.js";
+import { resultIsDiscarded } from "./call-position.js";
+import { lowerCallbackArg as lowerCallbackArgShared } from "./callback-arg.js";
 
 const DGRAM_SURFACE_HINT =
   "bind, connect, send, address, close, unref/ref, and on/once of " +
   "message/listening/close/connect/error are the supported dgram.Socket members";
 
+/** Dgram's callback policy: validate every positional parameter and require
+ * callbacks to return void; raw dyn values adapt only to zero-arg slots. */
+function lowerCallbackArg(
+  L: Lowerer,
+  node: ts.Expression,
+  what: string,
+  maxParams: number,
+  paramOk: (param: IrType, index: number) => boolean,
+  paramHint: string,
+): { cb: IrExpr; nparams: number } {
+  return lowerCallbackArgShared(L, node, what, maxParams, paramOk, paramHint, {
+    dynZero: true,
+    checkAllParams: true,
+    rejectValueReturn: true,
+  });
+}
+
 /** VOID-result socket calls are usable as statements and as concise arrow
  * bodies; anything consuming the result (Node returns `this` where this
  * surface returns void) is fenced — the lower-server stance. */
 function requireStatementPosition(L: Lowerer, call: ts.CallExpression, what: string): void {
-  if (ts.isExpressionStatement(call.parent) || ts.isArrowFunction(call.parent)) return;
+  if (resultIsDiscarded(call)) return;
   L.unsupported(
     "SC1090",
     call,
@@ -35,42 +54,6 @@ function requireStatementPosition(L: Lowerer, call: ts.CallExpression, what: str
  * return, at most `maxParams` parameters, each parameter's IR kind
  * satisfying `paramOk` (indexed). The lower-server helper's shape,
  * re-stated here so the spoke stays self-contained. */
-function lowerCallbackArg(
-  L: Lowerer,
-  node: ts.Expression,
-  what: string,
-  maxParams: number,
-  paramOk: (p: IrType, i: number) => boolean,
-  paramHint: string,
-): { cb: IrExpr; nparams: number } {
-  let cb = L.lowerExpr(node);
-  // A checked-dynamic callback (test/common's mustCall wrapper — a dyn
-  // value): the zero-parameter slots adapt through the dynCheck function
-  // boundary, the lower-server listen-callback precedent.
-  if (cb.type.kind === "dyn" && maxParams === 0) {
-    cb = { kind: "dynCheck", value: cb, type: funcOf([], VOID), loc: locOf(node) };
-  }
-  if (cb.type.kind !== "func" || cb.type.params.length > maxParams) {
-    L.unsupported(
-      "SC1090",
-      node,
-      `${what} with more than ${maxParams} parameter${maxParams === 1 ? "" : "s"} (${paramHint})`,
-    );
-  }
-  if (cb.type.ret.kind !== "void") {
-    L.unsupported(
-      "SC1090",
-      node,
-      "listeners returning a value (make the callback body a block, or return nothing)",
-    );
-  }
-  for (let i = 0; i < cb.type.params.length; i++) {
-    if (!paramOk(cb.type.params[i]!, i)) {
-      L.unsupported("SC1090", node, `${what} whose parameter is not supported (${paramHint})`);
-    }
-  }
-  return { cb, nparams: cb.type.params.length };
-}
 /** True iff `t` is the `Error | null` union — dns.lookup's first callback
  * parameter (NodeJS.ErrnoException maps to %Error in types.ts). */
 function isErrorOrNullUnion(L: Lowerer, t: IrType): boolean {

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -351,19 +351,22 @@ function requestInitConstBacked(
   );
 }
 
-/** Visit the source values of one property on a const-backed object. The
- * checker's property symbol can come from an annotation (a PropertySignature)
- * rather than the object literal that supplies the runtime value, so source
- * tracing has to follow the receiver initializer by key as well. */
-function visitRequestInitConstPropertyValues(
+type RequestInitValueSelector =
+  | { kind: "property"; key: string }
+  | { kind: "index"; index: number };
+
+/** Visit the values selected by one key or index on a const-backed object or
+ * array. Property symbols can come from annotations rather than the literal
+ * supplying the runtime value, so tracing follows receiver initializers. */
+function visitRequestInitConstSelectedValues(
   L: Lowerer,
   value: ts.Expression,
-  key: string,
+  selector: RequestInitValueSelector,
   seen: Set<ts.Symbol>,
   visit: (value: ts.Expression) => void,
 ): boolean {
   const expr = requestInitValueExpr(value);
-  if (ts.isObjectLiteralExpression(expr)) {
+  if (selector.kind === "property" && ts.isObjectLiteralExpression(expr)) {
     // Last contributor wins. A definite later property (including one from
     // a statically traced spread) hides earlier values exactly as it does at
     // runtime; a conditional/missing spread keeps the earlier contributor
@@ -371,17 +374,17 @@ function visitRequestInitConstPropertyValues(
     for (let i = expr.properties.length - 1; i >= 0; i--) {
       const property = expr.properties[i]!;
       if (ts.isSpreadAssignment(property)) {
-        const defines = visitRequestInitConstPropertyValues(
+        const defines = visitRequestInitConstSelectedValues(
           L,
           property.expression,
-          key,
+          selector,
           new Set(seen),
           visit,
         );
         if (defines) return true;
         continue;
       }
-      if (requestInitLiteralKey(L, property) !== key) continue;
+      if (requestInitLiteralKey(L, property) !== selector.key) continue;
       if (ts.isPropertyAssignment(property)) {
         visit(property.initializer);
       } else if (
@@ -394,93 +397,8 @@ function visitRequestInitConstPropertyValues(
     }
     return false;
   }
-  if (ts.isConditionalExpression(expr)) {
-    const selected = requestInitStaticBoolean(L, expr.condition);
-    if (selected !== null) {
-      return visitRequestInitConstPropertyValues(
-        L,
-        selected ? expr.whenTrue : expr.whenFalse,
-        key,
-        seen,
-        visit,
-      );
-    }
-    const whenTrue = visitRequestInitConstPropertyValues(
-      L,
-      expr.whenTrue,
-      key,
-      new Set(seen),
-      visit,
-    );
-    const whenFalse = visitRequestInitConstPropertyValues(
-      L,
-      expr.whenFalse,
-      key,
-      new Set(seen),
-      visit,
-    );
-    return whenTrue && whenFalse;
-  }
-  if (ts.isPropertyAccessExpression(expr) || ts.isElementAccessExpression(expr)) {
-    const member = ts.isPropertyAccessExpression(expr)
-      ? expr.name.text
-      : foldedStringKeyOf(L, expr.argumentExpression);
-    if (member === null) return false;
-    const nested: ts.Expression[] = [];
-    const receiverDefines = visitRequestInitConstPropertyValues(
-      L,
-      expr.expression,
-      member,
-      new Set(seen),
-      (value) => nested.push(value),
-    );
-    let nestedDefines = nested.length > 0;
-    for (const value of nested) {
-      if (!visitRequestInitConstPropertyValues(L, value, key, new Set(seen), visit)) {
-        nestedDefines = false;
-      }
-    }
-    return receiverDefines && nestedDefines;
-  }
-  if (!ts.isIdentifier(expr)) return false;
-  const symbol = L.resolveValueSymbol(expr);
-  if (!symbol || seen.has(symbol)) return false;
-  if (requestInitPropMutatedSymbols(L).has(symbol)) return false;
-  seen.add(symbol);
-  let sawDeclaration = false;
-  let defines = true;
-  for (const declaration of L.checker.declarationsOf(symbol)) {
-    if (
-      ts.isVariableDeclaration(declaration) &&
-      declaration.initializer !== undefined &&
-      ts.isVariableDeclarationList(declaration.parent) &&
-      (declaration.parent.flags & ts.NodeFlags.Const) !== 0
-    ) {
-      sawDeclaration = true;
-      if (!visitRequestInitConstPropertyValues(
-        L,
-        declaration.initializer,
-        key,
-        new Set(seen),
-        visit,
-      )) {
-        defines = false;
-      }
-    }
-  }
-  return sawDeclaration && defines;
-}
-
-function visitRequestInitConstIndexValues(
-  L: Lowerer,
-  value: ts.Expression,
-  index: number,
-  seen: Set<ts.Symbol>,
-  visit: (value: ts.Expression) => void,
-): boolean {
-  const expr = requestInitValueExpr(value);
-  if (ts.isArrayLiteralExpression(expr)) {
-    const element = expr.elements[index];
+  if (selector.kind === "index" && ts.isArrayLiteralExpression(expr)) {
+    const element = expr.elements[selector.index];
     if (
       element === undefined ||
       ts.isOmittedExpression(element) ||
@@ -494,25 +412,25 @@ function visitRequestInitConstIndexValues(
   if (ts.isConditionalExpression(expr)) {
     const selected = requestInitStaticBoolean(L, expr.condition);
     if (selected !== null) {
-      return visitRequestInitConstIndexValues(
+      return visitRequestInitConstSelectedValues(
         L,
         selected ? expr.whenTrue : expr.whenFalse,
-        index,
+        selector,
         seen,
         visit,
       );
     }
-    const whenTrue = visitRequestInitConstIndexValues(
+    const whenTrue = visitRequestInitConstSelectedValues(
       L,
       expr.whenTrue,
-      index,
+      selector,
       new Set(seen),
       visit,
     );
-    const whenFalse = visitRequestInitConstIndexValues(
+    const whenFalse = visitRequestInitConstSelectedValues(
       L,
       expr.whenFalse,
-      index,
+      selector,
       new Set(seen),
       visit,
     );
@@ -524,16 +442,16 @@ function visitRequestInitConstIndexValues(
       : foldedStringKeyOf(L, expr.argumentExpression);
     if (member === null) return false;
     const nested: ts.Expression[] = [];
-    const receiverDefines = visitRequestInitConstPropertyValues(
+    const receiverDefines = visitRequestInitConstSelectedValues(
       L,
       expr.expression,
-      member,
+      { kind: "property", key: member },
       new Set(seen),
       (value) => nested.push(value),
     );
     let nestedDefines = nested.length > 0;
     for (const value of nested) {
-      if (!visitRequestInitConstIndexValues(L, value, index, new Set(seen), visit)) {
+      if (!visitRequestInitConstSelectedValues(L, value, selector, new Set(seen), visit)) {
         nestedDefines = false;
       }
     }
@@ -554,10 +472,10 @@ function visitRequestInitConstIndexValues(
       (declaration.parent.flags & ts.NodeFlags.Const) !== 0
     ) {
       sawDeclaration = true;
-      if (!visitRequestInitConstIndexValues(
+      if (!visitRequestInitConstSelectedValues(
         L,
         declaration.initializer,
-        index,
+        selector,
         new Set(seen),
         visit,
       )) {
@@ -635,9 +553,7 @@ function visitRequestInitConstBindingValues(
       nestedDefines = false;
     }
   };
-  const defines = selector.kind === "property"
-    ? visitRequestInitConstPropertyValues(L, value, selector.key, seen, visitNested)
-    : visitRequestInitConstIndexValues(L, value, selector.index, seen, visitNested);
+  const defines = visitRequestInitConstSelectedValues(L, value, selector, seen, visitNested);
   return defines && nestedDefines;
 }
 
@@ -650,10 +566,10 @@ function fenceRequestInitProperty(
     ? access.name.text
     : foldedStringKeyOf(L, access.argumentExpression);
   if (key === null) return;
-  visitRequestInitConstPropertyValues(
+  visitRequestInitConstSelectedValues(
     L,
     access.expression,
-    key,
+    { kind: "property", key },
     new Set(),
     (value) => fenceRequestInitValueInner(L, value, seen),
   );
@@ -723,10 +639,10 @@ function fenceRequestInitObject(
     if (ts.isSpreadAssignment(prop)) {
       for (const row of rows) {
         if (shadowed.has(row.member)) continue;
-        const defines = visitRequestInitConstPropertyValues(
+        const defines = visitRequestInitConstSelectedValues(
           L,
           prop.expression,
-          row.member,
+          { kind: "property", key: row.member },
           new Set(seen),
           (value) => fence(row, value, value),
         );

--- a/packages/compiler/src/frontend/lowering/lower-server.ts
+++ b/packages/compiler/src/frontend/lowering/lower-server.ts
@@ -27,6 +27,9 @@ import {
 } from "./surfaces.js";
 import { conditionalSpreadOf } from "./lower-exprs.js";
 import { boolLit, numLit, strLit, varRef } from "../../ir/build.js";
+import { resultIsDiscarded } from "./call-position.js";
+import { lowerCallbackArg as lowerCallbackArgShared } from "./callback-arg.js";
+import { pairsSnapshotHelper } from "./pairs-snapshot.js";
 
 const NARROW_DATA_HINT =
   'write/end take one string or one Uint8Array/Buffer value (narrow unions first)';
@@ -50,7 +53,7 @@ function httpServerTimeoutField(name: string): number | null {
  * portless is made of); anything that would CONSUME the result (Node
  * returns `this`/a boolean where this surface returns void) is fenced. */
 function requireStatementPosition(L: Lowerer, call: ts.CallExpression, what: string): void {
-  if (ts.isExpressionStatement(call.parent) || ts.isArrowFunction(call.parent)) return;
+  if (resultIsDiscarded(call)) return;
   L.unsupported(
     "SC1090",
     call,
@@ -193,48 +196,10 @@ function lowerCallbackArg(
   paramHint: string,
   dynTuple?: readonly IrType[],
 ): { cb: IrExpr; nparams: number } {
-  const cb = L.lowerExpr(node);
-  if (cb.type.kind === "dyn" && dynTuple !== undefined) {
-    const toT = funcOf([...dynTuple], VOID);
-    return {
-      cb: { kind: "dynCheck", value: cb, type: toT, loc: locOf(node) },
-      nparams: dynTuple.length,
-    };
-  }
-  if (
-    dynTuple !== undefined &&
-    cb.type.kind === "func" &&
-    (cb.type.rest === true ||
-      (cb.type.params.length > 0 && cb.type.params.some((p) => !paramOk(p)))) &&
-    cb.type.params.every((p) => p.kind === "dyn") &&
-    canBoxFuncIntoDyn(cb.type, (id) => L.shapes.get(id), (id) => L.unions.get(id))
-  ) {
-    // A plain-JS listener whose params carry no contextual type (a
-    // hoisted `function onConn(socket)` — dyn params), or an
-    // arguments-reading rest function: box it and adapt through the
-    // dynCheck function boundary like the dyn flavor above — the event
-    // payloads box into the checked-dynamic tree (handles by reference) and the body's
-    // member uses dispatch at runtime.
-    const boxed: IrExpr = { kind: "dynFrom", value: cb, type: DYN, loc: locOf(node) };
-    const toT = funcOf([...dynTuple], VOID);
-    return {
-      cb: { kind: "dynCheck", value: boxed, type: toT, loc: locOf(node) },
-      nparams: dynTuple.length,
-    };
-  }
-  if (cb.type.kind !== "func" || cb.type.params.length > maxParams) {
-    L.unsupported(
-      "SC1090",
-      node,
-      `${what} with more than ${maxParams} parameter${maxParams === 1 ? "" : "s"} (${paramHint})`,
-    );
-  }
-  const param = cb.type.params[0];
-  if (param !== undefined && !paramOk(param)) {
-    L.unsupported("SC1090", node, `${what} whose parameter is not supported (${paramHint})`);
-  }
-  const adapted = voidizedCallback(L, cb, locOf(node));
-  return { cb: adapted, nparams: cb.type.params.length };
+  return lowerCallbackArgShared(L, node, what, maxParams, paramOk, paramHint, {
+    ...(dynTuple !== undefined ? { dynTuple } : {}),
+    adapt: (cb) => voidizedCallback(L, cb, locOf(node)),
+  });
 }
 /** Lowers a handle-kind method receiver. The checker's control flow can
  * narrow an untyped binding to the handle class (`let server; server =
@@ -1671,88 +1636,12 @@ export function lowerServerMethodCall(L: Lowerer, call: ts.CallExpression,
  * when the shape is not a pure index-signature record with a string arm
  * (the caller fences). */
 function headersSnapshotHelper(L: Lowerer, shapeId: string, loc: SrcLoc): string | null {
-  const shape = L.shapes.get(shapeId);
-  if (!shape || shape.tuple || shape.fields.length > 0 || !shape.indexValue) return null;
-  const iv = shape.indexValue;
-  if (iv.kind !== "union") return null;
-  const strTag = L.armTag(iv.unionId, STRING);
-  if (strTag < 0) return null;
-  const key = `headers.snapshot:${shapeId}`;
-  const existing = L.widthHelpers.get(key);
-  if (existing) return existing;
-  const name = `%headers.snapshot.${L.widthHelpers.size}`;
-  L.widthHelpers.set(key, name);
-  const recT: IrType = { kind: "record", shapeId };
-  const pairsT = arrayOf(STRING);
-
-  const pairAt = (offset: number): IrExpr => ({
-    kind: "arrayGet",
-    arr: varRef("ps.0", pairsT, loc),
-    index:
-      offset === 0
-        ? varRef("i.0", F64, loc)
-        : { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(offset, loc), type: F64, loc },
-    type: STRING,
-    loc,
-  });
-  const body: IrStmt[] = [
-    {
-      kind: "varDecl",
-      localId: "ps.0",
-      init: { kind: "libCall", fn: "http.reqHeaderPairs", args: [varRef("r.0", HTTPREQ_T, loc)], type: pairsT, loc },
-      loc,
-    },
-    {
-      kind: "varDecl",
-      localId: "out.0",
-      init: { kind: "recordLit", fields: [], type: recT, loc },
-      loc,
-    },
-    {
-      kind: "for",
-      init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
-      cond: {
-        kind: "bin",
-        op: "<",
-        left: varRef("i.0", F64, loc),
-        right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ps.0", pairsT, loc), args: [], type: F64, loc },
-        type: BOOL,
-        loc,
-      },
-      update: {
-        kind: "assign",
-        localId: "i.0",
-        value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(2, loc), type: F64, loc },
-        loc,
-      },
-      body: [
-        {
-          kind: "recordKeySet",
-          obj: varRef("out.0", recT, loc),
-          shapeId,
-          key: pairAt(0),
-          value: { kind: "unionWrap", unionId: iv.unionId, tag: strTag, value: pairAt(1), type: iv, loc },
-          loc,
-        },
-      ],
-      loc,
-    },
-    { kind: "return", value: varRef("out.0", recT, loc), loc },
-  ];
-  L.liftedFns.push({
-    name,
+  return pairsSnapshotHelper(L, shapeId, loc, {
+    keyPrefix: "headers",
+    libCall: "http.reqHeaderPairs",
     params: [{ localId: "r.0", name: "r", type: HTTPREQ_T }],
-    returnType: recT,
-    locals: [
-      { id: "r.0", name: "r", type: HTTPREQ_T, mutable: false },
-      { id: "ps.0", name: "ps", type: pairsT, mutable: false },
-      { id: "out.0", name: "out", type: recT, mutable: false },
-      { id: "i.0", name: "i", type: F64, mutable: true },
-    ],
-    body,
-    loc,
+    callArgs: [varRef("r.0", HTTPREQ_T, loc)],
   });
-  return name;
 }
 
 /** The `endStream` boolean of an h2 options object literal, as a literal

--- a/packages/compiler/src/frontend/lowering/lower-stmts.ts
+++ b/packages/compiler/src/frontend/lowering/lower-stmts.ts
@@ -1951,6 +1951,35 @@ export function isParseArgsDynCheckerType(L: Lowerer, type: ts.Type): boolean {
     return null;
   }
 
+/** Decode one non-rest object-assignment property into its static source
+ * field, destination expression, and optional default initializer. */
+  function destructuringPropertyOf(
+    L: Lowerer,
+    prop: ts.ObjectLiteralElementLike,
+  ): { fieldName: string; bindTo: ts.Expression; defaultInit: ts.Expression | null } {
+    if (ts.isShorthandPropertyAssignment(prop)) {
+      return {
+        fieldName: (prop.name as ts.Identifier).text,
+        bindTo: prop.name as ts.Identifier,
+        defaultInit: prop.objectAssignmentInitializer ?? null,
+      };
+    }
+    if (!ts.isPropertyAssignment(prop)) {
+      L.unsupported("SC1031", prop, "destructuring assignment with getter/setter or method properties");
+    }
+    const folded = patternKeyNameOf(L, prop.name);
+    if (folded === null) {
+      L.unsupported("SC1031", prop, "destructuring assignment with computed keys that do not fold to one property name");
+    }
+    let bindTo = prop.initializer;
+    let defaultInit: ts.Expression | null = null;
+    if (ts.isBinaryExpression(bindTo) && bindTo.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
+      defaultInit = bindTo.right;
+      bindTo = bindTo.left;
+    }
+    return { fieldName: folded, bindTo, defaultInit };
+  }
+
 /** True when the CHECKER types this expression as a string in every arm
    * (unions of string-likes included). The IR carries builtin IDENTITY
    * TOKENS as strings too (`globalThis.crypto` taken as a value in a JS
@@ -5205,27 +5234,10 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
             out.push({ kind: "assign", localId: targetBinding.id, value: L.coerceInto(prop, packed, targetBinding.type), loc: propLoc });
             continue;
           }
-          let fieldName: string;
-          let bindTo: ts.Expression;
-          let dfltInit: ts.Expression | null = null;
-          if (ts.isShorthandPropertyAssignment(prop)) {
-            fieldName = (prop.name as ts.Identifier).text;
-            bindTo = prop.name as ts.Identifier;
-            dfltInit = prop.objectAssignmentInitializer ?? null;
-          } else if (ts.isPropertyAssignment(prop)) {
-            const folded = patternKeyNameOf(L, prop.name);
-            if (folded === null) {
-              L.unsupported("SC1031", prop, "destructuring assignment with computed keys that do not fold to one property name");
-            }
-            fieldName = folded;
-            bindTo = prop.initializer;
-            if (ts.isBinaryExpression(bindTo) && bindTo.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-              dfltInit = bindTo.right;
-              bindTo = bindTo.left;
-            }
-          } else {
-            L.unsupported("SC1031", prop, "destructuring assignment with getter/setter or method properties");
-          }
+          const decoded = destructuringPropertyOf(L, prop);
+          const { fieldName } = decoded;
+          let { bindTo } = decoded;
+          const dfltInit = decoded.defaultInit;
           const dflt = dfltInit;
           const readOf = (targetT: IrType | null): IrExpr => {
             const fieldType = info.fields.get(fieldName);
@@ -5306,26 +5318,9 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
             "rest bindings over string sources (JS packs the wrapper's per-code-unit indices — split with [...s] instead)",
           );
         }
-        let fieldName: string;
-        let bindTo: ts.Expression;
-        if (ts.isShorthandPropertyAssignment(prop)) {
-          fieldName = (prop.name as ts.Identifier).text;
-          bindTo = prop.name as ts.Identifier;
-        } else if (ts.isPropertyAssignment(prop)) {
-          const folded = patternKeyNameOf(L, prop.name);
-          if (folded === null) {
-            L.unsupported("SC1031", prop, "destructuring assignment with computed keys that do not fold to one property name");
-          }
-          fieldName = folded;
-          bindTo = prop.initializer;
-          // `({ length: n = 3 } = s)`: the default is dead (length always
-          // exists) — strip it, exactly the evaluation JS skips.
-          if (ts.isBinaryExpression(bindTo) && bindTo.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-            bindTo = bindTo.left;
-          }
-        } else {
-          L.unsupported("SC1031", prop, "destructuring assignment with getter/setter or method properties");
-        }
+        const decoded = destructuringPropertyOf(L, prop);
+        const { fieldName } = decoded;
+        let { bindTo } = decoded;
         if (fieldName !== "length") {
           L.unsupported(
             "SC1031",
@@ -5379,7 +5374,6 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
       // Shorthand `{ a }` assigns local a from field a; `{ a: x }` assigns
       // x from field a (a PropertyAssignment whose initializer is the
       // target — JS reuses the literal syntax with inverted roles).
-      let fieldName: string;
       let bindTo: ts.Expression;
       let dfltInit: ts.Expression | null = null;
       if (ts.isSpreadAssignment(prop)) {
@@ -5443,29 +5437,10 @@ function isEsModuleStamp(expr: ts.Expression): boolean {
         });
         continue;
       }
-      if (ts.isShorthandPropertyAssignment(prop)) {
-        fieldName = (prop.name as ts.Identifier).text;
-        bindTo = prop.name as ts.Identifier;
-        dfltInit = prop.objectAssignmentInitializer ?? null;
-      } else if (ts.isPropertyAssignment(prop)) {
-        // Identifier keys spell themselves; literal and FOLDABLE computed
-        // keys (`{ [k]: v } = o` with a pure single-name k) resolve to the
-        // static field name tsc late-bound. Runtime-valued keys fence.
-        const folded = patternKeyNameOf(L, prop.name);
-        if (folded === null) {
-          L.unsupported("SC1031", prop, "destructuring assignment with computed keys that do not fold to one property name");
-        }
-        fieldName = folded;
-        bindTo = prop.initializer;
-        // `{ a: x = 1 }`: the renamed target with a default parses as the
-        // assignment `x = 1` in the initializer slot.
-        if (ts.isBinaryExpression(bindTo) && bindTo.operatorToken.kind === ts.SyntaxKind.EqualsToken) {
-          dfltInit = bindTo.right;
-          bindTo = bindTo.left;
-        }
-      } else {
-        L.unsupported("SC1031", prop, "destructuring assignment with getter/setter or method properties");
-      }
+      const decoded = destructuringPropertyOf(L, prop);
+      const fieldName = decoded.fieldName;
+      bindTo = decoded.bindTo;
+      dfltInit = decoded.defaultInit;
       while (ts.isParenthesizedExpression(bindTo)) bindTo = bindTo.expression;
       if (!ts.isIdentifier(bindTo)) {
         // Nested patterns and property/element targets: the element's

--- a/packages/compiler/src/frontend/lowering/lower-test.ts
+++ b/packages/compiler/src/frontend/lowering/lower-test.ts
@@ -13,6 +13,7 @@
  * options, non-literal skip/todo values. Never a generic rejection,
  * never silence. */
 import * as ts from "../ts7/adapter.js";
+import { resultIsDiscarded } from "./call-position.js";
 import type { Lowerer } from "./lowerer.js";
 import { locOf } from "../program.js";
 import { IrExpr, IrType, SrcLoc, STRING, VOID, isUnitType } from "../../ir/nodes.js";
@@ -27,7 +28,7 @@ const TESTCTX_SURFACE_HINT =
  * resolves through the runner — consuming it outside `await t.test(...)`
  * has no lowering, so top-level registrations stand as statements. */
 function requireStatementPosition(L: Lowerer, call: ts.CallExpression, what: string): void {
-  if (ts.isExpressionStatement(call.parent) || ts.isArrowFunction(call.parent)) return;
+  if (resultIsDiscarded(call)) return;
   L.noLowering(
     `using the result of ${what}`,
     call,

--- a/packages/compiler/src/frontend/lowering/pairs-snapshot.ts
+++ b/packages/compiler/src/frontend/lowering/pairs-snapshot.ts
@@ -1,0 +1,93 @@
+import { arrayOf, BOOL, F64, type IrExpr, type IrLibFn, type IrParam, type IrType, STRING, type SrcLoc } from "../../ir/nodes.js";
+import { numLit, varRef } from "../../ir/build.js";
+import type { Lowerer } from "./lowerer.js";
+
+/** Intern a helper that materializes a pure string-index record from a flat
+ * `[key, value, ...]` array returned by a runtime call. */
+export function pairsSnapshotHelper(
+  L: Lowerer,
+  shapeId: string,
+  loc: SrcLoc,
+  options: {
+    keyPrefix: string;
+    libCall: IrLibFn;
+    params?: IrParam[];
+    callArgs?: IrExpr[];
+    indexValueOk?: (indexValue: IrType) => boolean;
+  },
+): string | null {
+  const shape = L.shapes.get(shapeId);
+  if (!shape || shape.tuple || shape.fields.length > 0 || !shape.indexValue) return null;
+  const indexValue = shape.indexValue;
+  if (options.indexValueOk && !options.indexValueOk(indexValue)) return null;
+  if (indexValue.kind !== "union") return null;
+  const stringTag = L.armTag(indexValue.unionId, STRING);
+  if (stringTag < 0) return null;
+  const key = `${options.keyPrefix}.snapshot:${shapeId}`;
+  const existing = L.widthHelpers.get(key);
+  if (existing) return existing;
+  const name = `%${options.keyPrefix}.snapshot.${L.widthHelpers.size}`;
+  L.widthHelpers.set(key, name);
+  const recordType: IrType = { kind: "record", shapeId };
+  const pairsType = arrayOf(STRING);
+  const pairAt = (offset: number): IrExpr => ({
+    kind: "arrayGet",
+    arr: varRef("ps.0", pairsType, loc),
+    index:
+      offset === 0
+        ? varRef("i.0", F64, loc)
+        : { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(offset, loc), type: F64, loc },
+    type: STRING,
+    loc,
+  });
+  L.liftedFns.push({
+    name,
+    params: options.params ?? [],
+    returnType: recordType,
+    locals: [
+      ...(options.params ?? []).map((param) => ({ id: param.localId, name: param.name, type: param.type, mutable: false })),
+      { id: "ps.0", name: "ps", type: pairsType, mutable: false },
+      { id: "out.0", name: "out", type: recordType, mutable: false },
+      { id: "i.0", name: "i", type: F64, mutable: true },
+    ],
+    body: [
+      {
+        kind: "varDecl",
+        localId: "ps.0",
+        init: { kind: "libCall", fn: options.libCall, args: options.callArgs ?? [], type: pairsType, loc },
+        loc,
+      },
+      { kind: "varDecl", localId: "out.0", init: { kind: "recordLit", fields: [], type: recordType, loc }, loc },
+      {
+        kind: "for",
+        init: { kind: "varDecl", localId: "i.0", init: numLit(0, loc), loc },
+        cond: {
+          kind: "bin",
+          op: "<",
+          left: varRef("i.0", F64, loc),
+          right: { kind: "arrIntrinsic", method: "length", receiver: varRef("ps.0", pairsType, loc), args: [], type: F64, loc },
+          type: BOOL,
+          loc,
+        },
+        update: {
+          kind: "assign",
+          localId: "i.0",
+          value: { kind: "bin", op: "+", left: varRef("i.0", F64, loc), right: numLit(2, loc), type: F64, loc },
+          loc,
+        },
+        body: [{
+          kind: "recordKeySet",
+          obj: varRef("out.0", recordType, loc),
+          shapeId,
+          key: pairAt(0),
+          value: { kind: "unionWrap", unionId: indexValue.unionId, tag: stringTag, value: pairAt(1), type: indexValue, loc },
+          loc,
+        }],
+        loc,
+      },
+      { kind: "return", value: varRef("out.0", recordType, loc), loc },
+    ],
+    loc,
+  });
+  return name;
+}

--- a/packages/compiler/src/frontend/lowering/static-this.ts
+++ b/packages/compiler/src/frontend/lowering/static-this.ts
@@ -1,0 +1,30 @@
+import * as ts from "../ts7/adapter.js";
+import type { Lowerer } from "./lowerer.js";
+
+/** Walk a static class context for `this`/`super`. Arrows inherit the
+ * surrounding receiver and remain transparent; declarations that bind
+ * their own receiver (and nested classes) are opaque. */
+export function rejectStaticThis(
+  L: Lowerer,
+  root: ts.Node,
+  message: (keyword: "this" | "super") => string,
+  includeRoot = false,
+): void {
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isFunctionExpression(node) || ts.isFunctionDeclaration(node) ||
+      ts.isMethodDeclaration(node) || ts.isConstructorDeclaration(node) ||
+      ts.isGetAccessor(node) || ts.isSetAccessor(node) ||
+      ts.isClassDeclaration(node) || ts.isClassExpression(node)
+    ) {
+      return;
+    }
+    if (node.kind === ts.SyntaxKind.ThisKeyword || node.kind === ts.SyntaxKind.SuperKeyword) {
+      const keyword = node.kind === ts.SyntaxKind.ThisKeyword ? "this" : "super";
+      L.unsupported("SC1090", node, message(keyword));
+    }
+    node.forEachChild(visit);
+  };
+  if (includeRoot) visit(root);
+  else root.forEachChild(visit);
+}

--- a/packages/compiler/src/frontend/npm-static-rewrite.ts
+++ b/packages/compiler/src/frontend/npm-static-rewrite.ts
@@ -75,37 +75,12 @@
 
 import { dirname, join, resolve as resolvePath } from "node:path";
 import ts from "typescript5";
-import { cjsLexedExportsOf, cjsLexerVisibleNames } from "./cjs-lexer.js";
+import { bareRequireSpecOf, cjsLexedExportsOf, cjsLexerVisibleNames, isExportsIdent, isModuleExports } from "./cjs-lexer.js";
 import { trackedDirectoryExists, trackedFileExists, trackedReadFile } from "./input-tracker.js";
 import { resolveExports } from "./resolve.js";
+import { packageNameOfSpecifier } from "./shared.js";
 
 const NODE_REQUIRE_CONDITIONS = new Set(["require", "node", "default"]);
-
-/** True when `e` is exactly the `exports` identifier. */
-function isExportsIdent(e: ts.Expression): boolean {
-  return ts.isIdentifier(e) && e.text === "exports";
-}
-
-/** True when `e` is exactly `module.exports`. */
-function isModuleExports(e: ts.Expression): boolean {
-  return (
-    ts.isPropertyAccessExpression(e) &&
-    e.questionDotToken === undefined &&
-    ts.isIdentifier(e.expression) &&
-    e.expression.text === "module" &&
-    ts.isIdentifier(e.name) &&
-    e.name.text === "exports"
-  );
-}
-
-/** The bare `require('spec')` call (identifier callee, one string arg). */
-function bareRequireSpecOf(e: ts.Expression): string | null {
-  if (!ts.isCallExpression(e) || e.questionDotToken !== undefined) return null;
-  if (!ts.isIdentifier(e.expression) || e.expression.text !== "require") return null;
-  if (e.arguments.length !== 1) return null;
-  const arg = e.arguments[0]!;
-  return ts.isStringLiteral(arg) ? arg.text : null;
-}
 
 /** The last NAME of a callee: bare identifier or any member chain's final
  * name (`tslib_1.__exportStar` → "__exportStar"). */
@@ -274,7 +249,7 @@ function resolveRelativeCjs(fromFile: string, spec: string): string | null {
 function resolveBareRequireCjs(fromFile: string, spec: string): string | null {
   if (spec.startsWith("#") || spec.startsWith("node:")) return null;
   const parts = spec.split("/");
-  const name = spec.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!;
+  const name = packageNameOfSpecifier(spec);
   const subparts = spec.startsWith("@") ? parts.slice(2) : parts.slice(1);
   const subpath = subparts.length > 0 ? `./${subparts.join("/")}` : ".";
   for (let dir = dirname(fromFile); ; ) {

--- a/packages/compiler/src/frontend/npm.ts
+++ b/packages/compiler/src/frontend/npm.ts
@@ -87,6 +87,7 @@
  */
 import { dirname, extname, join, resolve } from "node:path";
 import ts from "typescript5";
+import { packageNameOfSpecifier as packageNameOf } from "./shared.js";
 import { cjsLexedExportsOf } from "./cjs-lexer.js";
 import { trackedDirectoryExists, trackedFileExists, trackedReadFile, trackedRealpath } from "./input-tracker.js";
 import { resolveExports } from "./resolve.js";
@@ -753,12 +754,6 @@ interface PkgJson {
   module?: string;
   type?: string;
   exports?: unknown;
-}
-
-/** Package name from a specifier ("@scope/pkg/sub" → "@scope/pkg"). */
-function packageNameOf(specifier: string): string {
-  const parts = specifier.split("/");
-  return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!;
 }
 
 /** Package name from a PATH into node_modules ("…/node_modules/@s/p/d/x.js"

--- a/packages/compiler/src/frontend/provenance.ts
+++ b/packages/compiler/src/frontend/provenance.ts
@@ -37,6 +37,7 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { promisify } from "node:util";
 import ts from "typescript5";
 import { resolveExports, resolveRelativeModule } from "./resolve.js";
+import { packageNameOfSpecifier as packageNameOf } from "./shared.js";
 import type { ProvenancePackageSource, ProvenanceSources } from "./provenance-registry.js";
 
 const NODE_IMPORT_CONDITIONS = new Set(["import", "node", "default"]);
@@ -70,11 +71,6 @@ function readJson(path: string): Record<string, unknown> | null {
   } catch {
     return null;
   }
-}
-
-function packageNameOf(specifier: string): string {
-  const parts = specifier.split("/");
-  return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!;
 }
 
 /* ── the bare-import prescan ─────────────────────────────────────────────

--- a/packages/compiler/src/frontend/resolve.ts
+++ b/packages/compiler/src/frontend/resolve.ts
@@ -18,6 +18,7 @@ import { dirname, isAbsolute, join, resolve } from "node:path";
 import { isNpmStaticPackage, npmStaticPackageOfPath, npmStaticTransformPkgJson } from "./npm-static.js";
 import { provenanceEntryFor } from "./provenance-registry.js";
 import { trackedAccessibleEntries, trackedDirectoryExists, trackedExists, trackedFileExists, trackedReadFile, trackedRealpath } from "./input-tracker.js";
+import { packageNameOfSpecifier } from "./shared.js";
 
 function isFile(path: string): boolean {
   return trackedFileExists(path);
@@ -665,13 +666,6 @@ export interface BareResolution {
   workspaceDir?: string;
 }
 
-/** Package name prefix of a bare specifier ("@scope/pkg/sub" → "@scope/pkg",
- * "pkg/sub" → "pkg"). */
-function packagePrefixOf(specifier: string): string {
-  const parts = specifier.split("/");
-  return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!;
-}
-
 /** The DefinitelyTyped name mangling: "@scope/pkg" → "scope__pkg". */
 function mangleScopedName(name: string): string {
   return name.startsWith("@") ? name.slice(1).replace("/", "__") : name;
@@ -699,7 +693,7 @@ export function resolveBareModule(
    * --npm-static set (the auto-detection probe); default follows the set. */
   mode?: "js-only",
 ): BareResolution | null {
-  const pkgName = packagePrefixOf(specifier);
+  const pkgName = packageNameOfSpecifier(specifier);
   const rest = specifier.slice(pkgName.length).replace(/^\//, "");
   const subpath = rest === "" ? "." : `./${rest}`;
   // An opted-in --npm-static package resolves to its RUNTIME JS: the js

--- a/packages/compiler/src/frontend/shared.ts
+++ b/packages/compiler/src/frontend/shared.ts
@@ -203,6 +203,13 @@ export function isRelativeSpecifier(spec: string): boolean {
   return spec === "." || spec === ".." || spec.startsWith("./") || spec.startsWith("../");
 }
 
+/** Package-name prefix of a bare specifier: "@scope/pkg/sub" becomes
+ * "@scope/pkg", while "pkg/sub" becomes "pkg". */
+export function packageNameOfSpecifier(specifier: string): string {
+  const parts = specifier.split("/");
+  return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!;
+}
+
 /** Package name from a path under node_modules — the LAST node_modules
  * segment (nested installs blame the innermost package), scoped-aware:
  * ".../node_modules/@scope/pkg/dist/x.d.ts" → "@scope/pkg". Paths with no

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -33,7 +33,7 @@ import { canonicalBuiltinModule, checkPreflight, isNodeTypesPath, loadProgram, l
 import { npmStaticIneligibleReason, npmStaticOffenders, npmStaticPackageOfPath } from "./frontend/npm-static.js";
 import { provenanceSources } from "./frontend/provenance-registry.js";
 import { clearResolveCaches, resolveBareModule } from "./frontend/resolve.js";
-import { isJsSourceFileName, isRelativeSpecifier } from "./frontend/shared.js";
+import { isJsSourceFileName, isRelativeSpecifier, packageNameOfSpecifier } from "./frontend/shared.js";
 import { lowerToIr, type LowerOptions, type LowerResult } from "./frontend/lowering/lowerer.js";
 import type { CoverageInput, NpmStaticStatus } from "./coverage/report.js";
 import { loadFfiProfile, type FfiProfile } from "./ffi/profile.js";
@@ -508,8 +508,7 @@ function packagesNamedByDiag(message: string, optedIn: ReadonlySet<string>): Set
   const hits = new Set<string>();
   for (const m of message.matchAll(/Module '"([^"]+)"'/g)) {
     const spec = m[1]!;
-    const parts = spec.split("/");
-    const prefix = spec.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!;
+    const prefix = packageNameOfSpecifier(spec);
     if (optedIn.has(prefix)) hits.add(prefix);
   }
   for (const m of message.matchAll(/import\("([^"]+)"\)/g)) {
@@ -517,14 +516,6 @@ function packagesNamedByDiag(message: string, optedIn: ReadonlySet<string>): Set
     if (pkg !== null && optedIn.has(pkg)) hits.add(pkg);
   }
   return hits;
-}
-
-/** The package-wide --npm-static name containing an exact bare specifier.
- * External mappings are exact (subpaths included), while npm-static owns a
- * whole package, so any mapped subpath conflicts with that package opt-in. */
-function packageNameOfBareSpecifier(specifier: string): string {
-  const parts = specifier.split("/");
-  return specifier.startsWith("@") ? parts.slice(0, 2).join("/") : parts[0]!;
 }
 
 /** The one frontend, three npm postures: `undefined`/explicit package
@@ -583,7 +574,7 @@ function runFrontend(
   if (requested.length > 0 && externalTypes !== undefined) {
     const externalSpecifiersByPackage = new Map<string, string[]>();
     for (const specifier of Object.keys(externalTypes)) {
-      const pkg = packageNameOfBareSpecifier(specifier);
+      const pkg = packageNameOfSpecifier(specifier);
       const specs = externalSpecifiersByPackage.get(pkg) ?? [];
       specs.push(specifier);
       externalSpecifiersByPackage.set(pkg, specs);


### PR DESCRIPTION
- Share frontend package, CJS, lowering, and snapshot helpers.
- Consolidate vendor builds, manifest loops, and generic parameter shaping.
- Reuse LLVM truthiness and reference-counting skeletons.