### PR TITLE
Add Windows GUI subsystem support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,11 @@ jobs:
       - run: pnpm build
       - name: Windows path regressions
         run: pnpm exec vitest run packages/compiler/test/ts7/program.test.ts packages/cli/test/paths.test.ts
+      - name: Windows GUI subsystem and bootstrap-cache regression
+        shell: pwsh
+        run: |
+          Remove-Item Env:SCRIPTC_NO_CACHE -ErrorAction SilentlyContinue
+          pnpm exec vitest run packages/cli/test/bootstrap.test.ts --testNamePattern "GUI subsystem"
       - name: Windows Sandbox path regression
         run: >-
           pnpm exec vitest run tests/harness/worktree-files.test.ts

--- a/docs/src/app/cli/page.mdx
+++ b/docs/src/app/cli/page.mdx
@@ -95,6 +95,9 @@ Prebuilds release runtime objects and native TLS/dynamic-engine archives for tar
   <dt><code>--print &lt;native-link-info&gt;</code></dt>
   <dd>Build an object (equivalent to <code>--emit=obj</code>) and print its machine-readable external link recipe as JSON instead of printing the artifact path. The document names the exact installed source runtime pack and all link inputs, but does not invoke a linker.</dd>
 
+  <dt><code>--subsystem &lt;console|windows&gt;</code></dt>
+  <dd>Windows executable subsystem. The default, <code>console</code>, retains the normal console PE executable. <code>windows</code> produces a GUI PE executable, so Windows does not create a console window for the program. This option is valid only for Windows <code>--emit=exe</code> builds (including <code>scriptc run</code>); it does not accept arbitrary linker flags and does not apply to object output or <code>--print=native-link-info</code>.</dd>
+
   <dt><code>--dynamic</code></dt>
   <dd>Embed the dynamic engine (~620KB) so npm dependencies and <code>any</code>-typed code can run. Static stays the default — without this flag, dynamic-tier sites are per-site compile errors. See <a href="/dependencies">npm Dependencies</a>.</dd>
 

--- a/docs/src/app/platforms/page.mdx
+++ b/docs/src/app/platforms/page.mdx
@@ -35,6 +35,18 @@ fib.exe: PE32+ executable (console) x86-64, for MS Windows
 
 The full corpus runs in a differential lane against Windows Node, including `--dynamic` programs and `child_process`. The Windows fixture lanes also exercise real loopback traffic through `net`, `http`, `https`, `tls`, `http2`, `dgram`, and `dns`, plus the native `fetch` implementation (including redirects, streaming bodies, compression, cancellation, and proxy handling).
 
+Console is the default executable subsystem. Build a GUI program with <code>--subsystem=windows</code>; this selects the PE GUI subsystem while keeping scriptc's ordinary <code>main</code> entry point:
+
+```console
+$ SCRIPTC_CC=zigcc SCRIPTC_TARGET=x86_64-windows-gnu scriptc build fib.ts --subsystem=windows -o fib-gui.exe
+$ llvm-readobj --file-headers fib-gui.exe | grep Subsystem
+  MajorSubsystemVersion: 6
+  MinorSubsystemVersion: 0
+  Subsystem: IMAGE_SUBSYSTEM_WINDOWS_GUI (0x2)
+```
+
+Only the two subsystem values are supported; scriptc does not expose arbitrary linker-flag passthrough.
+
 ### iOS and Android (arm64, library mode)
 
 Three mobile triples build **library-mode static archives** for an embedding app to link — a mobile app is the executable, so `scriptc build` without `--lib` rejects these targets with `SC3002`:

--- a/packages/cli/src/bootstrap.ts
+++ b/packages/cli/src/bootstrap.ts
@@ -62,6 +62,9 @@ async function tryFastPath(): Promise<number | null> {
     values.lib || values["from-c"] || values["provenance-sources"] ||
     (values["external-types"] ?? []).length > 0
   ) return null;
+  if (values.subsystem !== undefined && values.subsystem !== "console" && values.subsystem !== "windows") {
+    return null; // main owns exact user-error wording
+  }
   const backend = values.backend;
   if (backend !== undefined && backend !== "c" && backend !== "llvm") return null;
   const optimization = values.optimization;
@@ -88,6 +91,8 @@ async function tryFastPath(): Promise<number | null> {
   }
   const buildPlatform = startup.targetPlatform(driver);
   if (command === "run" && buildPlatform === "wasi") return null;
+  if (values.subsystem !== undefined && buildPlatform !== "win32") return null;
+  const executableSubsystem = values.subsystem === "windows" ? "windows" : undefined;
   const input = resolve(inputArg);
   const outDir = values.out ? dirname(resolve(values.out)) : join(dirname(input), ".scriptc");
   const stem = basename(input).replace(/\.(ts|mts|cts|js|mjs|cjs|c|ll)$/, "");
