### PR TITLE
lower Math.PI and Math.E statically

### DIFF
--- a/packages/compiler/src/coverage/surface-manifest.ts
+++ b/packages/compiler/src/coverage/surface-manifest.ts
@@ -52,6 +52,7 @@ import {
   MAP_METHODS,
   SET_COMBINE_METHODS,
   SET_METHODS,
+  STATIC_MATH_CONSTS,
   STATIC_MATH_FNS,
   STATIC_NUMBER_METHODS,
   STR_METHODS,
@@ -223,7 +224,14 @@ export function generateSurfaceManifest(compilerVersion: string): SurfaceManifes
     }
   }
   for (const name of Object.keys(ISLAND_SURFACE.math.props)) {
-    add({ id: `stdlib.math.${name}`, kind: "stdlib", name: `Math.${name}`, status: "dynamic-only", code: "SC2012" });
+    // PI/E are the STATIC IEEE constants now (STATIC_MATH_CONSTS) — they
+    // fold to f64 literals, so they're static even though they drove the
+    // props table the island surface reads.
+    if (STATIC_MATH_CONSTS[name] !== undefined) {
+      add({ id: `stdlib.math.${name}`, kind: "stdlib", name: `Math.${name}`, status: "static", note: "compiles to a static number literal (the IEEE Math constant)" });
+    } else {
+      add({ id: `stdlib.math.${name}`, kind: "stdlib", name: `Math.${name}`, status: "dynamic-only", code: "SC2012" });
+    }
   }
   const numberNames = new Set([
     ...Object.keys(STATIC_NUMBER_METHODS),

--- a/packages/compiler/src/frontend/lowering/lower-island.ts
+++ b/packages/compiler/src/frontend/lowering/lower-island.ts
@@ -6,7 +6,7 @@ import { InternalCompilerError } from "../../errors.js";
 import * as ts from "../ts7/adapter.js";
 import type { Lowerer } from "./lowerer.js";
 import { BOOL, BYTES_U8, DYN, F64, IrExpr, IrStmt, IrType, JSVAL, MAX_ISLAND_CALLBACK_ARITY, STRING, VOID, canConvertToDyn, canMarshalTypedFuncIntoIsland, islandPromisePayloadTag, isUnitType } from "../../ir/ir.js";
-import { ISLAND_SURFACE, IslandFnEntry, STATIC_MATH_FNS, boundaryIntoIslandMsg } from "./surfaces.js";
+import { ISLAND_SURFACE, IslandFnEntry, STATIC_MATH_CONSTS, STATIC_MATH_FNS, boundaryIntoIslandMsg } from "./surfaces.js";
 import { requiresDynamicApiDiag, requiresDynamicPackageDiag } from "../../diagnostics/diagnostic.js";
 import { isCjsJsFile, isJsSourceFile, locOf, npmPackageNameOf } from "../program.js";
 import { foldedStringKeyOf, lowerDynObjectLiteral, pureReemittable } from "./lower-exprs.js";
@@ -3218,14 +3218,24 @@ export function lowerStaticReadableStreamReaderCall(
     return finish(lowerer.jsvalIn(lowerer.lowerExpr(access.expression), access.expression), entry);
   }
 
-/** `Math.PI` / `Math.E` property READS: getProp off globalGet("Math"),
-   * exiting to the declared number type. Math methods referenced without a
+/** `Math.PI` / `Math.E` property READS (and the island-backed remaining
+   * readonly props): the two IEEE constants fold to static f64 literals
+   * (STATIC_MATH_CONSTS, no --dynamic); the island props exit to the
+   * declared number type via the engine. Math methods referenced without a
    * call are rejected specifically (no value form exists, --dynamic or
    * not). Null for non-Math receivers (the property chain keeps trying). */
   export function lowerMathProperty(lowerer: Lowerer, expr: ts.PropertyAccessExpression): IrExpr | null {
     const member = lowerer.stdlibGlobalMember(expr, "Math");
     if (member === null) return null;
     const loc = locOf(expr);
+    // The readonly IEEE constants (Math.PI, Math.E) fold to static f64
+    // literals — no island, no --dynamic (the ES-spec doubles are exactly
+    // representable; emitted through the same numLit path as every other
+    // literal, so --dynamic or not the value is identical).
+    const constValue = own(STATIC_MATH_CONSTS, member);
+    if (constValue !== undefined) {
+      return { kind: "numLit", value: constValue, type: F64, loc };
+    }
     const propType = own(ISLAND_SURFACE.math.props, member);
     if (propType !== undefined) {
       lowerer.requireDynamicApi(`'Math.${member}'`, expr);

--- a/packages/compiler/src/frontend/lowering/surfaces.ts
+++ b/packages/compiler/src/frontend/lowering/surfaces.ts
@@ -468,7 +468,8 @@ export const ISLAND_SURFACE = {
    * (rest/optional parameters aren't representable). */
   math: {
     // floor, min/max (two-arg), and random are STATIC now
-    // (STATIC_MATH_FNS below).
+    // (STATIC_MATH_FNS below), and PI/E fold statically too
+    // (STATIC_MATH_CONSTS). The dynamic-only members remain here.
     fns: {
       abs: ISL_N1, acos: ISL_N1, asin: ISL_N1, atan: ISL_N1, atan2: ISL_N2,
       cbrt: ISL_N1, ceil: ISL_N1, cos: ISL_N1, exp: ISL_N1,
@@ -532,6 +533,19 @@ export const STATIC_MATH_FNS: Record<string, { fn: IrLibFn; arity: number } | un
   min: { fn: "math.min", arity: 2 },
   max: { fn: "math.max", arity: 2 },
   random: { fn: "math.random", arity: 0 },
+};
+
+/** The READONLY IEEE Math constants that fold to static number literals —
+ * Math.PI and Math.E are FIXED doubles (not methods), so a plain read
+ * lowers to an f64 numLit. Checked BEFORE the island props table
+ * (lowerMathProperty): under --dynamic the read is still identical, so it
+ * compiles statically in either build. The exact values are Node's own
+ * ES-spec IEEE doubles, so the C and LLVM backends' literal emission (the
+ * shortest-roundtrip / bit-pattern paths used for every numLit) reproduces
+ * them exactly. */
+export const STATIC_MATH_CONSTS: Record<string, number | undefined> = {
+  PI: Math.PI,
+  E: Math.E,
 };
 
 /** Number prototype methods with dedicated STATIC lowering paths. The

--- a/packages/compiler/src/library/fence-eval.ts
+++ b/packages/compiler/src/library/fence-eval.ts
@@ -55,6 +55,7 @@ import {
   BUILTIN_MODULE_CONSTS,
   BUILTIN_MODULE_FNS,
   BUILTIN_MODULE_FN_ALIASES,
+  STATIC_MATH_CONSTS,
   STATIC_MATH_FNS,
   STATIC_NUMBER_METHODS,
   STR_METHODS,
@@ -165,6 +166,15 @@ function fenceTaxonomy(): FenceTaxonomy {
   for (const [mod, members] of Object.entries(BUILTIN_MODULE_CONSTS)) {
     for (const member of Object.keys(members!)) foldedIds.add(`${builtinRootId(mod)}.${member}`);
   }
+  // The stdlib Math constants (Math.PI, Math.E) fold the same way: a read
+  // is lowered to a per-binary f64 literal (STATIC_MATH_CONSTS in
+  // surfaces.ts), so the compiled artifact performs no runtime read a fence
+  // could deny. Registering them in foldedIds both yields the accurate
+  // "folds to a constant" message for an id fence and — critically — the
+  // prefix-sweep exemption below, so { prefix: "stdlib.math." } stays
+  // loadable now that these members are static. Their manifest ids are the
+  // stdlib.math.<member> spelling.
+  for (const member of Object.keys(STATIC_MATH_CONSTS)) foldedIds.add(`stdlib.math.${member}`);
   const ambientFns = new Map(AMBIENT_SURFACE_FNS.map((row) => [row.id, row.fns as readonly string[]]));
   taxonomy = { byId, ids: manifest.entries.map((e) => e.id), builtinFns, builtinRoots, foldedIds, ambientFns };
   return taxonomy;

--- a/packages/compiler/surface-manifest.json
+++ b/packages/compiler/surface-manifest.json
@@ -2560,15 +2560,15 @@
       "id": "stdlib.math.E",
       "kind": "stdlib",
       "name": "Math.E",
-      "status": "dynamic-only",
-      "code": "SC2012"
+      "status": "static",
+      "note": "compiles to a static number literal (the IEEE Math constant)"
     },
     {
       "id": "stdlib.math.PI",
       "kind": "stdlib",
       "name": "Math.PI",
-      "status": "dynamic-only",
-      "code": "SC2012"
+      "status": "static",
+      "note": "compiles to a static number literal (the IEEE Math constant)"
     },
     {
       "id": "stdlib.math.abs",

--- a/tests/corpus/2458-math-constants-static.ts
+++ b/tests/corpus/2458-math-constants-static.ts
@@ -1,0 +1,18 @@
+// Math.PI and Math.E are the fixed IEEE constants, so they compile to
+// plain static number literals — no island, no --dynamic, exactly Node's
+// doubles. Composed through arithmetic and printing like any number.
+console.log(Math.PI, Math.E);
+// Round-trip through static expressions: these bytes must equal Node's.
+console.log(2 * Math.PI, Math.PI / 2, Math.PI + Math.E, Math.E * Math.E);
+// Literal doubles flow into number methods and conditions like any f64.
+console.log(Math.PI.toFixed(9), Math.E.toFixed(9), Math.PI > Math.E);
+// A bare read is discarded with zero observable effect (Node evaluates,
+// throws the value away), as with any stdlib member read.
+Math.PI;
+{
+  const tau = Math.PI * 2;
+  console.log(tau > 6.28, tau < 6.285);
+}
+// Exact IEEE identity: the static literal IS the ES-spec double, so it
+// equals the value written as a decimal literal.
+console.log((Math.PI - 3.141592653589793) === 0, (Math.E - 2.718281828459045) === 0);

--- a/tests/diagnostics/dynamic-surface.ts
+++ b/tests/diagnostics/dynamic-surface.ts
@@ -1,14 +1,15 @@
-// The island-backed ambient surface (Math beyond the static members,
-// number methods, string-pattern replace/at, the Number statics, ...)
-// typechecks against real static types but executes in the embedded
-// engine: in a static build every use site is its own SC2012 naming the
-// flag — never an ICE, never a link error. (Math.floor/abs/round and the
-// ask-4 wholeness-discharge pair Math.trunc/ceil, .split(string), the
-// trim/pad variants, parseInt, isNaN, and the global parseFloat/isFinite
-// over exactly-typed arguments compile statically now and no longer
-// appear here.)
+// The island-backed ambient surface (Math beyond the static members and
+// the PI/E constants, number methods, string-pattern replace/at, the
+// Number statics, ...) typechecks against real static types but executes
+// in the embedded engine: in a static build every use site is its own
+// SC2012 naming the flag — never an ICE, never a link error.
+// (Math.floor/abs/round and the ask-4 wholeness-discharge pair
+// Math.trunc/ceil, Math.PI/Math.E, .split(string), the trim/pad variants,
+// parseInt, isNaN, and the global parseFloat/isFinite over
+// exactly-typed arguments compile statically now and no longer appear
+// here.)
 const up = Math.sqrt(2);
-const tau = Math.PI * 2;
+const tau = Math.pow(Math.PI * 2, 2);
 const price = (19.99).toPrecision(4);
 const swapped = "banana".replace("an", "AN");
 const ch = "hello".at(0);

--- a/tests/harness/__snapshots__/dynamic-surface.ts.txt
+++ b/tests/harness/__snapshots__/dynamic-surface.ts.txt
@@ -1,53 +1,53 @@
-dynamic-surface.ts:10:12 - error SC2012: 'Math.sqrt' runs in the embedded dynamic engine, which this build does not include
+dynamic-surface.ts:11:12 - error SC2012: 'Math.sqrt' runs in the embedded dynamic engine, which this build does not include
 
-   9 | // appear here.)
-  10 | const up = Math.sqrt(2);
+  10 | // here.)
+  11 | const up = Math.sqrt(2);
      |            ^~~~~~~~~~~~
-  11 | const tau = Math.PI * 2;
+  12 | const tau = Math.pow(Math.PI * 2, 2);
 
   hint: build with --dynamic to run this call in the embedded engine (adds ~620KB to the binary); static builds never include it
 
-dynamic-surface.ts:11:13 - error SC2012: 'Math.PI' runs in the embedded dynamic engine, which this build does not include
+dynamic-surface.ts:12:13 - error SC2012: 'Math.pow' runs in the embedded dynamic engine, which this build does not include
 
-  10 | const up = Math.sqrt(2);
-  11 | const tau = Math.PI * 2;
-     |             ^~~~~~~
-  12 | const price = (19.99).toPrecision(4);
+  11 | const up = Math.sqrt(2);
+  12 | const tau = Math.pow(Math.PI * 2, 2);
+     |             ^~~~~~~~~~~~~~~~~~~~~~~~
+  13 | const price = (19.99).toPrecision(4);
 
   hint: build with --dynamic to run this call in the embedded engine (adds ~620KB to the binary); static builds never include it
 
-dynamic-surface.ts:12:15 - error SC2012: '.toPrecision()' on numbers runs in the embedded dynamic engine, which this build does not include
+dynamic-surface.ts:13:15 - error SC2012: '.toPrecision()' on numbers runs in the embedded dynamic engine, which this build does not include
 
-  11 | const tau = Math.PI * 2;
-  12 | const price = (19.99).toPrecision(4);
+  12 | const tau = Math.pow(Math.PI * 2, 2);
+  13 | const price = (19.99).toPrecision(4);
      |               ^~~~~~~~~~~~~~~~~~~~~~
-  13 | const swapped = "banana".replace("an", "AN");
+  14 | const swapped = "banana".replace("an", "AN");
 
   hint: build with --dynamic to run this call in the embedded engine (adds ~620KB to the binary); static builds never include it
 
-dynamic-surface.ts:13:17 - error SC2012: '.replace()' on strings runs in the embedded dynamic engine, which this build does not include
+dynamic-surface.ts:14:17 - error SC2012: '.replace()' on strings runs in the embedded dynamic engine, which this build does not include
 
-  12 | const price = (19.99).toPrecision(4);
-  13 | const swapped = "banana".replace("an", "AN");
+  13 | const price = (19.99).toPrecision(4);
+  14 | const swapped = "banana".replace("an", "AN");
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
-  14 | const ch = "hello".at(0);
+  15 | const ch = "hello".at(0);
 
   hint: build with --dynamic to run this call in the embedded engine (adds ~620KB to the binary); static builds never include it
 
-dynamic-surface.ts:14:12 - error SC2012: '.at()' on strings runs in the embedded dynamic engine, which this build does not include
+dynamic-surface.ts:15:12 - error SC2012: '.at()' on strings runs in the embedded dynamic engine, which this build does not include
 
-  13 | const swapped = "banana".replace("an", "AN");
-  14 | const ch = "hello".at(0);
+  14 | const swapped = "banana".replace("an", "AN");
+  15 | const ch = "hello".at(0);
      |            ^~~~~~~~~~~~~
-  15 | const n = Number.parseFloat("3.14");
+  16 | const n = Number.parseFloat("3.14");
 
   hint: build with --dynamic to run this call in the embedded engine (adds ~620KB to the binary); static builds never include it
 
-dynamic-surface.ts:15:11 - error SC2012: 'Number.parseFloat' runs in the embedded dynamic engine, which this build does not include
+dynamic-surface.ts:16:11 - error SC2012: 'Number.parseFloat' runs in the embedded dynamic engine, which this build does not include
 
-  14 | const ch = "hello".at(0);
-  15 | const n = Number.parseFloat("3.14");
+  15 | const ch = "hello".at(0);
+  16 | const n = Number.parseFloat("3.14");
      |           ^~~~~~~~~~~~~~~~~~~~~~~~~
-  16 | 
+  17 | 
 
   hint: build with --dynamic to run this call in the embedded engine (adds ~620KB to the binary); static builds never include it

--- a/tests/harness/library-profile.test.ts
+++ b/tests/harness/library-profile.test.ts
@@ -548,6 +548,36 @@ describe("library profile fences", () => {
     expect(r.profile.fences[0]!.surfaces.map((s) => s.id)).toContain("node-builtin.os.homedir");
   });
 
+  test("the stdlib Math constants fold, so an id fence refuses with the folded reason and a math prefix stays loadable", () => {
+    // Math.PI and Math.E are static IEEE constants (STATIC_MATH_CONSTS):
+    // a read lowers to a per-binary f64 literal, so the compiled artifact
+    // performs no runtime read a fence could deny. An id fence naming one
+    // must refuse with the folded-constant reason — never the misleading
+    // 'no fence detector exists' — while a whole stdlib.math. prefix sweep
+    // stays usable (the fold IS the exemption, as with node-builtin os.EOL).
+    for (const id of ["stdlib.math.PI", "stdlib.math.E"]) {
+      expectSc4001(
+        { ...good, determinism: { fences: [{ id }] } },
+        "constant at compile time",
+      );
+    }
+    // The prefix sweep still resolves and exempts the folded constants.
+    const r = loadLibraryProfile(
+      writeProfile({ ...good, determinism: { fences: [{ prefix: "stdlib.math." }] } }),
+    );
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const mathIds = r.profile.fences[0]!.surfaces.map((s) => s.id);
+    expect(mathIds).not.toContain("stdlib.math.PI");
+    expect(mathIds).not.toContain("stdlib.math.E");
+    // The reachable static members (random, floor, min ...) still carry
+    // detectors, so the family fence has something real to deny; dynamic-only
+    // math members (sin, cos ...) resolve as refusals carrying no detector.
+    expect(mathIds).toContain("stdlib.math.random");
+    const random = r.profile.fences[0]!.surfaces.find((s) => s.id === "stdlib.math.random");
+    expect(random?.detector).toBeDefined();
+  });
+
   test("a desugared surface no detector can police refuses, id and prefix alike", () => {
     expectSc4001(
       { ...good, determinism: { fences: [{ id: "stdlib.array.map" }] } },

--- a/tests/harness/surface-manifest.test.ts
+++ b/tests/harness/surface-manifest.test.ts
@@ -116,6 +116,7 @@ const PROBES: Probe[] = [
   { id: "stdlib.array.unshift", source: "const xs: number[] = [2];\nconsole.log(xs.unshift(1), xs[0]);\n" },
   { id: "stdlib.array.reverse", source: "const xs: number[] = [1, 2];\nconsole.log(xs.reverse()[0]);\n" },
   { id: "stdlib.math.floor", source: "console.log(Math.floor(1.5));\n" },
+  { id: "stdlib.math.PI", source: "console.log(Math.PI);\n" },
   { id: "stdlib.map.has", source: 'const m = new Map<string, number>();\nm.set("a", 1);\nconsole.log(m.has("a"));\n' },
   { id: "stdlib.date.now", source: "console.log(Date.now() > 0);\n" },
   { id: "stdlib.number.toFixed", source: "const n = 1.2345;\nconsole.log(n.toFixed(2));\n" },
@@ -143,7 +144,6 @@ const PROBES: Probe[] = [
   // status dynamic-only — refused with the entry's code statically,
   // analyzed clean under --dynamic
   { id: "stdlib.math.sqrt", source: "console.log(Math.sqrt(2));\n" },
-  { id: "stdlib.math.PI", source: "console.log(Math.PI);\n" },
   { id: "stdlib.string.replace", source: 'console.log("aa".replace("a", "b"));\n' },
   {
     id: "stdlib.headers.entries",


### PR DESCRIPTION
## What changed

Math.PI and Math.E are fixed IEEE 754 doubles, not functions — common static math code uses them purely as numeric constants. Static builds previously rejected both with SC2012 (“runs in the embedded dynamic engine, which this build does not include”), forcing such programs to either add the ~620KB dynamic engine or fail to compile.

This change migrates both constants into the static tier, following the same pattern already used for `Math.floor`/`Math.abs`/`round`/`trunc`/`ceil`/`min`/`max`/`random`. A new `STATIC_MATH_CONSTS` table carries their exact ES-spec values, and `lowerMathProperty` checks it before the island surface table: a plain read of `Math.PI` or `Math.E` now lowers to a static `f64` number literal emitted through the same literal path both C and LLVM backends already use, so the compiled value is identical to Node’s in both static and `--dynamic` builds and matching Node byte-for-byte across the differential corpus.

A library determinism fence that names one of these constants now refuses with the accurate “folds to a constant at compile time” reason, and a whole-`stdlib.math.` prefix sweep remains loadable — the fold itself is the exemption, consistent with how other folded constants are handled.

## Why

These constants carry no runtime behavior and are trivially representable, so requiring the ~620KB embedded engine or emitting a hard compile error for them was an unnecessary barrier. Static builds are the default posture; this extends the Math surface the static tier already supports and lets otherwise-static math programs compile without the engine.