### PR TITLE
fix(compiler): keep targetless Zig native builds coherent

### DIFF
--- a/packages/compiler/src/backend/native-toolchain.test.ts
+++ b/packages/compiler/src/backend/native-toolchain.test.ts
@@ -205,6 +205,97 @@ test("native cache identities separate host architectures while cross targets re
   ).toBe("x86_64-linux-gnu.2.36");
 });
 
+test.skipIf(
+  process.platform === "win32" || zigExecutable === undefined ||
+  clangExecutable === undefined || arExecutable === undefined,
+)("targetless Zig vendor caches are separate from host-clang and reusable", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "scriptc-zig-vendor-cache-"));
+  scratch.push(dir);
+  const cacheRoot = join(dir, "cache");
+  const vendorRoot = join(dir, "vendor-cache");
+  const cPath = join(dir, "program.c");
+  const oldCacheDir = process.env["SCRIPTC_CACHE_DIR"];
+  const oldNoCache = process.env["SCRIPTC_NO_CACHE"];
+  const oldVendorCacheDir = process.env["SCRIPTC_TEST_VENDOR_CACHE_DIR"];
+  const oldCc = process.env["SCRIPTC_CC"];
+  const oldTarget = process.env["SCRIPTC_TARGET"];
+
+  try {
+    await writeFile(cPath, "int main(void) { return 0; }\n");
+    process.env["SCRIPTC_CACHE_DIR"] = cacheRoot;
+    process.env["SCRIPTC_TEST_VENDOR_CACHE_DIR"] = vendorRoot;
+    delete process.env["SCRIPTC_NO_CACHE"];
+    delete process.env["SCRIPTC_TARGET"];
+
+    process.env["SCRIPTC_CC"] = "clang";
+    await compileC({
+      cPath,
+      outPath: join(dir, "host"),
+      cacheIdentity: TEST_CACHE_IDENTITY,
+      dynamic: true,
+      net: true,
+      http: true,
+      tls: true,
+      zlib: true,
+      // Keep the complete executable tier out of this test: the second Zig
+      // invocation must walk the vendor cache and prove its artifacts are
+      // reusable independently of the output path.
+      systemLibraries: ["m"],
+    });
+    const hostEngine = (await readdir(vendorRoot)).find((name) =>
+      /^3c8f3d689539-plain-/.test(name)
+    );
+    const hostTls = (await readdir(vendorRoot)).find((name) => name.startsWith("mbedtls-"));
+    expect(hostEngine).toBeDefined();
+    expect(hostTls).toBeDefined();
+
+    process.env["SCRIPTC_CC"] = "zigcc";
+    const zigOptions = {
+      cPath,
+      cacheIdentity: TEST_CACHE_IDENTITY,
+      dynamic: true,
+      net: true,
+      http: true,
+      tls: true,
+      zlib: true,
+      systemLibraries: ["m"],
+    } as const;
+    await compileC({ ...zigOptions, outPath: join(dir, "zig-first") });
+
+    let vendorEntries = await readdir(vendorRoot);
+    expect(vendorEntries.filter((name) => /^3c8f3d689539-plain-/.test(name))).toHaveLength(2);
+    expect(vendorEntries.filter((name) => name.startsWith("mbedtls-")).length).toBe(2);
+    // Host clang uses system zlib, so only the Zig build materializes a zlib
+    // object family in the shared vendor root.
+    expect(vendorEntries.filter((name) => name.startsWith("zlib-")).length).toBe(1);
+    // Invalidate the host archive. A targetless Zig rebuild must continue to
+    // use the separately keyed Zig archive instead of repairing or consuming
+    // the host-clang entry.
+    await writeFile(join(vendorRoot, hostEngine!, "libqjs.a"), "host archive intentionally invalid\n");
+    await writeFile(join(vendorRoot, hostTls!, "libmbedtls.a"), "host archive intentionally invalid\n");
+    await compileC({ ...zigOptions, outPath: join(dir, "zig-second") });
+    vendorEntries = await readdir(vendorRoot);
+    expect(vendorEntries.filter((name) => /^3c8f3d689539-plain-/.test(name))).toHaveLength(2);
+    expect(await readFile(join(vendorRoot, hostEngine!, "libqjs.a"), "utf8")).toBe(
+      "host archive intentionally invalid\n",
+    );
+    expect(await readFile(join(vendorRoot, hostTls!, "libmbedtls.a"), "utf8")).toBe(
+      "host archive intentionally invalid\n",
+    );
+  } finally {
+    if (oldCacheDir === undefined) delete process.env["SCRIPTC_CACHE_DIR"];
+    else process.env["SCRIPTC_CACHE_DIR"] = oldCacheDir;
+    if (oldNoCache === undefined) delete process.env["SCRIPTC_NO_CACHE"];
+    else process.env["SCRIPTC_NO_CACHE"] = oldNoCache;
+    if (oldVendorCacheDir === undefined) delete process.env["SCRIPTC_TEST_VENDOR_CACHE_DIR"];
+    else process.env["SCRIPTC_TEST_VENDOR_CACHE_DIR"] = oldVendorCacheDir;
+    if (oldCc === undefined) delete process.env["SCRIPTC_CC"];
+    else process.env["SCRIPTC_CC"] = oldCc;
+    if (oldTarget === undefined) delete process.env["SCRIPTC_TARGET"];
+    else process.env["SCRIPTC_TARGET"] = oldTarget;
+  }
+}, 600_000);
+
 test("Zig COFF dry-run parsing retains every linker input on its single command line", async () => {
   const dir = await mkdtemp(join(tmpdir(), "scriptc-link-trace-"));
   scratch.push(dir);

--- a/packages/compiler/src/backend/native-toolchain.ts
+++ b/packages/compiler/src/backend/native-toolchain.ts
@@ -351,10 +351,11 @@ export interface CcOptions {
   netIsland?: boolean;
   /** The program uses zlib (index.ts detects zlib.* libCalls on the IR):
    * compiles scr_zlib.c — the regex/curl gating precedent, so zlib-free
-   * binaries keep their exact link line. Host builds link the SYSTEM libz
-   * (macOS ships it), byte-identical to the historical line; cross targets
-   * compile the vendored zlib per target instead (ensureZlibObjects — zig
-   * has no libz in its sysroots). Compressed bytes may differ between the
+   * binaries keep their exact link line. The default host-clang build links
+   * the SYSTEM libz (macOS ships it), byte-identical to the historical line;
+   * every Zig build compiles the vendored zlib with the selected driver instead
+   * (ensureZlibObjects — zig has no libz in its sysroots). Compressed bytes may
+   * differ between the
    * system and vendored libraries, which is why the corpus only ever
    * compares round-trips and fixed-blob inflation, never raw deflate
    * output. */
@@ -558,8 +559,8 @@ export function runtimeSrcDir(): string {
  * the scr_platform.h contract with kqueue and epoll backends; libregexp,
  * zlib, mbedTLS, and the engine archive (--dynamic) build per target
  * (ensureLreObjects / ensureZlibObjects / ensureTlsArchive /
- * buildEngineArchiveDirect — host zlib builds still link the system libz,
- * byte-identically).
+ * buildEngineArchiveDirect — default host-clang zlib builds still link the
+ * system libz, byte-identically; Zig builds use vendored zlib objects).
  * Windows triples (x86_64-windows-gnu, mingw-w64 headers and CRT via zig)
  * have no gates left: events, net/http, fetch, watch, zlib, dgram/dns,
  * tls, and the engine archive (--dynamic) all build per target through
@@ -592,6 +593,13 @@ export interface CcDriver {
   targetArgs: string[];
   /** Platform libraries appended after every object/archive input. */
   linkArgs: string[];
+}
+
+/** Whether the selected compiler driver is Zig. This is deliberately based on
+ * the executable prefix rather than target presence: targetless Zig is still
+ * a Zig build, while target presence is only the platform/target contract. */
+export function isZigDriver(driver: Pick<CcDriver, "argv">): boolean {
+  return driver.argv[0] === "zig";
 }
 
 /* ── mobile targets (library mode) ─────────────────────────────────────────
@@ -1181,7 +1189,7 @@ export async function compileLibArchive(opts: LibArchiveOptions): Promise<void> 
     ? [...cflags, "-Wno-override-module"]
     : cflags;
   const programSourceExtension = opts.cPath.endsWith(".ll") ? ".ll" : ".c";
-  const arArgv = driver.argv[0] === "zig" ? [driver.argv[0]!, "ar"] : ["ar"];
+  const arArgv = isZigDriver(driver) ? [driver.argv[0]!, "ar"] : ["ar"];
   const cachePolicy = toolchainEnvironmentCachePolicy();
   const configuredCacheRoot = cacheRootDir();
   const toolchainEnv = toolchainEnvironmentFingerprint();
@@ -3370,6 +3378,7 @@ const {
 } = createVendorArchives({
   runtimeSrcDir,
   targetPlatform,
+  isZigDriver,
   resolvedToolIdentity,
   runtimeFingerprint,
 });
@@ -4284,11 +4293,11 @@ async function compileCInternal(
   let lreObjects = regex && !dynamic
     ? lreObjectPaths(sanitize, driver, vendorBuildIdentity, vendorCacheRoot)
     : [];
-  // Vendored zlib is the CROSS story only — host builds keep the exact
+  // Vendored zlib is the Zig story — default host-clang builds keep the exact
   // historical `-lz` system link (see CcOptions.zlib). The native fetch's
   // gzip decoder rides the same objects/link.
   let zlibObjects =
-    ((opts.zlib ?? false) || nativeFetch) && driver.target !== null
+    ((opts.zlib ?? false) || nativeFetch) && isZigDriver(driver)
       ? zlibObjectPaths(sanitize, driver, vendorBuildIdentity, vendorCacheRoot)
       : [];
   // The libcurl import stub is likewise CROSS-only — host builds keep the
@@ -4434,14 +4443,14 @@ async function compileCInternal(
     ...(opts.dc ? [rt(join(rtDir, "scr_dc.c"))] : []),
     ...(opts.dynAsync || opts.dynInvoke || opts.dc || nativeFetch ? [rt(join(rtDir, "scr_async_dyn.c"))] : []),
     // The zlib UNIT (scr_zlib.c) gates on zlib.* IR use; the LINK (system
-    // libz on hosts, the vendored per-target objects on cross builds)
+    // libz on the default host-clang build, vendored objects on Zig builds)
     // also serves the native fetch's gzip decoder — spread exactly once.
     ...(opts.zlib
-      ? driver.target !== null
+      ? isZigDriver(driver)
         ? ["-I", vendorZlibDir(), rt(join(rtDir, "scr_zlib.c")), ...zlibObjects]
         : [rt(join(rtDir, "scr_zlib.c"))]
       : nativeFetch
-        ? driver.target !== null
+        ? isZigDriver(driver)
           ? ["-I", vendorZlibDir(), ...zlibObjects]
           : []
       : []),
@@ -4560,10 +4569,10 @@ async function compileCInternal(
     ...(opts.linkInputs ?? []),
     ...(opts.systemLibraries ?? []).map((name) => `-l${name}`),
     // GNU ld resolves libraries from left to right and commonly enables
-    // --as-needed: host libz must follow scr_zlib.c/scr_fetch.c and every
+    // --as-needed: host-clang libz must follow scr_zlib.c/scr_fetch.c and every
     // generated/native input that references inflate symbols. Cross
-    // builds use vendored zlib objects in the input section above.
-    ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null
+    // and targetless Zig builds use vendored zlib objects in the input section above.
+    ...(((opts.zlib ?? false) || nativeFetch) && !isZigDriver(driver)
       ? ["-lz"]
       : []),
     // glibc keeps libm separate from libc. This must trail the generated
@@ -4766,7 +4775,7 @@ async function compileCInternal(
     ...(tlsCa && targetPlatform(driver) === "win32" ? ["-lcrypt32"] : []),
     ...(curlFetch && driver.target === null ? ["-lcurl"] : []),
     ...(dynamic && !driver.linkArgs.includes("-lm") ? ["-lm"] : []),
-    ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null ? ["-lz"] : []),
+    ...(((opts.zlib ?? false) || nativeFetch) && !isZigDriver(driver) ? ["-lz"] : []),
     ...driver.linkArgs,
     ...executableSectionFlags.link,
   ];
@@ -4786,7 +4795,7 @@ async function compileCInternal(
     ...(dynamic && targetPlatform(driver) === "win32"
       ? ["-Wl,--stack,8388608"]
       : []),
-    ...(((opts.zlib ?? false) || nativeFetch) && driver.target === null ? ["-lz"] : []),
+    ...(((opts.zlib ?? false) || nativeFetch) && !isZigDriver(driver) ? ["-lz"] : []),
     ...driver.linkArgs,
     ...executableSectionFlags.link,
   ];
@@ -5148,7 +5157,7 @@ async function compileCInternal(
             ]);
           }));
         }
-        const arArgv = driver.argv[0] === "zig" ? [driver.argv[0]!, "ar"] : ["ar"];
+        const arArgv = isZigDriver(driver) ? [driver.argv[0]!, "ar"] : ["ar"];
         const merged = await localizeLibraryObjects(
           driver,
           arArgv,

--- a/packages/compiler/src/backend/vendor-archives.ts
+++ b/packages/compiler/src/backend/vendor-archives.ts
@@ -22,6 +22,7 @@ export const ZLIB_SOURCES = ["adler32.c", "compress.c", "crc32.c", "deflate.c", 
 export interface VendorArchiveContext {
   runtimeSrcDir(): string;
   targetPlatform(driver: CcDriver): string;
+  isZigDriver(driver: Pick<CcDriver, "argv">): boolean;
   resolvedToolIdentity(command: string): Promise<string | null>;
   runtimeFingerprint(runtimeDir: string): Promise<string>;
 }
@@ -30,6 +31,7 @@ export function createVendorArchives(context: VendorArchiveContext) {
   const {
     runtimeSrcDir,
     targetPlatform,
+    isZigDriver,
     resolvedToolIdentity,
     runtimeFingerprint,
   } = context;
@@ -91,14 +93,10 @@ export function createVendorArchives(context: VendorArchiveContext) {
     driver: Pick<CcDriver, "argv" | "target">,
     environmentFingerprint: string,
   ): Promise<string> {
-    // Native vendor recipes additionally use bare clang/ar; cross
-    // recipes use the zig driver for compilation and `zig ar`. Include every
-    // executable that can affect the cached prerequisite, not just the
-    // final program's driver.
-    const commands = [
-      driver.argv[0] ?? "clang",
-      ...(driver.target === null ? ["clang", "ar"] : []),
-    ].filter((command, index, all) => all.indexOf(command) === index);
+    // Zig recipes use Zig for both compilation and archiving, including the
+    // targetless host-native path. The default host-clang recipe uses the
+    // separate bare clang and ar tools.
+    const commands = isZigDriver(driver) ? [driver.argv[0] ?? "zig"] : ["clang", "ar"];
     const identities = await Promise.all(
       commands.map(async (command) => {
         const spellingKey = `${environmentFingerprint}\0${command}`;
@@ -207,11 +205,11 @@ export function createVendorArchives(context: VendorArchiveContext) {
    * private temp dir and publish with an atomic rename — first one wins,
    * losers discard their work and use the winner's archive.
    *
-   * The qjs library target is just four TUs (QJS_ENGINE_SOURCES), so both host
-   * and cross builds use the same direct per-TU recipe. This removes CMake from
+   * The qjs library target is just four TUs (QJS_ENGINE_SOURCES), so host-clang,
+   * targetless Zig, and cross builds use the same direct per-TU recipe. This removes CMake from
    * the runtime dependency set and lets cache warming compile exactly the
-   * archive a later program consumes. Host builds use clang + ar; cross builds
-   * use the selected zig driver + zig ar. */
+   * archive a later program consumes. The default host-clang driver uses bare
+   * clang + ar; every Zig driver uses the selected zig cc + zig ar. */
   async function ensureEngineArchive(
     sanitize: boolean,
     driver: CcDriver,
@@ -240,8 +238,8 @@ export function createVendorArchives(context: VendorArchiveContext) {
   async function buildEngineArchiveDirect(sanitize: boolean, driver: CcDriver, cacheRoot: string, cacheDir: string): Promise<string> {
     const vendor = vendorEngineDir();
     const archive = join(cacheDir, "libqjs.a");
-    const compileArgv = driver.target === null ? ["clang"] : driver.argv;
-    const arArgv = driver.target === null ? ["ar"] : [...driver.argv.slice(0, 1), "ar"];
+    const compileArgv = isZigDriver(driver) ? driver.argv : ["clang"];
+    const arArgv = isZigDriver(driver) ? [...driver.argv.slice(0, 1), "ar"] : ["ar"];
     const cflags = [
       "-std=gnu11",
       ...driver.targetArgs,
@@ -340,10 +338,11 @@ export function createVendorArchives(context: VendorArchiveContext) {
     return join(runtimeSrcDir(), "..", "vendor", "zlib");
   }
   
-  /** The vendored zlib TUs behind CROSS-target zlib support: every root *.c
+  /** The vendored zlib TUs behind Zig zlib support: every root *.c
    * except the gzFile file-I/O units (gz*.c — nothing in scr_zlib.c
    * references the gzFile API, and those TUs alone want unistd/io headers).
-   * Host builds never touch this list — they link the system libz. */
+   * The default host-clang build links the system libz; Zig builds use this
+   * list so targetless and explicit-target Zig inputs stay on one toolchain. */
   
   function zlibObjectPaths(
     sanitize: boolean,
@@ -360,12 +359,12 @@ export function createVendorArchives(context: VendorArchiveContext) {
   }
   
   /** The zlib objects for one flavor, compiled lazily on the first zlib-using
-   * CROSS build (~1s) and cached like the lre objects —
+   * Zig build (~1s) and cached like the lre objects —
    * <build-cache>/vendor/zlib-<version>-<flavor>-<target>-<toolchain>/*.o — with the same atomic-rename
    * publish (parallel first builds race safely; losers discard their work).
    * Plain is -Os, asan matches the final link so the sanitized lane
    * instruments the codec too. The flavor keys the driver and target exactly
-   * like the lre flavor: only cross builds call this today, but the keying
+   * like the lre flavor: the keying
    * must never hand a zig-built object set to a clang link off a shared
    * directory. */
   async function ensureZlibObjects(
@@ -522,10 +521,10 @@ export function createVendorArchives(context: VendorArchiveContext) {
    * per-TU `-c` compiles plus one `ar rcs` — vendored-build machinery the
    * lre-objects cache already established.
    *
-   * SCRIPTC_TARGET adds a per-target cache flavor (the lre-objects story):
-   * TUs compile with `zig cc -target <triple>` and the archive is packed
+   * Zig drivers add a per-target or native cache flavor (the lre-objects story):
+   * TUs compile with the selected `zig cc` invocation and the archive is packed
    * with `zig ar` (llvm-ar — the host BSD ar has no business indexing ELF
-   * objects). Host builds keep the exact historical clang + ar recipe. */
+   * objects). The default host-clang driver keeps the exact historical clang + ar recipe. */
   async function ensureTlsArchive(
     sanitize: boolean,
     driver: CcDriver,
@@ -533,8 +532,8 @@ export function createVendorArchives(context: VendorArchiveContext) {
     cacheRoot: string = vendorBuildCacheRoot(),
   ): Promise<string> {
     const flavor = `${sanitize ? "asan" : "plain"}-${vendorCacheTargetFlavor(driver)}-${buildIdentity}`;
-    const compileArgv = driver.target !== null ? driver.argv : ["clang"];
-    const arArgv = driver.target !== null ? [...driver.argv.slice(0, 1), "ar"] : ["ar"];
+    const compileArgv = isZigDriver(driver) ? driver.argv : ["clang"];
+    const arArgv = isZigDriver(driver) ? [...driver.argv.slice(0, 1), "ar"] : ["ar"];
     const vendor = vendorTlsDir();
     const archive = tlsArchivePath(sanitize, driver, buildIdentity, cacheRoot);
     if (await validVendorArtifact(archive)) return archive;

--- a/packages/compiler/test/cc-driver.test.ts
+++ b/packages/compiler/test/cc-driver.test.ts
@@ -17,12 +17,13 @@
 import { execFile, execFileSync } from "node:child_process";
 import { chmod, mkdir, mkdtemp, readFile, writeFile } from "node:fs/promises";
 import { EOL, tmpdir } from "node:os";
-import { join } from "node:path";
+import { delimiter, join } from "node:path";
 import { promisify } from "node:util";
 import { describe, expect, test } from "vitest";
 import {
   compileC,
   configuredTargetPlatform,
+  isZigDriver,
   resolveCc,
   runtimeSrcDir,
   subprocessFailureDetail,
@@ -124,6 +125,7 @@ test.skipIf(process.platform === "win32")("iOS SDK discovery uses the resolver's
 
 test("zigcc resolves to `zig cc`; linux triples add their libc target flags", () => {
   const native = resolveCc({ SCRIPTC_CC: "zigcc" }, "darwin");
+  expect(isZigDriver(native)).toBe(true);
   expect(native.argv).toEqual(["zig", "cc"]);
   expect(native.targetArgs).toEqual([]);
   expect(native.linkArgs).toEqual([]);
@@ -175,6 +177,7 @@ test("zigcc resolves to `zig cc`; linux triples add their libc target flags", ()
   expect(wasi.linkArgs).toEqual([
     "-lwasi-emulated-signal", "-lwasi-emulated-process-clocks",
   ]);
+  expect(isZigDriver(resolveCc({}, "linux"))).toBe(false);
 });
 
 /** Runs body with SCRIPTC_CC/SCRIPTC_TARGET set, restoring the previous values. */
@@ -310,6 +313,97 @@ describe.skipIf(!zigOnPath())("zig cc builds (zig on PATH)", () => {
     const { stdout } = await execFileAsync(outPath);
     expect(stdout).toBe("zigcc says hi\n");
   });
+
+  test("host-native zigcc builds dynamic, TLS, zlib, and native fetch together", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "scr-zigcc-host-features-"));
+    const cPath = join(dir, "program.c");
+    await writeFile(
+      cPath,
+      '#include <stdio.h>\nvoid scr_fetch_install(void);\nint main(void) { scr_fetch_install(); puts("zigcc host features ok"); return 0; }\n',
+    );
+    const outPath = join(dir, "program");
+    await withCcEnv("zigcc", undefined, () =>
+      compileC({ cPath, outPath, dynamic: true, tls: true, zlib: true, fetch: true }),
+    );
+    const { stdout } = await execFileAsync(outPath);
+    expect(stdout).toBe("zigcc host features ok\n");
+  }, 600_000);
+
+  test("targetless zigcc keeps vendor builds on zig cc and zig ar", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "scr-zigcc-vendor-tools-"));
+    const binDir = join(dir, "bin");
+    const logPath = join(dir, "zig.log");
+    const unexpectedToolPath = join(dir, "unexpected-tool");
+    const oldPath = process.env["PATH"];
+    const oldNoCache = process.env["SCRIPTC_NO_CACHE"];
+    const oldRealZig = process.env["SCRIPTC_TEST_REAL_ZIG"];
+    const realZig = (oldPath ?? "")
+      .split(delimiter)
+      .map((entry) => join(entry === "" ? process.cwd() : entry, "zig"))
+      .find((candidate) => {
+        try {
+          execFileSync(candidate, ["version"], { stdio: "ignore" });
+          return true;
+        } catch {
+          return false;
+        }
+      });
+    expect(realZig).toBeDefined();
+
+    try {
+      await mkdir(binDir);
+      await writeFile(
+        join(binDir, "zig"),
+        `#!/bin/sh
+printf '%s\n' "$*" >> "$SCRIPTC_TEST_ZIG_LOG"
+exec "$SCRIPTC_TEST_REAL_ZIG" "$@"
+`,
+      );
+      for (const tool of ["clang", "ar"]) {
+        await writeFile(
+          join(binDir, tool),
+          `#!/bin/sh
+: > "$SCRIPTC_TEST_UNEXPECTED_TOOL"
+exit 99
+`,
+        );
+      }
+      await Promise.all([
+        chmod(join(binDir, "zig"), 0o755),
+        chmod(join(binDir, "clang"), 0o755),
+        chmod(join(binDir, "ar"), 0o755),
+      ]);
+      process.env["PATH"] = `${binDir}${delimiter}${oldPath ?? ""}`;
+      process.env["SCRIPTC_TEST_ZIG_LOG"] = logPath;
+      process.env["SCRIPTC_TEST_UNEXPECTED_TOOL"] = unexpectedToolPath;
+      process.env["SCRIPTC_TEST_REAL_ZIG"] = realZig!;
+      process.env["SCRIPTC_NO_CACHE"] = "1";
+
+      const cPath = join(dir, "program.c");
+      await writeFile(cPath, "int main(void) { return 0; }\n");
+      await withCcEnv("zigcc", undefined, () =>
+        compileC({ cPath, outPath: join(dir, "program"), dynamic: true, tls: true, zlib: true }),
+      );
+
+      const invocations = (await readFile(logPath, "utf8")).trim().split(/\r?\n/);
+      expect(invocations.some((line) => /^cc .*quickjs-ng/.test(line))).toBe(true);
+      expect(invocations.some((line) => /^cc .*mbedtls.*library/.test(line))).toBe(true);
+      expect(invocations.some((line) => /^cc .*vendor.*zlib/.test(line))).toBe(true);
+      expect(invocations.some((line) => /^ar rcs .*libqjs\.a/.test(line))).toBe(true);
+      expect(invocations.some((line) => /^ar rcs .*libmbedtls\.a/.test(line))).toBe(true);
+      expect(invocations.some((line) => line.includes("-lz"))).toBe(false);
+      expect(await readFile(unexpectedToolPath).catch(() => "")).toBe("");
+    } finally {
+      if (oldPath === undefined) delete process.env["PATH"];
+      else process.env["PATH"] = oldPath;
+      if (oldNoCache === undefined) delete process.env["SCRIPTC_NO_CACHE"];
+      else process.env["SCRIPTC_NO_CACHE"] = oldNoCache;
+      if (oldRealZig === undefined) delete process.env["SCRIPTC_TEST_REAL_ZIG"];
+      else process.env["SCRIPTC_TEST_REAL_ZIG"] = oldRealZig;
+      delete process.env["SCRIPTC_TEST_ZIG_LOG"];
+      delete process.env["SCRIPTC_TEST_UNEXPECTED_TOOL"];
+    }
+  }, 600_000);
 
   test("cross build for aarch64-linux-gnu produces an ELF", async () => {
     const dir = await mkdtemp(join(tmpdir(), "scr-zigcc-cross-"));


### PR DESCRIPTION
## Summary

Targetless `SCRIPTC_CC=zigcc` native builds now use a coherent Zig toolchain for all vendored prerequisites and zlib integration.

- Build the QuickJS engine and mbedTLS archives with the selected Zig driver and `zig ar`, including host-native builds.
- Compile and link vendored zlib for every Zig build while preserving the system `-lz` path for default host-clang builds.
- Include the selected driver and toolchain recipe in vendor cache identities so Zig and clang artifacts remain isolated.
- Add regression coverage for targetless Zig feature builds, tool selection, and cache separation.

Previously, targetless Zig builds were classified by the absence of a target and could mix Zig output with host clang/ar or system zlib. That could fail on Windows and produce incompatible intermediate artifacts on POSIX hosts.

Closes #252