### PR TITLE
fix(compiler): handle nested mutual recursion

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -3,6 +3,7 @@
  * function/lambda lowering and signature collection, and monomorphizing
  * generic instantiation (bounded by MAX_GENERIC_INSTANCES). */
 import * as ts from "../ts7/adapter.js";
+import { InternalCompilerError } from "../../errors.js";
 import type { Lowerer } from "./lowerer.js";
 import { lowerGenMethodCall } from "./lower-generators.js";
 import { BOOL, CAUGHT, DYN, F64, IrExpr, IrFunction, IrLocal, IrParam, IrStmt, IrType, JSVAL, STRING, SYMBOL_T, SrcLoc, UNDEFINED_T, VOID, arrayOf, canBoxFuncIntoDyn, canConvertToDyn, canDynCheckTo, canMarshalTypedFuncIntoIsland, ffiClassType, ffiSourceParamTypes, funcOf, isFfiCallbackParam, isFfiContextParam, isFfiReleaseParam, isUnitType, shapeHasAccessorSlots, typeEquals } from "../../ir/ir.js";
@@ -5502,20 +5503,19 @@ const inliningPredicates = new Set<ts.Symbol>();
     );
   }
 
-/** Nested `function name(...) {...}`: lowered as `const name = <lambda>`
-   * at the declaration's statement position (JS hoists function declarations
-   * to the top of the enclosing function — calling one before this statement
-   * is a compile error here, not a silent divergence). Self-references inside
-   * the body lower to `selfRef`, not a capture: a box holding its own
-   * closure would be an RC cycle. Reserve the box before lowering the body so
-   * mutually recursive declarations can capture each other's live boxes. */
+/** Nested `function name(...) {...}` reserves its binding first, then lowers
+   * the lambda and assigns the resulting closure to that binding. The local is
+   * mutable in IR because this two-phase form lets mutually recursive
+   * declarations capture each other's live boxes before either closure is
+   * initialized. Self-references inside the body lower to `selfRef`, not a
+   * capture: a box holding its own closure would be an RC cycle. */
   export function lowerNestedFunctionDecl(lowerer: Lowerer, stmt: ts.FunctionDeclaration): IrStmt {
     if (!stmt.name) lowerer.unsupported("SC1090", stmt, "anonymous function declarations");
     const { funcType } = lowerer.lambdaSignature(stmt);
-    const local = lowerer.declareLocal(stmt.name, stmt.name.text, funcType, false);
-    local.mutable = true;
+    const local = lowerer.declareLocal(stmt.name, stmt.name.text, funcType, true);
     const active = [...lowerer.activeStmtLists].reverse().find((entry) => entry.stmts.includes(stmt));
-    active?.out.push({ kind: "varDecl", localId: local.id, init: null, loc: locOf(stmt) });
+    if (!active) throw new InternalCompilerError("lowerer bug: nested function has no owning statement list");
+    active.out.push({ kind: "varDecl", localId: local.id, init: null, loc: locOf(stmt) });
     const init = lowerer.lowerLambda(stmt);
     return { kind: "assign", localId: local.id, value: init, loc: locOf(stmt) };
   }

--- a/packages/compiler/src/frontend/lowering/lower-calls.ts
+++ b/packages/compiler/src/frontend/lowering/lower-calls.ts
@@ -5507,13 +5507,17 @@ const inliningPredicates = new Set<ts.Symbol>();
    * to the top of the enclosing function — calling one before this statement
    * is a compile error here, not a silent divergence). Self-references inside
    * the body lower to `selfRef`, not a capture: a box holding its own
-   * closure would be an RC cycle. */
+   * closure would be an RC cycle. Reserve the box before lowering the body so
+   * mutually recursive declarations can capture each other's live boxes. */
   export function lowerNestedFunctionDecl(lowerer: Lowerer, stmt: ts.FunctionDeclaration): IrStmt {
     if (!stmt.name) lowerer.unsupported("SC1090", stmt, "anonymous function declarations");
     const { funcType } = lowerer.lambdaSignature(stmt);
     const local = lowerer.declareLocal(stmt.name, stmt.name.text, funcType, false);
+    local.mutable = true;
+    const active = [...lowerer.activeStmtLists].reverse().find((entry) => entry.stmts.includes(stmt));
+    active?.out.push({ kind: "varDecl", localId: local.id, init: null, loc: locOf(stmt) });
     const init = lowerer.lowerLambda(stmt);
-    return { kind: "varDecl", localId: local.id, init, loc: locOf(stmt) };
+    return { kind: "assign", localId: local.id, value: init, loc: locOf(stmt) };
   }
 
 /** Signature checks + param shapes + IR func type for any lambda-like

--- a/tests/corpus/606-nested-mutual-recursion.ts
+++ b/tests/corpus/606-nested-mutual-recursion.ts
@@ -1,0 +1,17 @@
+export {}
+
+function outer(n: number): number {
+  function even(k: number): number {
+    if (k === 0) return 1
+    return odd(k - 1)
+  }
+
+  function odd(k: number): number {
+    if (k === 0) return 0
+    return even(k - 1)
+  }
+
+  return even(n)
+}
+
+console.log(`r=${outer(4)}`)


### PR DESCRIPTION
Summary

Fix nested mutually recursive function declarations that previously compiled successfully but aborted at runtime.

The issue occurred because one nested function closure could capture another function's binding before its boxed binding had been initialized.

This change reserves the function binding before lowering the closure initializer, allowing mutually recursive nested functions to safely capture each other's bindings.

Reproduction
function outer(n: number): number {
  function even(k: number): number {
    if (k === 0) return 1
    return odd(k - 1)
  }

  function odd(k: number): number {
    if (k === 0) return 0
    return even(k - 1)
  }

  return even(n)
}

console.log(`r=${outer(4)}`)

Previously, the compiled program aborted at runtime.

Now it correctly outputs:
r=1

Testing:
Added regression coverage for nested mutual recursion.
Verified the new regression case.
Verified the original reproduction.
pnpm lint passes.
git diff --check passes.

Fixes #34