### PR TITLE
Reshape inline record assertions before indexed access

### DIFF
--- a/packages/compiler/src/frontend/lowering/lower-exprs.ts
+++ b/packages/compiler/src/frontend/lowering/lower-exprs.ts
@@ -229,9 +229,10 @@ function lowerExprInner(lowerer: Lowerer, expr: ts.Expression): IrExpr {
     // Type-level wrappers: `satisfies` and `!` erase completely; the runtime
     // value is the inner expression's. `as` erases too UNLESS the inner
     // value is dyn ('unknown') — then the cast is THE dynamic boundary and
-    // compiles to a runtime validation (see lowerAsExpression). A cast
-    // between non-dyn IR types can't change representation (the inner
-    // expression's own lowering/mapType already rejects what doesn't map).
+    // compiles to a runtime validation (see lowerAsExpression). The one
+    // static exception is a record assertion that changes monomorphic
+    // shape: it uses the established copy/reshape path so subsequent
+    // record reads name the representation the assertion selected.
     // `x!` erases the TYPE but must NARROW the VALUE: tsc types the
     // assertion as the non-nullish type, so a union-typed inner bridges to
     // the asserted arm (`groups.get(k)!.push(v)` — the Map get-or-init
@@ -7047,7 +7048,9 @@ export function lowerTemplate(lowerer: Lowerer, expr: ts.TemplateExpression): Ir
     return pieces.reduce((acc, p) => ({ kind: "strConcat", left: acc, right: p, type: STRING, loc }));
   }
 