@@ -110,6 +115,7 @@ async function tryFastPath(): Promise<number | null> {
     emitIr: values["emit-ir"],
     sanitize: values.sanitize,
     dynamic: values.dynamic,
+    ...(executableSubsystem === undefined ? {} : { executableSubsystem }),
     backend: backend ?? "auto",
     ...(optimization === "dev" ? { optimization: "dev" as const } : {}),
     npmStatic,

--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -36,6 +36,11 @@ function fail(msg: string): never {
   throw new CliExit(1);
 }
 
+function normalizeExecutableSubsystem(value: string | undefined): "console" | "windows" | undefined {
+  if (value === undefined || value === "console" || value === "windows") return value;
+  fail(`unknown subsystem "${value}" (supported: console, windows)\n\n${USAGE}`);
+}
+
 /** parseArgs, with its throw turned into the CLI's own one-line error.
  * Unparseable arguments are a USER error — an unknown flag or a missing
  * value used to reach the top level as an uncaught ERR_PARSE_ARGS_* and
@@ -67,10 +72,12 @@ async function main(): Promise<number> {
     return values.help ? 0 : 1;
   }
 
+  const subsystem = normalizeExecutableSubsystem(values.subsystem);
+
   const [command, inputArg] = positionals;
   if (command === "cache") {
     if (inputArg !== "warm") fail(`unknown cache command "${inputArg ?? ""}" (supported: warm)\n\n${USAGE}`);
-    if (values.lib || values.dynamic || values.backend !== undefined || values.emit !== undefined || values.print !== undefined || values["from-c"] || values.ffi !== undefined || values.profile !== undefined || (values["npm-static"] ?? []).length > 0 || values["provenance-sources"] || externalTypeArgs.length > 0 || values.out !== undefined || values["emit-ir"] || !values["keep-c"]) {
+    if (values.lib || values.dynamic || values.backend !== undefined || values.emit !== undefined || subsystem !== undefined || values.print !== undefined || values["from-c"] || values.ffi !== undefined || values.profile !== undefined || (values["npm-static"] ?? []).length > 0 || values["provenance-sources"] || externalTypeArgs.length > 0 || values.out !== undefined || values["emit-ir"] || !values["keep-c"]) {
       fail(`scriptc cache warm takes only native optimization/sanitizer options and profile names\n\n${USAGE}`);
     }
     const optimization = values.optimization;
@@ -118,9 +125,9 @@ async function main(): Promise<number> {
     if (inputArg) {
       fail("scriptc build --lib takes no input positional: the profile names the entry module");
     }
-    if (values.dynamic || values.backend !== undefined || values.emit !== undefined || values.print !== undefined || values.optimization !== undefined || values.ffi !== undefined || (values["npm-static"] ?? []).length > 0 || externalTypeArgs.length > 0) {
+    if (values.dynamic || values.backend !== undefined || values.emit !== undefined || subsystem !== undefined || values.print !== undefined || values.optimization !== undefined || values.ffi !== undefined || (values["npm-static"] ?? []).length > 0 || externalTypeArgs.length > 0) {
       fail(
-        "scriptc build --lib takes no --dynamic/--backend/--emit/--print/--optimization/--npm-static/--ffi/--external-types: the profile pins the emission and optimization, npm imports are judged automatically, outbound FFI belongs to executable builds, and external type mappings belong to coverage",
+        "scriptc build --lib takes no --dynamic/--backend/--emit/--subsystem/--print/--optimization/--npm-static/--ffi/--external-types: the profile pins the emission and optimization, npm imports are judged automatically, outbound FFI belongs to executable builds, and external type mappings belong to coverage",
       );
     }
     const profilePath = resolve(profileArg);
@@ -153,6 +160,9 @@ async function main(): Promise<number> {
   const input = resolve(inputArg);
   if (command === "coverage" && values.emit !== undefined) {
     fail(`--emit is a build/run option\n\n${USAGE}`);
+  }
+  if (command === "coverage" && subsystem !== undefined) {
+    fail(`--subsystem is supported only for Windows executable builds\n\n${USAGE}`);
   }
   if (values.print !== undefined && values.print !== "native-link-info") {
     fail(`unknown print kind "${values.print}" (supported: native-link-info)\n\n${USAGE}`);
@@ -206,6 +216,7 @@ async function main(): Promise<number> {
         ...(values.emit === undefined && !printNativeLinkInfo
           ? {}
           : { emit: values.emit ?? "obj" }),
+        ...(subsystem === undefined ? {} : { subsystem }),
         emitIr: values["emit-ir"],
         ...(values.backend === undefined ? {} : { backend: values.backend }),
         fromC: values["from-c"],
@@ -216,6 +227,10 @@ async function main(): Promise<number> {
       });
   if (output !== null && !output.ok) fail(`${output.message}\n\n${USAGE}`);
   const backend = output?.ok ? output.backend : undefined;
+  const executableSubsystem = output?.ok ? output.executableSubsystem : undefined;
+  if (executableSubsystem !== undefined && buildTargetPlatform() !== "win32") {
+    fail(`--subsystem is supported only for Windows executable builds\n\n${USAGE}`);
+  }
 
   // --npm-static: repeatable and comma-splittable; the literal "auto"
   // switches to eligibility-based detection (mixing "auto" with names
@@ -270,6 +285,7 @@ async function main(): Promise<number> {
         outPath,
         sanitize: values.sanitize,
         dynamic: values.dynamic,
+        ...(executableSubsystem === undefined ? {} : { executableSubsystem }),
         ...(optimization !== undefined ? { optimization } : {}),
       });
       return outPath;
@@ -282,6 +298,7 @@ async function main(): Promise<number> {
       emitIr: output.emitIr,
       sanitize: values.sanitize,
       dynamic: values.dynamic,
+      ...(executableSubsystem === undefined ? {} : { executableSubsystem }),
       ...(backend !== undefined ? { backend } : {}),
       ...(optimization !== undefined ? { optimization } : {}),
       ...(npmStatic !== undefined ? { npmStatic } : {}),

--- a/packages/cli/src/output-options.ts
+++ b/packages/cli/src/output-options.ts
@@ -1,8 +1,9 @@
-import type { CompileOutputKind } from "@scriptc/compiler";
+import type { CompileOutputKind, ExecutableSubsystem } from "@scriptc/compiler";
 import type { CliOutputKind } from "./paths.js";
 
 export interface OutputOptionValues {
   emit?: string;
+  subsystem?: string;
   emitIr: boolean;
   backend?: string;
   fromC: boolean;
@@ -18,6 +19,7 @@ export type OutputOptionResolution =
       outputKind: CompileOutputKind;
       cliOutputKind: CliOutputKind;
       backend?: "c" | "llvm";
+      executableSubsystem?: ExecutableSubsystem;
       emitIr: boolean;
       deprecateEmitIr: boolean;
     }
@@ -46,6 +48,18 @@ export function resolveOutputOptions(
     };
   }
   const emit = (rawEmit ?? "exe") as CliOutputKind;
+  if (values.subsystem !== undefined && values.subsystem !== "console" && values.subsystem !== "windows") {
+    return {
+      ok: false,
+      message: `unknown subsystem "${values.subsystem}" (supported: console, windows)`,
+    };
+  }
+  if (values.subsystem !== undefined && emit !== "exe") {
+    return {
+      ok: false,
+      message: "--subsystem is supported only for executable output (--emit=exe)",
+    };
+  }
   if (command === "run" && emit !== "exe") {
     return { ok: false, message: `scriptc run requires --emit=exe` };
   }
@@ -91,6 +105,11 @@ export function resolveOutputOptions(
       : emit === "llvm" || NATIVE_ARTIFACT_KINDS.has(emit)
         ? { backend: "llvm" as const }
         : backend === undefined ? {} : { backend }),
+    ...(values.subsystem === "windows"
+      ? { executableSubsystem: "windows" as const }
+      : values.subsystem === "console"
+        ? { executableSubsystem: "console" as const }
+        : {}),
     emitIr: values.emitIr && emit === "exe",
     deprecateEmitIr: values.emitIr,
   };

--- a/packages/cli/src/usage.ts
+++ b/packages/cli/src/usage.ts
@@ -20,6 +20,9 @@ Options:
   -o, --out <path>   primary output path (default: .scriptc/<name><suffix>)
       --emit <kind>  primary output: ir, c, llvm, asm, obj, or exe
                      (default: exe). asm/obj currently support macOS 15+ arm64
+      --subsystem <console|windows>
+                     Windows executable subsystem (default: console). windows
+                     creates a GUI executable; executable Windows builds only
       --print <kind> print machine-readable metadata instead of the output path
                      (native-link-info implies --emit=obj and never links)
       --backend <b>  code generator. llvm is the default and the output that
@@ -71,6 +74,7 @@ Options:
 export const CLI_OPTIONS = {
   out: { type: "string", short: "o" },
   emit: { type: "string" },
+  subsystem: { type: "string" },
   print: { type: "string" },
   backend: { type: "string" },
   optimization: { type: "string" },

--- a/packages/cli/test/bootstrap.test.ts
+++ b/packages/cli/test/bootstrap.test.ts
@@ -2,6 +2,7 @@ import { execFile } from "node:child_process";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { pathToFileURL } from "node:url";
 import { promisify } from "node:util";
 import { expect, test } from "vitest";
 
@@ -30,9 +31,9 @@ test("bootstrap serves version and help without loading the compiler graph", asy
       "}});",
       "",
     ].join("\n"));
-    const version = await execFileAsync(process.execPath, ["--import", preload, bootstrap, "--version"]);
+    const version = await execFileAsync(process.execPath, ["--import", pathToFileURL(preload).href, bootstrap, "--version"]);
     expect(version.stdout.trim()).toMatch(/^\d+\.\d+\.\d+$/);
-    const help = await execFileAsync(process.execPath, ["--import", preload, bootstrap, "--help"]);
+    const help = await execFileAsync(process.execPath, ["--import", pathToFileURL(preload).href, bootstrap, "--help"]);
     expect(help.stdout).toContain("scriptc build <file.ts|.js>");
   } finally {
     await rm(preloadDir, { recursive: true, force: true }).catch(() => undefined);
@@ -49,7 +50,7 @@ test("bootstrap exact builds use the routed cache and source edits fall through"
   const env = { ...process.env, SCRIPTC_CACHE_DIR: cacheRoot, SCRIPTC_TIMING: "1" };
   const build = (rejectFullCompiler = false): Promise<{ stderr: string }> =>
     execFileAsync(process.execPath, [
-      ...(rejectFullCompiler ? ["--import", preload] : []),
+      ...(rejectFullCompiler ? ["--import", pathToFileURL(preload).href] : []),
       bootstrap,
       "build",
       entry,
@@ -118,7 +119,7 @@ test.skipIf(process.platform !== "win32")(
     };
     delete env.SCRIPTC_NO_CACHE;
     const build = (subsystem?: "windows", rejectFullCompiler = false) => execFileAsync(process.execPath, [
-      ...(rejectFullCompiler ? ["--import", preload] : []),
+      ...(rejectFullCompiler ? ["--import", pathToFileURL(preload).href] : []),
       bootstrap,
       "build",
       entry,

--- a/packages/cli/test/bootstrap.test.ts
+++ b/packages/cli/test/bootstrap.test.ts
@@ -9,6 +9,15 @@ const execFileAsync = promisify(execFile);
 const repoRoot = join(import.meta.dirname, "../../..");
 const bootstrap = join(repoRoot, "packages/cli/dist/bootstrap.js");
 
+function peSubsystem(bytes: Buffer): number {
+  expect(bytes.subarray(0, 2)).toEqual(Buffer.from("MZ"));
+  const peOffset = bytes.readUInt32LE(0x3c);
+  expect(bytes.subarray(peOffset, peOffset + 4)).toEqual(Buffer.from("PE\0\0"));
+  const optionalHeader = peOffset + 4 + 20;
+  expect(bytes.readUInt16LE(optionalHeader)).toBe(0x20b);
+  return bytes.readUInt16LE(optionalHeader + 0x44);
+}
+
 test("bootstrap serves version and help without loading the compiler graph", async () => {
   const preloadDir = await mkdtemp(join(tmpdir(), "scriptc-bootstrap-preload-"));
   const preload = join(preloadDir, "preload.mjs");
@@ -92,3 +101,55 @@ test("bootstrap exact builds use the routed cache and source edits fall through"
     await rm(dir, { recursive: true, force: true });
   }
 }, 120_000);
+
+test.skipIf(process.platform !== "win32")(
+  "bootstrap routed cache keeps Windows GUI subsystem artifacts separate",
+  async () => {
+    const dir = await mkdtemp(join(tmpdir(), "scriptc-bootstrap-subsystem-"));
+    const cacheRoot = join(dir, "cache");
+    const entry = join(dir, "main.ts");
+    const outPath = join(dir, "main.exe");
+    const preload = join(dir, "reject-full-compiler.mjs");
+    const env: NodeJS.ProcessEnv = {
+      ...process.env,
+      SCRIPTC_CACHE_DIR: cacheRoot,
+      SCRIPTC_CC: "zigcc",
+      SCRIPTC_TARGET: "x86_64-windows-gnu",
+    };
+    delete env.SCRIPTC_NO_CACHE;
+    const build = (subsystem?: "windows", rejectFullCompiler = false) => execFileAsync(process.execPath, [
+      ...(rejectFullCompiler ? ["--import", preload] : []),
+      bootstrap,
+      "build",
+      entry,
+      "-o",
+      outPath,
+      ...(subsystem === undefined ? [] : ["--subsystem=windows"]),
+    ], { env, maxBuffer: 16 * 1024 * 1024 });
+    try {
+      await mkdir(cacheRoot, { mode: 0o700 });
+      await Promise.all([
+        writeFile(entry, "process.exit(0);\n"),
+        writeFile(preload, [
+          "import { registerHooks } from 'node:module';",
+          "registerHooks({ load(url, context, nextLoad) {",
+          "  if (url.includes('/packages/compiler/dist/index.js')) throw new Error('compiler graph loaded');",
+          "  return nextLoad(url, context);",
+          "}});",
+          "",
+        ].join("\n")),
+      ]);
+      await build();
+      expect(peSubsystem(await readFile(outPath))).toBe(3);
+      await build("windows");
+      expect(peSubsystem(await readFile(outPath))).toBe(2);
+      await expect(build("windows", true)).resolves.toMatchObject({ stderr: "" });
+      await expect(execFileAsync(outPath, [], { windowsHide: true, encoding: "utf8" })).resolves.toMatchObject({
+        stderr: "",
+      });
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+  120_000,
+);

--- a/packages/cli/test/native-link-info.test.ts
+++ b/packages/cli/test/native-link-info.test.ts
@@ -42,6 +42,8 @@ test("print option validation is explicit", async () => {
     .rejects.toMatchObject({ stderr: expect.stringContaining("requires --emit=obj") });
   await expect(cli(["run", entry, "--print=native-link-info"]))
     .rejects.toMatchObject({ stderr: expect.stringContaining("is a build option") });
+  await expect(cli(["build", entry, "--print=native-link-info", "--subsystem=windows"]))
+    .rejects.toMatchObject({ stderr: expect.stringContaining("subsystem is supported only for executable output") });
 });
 
 describe.runIf(supported)("macOS arm64 native link info", () => {

--- a/packages/cli/test/output-options.test.ts
+++ b/packages/cli/test/output-options.test.ts
@@ -46,6 +46,12 @@ describe("output option compatibility", () => {
     [{ emit: "llvm", emitIr: true }, /emit-ir/],
     [{ emit: "ir", emitIr: true }, /same output/],
     [{ backend: "wat" }, /unknown backend/],
+    [{ subsystem: "gui" }, /unknown subsystem/],
+    [{ emit: "ir", subsystem: "windows" }, /subsystem.*executable output/],
+    [{ emit: "c", subsystem: "windows" }, /subsystem.*executable output/],
+    [{ emit: "llvm", subsystem: "windows" }, /subsystem.*executable output/],
+    [{ emit: "asm", subsystem: "windows" }, /subsystem.*executable output/],
+    [{ emit: "obj", subsystem: "windows" }, /subsystem.*executable output/],
   ] as const)("rejects %j", (override, message) => {
     const result = resolveOutputOptions("build", { ...BASE, ...override });
     expect(result).toEqual({ ok: false, message: expect.stringMatching(message) });
@@ -80,6 +86,22 @@ describe("output option compatibility", () => {
       outputKind: "exe",
       emitIr: true,
       deprecateEmitIr: true,
+    });
+  });
+
+  test.each(["console", "windows"] as const)("accepts --subsystem=%s for executable output", (subsystem) => {
+    expect(resolveOutputOptions("build", { ...BASE, emit: "exe", subsystem })).toMatchObject({
+      ok: true,
+      outputKind: "exe",
+      executableSubsystem: subsystem,
+    });
+  });
+
+  test.each(["console", "windows"] as const)("run accepts --subsystem=%s", (subsystem) => {
+    expect(resolveOutputOptions("run", { ...BASE, subsystem })).toMatchObject({
+      ok: true,
+      outputKind: "exe",
+      executableSubsystem: subsystem,
     });
   });
 

--- a/packages/compiler/src/backend/native-toolchain.test.ts
+++ b/packages/compiler/src/backend/native-toolchain.test.ts
@@ -85,6 +85,14 @@ const nativeShardMergeAvailable =
       : process.platform === "win32" && process.arch === "x64";
 const completeArtifacts = async (root: string, kind: "bin" | "lib"): Promise<string[]> =>
   (await readdir(join(root, kind))).filter((name) => !name.endsWith(".sha256"));
+const peSubsystem = (bytes: Buffer): number => {
+  expect(bytes.subarray(0, 2)).toEqual(Buffer.from("MZ"));
+  const peOffset = bytes.readUInt32LE(0x3c);
+  expect(bytes.subarray(peOffset, peOffset + 4)).toEqual(Buffer.from("PE\0\0"));
+  const optionalHeader = peOffset + 4 + 20;
+  expect(bytes.readUInt16LE(optionalHeader)).toBe(0x20b);
+  return bytes.readUInt16LE(optionalHeader + 0x44);
+};
 const cacheTreeBytes = async (root: string): Promise<number> => {
   let total = 0;
   const walk = async (directory: string): Promise<void> => {
@@ -1519,6 +1527,7 @@ test.skipIf(process.platform === "win32" || zigExecutable === undefined)(
       const firstOut = join(dir, "first.exe");
       await compileC({ cPath, outPath: firstOut, cacheIdentity: TEST_CACHE_IDENTITY });
       expect(await completeArtifacts(cacheRoot, "bin")).toHaveLength(1);
+      expect(peSubsystem(await readFile(firstOut))).toBe(3);
 
       // lld-link rejects GNU ld's `-t`; the Zig `-###` fallback must still
       // capture every absolute CRT/import-library input. Pin the object-cache
@@ -1536,6 +1545,34 @@ test.skipIf(process.platform === "win32" || zigExecutable === undefined)(
       for (const name of objectNames) {
         expect((await stat(join(objectDir, name))).mtimeMs).toBe(pinnedTime.getTime());
       }
+
+      const consoleOut = join(dir, "console.exe");
+      await compileC({
+        cPath,
+        outPath: consoleOut,
+        cacheIdentity: TEST_CACHE_IDENTITY,
+        executableSubsystem: "console",
+      });
+      expect(peSubsystem(await readFile(consoleOut))).toBe(3);
+      expect(await completeArtifacts(cacheRoot, "bin")).toHaveLength(1);
+      for (const name of objectNames) {
+        expect((await stat(join(objectDir, name))).mtimeMs).toBe(pinnedTime.getTime());
+      }
+
+      const windowsOut = join(dir, "windows.exe");
+      await compileC({
+        cPath,
+        outPath: windowsOut,
+        cacheIdentity: TEST_CACHE_IDENTITY,
+        executableSubsystem: "windows",
+      });
+      expect(peSubsystem(await readFile(windowsOut))).toBe(2);
+      expect(await completeArtifacts(cacheRoot, "bin")).toHaveLength(2);
+      // GUI selection changes only the final link. The complete-artifact
+      // cache therefore receives a distinct PE while the one existing
+      // runtime-object family is reused (and its LRU times are refreshed).
+      expect((await readdir(objectDir)).filter((name) => name.endsWith(".o")).sort())
+        .toEqual(objectNames.sort());
     } finally {
       if (oldCacheDir === undefined) delete process.env["SCRIPTC_CACHE_DIR"];
       else process.env["SCRIPTC_CACHE_DIR"] = oldCacheDir;

--- a/packages/compiler/src/backend/native-toolchain.ts
+++ b/packages/compiler/src/backend/native-toolchain.ts
@@ -226,6 +226,8 @@ export async function executableNativeEnvironmentFingerprint(
   return hash.digest("hex");
 }
 
+export type ExecutableSubsystem = "console" | "windows";
+
 export interface CcOptions {
   /** Path of the generated (or hand-written) program TU: a .c file, or the
    * LLVM backend's .ll — clang compiles IR text natively on the same
@@ -233,6 +235,9 @@ export interface CcOptions {
   cPath: string;
   /** Path of the native executable to produce. */
   outPath: string;
+  /** Windows PE executable subsystem. `windows` selects GUI startup; omitted
+   * and `console` retain the existing console executable behavior. */
+  executableSubsystem?: ExecutableSubsystem;
   /** Additional identity for a translation unit whose complete non-system
    * dependency graph is owned by the caller. Persistent caching is disabled
    * when omitted: arbitrary C can depend on same-path edited headers and on
@@ -3645,7 +3650,8 @@ function localArtifactIdentity(
       // instead of materializing a second giant JSON string solely for this
       // output-local fast-path identity.
       .filter(([key, value]) =>
-        value !== undefined && key !== "programShards" && key !== "programPublicSymbols"
+        value !== undefined && key !== "programShards" && key !== "programPublicSymbols" &&
+        !(key === "executableSubsystem" && value === "console")
       )
       .sort(([a], [b]) => a.localeCompare(b)),
   );
@@ -3948,6 +3954,16 @@ async function compileCInternal(
   const tls = (opts.tls ?? false) || nativeFetch || netIsland;
   const tlsCa = (opts.tlsCa ?? false) || tls;
   const driver = resolveCc();
+  if (opts.executableSubsystem !== undefined &&
+      opts.executableSubsystem !== "console" && opts.executableSubsystem !== "windows") {
+    throw new Error("executable subsystem must be console or windows");
+  }
+  if (opts.executableSubsystem !== undefined && targetPlatform(driver) !== "win32") {
+    throw new Error("--subsystem is supported only for Windows executable builds");
+  }
+  const executableSubsystemLinkArgs = opts.executableSubsystem === "windows"
+    ? ["-Wl,--subsystem,windows"]
+    : [];
   const shardNames = new Set<string>();
   const programShardsValid = opts.programShards?.every((shard) => {
     if (
@@ -4525,6 +4541,7 @@ async function compileCInternal(
     // program and every native FFI input because GNU ld resolves archives
     // from left to right.
     ...driver.linkArgs,
+    ...executableSubsystemLinkArgs,
     "-o", build.outPath ?? opts.outPath,
   ];
   // Compile-only flags shared by runtime-object population and the caller-TU
@@ -4721,6 +4738,7 @@ async function compileCInternal(
     ...(dynamic && !driver.linkArgs.includes("-lm") ? ["-lm"] : []),
     ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null ? ["-lz"] : []),
     ...driver.linkArgs,
+    ...executableSubsystemLinkArgs,
   ];
   // Both the wrapper dry run and dependency trace need the real build's
   // compile/link flag shape: wrappers commonly inject flags or native inputs
@@ -4741,6 +4759,7 @@ async function compileCInternal(
       : []),
     ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null ? ["-lz"] : []),
     ...driver.linkArgs,
+    ...executableSubsystemLinkArgs,
   ];
   // A complete hit is checked before cross-target curl's generated import stub
   // is materialized. Its -L spelling still joins the dry-run identity, while

--- a/packages/compiler/src/backend/native-toolchain.ts
+++ b/packages/compiler/src/backend/native-toolchain.ts
@@ -3781,7 +3781,15 @@ async function publishLocalArtifactStamp(
       integrity: localArtifactStampIntegrity(unsigned),
     };
     await writeFile(tmp, `${JSON.stringify(stamp)}\n`, { mode: 0o600 });
-    await rename(tmp, stampPath);
+    await rename(tmp, stampPath).catch(async () => {
+      // POSIX rename replaces a previous same-output stamp, but Windows does
+      // not. A console build followed by a GUI build deliberately has a new
+      // identity at the same output path; failing to replace this metadata
+      // suppresses onArtifactReady, leaving the GUI executable unavailable to
+      // the bootstrap's routed cache on its next invocation.
+      await rm(stampPath, { force: true });
+      await rename(tmp, stampPath);
+    });
     return stamp;
   } finally {
     await rm(tmp, { force: true }).catch(() => undefined);

--- a/packages/compiler/src/executable/executable-cache.test.ts
+++ b/packages/compiler/src/executable/executable-cache.test.ts
@@ -160,6 +160,7 @@ test("early executable keys isolate compile modes, paths, implementation, and FF
     { ...f.options, sanitize: true },
     { ...f.options, dynamic: true },
     { ...f.options, backend: "c" },
+    { ...f.options, executableSubsystem: "windows" },
     { ...f.options, optimization: "dev" },
     { ...f.options, npmStatic: "auto" },
     { ...f.options, npmStatic: ["commander"] },
@@ -294,6 +295,10 @@ test("routed executable hits require an unchanged compiler implementation proof"
   const old = new Date("2000-01-01T00:00:00.000Z");
   await Promise.all([routePath, proofPath].map((path) => utimes(path, old, old)));
   expect(await readRoutedExecutableCache(f.root, route)).not.toBeNull();
+  expect(await readRoutedExecutableCache(f.root, {
+    ...route,
+    executableSubsystem: "windows",
+  })).toBeNull();
   for (const path of [routePath, proofPath]) {
     expect((await stat(path)).mtimeMs).toBeGreaterThan(old.getTime());
   }

--- a/packages/compiler/src/executable/executable-cache.ts
+++ b/packages/compiler/src/executable/executable-cache.ts
@@ -82,6 +82,8 @@ export interface EarlyExecutableCacheOptions {
   sanitize: boolean;
   dynamic: boolean;
   backend: "auto" | "c" | "llvm";
+  /** The GUI-subsystem variant. Omitted retains the historical console key. */
+  executableSubsystem?: "windows";
   /** Omitted is the historical release posture and preserves v1 keys. */
   optimization?: "dev";
   npmStatic: readonly string[] | "auto" | null;
@@ -183,6 +185,7 @@ function cacheKey(options: EarlyExecutableCacheOptions): string {
     options.sanitize ? "sanitize" : "plain",
     options.dynamic ? "dynamic" : "static",
     options.backend,
+    ...(options.executableSubsystem === "windows" ? ["subsystem-windows"] : []),
     ...(options.optimization === "dev" ? ["optimization-dev"] : []),
     options.npmStatic === null
       ? "<npm-static-off>"
@@ -210,6 +213,7 @@ function routeKey(options: EarlyExecutableRouteOptions): string {
     .update(options.sanitize ? "sanitize" : "plain").update("\0")
     .update(options.dynamic ? "dynamic" : "static").update("\0")
     .update(options.backend).update("\0");
+  if (options.executableSubsystem === "windows") hash.update("subsystem-windows\0");
   if (options.optimization === "dev") hash.update("optimization-dev\0");
   hash
     .update(options.npmStatic === null

--- a/packages/compiler/src/index.ts
+++ b/packages/compiler/src/index.ts
@@ -2,7 +2,7 @@ import { InternalCompilerError } from "./errors.js";
 import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { basename, dirname, join, resolve } from "node:path";
-import { buildCacheRoot, CcCompileError, clearCcCaches, compileC, compileLibArchive, compilerDriverSupportsPersistentCache, configuredTargetPlatform, executableNativeEnvironmentFingerprint, mobileLibraryTarget, mobileTargetRefusal, prepareBuildCacheRoot, pruneBuildCache, resolveCc, targetPlatform, toolchainEnvironmentCachePolicy, toolchainEnvironmentFingerprint, type NativeArtifactDependency } from "./backend/native-toolchain.js";
+import { buildCacheRoot, CcCompileError, clearCcCaches, compileC, compileLibArchive, compilerDriverSupportsPersistentCache, configuredTargetPlatform, executableNativeEnvironmentFingerprint, mobileLibraryTarget, mobileTargetRefusal, prepareBuildCacheRoot, pruneBuildCache, resolveCc, targetPlatform, toolchainEnvironmentCachePolicy, toolchainEnvironmentFingerprint, type ExecutableSubsystem, type NativeArtifactDependency } from "./backend/native-toolchain.js";
 import { emitCModule } from "./backend/c/c-emitter.js";
 import { emitLlvmModule, LlvmUnsupportedError } from "./backend/llvm/emitter.js";
 import { emitNativeArtifact, NativeCodegenError } from "./backend/native-codegen.js";
@@ -59,6 +59,7 @@ export {
   RUNTIME_ABI_VERSION,
 } from "./backend/runtime-abi.js";
 export type { NativeLinkInfo, NativeLinkFeatures } from "./backend/native-link-info.js";
+export type { ExecutableSubsystem } from "./backend/native-toolchain.js";
 
 export { InternalCompilerError } from "./errors.js";
 export {
@@ -224,6 +225,9 @@ export interface CompileBaseOptions {
  * historical compile() API, whose omitted output kind means executable. */
 export interface CompileOptions extends CompileBaseOptions {
   outputKind?: "exe";
+  /** Windows PE executable subsystem. Omit (or use `console`) for the
+   * historical console executable; `windows` emits a GUI executable. */
+  executableSubsystem?: ExecutableSubsystem;
   /** Internal validation lane retained for helper-object artifact tests.
    * Supported ordinary LLVM executable builds select this path automatically. */
   nativeProgramObject?: boolean;
@@ -238,6 +242,9 @@ export interface CompileSourceOptions extends CompileBaseOptions {
  * Statically executable/source callers should prefer the narrower interfaces. */
 export interface CompileRequestOptions extends CompileBaseOptions {
   outputKind?: CompileOutputKind;
+  /** Dynamic callers may set this only when outputKind resolves to `exe` and
+   * the effective build target is Windows. */
+  executableSubsystem?: ExecutableSubsystem;
   /** Internal validation lane for executable requests. */
   nativeProgramObject?: boolean;
 }
@@ -1048,6 +1055,7 @@ async function compileExecutableNative(
   cPath: string,
   outPath: string,
   sanitize: boolean,
+  executableSubsystem: ExecutableSubsystem | undefined,
   ffi: FfiProfile | null,
   programSplit: ReturnType<typeof splitLlvmProgram> = null,
   programObjectDependencies: readonly NativeArtifactDependency[] = [],
@@ -1109,6 +1117,7 @@ async function compileExecutableNative(
             programPublicSymbols: effectiveProgramSplit.publicSymbols,
           }),
       sanitize,
+      ...(executableSubsystem === "windows" ? { executableSubsystem } : {}),
       dynamic: features.dynamic,
       regex: features.regex,
       copying: features.copying,
@@ -1207,6 +1216,25 @@ async function compileTracked(
 ): Promise<CompileRequestResult> {
   entryPath = resolve(entryPath);
   const outputKind = opts.outputKind ?? "exe";
+  if (opts.executableSubsystem !== undefined &&
+      opts.executableSubsystem !== "console" && opts.executableSubsystem !== "windows") {
+    return {
+      ok: false,
+      diagnostics: [nativeCodegenDiag("SC3002", "executable subsystem must be console or windows", entryPath)],
+      sourceTexts: new Map(),
+    };
+  }
+  if (opts.executableSubsystem !== undefined && outputKind !== "exe") {
+    return {
+      ok: false,
+      diagnostics: [nativeCodegenDiag(
+        "SC3002",
+        "executable subsystem is supported only for Windows executable builds",
+        entryPath,
+      )],
+      sourceTexts: new Map(),
+    };
+  }
   if (opts.nativeLinkInfo === true && outputKind !== "obj") {
     return {
       ok: false,
@@ -1244,6 +1272,17 @@ async function compileTracked(
   let buildPlatform: string;
   if (outputKind === "exe") {
     buildPlatform = buildTargetPlatform();
+    if (opts.executableSubsystem !== undefined && buildPlatform !== "win32") {
+      return {
+        ok: false,
+        diagnostics: [nativeCodegenDiag(
+          "SC3002",
+          "executable subsystem is supported only for Windows executable builds",
+          entryPath,
+        )],
+        sourceTexts: new Map(),
+      };
+    }
   } else {
     try {
       buildPlatform = sourceTargetPlatform();
@@ -1324,6 +1363,9 @@ async function compileTracked(
       sanitize: opts.sanitize ?? false,
       dynamic: opts.dynamic ?? false,
       backend: opts.backend ?? "auto",
+      ...(opts.executableSubsystem === "windows"
+        ? { executableSubsystem: "windows" as const }
+        : {}),
       ...(opts.optimization === "dev" ? { optimization: "dev" as const } : {}),
       npmStatic: opts.npmStatic ?? null,
       ffiProfile:
@@ -1422,6 +1464,7 @@ async function compileTracked(
         nativeInputPath,
         opts.outPath,
         opts.sanitize ?? false,
+        opts.executableSubsystem,
         ffi,
         null,
         nativeProgramObject?.dependencies,
@@ -1744,6 +1787,7 @@ async function compileTracked(
       nativeProgramObject?.linkPath ?? cPath,
       opts.outPath,
       opts.sanitize ?? false,
+      opts.executableSubsystem,
       ffi,
       programSplit,
       nativeProgramObject?.dependencies,

--- a/packages/compiler/test/cc-driver.test.ts
+++ b/packages/compiler/test/cc-driver.test.ts
@@ -30,6 +30,15 @@ import {
 
 const execFileAsync = promisify(execFile);
 
+function peSubsystem(bytes: Buffer): number {
+  expect(bytes.subarray(0, 2)).toEqual(Buffer.from("MZ"));
+  const peOffset = bytes.readUInt32LE(0x3c);
+  expect(bytes.subarray(peOffset, peOffset + 4)).toEqual(Buffer.from("PE\0\0"));
+  const optionalHeader = peOffset + 4 + 20;
+  expect(bytes.readUInt16LE(optionalHeader)).toBe(0x20b); // PE32+
+  return bytes.readUInt16LE(optionalHeader + 0x44);
+}
+
 function zigOnPath(): boolean {
   try {
     execFileSync("zig", ["version"], { stdio: "ignore" });
@@ -85,6 +94,17 @@ test("subprocess failures retain diagnostics when stderr is empty", () => {
     stdout: "",
   });
   expect(subprocessFailureDetail(noOutput)).toBe("zig cc exited with code 1");
+});
+
+test("compileC rejects Windows subsystem selection for a non-Windows driver", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "scr-subsystem-driver-"));
+  const cPath = join(dir, "program.c");
+  await writeFile(cPath, "int main(void) { return 0; }\n");
+  await expect(compileC({
+    cPath,
+    outPath: join(dir, "program"),
+    executableSubsystem: "windows",
+  })).rejects.toThrow("--subsystem is supported only for Windows executable builds");
 });
 
 test("an empty ANDROID_NDK_ROOT does not mask ANDROID_NDK_HOME", async () => {
@@ -446,6 +466,23 @@ describe.skipIf(!zigOnPath())("zig cc builds (zig on PATH)", () => {
       } finally {
         delete process.env["SCRIPTC_FETCH_CURL"];
       }
+    });
+  }, 600_000);
+
+  test("Windows executable subsystem selects console or GUI PE startup", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "scr-zigcc-win-subsystem-"));
+    const cPath = join(dir, "program.c");
+    await writeFile(cPath, HELLO_C);
+    await withCcEnv("zigcc", "x86_64-windows-gnu", async () => {
+      const defaultOut = join(dir, "default.exe");
+      const consoleOut = join(dir, "console.exe");
+      const windowsOut = join(dir, "windows.exe");
+      await compileC({ cPath, outPath: defaultOut });
+      await compileC({ cPath, outPath: consoleOut, executableSubsystem: "console" });
+      await compileC({ cPath, outPath: windowsOut, executableSubsystem: "windows" });
+      expect(peSubsystem(await readFile(defaultOut))).toBe(3); // IMAGE_SUBSYSTEM_WINDOWS_CUI
+      expect(peSubsystem(await readFile(consoleOut))).toBe(3);
+      expect(peSubsystem(await readFile(windowsOut))).toBe(2); // IMAGE_SUBSYSTEM_WINDOWS_GUI
     });
   }, 600_000);
 

--- a/packages/compiler/test/source-output.test.ts
+++ b/packages/compiler/test/source-output.test.ts
@@ -2,7 +2,7 @@ import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from "node:fs/promis
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, expect, test } from "vitest";
-import { compile, deserializeModule, validateModule } from "../src/index.js";
+import { compile, deserializeModule, validateModule, type CompileRequestOptions } from "../src/index.js";
 
 const dirs: string[] = [];
 afterEach(async () => {
@@ -98,6 +98,46 @@ test("an executable build never deletes same-stem assembly or object artifacts",
   if (!result.ok) throw new Error("executable build failed");
   for (const path of siblings) {
     await expect(readFile(path, "utf8")).resolves.toBe(`caller-owned ${path}\n`);
+  }
+});
+
+test("dynamic API subsystem requests reject non-executable output before creating artifacts", async () => {
+  const { entry, outDir } = await fixture();
+  const result = await compile(entry, {
+    outDir,
+    outPath: join(outDir, "main.ir.json"),
+    outputKind: "ir",
+    executableSubsystem: "windows",
+  } satisfies CompileRequestOptions);
+  expect(result).toMatchObject({
+    ok: false,
+    diagnostics: [{ code: "SC3002", message: expect.stringContaining("Windows executable builds") }],
+  });
+  await expect(readdir(outDir)).rejects.toMatchObject({ code: "ENOENT" });
+});
+
+test("dynamic API subsystem requests reject non-Windows targets before frontend work", async () => {
+  const { entry, outDir } = await fixture();
+  const previousCc = process.env["SCRIPTC_CC"];
+  const previousTarget = process.env["SCRIPTC_TARGET"];
+  process.env["SCRIPTC_CC"] = "zigcc";
+  process.env["SCRIPTC_TARGET"] = "wasm32-wasi";
+  try {
+    const result = await compile(entry, {
+      outDir,
+      outPath: join(outDir, "main"),
+      executableSubsystem: "windows",
+    } satisfies CompileRequestOptions);
+    expect(result).toMatchObject({
+      ok: false,
+      diagnostics: [{ code: "SC3002", message: expect.stringContaining("Windows executable builds") }],
+    });
+    await expect(readdir(outDir)).rejects.toMatchObject({ code: "ENOENT" });
+  } finally {
+    if (previousCc === undefined) delete process.env["SCRIPTC_CC"];
+    else process.env["SCRIPTC_CC"] = previousCc;
+    if (previousTarget === undefined) delete process.env["SCRIPTC_TARGET"];
+    else process.env["SCRIPTC_TARGET"] = previousTarget;
   }
 });
 


### PR DESCRIPTION
Adds `--subsystem <console|windows>` for Windows executable builds. `console` remains the default, while `windows` emits a GUI PE executable so Windows does not create a console window, while retaining scriptc’s ordinary `main` entry point.

Exposes the subsystem selection through the CLI and compiler API, restricts it to Windows executable output, and rejects unsupported values and arbitrary linker-flag passthrough.

Includes the subsystem in final-artifact and routed executable cache identities so console and GUI builds cannot reuse each other’s binaries. Updates the CLI and platform documentation with the supported usage and behavior.