### PR TITLE
Optimize canonical string self-concatenation

### DIFF
--- a/packages/compiler/src/backend/c/exprs.ts
+++ b/packages/compiler/src/backend/c/exprs.ts
@@ -10,7 +10,7 @@ import { OVERFLOW_MEMBER } from "./shapes.js";
 import { dynDestrCheckHelper, dynIterNHelper, dynKeyGetHelper } from "./walkers.js";
 import { collectFfiRetainedOps, parseFfiCallbackKey } from "../ffi-callbacks.js";
 import { genResultThunkFor } from "./async.js";
-import { isStableBytesOperand, newValueMayThrow, streamTypedRefEligible, undefinedArmTag } from "../../ir/analysis.js";
+import { isStableBytesOperand, matchStringSelfConcat, newValueMayThrow, streamTypedRefEligible, undefinedArmTag } from "../../ir/analysis.js";
 
 function streamTypedRefCommitAdapter(
   emitter: CEmitter,
@@ -799,6 +799,37 @@ function emitOperatorExpr(
         // and the temp is the expression's value. Mirrors the `assign`
         // statement's old-value release / boxed-set behavior exactly.
         const local = emitter.currentLocals.get(e.localId);
+        const concat = e.value;
+        const suffix = matchStringSelfConcat(e.localId, concat);
+        if (suffix && concat.kind === "strConcat") {
+          // Keep the old left value alive across suffix evaluation, then
+          // detach whichever value the binding holds at that point. This is
+          // the expression-position twin of stmt assign's ownership handoff.
+          const snapshot = emitter.emitExpr(concat.left);
+          const right = emitter.emitExpr(suffix);
+          if (!local && !emitter.globalsById.has(e.localId)) {
+            throw new InternalCompilerError(`emitter bug: assignExpr to unknown binding ${e.localId}`);
+          }
+          const target = local ? mangleLocal(e.localId) : mangleGlobal(e.localId);
+          if (local?.boxed) {
+            emitter.line(`scr_box_set_ref(${target}, NULL);`);
+          } else {
+            const old = `sc_t${emitter.tempCounter++}`;
+            emitter.line(`ScrStr *${old} = ${target};`);
+            emitter.line(`${target} = NULL;`);
+            emitter.releaseValue(old, snapshot.type);
+          }
+          const result = emitter.newTemp(e.type, `scr_str_concat(${snapshot.name}, ${right.name})`);
+          // An assignment expression yields its own +1, so give the binding
+          // a retained sibling reference rather than moving result out.
+          const stored = retainCallC(result.type, result.name);
+          if (local?.boxed) {
+            emitter.line(`scr_box_set_ref(${target}, ${stored});`);
+          } else {
+            emitter.line(`${target} = ${stored};`);
+          }
+          return result;
+        }
         const v = emitter.emitExpr(e.value);
         if (local?.boxed) {
           // box_set takes ownership of the passed reference, so hand it a

--- a/packages/compiler/src/backend/c/stmts.ts
+++ b/packages/compiler/src/backend/c/stmts.ts
@@ -11,7 +11,7 @@ import { boxAccess, cDecl, cStringLiteral, elemAccess, vAdapters } from "./types
 import { OVERFLOW_MEMBER } from "./shapes.js";
 import { emitBytesReceiver } from "./exprs.js";
 import { matchIntegerBytesForLoop } from "../../ir/integer-loops.js";
-import { endsWithJump } from "../../ir/analysis.js";
+import { endsWithJump, matchStringSelfConcat } from "../../ir/analysis.js";
 
 
 
@@ -219,6 +219,36 @@ export function emitStmt(emitter: CEmitter, s: IrStmt): void {
       }
       case "assign": {
         const local = emitter.currentLocals.get(s.localId);
+        const concat = s.value;
+        const suffix = matchStringSelfConcat(s.localId, concat);
+        if (suffix && concat.kind === "strConcat") {
+          // Snapshot the old left value before evaluating the suffix.  The
+          // snapshot is a normal frame-owned +1: the suffix may reassign the
+          // destination or throw, in which case unwinding must still release
+          // it while leaving the original binding intact.
+          const snapshot = emitter.emitExpr(concat.left);
+          const right = emitter.emitExpr(suffix);
+          const target = local ? mangleLocal(s.localId) : mangleGlobal(s.localId);
+          if (local?.boxed) {
+            // set_ref unlinks then releases the binding's CURRENT value. It
+            // may differ from snapshot when the suffix itself assigned target.
+            emitter.line(`scr_box_set_ref(${target}, NULL);`);
+          } else {
+            const old = `sc_t${emitter.tempCounter++}`;
+            emitter.line(`ScrStr *${old} = ${target};`);
+            emitter.line(`${target} = NULL;`);
+            emitter.releaseValue(old, snapshot.type);
+          }
+          const result = emitter.newTemp(s.value.type, `scr_str_concat(${snapshot.name}, ${right.name})`);
+          if (local?.boxed) {
+            emitter.moveTemp(result); // the box takes the concat result's +1
+            emitter.line(`scr_box_set_ref(${target}, ${result.name});${emitter.srcComment(s.loc)}`);
+          } else {
+            emitter.moveTemp(result); // binding takes the concat result's +1
+            emitter.line(`${target} = ${result.name};${emitter.srcComment(s.loc)}`);
+          }
+          break;
+        }
         if (!local) {
           // Module global: plain static storage, never boxed. Old-value
           // release is NULL-tolerant (statics start NULL).

--- a/packages/compiler/src/backend/llvm/emitter.ts
+++ b/packages/compiler/src/backend/llvm/emitter.ts
@@ -62,7 +62,7 @@ import { InternalCompilerError } from "../../errors.js";
  * lazy-inflate representation as the C debugging backend.
  */
 import { deflateRawSync } from "node:zlib";
-import { endsWithJump } from "../../ir/analysis.js";
+import { endsWithJump, matchStringSelfConcat } from "../../ir/analysis.js";
 import { emitLibraryIdentityLines } from "../library-identity-markers.js";
 import type {
   IrBytesElem,
@@ -3081,6 +3081,12 @@ class LlEmitter {
         break;
       }
       case "assign": {
+        const concat = s.value;
+        const suffix = matchStringSelfConcat(s.localId, concat);
+        if (suffix && concat.kind === "strConcat") {
+          this.emitStringSelfConcatAssign(s.localId, concat.left, suffix, false);
+          break;
+        }
         const b = this.binding(s.localId);
         const v = this.emitExpr(s.value);
         if (b.kind === "boxed") {
@@ -3942,6 +3948,47 @@ class LlEmitter {
 
   private emitStringExpr(e: ExprOf<"strConcat" | "strEq" | "strCmp" | "toString" | "strIntrinsic" | "regexLit" | "templateStrings" | "regexIntrinsic">): LlValue {
     return emitStringExpr(this.expressionContext(), e);
+  }
+
+  /**
+   * Lower canonical `target = target + suffix` after evaluating the old
+   * left side and suffix in JavaScript order.  The snapshot stays owned by
+   * the statement frame while the destination relinquishes its CURRENT
+   * value, making the snapshot unique unless a real observable alias exists.
+   */
+  private emitStringSelfConcatAssign(
+    localId: string,
+    left: IrExpr,
+    suffix: IrExpr,
+    retainForYield: boolean,
+  ): LlValue {
+    const snapshot = this.emitExpr(left);
+    const right = this.emitExpr(suffix);
+    const b = this.binding(localId);
+    const B = this.B;
+    if (b.kind === "boxed") {
+      // set_ref(NULL) unlinks then releases the binding's post-suffix value.
+      this.boxSet(this.loadBox(b.slot), b.type, "null");
+    } else {
+      const old = B.tmp();
+      B.line(`${old} = load ptr, ptr ${b.slot}`);
+      B.line(`store ptr null, ptr ${b.slot}`);
+      this.releaseValue(old, b.type);
+    }
+    this.declare(`declare ptr @scr_str_concat(ptr, ptr)`);
+    const raw = B.tmp();
+    B.line(`${raw} = call ptr @scr_str_concat(ptr ${snapshot.name}, ptr ${right.name})`);
+    const result = this.own({ name: raw, type: left.type });
+    if (retainForYield) {
+      const stored = this.retainValue(result.name, result.type);
+      if (b.kind === "boxed") this.boxSet(this.loadBox(b.slot), b.type, stored);
+      else B.line(`store ptr ${stored}, ptr ${b.slot}`);
+    } else {
+      this.moveTemp(result);
+      if (b.kind === "boxed") this.boxSet(this.loadBox(b.slot), b.type, result.name);
+      else B.line(`store ptr ${result.name}, ptr ${b.slot}`);
+    }
+    return result;
   }
 
   private emitContainerExpr(e: ExprOf<"arrayLit" | "arrayNewLen" | "arrayGet" | "arrIntrinsic" | "bytesNew" | "bytesIntrinsic" | "mapNew" | "mapIntrinsic" | "setIntrinsic" | "setNew">): LlValue {

--- a/packages/compiler/src/backend/llvm/expr-context.ts
+++ b/packages/compiler/src/backend/llvm/expr-context.ts
@@ -105,6 +105,7 @@ export interface LlvmEmitterContext extends ShapeHost {
   emitStrIntrinsic(e: IrExpr & { kind: "strIntrinsic" }): LlValue;
   emitStreamLibCall(e: LibCallExpr): LlValue;
   emitStringExpr(e: ExprOf<"strConcat" | "strEq" | "strCmp" | "toString" | "strIntrinsic" | "regexLit" | "templateStrings" | "regexIntrinsic">): LlValue;
+  emitStringSelfConcatAssign(localId: string, left: IrExpr, suffix: IrExpr, retainForYield: boolean): LlValue;
   emitThrowValue(v: LlValue): void;
   emitWasiSuspend(promise: string | null): void;
   emitWasiSuspendPrepared(): void;

--- a/packages/compiler/src/backend/llvm/expr-primitives.ts
+++ b/packages/compiler/src/backend/llvm/expr-primitives.ts
@@ -1,6 +1,6 @@
 /* Focused LLVM expression emission extracted from emitter.ts. */
 import { InternalCompilerError } from "../../errors.js";
-import { undefinedArmTag } from "../../ir/analysis.js";
+import { matchStringSelfConcat, undefinedArmTag } from "../../ir/analysis.js";
 import { isRefCounted } from "../../ir/ir.js";
 import { mangleRecordClone, mangleRecordNew } from "../mangle.js";
 import { arrNewCall, elemAccess } from "./shapes.js";
@@ -171,6 +171,11 @@ export function emitOperatorExpr(host: LlvmEmitterContext, e: ExprOf<"bin" | "un
         // `x = e` in expression position: the binding takes its OWN
         // reference (retain for ref kinds), the temp stays the yielded
         // value — CEmitter's order exactly (release old, store retained).
+        const concat = e.value;
+        const suffix = matchStringSelfConcat(e.localId, concat);
+        if (suffix && concat.kind === "strConcat") {
+          return host.emitStringSelfConcatAssign(e.localId, concat.left, suffix, true);
+        }
         const b = host.binding(e.localId);
         const v = host.emitExpr(e.value);
         if (b.kind === "boxed") {

--- a/packages/compiler/src/ir/analysis.test.ts
+++ b/packages/compiler/src/ir/analysis.test.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "vitest";
+import { matchStringSelfConcat } from "./analysis.js";
+import { F64, STRING, type IrExpr } from "./ir.js";
+
+const loc = { file: "analysis.ts", start: 0, end: 0 };
+const str = (value: string): IrExpr => ({ kind: "strLit", value, type: STRING, loc });
+const ref = (localId: string, type = STRING): IrExpr => ({ kind: "varRef", localId, type, loc });
+const concat = (left: IrExpr, right: IrExpr, type = STRING): IrExpr => ({
+  kind: "strConcat", left, right, type, loc,
+});
+
+test("matchStringSelfConcat recognizes only the immediate string self-concat", () => {
+  const suffix = str("x");
+  expect(matchStringSelfConcat("acc", concat(ref("acc"), suffix))).toBe(suffix);
+});
+
+test("matchStringSelfConcat rejects non-canonical and non-string shapes", () => {
+  expect(matchStringSelfConcat("acc", concat(ref("other"), str("x")))).toBeNull();
+  expect(matchStringSelfConcat("acc", concat(concat(ref("acc"), str("x")), str("y")))).toBeNull();
+  expect(matchStringSelfConcat("acc", str("x"))).toBeNull();
+  expect(matchStringSelfConcat("acc", concat(ref("acc", F64), str("x")))).toBeNull();
+  expect(matchStringSelfConcat("acc", concat(ref("acc"), str("x"), F64))).toBeNull();
+});

--- a/packages/compiler/src/ir/analysis.ts
+++ b/packages/compiler/src/ir/analysis.ts
@@ -9,6 +9,31 @@ import {
   type IrUnionDef,
 } from "./ir.js";
 
+/**
+ * Recognize the one concat shape whose destination binding can temporarily
+ * hand off its ownership to the left operand:
+ *
+ *     target = target + suffix
+ *
+ * Both native emitters use this rather than attempting a wider purity or
+ * alias analysis.  In particular, fields, nested concat trees, dynamic
+ * operations, and a different destination all retain the ordinary borrowed
+ * concat lowering.
+ */
+export function matchStringSelfConcat(targetLocalId: string, value: IrExpr): IrExpr | null {
+  if (
+    value.kind !== "strConcat" ||
+    value.type.kind !== "string" ||
+    value.left.kind !== "varRef" ||
+    value.left.type.kind !== "string" ||
+    value.left.localId !== targetLocalId ||
+    value.right.type.kind !== "string"
+  ) {
+    return null;
+  }
+  return value.right;
+}
+
 /** The class-graph surface needed by backend-independent hierarchy queries. */
 export interface IrClassGraphNode {
   readonly def: { readonly name: string };

--- a/packages/compiler/test/string-accumulation-emission.test.ts
+++ b/packages/compiler/test/string-accumulation-emission.test.ts
@@ -1,0 +1,119 @@
+import { expect, test } from "vitest";
+import { emitCModule } from "../src/backend/c/c-emitter.js";
+import { emitLlvmModule } from "../src/backend/llvm/emitter.js";
+import { STRING, VOID, type IrExpr, type IrFunction, type IrLocal, type IrModule, type IrStmt } from "../src/ir/ir.js";
+import { validateModule } from "../src/ir/validate.js";
+
+const loc = { file: "string-accumulation.ts", start: 0, end: 0 };
+const str = (value: string): IrExpr => ({ kind: "strLit", value, type: STRING, loc });
+const ref = (localId: string): IrExpr => ({ kind: "varRef", localId, type: STRING, loc });
+const selfConcat = (localId: string, right: IrExpr = str("+")): IrExpr => ({
+  kind: "strConcat", left: ref(localId), right, type: STRING, loc,
+});
+const assign = (localId: string, value: IrExpr): IrStmt => ({ kind: "assign", localId, value, loc });
+
+function functionWithLocal(name: string, local: IrLocal, body: IrStmt[]): IrFunction {
+  return { name, params: [], returnType: VOID, locals: [local], body, loc };
+}
+
+function fixture(): IrModule {
+  const plain: IrLocal = { id: "acc", name: "acc", type: STRING, mutable: true };
+  const boxed: IrLocal = { id: "boxed", name: "boxed", type: STRING, mutable: true, boxed: true };
+  const functions: IrFunction[] = [
+    functionWithLocal("plain", plain, [
+      { kind: "varDecl", localId: "acc", init: str("seed"), loc },
+      assign("acc", selfConcat("acc")),
+    ]),
+    functionWithLocal("assignExpr", plain, [
+      { kind: "varDecl", localId: "acc", init: str("seed"), loc },
+      { kind: "exprStmt", expr: { kind: "assignExpr", localId: "acc", value: selfConcat("acc"), type: STRING, loc }, loc },
+    ]),
+    functionWithLocal("suffixReassign", plain, [
+      { kind: "varDecl", localId: "acc", init: str("seed"), loc },
+      assign("acc", selfConcat("acc", {
+        kind: "assignExpr", localId: "acc", value: str("replacement"), type: STRING, loc,
+      })),
+    ]),
+    functionWithLocal("boxed", boxed, [
+      { kind: "varDecl", localId: "boxed", init: str("seed"), loc },
+      assign("boxed", selfConcat("boxed")),
+    ]),
+    functionWithLocal("negative", plain, [
+      { kind: "varDecl", localId: "acc", init: str("seed"), loc },
+      assign("acc", { kind: "strConcat", left: ref("other"), right: str("+"), type: STRING, loc }),
+    ]),
+    {
+      name: "__main", params: [], returnType: VOID, locals: [],
+      body: [
+        assign("%g.e.acc", str("global")),
+        assign("%g.e.acc", selfConcat("%g.e.acc")),
+      ], loc,
+    },
+  ];
+  // The negative function needs a real, distinct left binding.
+  functions.find((fn) => fn.name === "negative")!.locals.push(
+    { id: "other", name: "other", type: STRING, mutable: false },
+  );
+  functions.find((fn) => fn.name === "negative")!.body.splice(1, 0,
+    { kind: "varDecl", localId: "other", init: str("other"), loc },
+  );
+  return {
+    irVersion: 6,
+    sourceFile: loc.file,
+    entry: "__main",
+    globals: [{ id: "%g.e.acc", name: "globalAccumulator", type: STRING, mutable: true }],
+    functions,
+  };
+}
+
+function expectInOrder(text: string, fragments: readonly string[]): void {
+  let offset = 0;
+  for (const fragment of fragments) {
+    const found = text.indexOf(fragment, offset);
+    expect(found, `missing or out-of-order fragment: ${fragment}`).toBeGreaterThanOrEqual(offset);
+    offset = found + fragment.length;
+  }
+}
+
+test("C and LLVM hand off canonical string self-concats after suffix evaluation", () => {
+  const mod = fixture();
+  expect(validateModule(mod)).toEqual([]);
+  const c = emitCModule(mod);
+  const llvm = emitLlvmModule(mod);
+
+  // Plain local: retained snapshot, suffix, detach/release, concat, move.
+  expectInOrder(c, [
+    "scr_str_retain(sc_l_acc)",
+    "ScrStr *sc_t", "= sc_l_acc;", "sc_l_acc = NULL;", "scr_str_release(sc_t",
+    "scr_str_concat(sc_t", "sc_l_acc = sc_t",
+  ]);
+  expectInOrder(llvm, [
+    "call ptr @scr_str_retain_v(ptr %t",
+    "load ptr, ptr %sc_l_acc", "store ptr null, ptr %sc_l_acc",
+    "call void @scr_str_release", "call ptr @scr_str_concat", "store ptr %",
+  ]);
+
+  // Module globals use the same plain-slot handoff; boxes use set_ref(NULL).
+  expect(c).toContain("sc_g_e_acc = NULL;");
+  expect(llvm).toContain("store ptr null, ptr @sc_g_e_acc");
+  expect(c).toContain("scr_box_set_ref(sc_l_boxed, NULL);");
+  expect(llvm).toContain("call void @scr_box_set_ref(ptr %");
+
+  // The expression form leaves its own result live and gives the binding a
+  // retained sibling. A suffix assignment changes the binding before the
+  // final detach, so the detach must occur after its replacement store.
+  expect(c).toMatch(/scr_str_concat\(sc_t\d+, sc_t\d+\);\n\s*scr_box_set_ref|scr_str_concat\(sc_t\d+, sc_t\d+\);\n\s*sc_l_acc = scr_str_retain/);
+  const replacementStore = c.indexOf("sc_l_acc = scr_str_retain(sc_t");
+  const postSuffixDetach = c.indexOf("sc_l_acc = NULL;", replacementStore);
+  expect(replacementStore).toBeGreaterThanOrEqual(0);
+  expect(postSuffixDetach).toBeGreaterThan(replacementStore);
+
+  // A different left binding keeps the generic concat lowering: it never
+  // clears the destination before invoking concat.
+  const negativeStart = c.indexOf("static void sc_f_negative(void) {");
+  const negativeEnd = c.indexOf("}", negativeStart);
+  const negative = c.slice(negativeStart, negativeEnd);
+  expect(negativeStart).toBeGreaterThanOrEqual(0);
+  expect(negative).toContain("scr_str_concat(");
+  expect(negative).not.toMatch(/sc_l_acc = NULL;\n\s*scr_str_release\(sc_t\d+\);\n\s*ScrStr \*sc_t\d+ = scr_str_concat/);
+});

--- a/packages/runtime/src/scr_string.c
+++ b/packages/runtime/src/scr_string.c
@@ -83,12 +83,12 @@ ScrStr *scr_str_new(const char *bytes, size_t len) {
   return s;
 }
 
-/* One-slot free-block cache for append loops: `s += x` compiles to
- * concat + release-of-the-old-string every iteration, so the block freed
- * on iteration n is (with the geometric slack below) big enough for the
- * allocation on iteration n+1 — the loop ping-pongs between two warm
- * blocks instead of paging in fresh zero-filled memory 40k times. Disabled
- * in the audit lane so ASan sees every logical free as a real free. */
+/* One-slot free-block cache for concat callers that must copy: observable
+ * aliases, `s = s + s`, and non-canonical concat shapes still allocate a
+ * replacement result. The compiler's canonical self-assignment handoff
+ * leaves its left snapshot uniquely owned, so it instead uses the in-place
+ * path below; this cache remains useful for the copy cases. Disabled in the
+ * audit lane so ASan sees every logical free as a real free. */
 #ifndef SCR_RC_AUDIT
 static SCR_TL ScrStr *scr_str_spare;
 #endif
@@ -166,12 +166,11 @@ ScrStr *scr_str_concat(ScrStr *a, ScrStr *b) {
     a->rc = 2; /* +1 for the returned reference, beside the caller's borrow */
     return a;
   }
-  /* Copy path. Geometric slack keeps appenders amortized: a uniquely-owned
-   * left side that outgrew its capacity is a concat chain, and any sizable
-   * result is presumed an append loop's accumulator (`s += x` reaches here
-   * with rc == 2 — the variable plus the emitted temp — every iteration;
-   * the slack is what lets the free-block cache above satisfy the next
-   * iteration's slightly-larger allocation). */
+  /* Copy path. Geometric slack keeps uniquely-owned concat chains and the
+   * optimized self-assignment handoff amortized when they outgrow capacity.
+   * Aliases and `s = s + s` deliberately arrive with rc > 1 and stay on this
+   * path, preserving string immutability; their sizable replacement results
+   * can still benefit from the spare-block cache above. */
   size_t newcap = newlen;
   if (a->rc == 1) {
     size_t grown = a->cap + (a->cap >> 1) + 16;

--- a/packages/runtime/test/test_string.c
+++ b/packages/runtime/test/test_string.c
@@ -147,6 +147,77 @@ static void divergence_asserts(void) {
   scr_str_release(s);
 }
 
+/* Model the compiler's canonical `s = s + suffix` ownership handoff. The
+ * retained snapshot survives suffix evaluation; the binding then gives up
+ * whichever value it currently holds, and concat returns the new binding
+ * value. The snapshot's release balances concat's second reference when it
+ * appends in place. */
+static void handoff_append(ScrStr **binding, ScrStr *suffix) {
+  ScrStr *snapshot = scr_str_retain(*binding);
+  ScrStr *old = *binding;
+  *binding = NULL;
+  scr_str_release(old);
+  *binding = scr_str_concat(snapshot, suffix);
+  scr_str_release(snapshot);
+}
+
+static void accumulation_asserts(void) {
+  ScrStr *piece = scr_str_new("x", 1);
+  ScrStr *acc = scr_str_new("", 0);
+  size_t relocations = 0;
+  enum { APPENDS = 8192 };
+  for (size_t i = 0; i < APPENDS; i++) {
+    ScrStr *before = acc;
+    handoff_append(&acc, piece);
+    if (acc != before) relocations++;
+  }
+  if (acc->len != APPENDS || relocations > 2 + 2 * 13) {
+    failed++;
+    fprintf(stderr, "ACCUMULATION: len=%zu relocations=%zu\n", acc->len,
+            relocations);
+  }
+  scr_str_release(acc);
+  scr_str_release(piece);
+
+  /* A real alias keeps rc > 1, so concat copies and the alias sees its old
+   * bytes. Prime slack first to ensure this checks ownership rather than an
+   * unavoidable first growth. */
+  ScrStr *seed = scr_str_new("seed", 4);
+  ScrStr *x = scr_str_new("x", 1);
+  handoff_append(&seed, x);
+  ScrStr *alias = scr_str_retain(seed);
+  ScrStr *before = seed;
+  ScrStr *bang = scr_str_new("!", 1);
+  handoff_append(&seed, bang);
+  if (seed == alias || alias != before || alias->len != 5 ||
+      memcmp(alias->data, "seedx", 5) != 0 || seed->len != 6 ||
+      memcmp(seed->data, "seedx!", 6) != 0) {
+    failed++;
+    fprintf(stderr, "ACCUMULATION: alias was mutated or not copied\n");
+  }
+  scr_str_release(bang);
+  scr_str_release(alias);
+  scr_str_release(seed);
+  scr_str_release(x);
+
+  /* Populate the UTF-16 cache, then take an in-place multibyte append. The
+   * cached length must be invalidated while its byte/unit cursor remains a
+   * valid prefix cursor. */
+  ScrStr *unicode = scr_str_new("\xC3\xA9", 2); /* é */
+  handoff_append(&unicode, x = scr_str_new("x", 1));
+  (void)scr_str_utf16_len(unicode); /* cache: éx is two UTF-16 units */
+  ScrStr *astral = scr_str_new("\xF0\x9F\x98\x80", 4); /* 😀 */
+  ScrStr *unicode_before = unicode;
+  handoff_append(&unicode, astral);
+  if (unicode != unicode_before || scr_str_utf16_len(unicode) != 4) {
+    failed++;
+    fprintf(stderr, "ACCUMULATION: UTF-16 cache was not invalidated\n");
+  }
+  scr_str_release(astral);
+  scr_str_release(x);
+  scr_str_release(unicode);
+}
+
 int main(int argc, char **argv) {
   if (argc > 1 && strncmp(argv[1], "--crash-repeat", 14) == 0) {
     ScrStr *s = scr_str_new("ab", 2);
@@ -301,6 +372,7 @@ int main(int argc, char **argv) {
   if (in != stdin) fclose(in);
 
   divergence_asserts();
+  accumulation_asserts();
 
 #ifdef SCR_RC_AUDIT
   if (scr_str_live_count() != 0) {

--- a/tests/corpus/2692-string-accumulation.ts
+++ b/tests/corpus/2692-string-accumulation.ts
@@ -1,0 +1,48 @@
+// Canonical self-concatenating writes must retain JavaScript's aliasing and
+// RHS-order semantics while using the runtime's geometric in-place append.
+let repeated = "";
+for (let i = 0; i < 12000; i++) repeated = repeated + "x";
+
+let compound = "";
+const piece = "y";
+for (let i = 0; i < 12000; i++) compound += piece;
+console.log(repeated.length, repeated.slice(0, 2), repeated.slice(-2));
+console.log(compound.length, compound.slice(0, 2), compound.slice(-2));
+
+let aliased = "seed";
+const alias = aliased;
+aliased = aliased + "!";
+console.log(alias, aliased);
+
+let rhsReassign = "left";
+rhsReassign = rhsReassign + (rhsReassign = "replacement");
+console.log(rhsReassign);
+
+let expressionPosition = "expr";
+const yielded = expressionPosition = expressionPosition + "!";
+console.log(yielded, expressionPosition);
+
+let doubled = "ab";
+doubled = doubled + doubled;
+console.log(doubled);
+
+let unicode = "é";
+const beforeUnits = unicode.length;
+unicode = unicode + "😀";
+console.log(beforeUnits, unicode.length, unicode);
+
+// Module-scoped bindings use plain global storage in the native emitters.
+let moduleAccumulator = "";
+for (let i = 0; i < 2000; i++) moduleAccumulator = moduleAccumulator + "g";
+console.log(moduleAccumulator.length, moduleAccumulator.slice(0, 1), moduleAccumulator.slice(-1));
+
+// A captured binding is stored in a ScrBox rather than a local/global slot.
+function makeAppender(): () => string {
+  let captured = "";
+  return () => {
+    captured = captured + "z";
+    return captured;
+  };
+}
+const append = makeAppender();
+console.log(append(), append(), append());


### PR DESCRIPTION
Canonical string self-assignments such as `value = value + suffix` and `value += suffix` now hand the destination binding's ownership to the evaluated left snapshot in both the C and LLVM emitters. This leaves that snapshot uniquely owned when it reaches `scr_str_concat`, enabling the runtime's in-place, geometric-growth append path for repeated string accumulation.

The specialized lowering preserves JavaScript evaluation order and aliasing behavior across locals, module globals, captured bindings, assignment expressions, RHS reassignment, and exceptions. Non-canonical concatenations and observable aliases continue to use the copying path so existing string immutability semantics remain intact.

The change also adds focused compiler, runtime, and differential coverage for ownership handoff, emission order, alias preservation, buffer relocation, and UTF-16 cache invalidation.

Closes #258