-/** `x as T`. Non-dyn inner values keep today's pure-erasure semantics.
+/** `x as T`. Non-dyn inner values ordinarily erase; a record assertion
+   * changing monomorphic shape rebuilds through the established width-copy
+   * path so its represented value agrees with its asserted type.
    * A dyn ('unknown') inner value makes this THE dynamic boundary:
    * - `as unknown` (dyn → dyn) stays erasure;
    * - dyn → a JSON-representable target type T compiles to `dynCheck`, a
@@ -7119,6 +7122,19 @@ export function lowerTemplate(lowerer: Lowerer, expr: ts.TemplateExpression): Ir
       if (targetTs0.flags & ts.TypeFlags.Any && lowerer.dynamic) {
         return lowerer.jsvalIn(inner, expr.expression);
       }
+      const target = lowerer.mapTypeOf(targetTs0);
+      // Static assertions normally erase, but record layouts are
+      // monomorphic: a consumer selected from the asserted shape must see
+      // that shape physically. Reuse the ordinary slot coercion so plain
+      // widths and index-signature captures share their established copy
+      // semantics (and unsupported pairs report SC2002 at this assertion).
+      if (
+        inner.type.kind === "record" &&
+        target?.kind === "record" &&
+        inner.type.shapeId !== target.shapeId
+      ) {
+        return lowerer.coerceInto(expr, inner, target);
+      }
       // `u as Arm` on a UNION value is `u!`'s spelling with a named arm
       // (`req.headers[h] as string`): the CHECKED single-arm extraction —
       // the asserted arm's payload comes out, any other arm throws the
@@ -7127,7 +7143,6 @@ export function lowerTemplate(lowerer: Lowerer, expr: ts.TemplateExpression): Ir
       // opaque union-mismatch fence). Sub-union targets and same-type
       // casts keep the historic erasure.
       if (inner.type.kind === "union") {
-        const target = lowerer.mapTypeOf(targetTs0);
         if (target && target.kind !== "union" && !typeEquals(target, inner.type)) {
           const helper = lowerer.narrowedArmHelper(inner.type.unionId, target, locOf(expr));
           if (helper) {

--- a/packages/compiler/test/inline-record-assertion.test.ts
+++ b/packages/compiler/test/inline-record-assertion.test.ts
@@ -1,0 +1,58 @@
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, expect, test } from "vitest";
+import { compile, deserializeModule, validateModule } from "../src/index.js";
+
+const dirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(dirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })));
+});
+
+function checkRecordReadReceivers(value: unknown, seen = new Set<object>()): void {
+  if (value === null || typeof value !== "object") return;
+  if (seen.has(value)) return;
+  seen.add(value);
+  if (Array.isArray(value)) {
+    for (const item of value) checkRecordReadReceivers(item, seen);
+    return;
+  }
+  const node = value as {
+    kind?: unknown;
+    obj?: { type?: { kind?: unknown; shapeId?: unknown } };
+    shapeId?: unknown;
+  };
+  if (node.kind === "recordGet" || node.kind === "recordKeyGet") {
+    expect(node.obj?.type).toEqual({ kind: "record", shapeId: node.shapeId });
+  }
+  for (const child of Object.values(value)) checkRecordReadReceivers(child, seen);
+}
+
+test("inline static record assertions reshape reads to the asserted representation", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "scriptc-inline-record-assertion-"));
+  dirs.push(dir);
+  const entry = join(dir, "main.ts");
+  const outDir = join(dir, ".scriptc");
+  const outPath = join(outDir, "main.ir.json");
+  await writeFile(
+    entry,
+    [
+      'const rec = { a: 1, b: "two" };',
+      'console.log((rec as Record<string, unknown>)["a"]);',
+      "const wide = { a: 3, b: 4 };",
+      "console.log((wide as { a: number }).a, (wide as { a: number })[\"a\"]);",
+      "",
+    ].join("\n"),
+  );
+
+  const result = await compile(entry, { outDir, outPath, outputKind: "ir" });
+  if (!result.ok) {
+    throw new Error(result.diagnostics.map((diagnostic) => `${diagnostic.code}: ${diagnostic.message}`).join("\n"));
+  }
+
+  const module = deserializeModule(await readFile(outPath, "utf8"));
+  expect(validateModule(module)).toEqual([]);
+  expect(module.functions.some((fn) => fn.name.startsWith("%rec.capture."))).toBe(true);
+  checkRecordReadReceivers(module);
+});

--- a/tests/corpus/2692-inline-record-assert-index.ts
+++ b/tests/corpus/2692-inline-record-assert-index.ts
@@ -1,0 +1,32 @@
+// Inline record assertions must materialize the asserted record shape before
+// field/key reads select it. These are read-only because width reshapes copy.
+const mixed = { a: 1, b: "two" };
+console.log((mixed as Record<string, unknown>)["a"]);
+
+const runtimeKey = "b";
+console.log((mixed as Record<string, unknown>)[runtimeKey]);
+
+const counts = { one: 1, two: 2 };
+const countKey = "two";
+console.log((counts as Record<string, number>)[countKey]);
+
+const heterogeneous = { ready: true, label: "yes" };
+const unknownValues = heterogeneous as Record<string, unknown>;
+console.log(typeof unknownValues["ready"], typeof unknownValues["label"]);
+
+const viaUnknown = { score: 7 };
+console.log((viaUnknown as unknown as Record<string, number>)["score"]);
+
+const wide = { a: 11, dropped: 12 };
+console.log((wide as { a: number }).a, (wide as { a: number })["a"]);
+
+let trace = "";
+function make(): { value: number; spare: number } {
+  trace += "receiver,";
+  return { value: 6, spare: 7 };
+}
+function makeKey(): string {
+  trace += "key";
+  return "value";
+}
+console.log((make() as Record<string, number>)[makeKey()], trace);


### PR DESCRIPTION
Static record assertions can select a different monomorphic record shape than the source expression. Subsequent field or indexed reads must receive a value with that asserted representation, rather than the original shape.

Materialize shape-changing static record assertions through the existing record coercion and copy path. This preserves the IR’s exact receiver-shape contract, retains established width and index-signature reshape semantics, and prevents supported asserted record reads from failing with an internal compiler error.

Add regression coverage for asserted records read through literal and runtime keys, typed and unknown record flows, fixed-record field and bracket access, chained unknown assertions, and receiver/key evaluation order.

Closes #262