### PR TITLE
fix(backend): use the zig toolchain for vendored prerequisites and zlib on host-native zigcc builds

### DIFF
--- a/packages/compiler/src/backend/native-toolchain.ts
+++ b/packages/compiler/src/backend/native-toolchain.ts
@@ -14,6 +14,7 @@ import {
   createVendorArchives,
   MBEDTLS_VERSION,
   QJS_COMMIT,
+  usesVendoredZlib,
   ZLIB_VERSION,
 } from "./vendor-archives.js";
 import {
@@ -4210,11 +4211,12 @@ async function compileCInternal(
   let lreObjects = regex && !dynamic
     ? lreObjectPaths(sanitize, driver, vendorBuildIdentity, vendorCacheRoot)
     : [];
-  // Vendored zlib is the CROSS story only — host builds keep the exact
-  // historical `-lz` system link (see CcOptions.zlib). The native fetch's
-  // gzip decoder rides the same objects/link.
+  // Vendored zlib serves every cross build and every zig-driven host build;
+  // only a bare-clang host build keeps the exact historical `-lz` system
+  // link (see CcOptions.zlib). The native fetch's gzip decoder rides the
+  // same objects/link.
   let zlibObjects =
-    ((opts.zlib ?? false) || nativeFetch) && driver.target !== null
+    ((opts.zlib ?? false) || nativeFetch) && usesVendoredZlib(driver)
       ? zlibObjectPaths(sanitize, driver, vendorBuildIdentity, vendorCacheRoot)
       : [];
   // The libcurl import stub is likewise CROSS-only — host builds keep the
@@ -4362,11 +4364,11 @@ async function compileCInternal(
     // libz on hosts, the vendored per-target objects on cross builds)
     // also serves the native fetch's gzip decoder — spread exactly once.
     ...(opts.zlib
-      ? driver.target !== null
+      ? usesVendoredZlib(driver)
         ? ["-I", vendorZlibDir(), rt(join(rtDir, "scr_zlib.c")), ...zlibObjects]
         : [rt(join(rtDir, "scr_zlib.c"))]
       : nativeFetch
-        ? driver.target !== null
+        ? usesVendoredZlib(driver)
           ? ["-I", vendorZlibDir(), ...zlibObjects]
           : []
       : []),
@@ -4493,7 +4495,7 @@ async function compileCInternal(
     // --as-needed: host libz must follow scr_zlib.c/scr_fetch.c and every
     // generated/native input that references inflate symbols. Cross
     // builds use vendored zlib objects in the input section above.
-    ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null
+    ...(((opts.zlib ?? false) || nativeFetch) && !usesVendoredZlib(driver)
       ? ["-lz"]
       : []),
     // glibc keeps libm separate from libc. This must trail the generated
@@ -4694,7 +4696,7 @@ async function compileCInternal(
     ...(tlsCa && targetPlatform(driver) === "win32" ? ["-lcrypt32"] : []),
     ...(curlFetch && driver.target === null ? ["-lcurl"] : []),
     ...(dynamic && !driver.linkArgs.includes("-lm") ? ["-lm"] : []),
-    ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null ? ["-lz"] : []),
+    ...(((opts.zlib ?? false) || nativeFetch) && !usesVendoredZlib(driver) ? ["-lz"] : []),
     ...driver.linkArgs,
   ];
   // Both the wrapper dry run and dependency trace need the real build's
@@ -4714,7 +4716,7 @@ async function compileCInternal(
     ...(dynamic && targetPlatform(driver) === "win32"
       ? ["-Wl,--stack,8388608"]
       : []),
-    ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null ? ["-lz"] : []),
+    ...(((opts.zlib ?? false) || nativeFetch) && !usesVendoredZlib(driver) ? ["-lz"] : []),
     ...driver.linkArgs,
   ];
   // A complete hit is checked before cross-target curl's generated import stub

--- a/packages/compiler/src/backend/vendor-archives.test.ts
+++ b/packages/compiler/src/backend/vendor-archives.test.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "vitest";
+import { resolveCc } from "./native-toolchain.js";
+import { driverUsesZig, usesVendoredZlib, vendorArArgv } from "./vendor-archives.js";
+
+/** The vendored-prerequisite recipes and the zlib link once keyed their
+ * toolchain choices on `driver.target === null` — "is this a host build?" —
+ * which conflates the build being native with a POSIX toolchain and system
+ * libraries being present. Those are independent: `SCRIPTC_CC=zigcc` with no
+ * `SCRIPTC_TARGET` is a host build driven by zig, which supplies its own
+ * archiver and needs the vendored zlib. These pin the driver-based dispatch. */
+
+test("bare clang host driver keeps the historical system ar and -lz", () => {
+  const driver = resolveCc({}, "linux");
+
+  expect(driver.argv).toEqual(["clang"]);
+  expect(driver.target).toBeNull();
+  expect(driverUsesZig(driver)).toBe(false);
+  expect(vendorArArgv(driver)).toEqual(["ar"]);
+  expect(usesVendoredZlib(driver)).toBe(false);
+});
+
+test("host-native zigcc archives with zig ar, not a system ar", () => {
+  const driver = resolveCc({ SCRIPTC_CC: "zigcc" }, "linux");
+
+  // A host build (target === null) that is nonetheless driven by zig.
+  expect(driver.argv).toEqual(["zig", "cc"]);
+  expect(driver.target).toBeNull();
+  expect(driverUsesZig(driver)).toBe(true);
+  // Regression: keying on `target === null` yielded ["ar"] here, handing a
+  // clang-built archive to a zig link — and failing outright on hosts with
+  // no system ar at all.
+  expect(vendorArArgv(driver)).toEqual(["zig", "ar"]);
+});
+
+test("host-native zigcc links the vendored zlib, not a system -lz", () => {
+  const driver = resolveCc({ SCRIPTC_CC: "zigcc" }, "win32");
+
+  expect(driver.target).toBeNull();
+  // Regression: keying on `target === null` selected the system `-lz` (and
+  // omitted the vendored zlib headers), which no zig host toolchain provides.
+  expect(usesVendoredZlib(driver)).toBe(true);
+});
+
+test("cross builds keep using the zig toolchain and vendored zlib", () => {
+  const driver = resolveCc(
+    { SCRIPTC_CC: "zigcc", SCRIPTC_TARGET: "x86_64-linux-gnu" },
+    "linux",
+  );
+
+  expect(driver.target).toBe("x86_64-linux-gnu");
+  expect(driverUsesZig(driver)).toBe(true);
+  expect(vendorArArgv(driver)).toEqual(["zig", "ar"]);
+  expect(usesVendoredZlib(driver)).toBe(true);
+});
+
+test("the archiver spelling tracks the driver argv rather than a literal", () => {
+  // vendorArArgv must derive the zig spelling from argv[0], so a renamed or
+  // absolute driver spelling still archives with its own `ar` subcommand.
+  expect(vendorArArgv({ argv: ["zig", "cc"] })).toEqual(["zig", "ar"]);
+  expect(vendorArArgv({ argv: ["clang"] })).toEqual(["ar"]);
+});

--- a/packages/compiler/src/backend/vendor-archives.ts
+++ b/packages/compiler/src/backend/vendor-archives.ts
@@ -19,6 +19,31 @@ export const QJS_ENGINE_SOURCES = ["dtoa.c", "libregexp.c", "libunicode.c", "qui
 export const LRE_SOURCES = ["libregexp.c", "libunicode.c"] as const;
 export const ZLIB_SOURCES = ["adler32.c", "compress.c", "crc32.c", "deflate.c", "infback.c", "inffast.c", "inflate.c", "inftrees.c", "trees.c", "uncompr.c", "zutil.c"] as const;
 
+/** A zig driver supplies its own archiver (`zig ar`) and its own vendored
+ * zlib. Only the bare-clang host driver may assume a system `ar` and a system
+ * `-lz`.
+ *
+ * Keying those choices on `driver.target === null` conflates "this build is
+ * native" with "a POSIX toolchain and system libraries are present". They are
+ * independent: under SCRIPTC_CC=zigcc a host build silently mixes a clang-built
+ * vendor archive into a zig link, and on Windows it cannot work at all, since
+ * there is no `ar` and no system libz. Mirrors the dispatch that
+ * ensureLreObjects and ensureZlibObjects already use. */
+export function driverUsesZig(driver: Pick<CcDriver, "argv">): boolean {
+  return driver.argv[0] === "zig";
+}
+
+/** The archiver spelling for a vendored prerequisite built with `driver`. */
+export function vendorArArgv(driver: Pick<CcDriver, "argv">): string[] {
+  return driverUsesZig(driver) ? [...driver.argv.slice(0, 1), "ar"] : ["ar"];
+}
+
+/** Whether this build links scriptc's vendored zlib objects instead of a
+ * system `-lz`: every cross build, and every zig-driven host build. */
+export function usesVendoredZlib(driver: Pick<CcDriver, "argv" | "target">): boolean {
+  return driver.target !== null || driverUsesZig(driver);
+}
+
 export interface VendorArchiveContext {
   runtimeSrcDir(): string;
   targetPlatform(driver: CcDriver): string;
@@ -91,13 +116,13 @@ export function createVendorArchives(context: VendorArchiveContext) {
     driver: Pick<CcDriver, "argv" | "target">,
     environmentFingerprint: string,
   ): Promise<string> {
-    // Native vendor recipes additionally use bare clang/ar; cross
+    // Bare-clang host recipes additionally use clang/ar; zig-driven
     // recipes use the zig driver for compilation and `zig ar`. Include every
     // executable that can affect the cached prerequisite, not just the
     // final program's driver.
     const commands = [
       driver.argv[0] ?? "clang",
-      ...(driver.target === null ? ["clang", "ar"] : []),
+      ...(driver.target === null && !driverUsesZig(driver) ? ["clang", "ar"] : []),
     ].filter((command, index, all) => all.indexOf(command) === index);
     const identities = await Promise.all(
       commands.map(async (command) => {
@@ -240,8 +265,8 @@ export function createVendorArchives(context: VendorArchiveContext) {
   async function buildEngineArchiveDirect(sanitize: boolean, driver: CcDriver, cacheRoot: string, cacheDir: string): Promise<string> {
     const vendor = vendorEngineDir();
     const archive = join(cacheDir, "libqjs.a");
-    const compileArgv = driver.target === null ? ["clang"] : driver.argv;
-    const arArgv = driver.target === null ? ["ar"] : [...driver.argv.slice(0, 1), "ar"];
+    const compileArgv = driver.argv;
+    const arArgv = vendorArArgv(driver);
     const cflags = [
       "-std=gnu11",
       ...driver.targetArgs,
@@ -525,7 +550,8 @@ export function createVendorArchives(context: VendorArchiveContext) {
    * SCRIPTC_TARGET adds a per-target cache flavor (the lre-objects story):
    * TUs compile with `zig cc -target <triple>` and the archive is packed
    * with `zig ar` (llvm-ar — the host BSD ar has no business indexing ELF
-   * objects). Host builds keep the exact historical clang + ar recipe. */
+   * objects). Bare-clang host builds keep the exact historical clang + ar
+   * recipe; a zig-driven host build uses zig cc and `zig ar` like a cross one. */
   async function ensureTlsArchive(
     sanitize: boolean,
     driver: CcDriver,
@@ -533,8 +559,8 @@ export function createVendorArchives(context: VendorArchiveContext) {
     cacheRoot: string = vendorBuildCacheRoot(),
   ): Promise<string> {
     const flavor = `${sanitize ? "asan" : "plain"}-${vendorCacheTargetFlavor(driver)}-${buildIdentity}`;
-    const compileArgv = driver.target !== null ? driver.argv : ["clang"];
-    const arArgv = driver.target !== null ? [...driver.argv.slice(0, 1), "ar"] : ["ar"];
+    const compileArgv = driver.argv;
+    const arArgv = vendorArArgv(driver);
     const vendor = vendorTlsDir();
     const archive = tlsArchivePath(sanitize, driver, buildIdentity, cacheRoot);
     if (await validVendorArtifact(archive)) return archive;


### PR DESCRIPTION
## Summary

Refs #252

The vendored-prerequisite recipes and the zlib link keyed their toolchain choices on `driver.target === null` — "is this a host build?" — which conflates the build being native with a POSIX toolchain and system libraries being present. Those are independent properties.

Under `SCRIPTC_CC=zigcc` with no `SCRIPTC_TARGET`, the quickjs and mbedTLS archives were therefore built with a system `clang` and packed with a system `ar`, and the link took a system `-lz` while the vendored zlib headers and objects were skipped — even though the program TU, the lre/zlib objects, and the final link all used `zig cc`.

On Linux/macOS that silently mixes toolchains but usually links, which is why CI stays green. On Windows it fails outright, in three stages: `ENOENT` on `ar`, then `unable to find dynamic system library 'z'`, then `scr_fetch.c:95: 'zlib.h' file not found`. `SCRIPTC_TARGET=<host triple>` already avoids all of it, because every one of these sites is correct on the cross path.

`ensureLreObjects` and `ensureZlibObjects` already solve this correctly, under the comment *"a zig-cc-built object set must never be handed to a clang link (or vice versa)"*. This makes the remaining sites agree with that rule.

## Changes

Three helpers in `vendor-archives.ts`, which is the leaf module here (`native-toolchain.ts` already imports runtime values from it, and it takes `CcDriver` as a type only, so there is no cycle):

- `driverUsesZig(driver)` — `driver.argv[0] === "zig"`
- `vendorArArgv(driver)` — `zig ar` for a zig driver, else `ar`
- `usesVendoredZlib(driver)` — every cross build, and every zig-driven host build

Applied at the sites that were keyed on `driver.target`:

- `buildEngineArchiveDirect` (quickjs) and `ensureTlsArchive` (mbedTLS) now compile with `driver.argv` and archive with `vendorArArgv(driver)`.
- `currentVendorCacheBuildIdentity` only adds `clang`/`ar` to the identity for a bare-clang host build, so a zig host build no longer records tools it does not use.
- The six zlib gates in `native-toolchain.ts` use `usesVendoredZlib(driver)`. Because the `-I vendorZlibDir()` spread is already keyed on `zlibObjects.length > 0`, the header path follows from the gate change.

No cache-key change is needed: `currentVendorCacheBuildIdentity` starts its command list with `driver.argv[0]`, so clang-driven and zig-driven builds already resolve to different `buildIdentity` values and never share an archive.

Behavior for the bare-clang host driver and for every cross build is unchanged.

## Test plan

New co-located `vendor-archives.test.ts` (5 tests), driven off real `resolveCc` output rather than hand-built driver objects:

- bare clang host driver still selects a system `ar` and a system `-lz`
- host-native zigcc archives with `zig ar`
- host-native zigcc links the vendored zlib
- cross builds keep the zig toolchain and vendored zlib
- the archiver spelling derives from `argv[0]` rather than a literal

Reverting the helper bodies to the previous `driver.target` semantics fails the two host-zig tests while the bare-clang control still passes, so these pin the corrected behavior rather than merely restating it.

Also run: `tsc --noEmit` clean; `eslint` 0 errors with no new warnings (the pre-existing 40 `no-non-null-assertion` warnings in `native-toolchain.ts` are unchanged).

Not run: the full `test:sandbox` gate, which needs Vercel credentials. Worth a maintainer running both lanes before merge.

End-to-end, an out-of-tree project that previously failed on Windows builds, links, and runs under plain `SCRIPTC_CC=zigcc` with this change and no PATH shims, with results identical to the `SCRIPTC_TARGET=x86_64-windows-gnu` path.
